### PR TITLE
added ollama and open base url support

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ OPENAI_API_KEY=
 ANTHROPIC_API_KEY=                 
 GOOGLE_API_KEY=                  
 AWS_BEARER_TOKEN_BEDROCK=
-OLLAMA_URL=
-OPENAI_BASE_URL                   # Optional - if you are running local endpoints         
+OLLAMA_BASE_URL=
+OPENAI_BASE_URL=                   # Optional: Custom OpenAI endpoint
 
 # Core Configuration
 CACHING_DOCUMENTATION=false        # Enable/disable documentation caching

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 It’s designed to support onboarding, documentation, and comprehension for large, complex systems.
 
 - Extract modules and their relationships based on the control flow graph of the project.
-- Builds different levels of abstraction with an LLM agent (multi-provider support)
+- Builds different levels of abstraction with an LLM agent (multi-provider support) using remote and local inference.
 - Outputs interactive diagrams (Mermaid.js) for integration into docs, IDEs, CI/CD.
 
 📄 Existing visual generations: [GeneratedOnBoardings](https://github.com/CodeBoarding/GeneratedOnBoardings)  
@@ -72,7 +72,9 @@ pip install pygraphviz \
 OPENAI_API_KEY=                 
 ANTHROPIC_API_KEY=                 
 GOOGLE_API_KEY=                  
-AWS_BEARER_TOKEN_BEDROCK=         
+AWS_BEARER_TOKEN_BEDROCK=
+OLLAMA_URL=
+OPENAI_BASE_URL                   # Optional - if you are running local endpoints         
 
 # Core Configuration
 CACHING_DOCUMENTATION=false        # Enable/disable documentation caching

--- a/agents/agent.py
+++ b/agents/agent.py
@@ -96,7 +96,7 @@ class CodeBoardingAgent:
         elif self.ollama_base_url:
             logging.info("Using Ollama LLM")
             return ChatOllama(
-                model="qwen2.5:32b-instruct",
+                model="qwen3-coder:30b",
                 base_url=self.ollama_base_url,
                 temperature=0,
                 max_tokens=None,

--- a/agents/agent.py
+++ b/agents/agent.py
@@ -44,12 +44,12 @@ class CodeBoardingAgent:
         load_dotenv()
         # Check for API keys in priority order: OpenAI > Anthropic > Google > AWS Bedrock > Ollama
         self.openai_api_key = os.getenv("OPENAI_API_KEY")
+        self.openai_base_url = os.getenv("OPENAI_BASE_URL")
         self.anthropic_api_key = os.getenv("ANTHROPIC_API_KEY")
         self.google_api_key = os.getenv("GOOGLE_API_KEY")
         self.aws_bearer_token = os.getenv("AWS_BEARER_TOKEN_BEDROCK")
         self.aws_region = os.getenv("AWS_DEFAULT_REGION", "us-east-1")
         self.ollama_base_url = os.getenv("OLLAMA_BASE_URL")
-        self.openai_base_url = os.getenv("OPENAI_BASE_URL")
 
     def _initialize_llm(self):
         """Initialize LLM based on available API keys with priority order."""

--- a/agents/agent.py
+++ b/agents/agent.py
@@ -96,7 +96,7 @@ class CodeBoardingAgent:
         elif self.ollama_base_url:
             logging.info("Using Ollama LLM")
             return ChatOllama(
-                model="qwen3-coder:30b",
+                model="qwen3:32b",
                 base_url=self.ollama_base_url,
                 temperature=0,
                 max_tokens=None,

--- a/requirements.txt
+++ b/requirements.txt
@@ -96,6 +96,7 @@ langchain-aws==0.2.27
 langchain-community==0.3.27
 langchain-core==0.3.72
 langchain-google-genai==2.1.4
+langchain-ollama==0.3.6
 langchain-openai==0.3.28
 langchain-text-splitters==0.3.8
 langgraph==0.4.1
@@ -125,6 +126,7 @@ nest-asyncio==1.6.0
 networkx==3.4.2
 numpy==2.3.1
 oauth2client==4.1.3
+ollama==0.5.1
 onnxruntime==1.21.1
 openai==1.97.1
 opencensus==0.11.4


### PR DESCRIPTION
Hey @Slach, and thank you for your suggestion in #35, it is very helpful for us this early in the project.
 
I've just added support for both `Ollama` and custom `OpenAI` base URLs. Finding a model that uses the tools correctly took some experimenting. I ended up going with `qwen2.5:32b-instruct`. Unfortunately, smaller models struggle with this type of generation, so running the chosen model locally may be quite slow.

Please try it out and let me know what you think :)
