### PR TITLE
feat: add TypeScript multi-project support for mono-repos

### DIFF
--- a/static_analyzer/__init__.py
+++ b/static_analyzer/__init__.py
@@ -5,6 +5,7 @@ from typing import List
 from static_analyzer.lsp_client.client import LSPClient
 from static_analyzer.lsp_client.typescript_client import TypeScriptClient
 from static_analyzer.programming_language import ProgrammingLanguage
+from static_analyzer.typescript_config_scanner import TypeScriptConfigScanner
 
 logger = logging.getLogger(__name__)
 
@@ -17,7 +18,19 @@ def create_clients(programming_languages: List[ProgrammingLanguage], repository_
             continue
         try:
             if pl.language in ['TypeScript']:
-                clients.append(TypeScriptClient(language=pl, project_path=repository_path))
+                # For TypeScript, scan for multiple project configurations (mono-repo support)
+                config_scanner = TypeScriptConfigScanner(repository_path)
+                typescript_projects = config_scanner.find_typescript_projects()
+                
+                if typescript_projects:
+                    # Create a separate client for each TypeScript project found
+                    for project_path in typescript_projects:
+                        logger.info(f"Creating TypeScript client for project at: {project_path.relative_to(repository_path)}")
+                        clients.append(TypeScriptClient(language=pl, project_path=project_path))
+                else:
+                    # Fallback: No config files found, use repository root
+                    logger.info("No TypeScript config files found, using repository root")
+                    clients.append(TypeScriptClient(language=pl, project_path=repository_path))
             else:
                 clients.append(LSPClient(language=pl, project_path=repository_path))
         except RuntimeError as e:

--- a/static_analyzer/typescript_config_scanner.py
+++ b/static_analyzer/typescript_config_scanner.py
@@ -1,0 +1,47 @@
+import logging
+from pathlib import Path
+from typing import List
+
+logger = logging.getLogger(__name__)
+
+
+class TypeScriptConfigScanner:
+    """
+    Scanner for finding TypeScript/JavaScript configuration files in a repository.
+    Supports multi-project setups (mono-repos) by finding all tsconfig.json and jsconfig.json files.
+    """
+
+    CONFIG_FILES = ['tsconfig.json', 'jsconfig.json']
+
+    def __init__(self, repo_location: Path):
+        self.repo_location = repo_location
+
+    def find_typescript_projects(self) -> List[Path]:
+        """
+        Scan the repository for TypeScript/JavaScript configuration files.
+
+        Returns:
+            List[Path]: List of directories containing TypeScript/JavaScript projects (config file locations).
+                        Each path is the directory containing a tsconfig.json or jsconfig.json.
+        """
+        project_roots = []
+        seen_dirs = set()
+
+        for config_file in self.CONFIG_FILES:
+            # Find all config files recursively
+            for config_path in self.repo_location.rglob(config_file):
+                if config_path.is_file():
+                    project_dir = config_path.parent
+                    
+                    # Avoid duplicates (e.g., if both tsconfig.json and jsconfig.json exist)
+                    if project_dir not in seen_dirs:
+                        seen_dirs.add(project_dir)
+                        project_roots.append(project_dir)
+                        logger.info(f"Found TypeScript project at: {project_dir.relative_to(self.repo_location)}")
+
+        if not project_roots:
+            logger.warning(f"No TypeScript configuration files found in {self.repo_location}")
+        else:
+            logger.info(f"Found {len(project_roots)} TypeScript project(s) in repository")
+
+        return project_roots


### PR DESCRIPTION
## What does this PR do?

This PR adds support for TypeScript multi-project configurations in mono-repo setups. Previously, CodeBoarding only looked for TypeScript configuration files (`tsconfig.json`/`jsconfig.json`) at the repository root, which prevented proper analysis of mono-repos where TypeScript projects exist in subdirectories.

- Fixes #74 

**Changes:**
- Added `TypeScriptConfigScanner` to recursively discover all TypeScript projects in the repository
- Modified `create_clients()` to create separate LSP client instances for each discovered TypeScript project
- Each TypeScript project now gets its own properly scoped LSP server with the correct configuration

**Impact:**
-  Supports mono-repos with multiple TypeScript projects 
-  Each project uses its own `tsconfig.json` with proper scoping
-  More efficient analysis (each LSP server loads only its project)
-  Backward compatible (falls back to root if no configs found)


