### PR TITLE
Enhancement: Added Dockerfile to build the codeboarding environment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -63,3 +63,4 @@ node_modules/
 *.tmp
 *.bak
 .cache/
+.ssh/

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -e
+
+# Handle SSH keys if mounted
+if [ -d "/tmp/host_ssh" ] && [ "$(ls -A /tmp/host_ssh 2>/dev/null)" ]; then
+    echo "Setting up SSH keys..."
+    
+    # Ensure .ssh directory exists with correct permissions
+    mkdir -p /root/.ssh
+    chmod 700 /root/.ssh
+    
+    # Copy all files from mounted directory
+    cp -r /tmp/host_ssh/* /root/.ssh/ 2>/dev/null || true
+    
+    # Set correct permissions
+    chmod 700 /root/.ssh
+    
+    # Private keys should be 600
+    find /root/.ssh -type f -name "id_*" ! -name "*.pub" -exec chmod 600 {} \; 2>/dev/null || true
+    
+    # Public keys should be 644
+    find /root/.ssh -type f -name "*.pub" -exec chmod 644 {} \; 2>/dev/null || true
+    
+    # Config and known_hosts should be 644
+    chmod 644 /root/.ssh/known_hosts* 2>/dev/null || true
+    chmod 644 /root/.ssh/config 2>/dev/null || true
+    
+    echo "SSH keys configured successfully"
+else
+    echo "=========================================="
+    echo "WARNING: No SSH keys found!"
+    echo "=========================================="
+    echo "SSH keys were not mounted to the container."
+    echo ""
+    echo "To mount SSH keys, run the container with:"
+    echo "docker run -v <local_ssh_path>:/tmp/host_ssh:ro -it <image_name>"
+    echo ""
+fi
+
+# Execute the main command
+exec "$@"


### PR DESCRIPTION
Issue Link: https://github.com/CodeBoarding/CodeBoarding/issues/48

Added a Dockerfile to containerize the application by using docker

Commands:

While running the docker image, Mount the SSH keys to your container under /tmp/host_ssh directory. Since we will be cloning the repos inside docker container, this SSH keys are required to be present inside container.

>  docker build --no-cache -t codeboarding-img .
>  docker run -v <path_to_ssh_keys>/.ssh:/tmp/host_ssh:ro -it codeboarding-img7

Inside the docker container, we can execute the same setup steps given in README.
   uv venv --python 3.11
   source .venv/bin/activate
   python setup.py


Tested locally.

<img width="1595" height="992" alt="image" src="https://github.com/user-attachments/assets/50d552bf-6a95-471f-ab71-f131fd07071c" />


@ivanmilevtues @brovatten Could you please review this PR.