### PR TITLE
Remove pathlib from dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,6 @@ dependencies = [
     "opencensus-ext-azure==1.1.14",
     "openpyxl==3.1.5",
     "pandas==2.2.3",
-    "pathlib==1.0.1",
     "pathspec==0.12.1",
     "py2puml==0.10.0",
     "pydot==3.0.4",


### PR DESCRIPTION
Remove pathlib from the dependencies package is an obsolete backport of a standard library package.