### PR TITLE
Fix typo in Readme.md documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ Codeboarding is integrated with everything we use:
   with the diagram directly in your IDE.
 - ⚙️ [**GitHub Action**](https://github.com/marketplace/actions/codeboarding-diagram-first-documentation): Automate
   diagram generation in CI/CD.
-- 🔗 [**MCP Server**](https://github.com/CodeBoarding/CodeBoarding-MCP): Serves the consize documentation to your AI
+- 🔗 [**MCP Server**](https://github.com/CodeBoarding/CodeBoarding-MCP): Serves the concise documentation to your AI
   Agent assistant (ClaudeCode, VSCode, Cursor, etc.)
 
 ## 🤝 Contributing


### PR DESCRIPTION
Hi, while reading the readme documentation,  I came across the typo and fixed it.
- consize → concise