### PR TITLE
Fix demo.py for Windows

### DIFF
--- a/static_analysis_config.yml
+++ b/static_analysis_config.yml
@@ -2,14 +2,14 @@ lsp_servers:
   python:
     name: Pyright Language Server
     command:
-    - ./static_analyzer/servers/py-lsp
+    - ./static_analyzer/servers/node_modules/.bin/pyright-langserver
     - --stdio
     languages:
     - python
     file_extensions:
     - .py
     - .pyi
-    install_commands: pip install pyright
+    install_commands: npm install pyright
   typescript:
     name: TypeScript Language Server
     command:

--- a/vscode_constants.py
+++ b/vscode_constants.py
@@ -44,10 +44,10 @@ VSCODE_CONFIG = {
     "lsp_servers": {
         "python": {
             "name": "Pyright Language Server",
-            "command": ["py-lsp", "--stdio"],
+            "command": ["pyright-langserver", "--stdio"],
             "languages": ["python"],
             "file_extensions": [".py", ".pyi"],
-            "install_commands": "pip install pyright",
+            "install_commands": "npm install pyright",
         },
         "typescript": {
             "name": "TypeScript Language Server",


### PR DESCRIPTION
The main changes @brovatten and I did here:
- replace the `py-lsp` executable with `pyright` that is now downloaded using npm
- fixed `npm` usage for Windows
- fixed the download from gdrive function, which was downloading HTML files due to a warning