### PR TITLE
Analysis doesn't fail on bad git state

### DIFF
--- a/repo_utils/__init__.py
+++ b/repo_utils/__init__.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 # Handle the case where git is not installed on the system
 try:
-    from git import Repo, Git, GitCommandError, InvalidGitRepositoryError, GitError
+    from git import Repo, Git, GitCommandError, GitError
 
     GIT_AVAILABLE = True
 except ImportError:


### PR DESCRIPTION
We used to fail whenever the git state was bad, when instantiating a Repo.
Now it is passively handled.