### PR TITLE
Fix residual langchain dependency model changes - class_qualified_name

### DIFF
--- a/agents/tools/read_packages.py
+++ b/agents/tools/read_packages.py
@@ -1,5 +1,4 @@
 import logging
-from typing import Optional, List
 from langchain_core.tools import ArgsSchema
 from pydantic import BaseModel, Field
 from agents.tools.base import BaseRepoTool
@@ -33,10 +32,10 @@ class PackageRelationsTool(BaseRepoTool):
         "Use only for primary project packages, not for detailed exploration. "
         "Prefer analyzing CFG data before using this tool."
     )
-    args_schema: Optional[ArgsSchema] = PackageInput
+    args_schema: ArgsSchema | None = PackageInput
     return_direct: bool = False
 
-    def _run(self, root_package: str, line: int = 0) -> str:
+    def _run(self, root_package: str) -> str:
         """
         Run the tool with the given input.
         """

--- a/agents/tools/read_structure.py
+++ b/agents/tools/read_structure.py
@@ -1,5 +1,4 @@
 import logging
-from typing import Optional, List
 from langchain_core.tools import ArgsSchema
 from pydantic import BaseModel, Field
 from agents.tools.base import BaseRepoTool
@@ -21,7 +20,7 @@ class CodeStructureTool(BaseRepoTool):
         "Use only when CFG data is insufficient for understanding component boundaries. "
         "Focus on main packages only - avoid utility/helper package analysis."
     )
-    args_schema: Optional[ArgsSchema] = ClassQualifiedName
+    args_schema: ArgsSchema | None = ClassQualifiedName
     return_direct: bool = False
 
     def _run(self, class_qualified_name: str) -> str:


### PR DESCRIPTION
As part of [the langchain dependency updates](https://github.com/CodeBoarding/CodeBoarding/commit/b6967673a52675df35a88f91a997d50d0ec1f4c4) I have missed something that's still causing the analysis to fail with:
```
CodeStructureTool._run() got an unexpected keyword argument 'class_qualified_name'
```

I was confused how this fixes things but here is the reason:
In LangChain 0.3.x, the framework had looser parameter matching. When it invoked a tool:
- It would look at the `args_schema` to understand what arguments the LLM should provide
- When calling `_run()`, it would pass arguments by position OR by name, with some fallback logic
- If there was a mismatch, it might try alternative approaches or just pass the arguments positionally

This meant the code worked even though:
- Schema field: `class_qualified_name`
- Method parameter: `qualified_class_name`

The framework was forgiving and would still route the argument correctly, possibly by position. LangChain 1.x introduced strict Pydantic v2 validation and changed how it binds arguments to tool methods:
- It now uses the Pydantic model field names as keyword arguments when calling `_run()`
- The parameter names in `_run()` must exactly match the field names in the schema
- No fallback logic - if names don't match, you get: `TypeError: _run()` got an unexpected keyword argument