### PR TITLE
Chunk logs

### DIFF
--- a/logging_config.py
+++ b/logging_config.py
@@ -8,10 +8,10 @@ from pathlib import Path
 
 def setup_logging(
     default_level: str = "INFO",
-    log_filename: str = "codeboarding.log",
     max_bytes: int = 10 * 1024 * 1024,
     backup_count: int = 5,
     log_dir: Path | None = None,
+    log_filename: str | None = None,
 ):
     """
     Configure:
@@ -36,12 +36,16 @@ def setup_logging(
     # Create logs directory if it doesn't exist
     logs_dir.mkdir(parents=True, exist_ok=True)
 
-    # Generate timestamped filename for per-run logs
-    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    timestamped_filename = f"{timestamp}.log"
+    # Generate filename
+    if log_filename:
+        filename = log_filename
+    else:
+        # Generate timestamped filename for per-run logs
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        filename = f"{timestamp}.log"
 
     # Create full path for log file
-    log_file_path = logs_dir / timestamped_filename
+    log_file_path = logs_dir / filename
 
     # Basic config structure with both handlers defined upfront
     config = {
@@ -91,7 +95,7 @@ def setup_logging(
 
         # Try to create a symlink (works on Unix and Windows with Developer Mode)
         # Use relative path for portability
-        os.symlink(timestamped_filename, latest_log_path)
+        os.symlink(filename, latest_log_path)
     except (OSError, AttributeError):
         # Fallback to copying the file if symlinking fails
         try:

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -49,6 +49,7 @@ class TestLoggingConfig(unittest.TestCase):
 
             logs_dir = temp_path / "logs"
             self.assertTrue(logs_dir.exists())
+            self.assertTrue((logs_dir / "custom.log").exists())
 
             self._clean_logging_handlers()
 
@@ -99,7 +100,7 @@ class TestLoggingConfig(unittest.TestCase):
     def test_setup_logging_timestamped_filename(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_path = Path(temp_dir)
-            setup_logging(log_filename="test.log", log_dir=temp_path)
+            setup_logging(log_dir=temp_path)
 
             logs_dir = temp_path / "logs"
             log_files = list(logs_dir.glob("*.log"))


### PR DESCRIPTION
This separates the logs into separate runs, titled by the timestamp, and using a symlink to `_latest.log` to easily see you ongoing/latest run.

Here's a screenshot where I put `--output-dir `

<img width="584" height="234" alt="image" src="https://github.com/user-attachments/assets/6b473e73-81b3-4e53-9923-66d00f7a8e2d" />

I tested by running it with and without `output_dir` specified.