### PR TITLE
Set timeout for agent invoke method that can otherwise take an unbounded amount of time

### DIFF
--- a/tests/agents/test_agent.py
+++ b/tests/agents/test_agent.py
@@ -225,7 +225,7 @@ class TestCodeBoardingAgent(unittest.TestCase):
         self.assertEqual(result, "Success")
         # Should have retried
         self.assertEqual(mock_agent_executor.invoke.call_count, 2)
-        mock_sleep.assert_called_with(60)
+        mock_sleep.assert_called_with(30)
 
     @patch("agents.agent.create_react_agent")
     @patch("time.sleep")


### PR DESCRIPTION
Opening this PR based on some of the logs we've seen from recent executions, e.g:
```
2025-12-26 06:21:08 INFO     [agents.abstraction_agent:66] [AbstractionAgent] Analyzing CFG for project: <project>
2025-12-26 06:36:19 WARNING  [langchain_google_genai.chat_models:65] Retrying langchain_google_genai.chat_models._chat_with_retry.<locals>._chat_with_retry in 2.0 seconds as it raised DeadlineExceeded: 504 Deadline Exceeded.
2025-12-26 06:52:01 ERROR    [agents.agent:195] Resource exhausted, retrying... in 60 seconds: Type(<class 'google.api_core.exceptions.DeadlineExceeded'>) 504 Deadline Exceeded
2025-12-26 09:05:56 INFO     [monitoring:58] LLM Usage: step=step_cfg model=gemini-2.5-flash usage={'prompt_tokens': 1360, 'completion_tokens': 23, 'total_tokens': 1823}
2025-12-26 09:23:41 WARNING  [langchain_google_genai.chat_models:65] Retrying langchain_google_genai.chat_models._chat_with_retry.<locals>._chat_with_retry in 2.0 seconds as it raised DeadlineExceeded: 504 Deadline Exceeded.
2025-12-26 09:23:45 INFO     [monitoring:58] LLM Usage: step=step_cfg model=gemini-2.5-flash usage={'prompt_tokens': 3408, 'completion_tokens': 13, 'total_tokens': 3574}
2025-12-26 09:38:52 WARNING  [langchain_google_genai.chat_models:65] Retrying langchain_google_genai.chat_models._chat_with_retry.<locals>._chat_with_retry in 2.0 seconds as it raised DeadlineExceeded: 504 Deadline Exceeded.
2025-12-26 09:54:08 ERROR    [agents.agent:195] Resource exhausted, retrying... in 60 seconds: Type(<class 'google.api_core.exceptions.DeadlineExceeded'>) 504 Deadline Exceeded
... <another 3h before moving forward>
```

I'm not an expert on the topic but from what I checked out, it seems like the `agent.invoke()` does not have built-in timeouts. It will run until:
- The LLM decides to stop (returns a message without tool calls)
- The `recursion_limit` is exhausted
- An external timeout/error interrupts it

We set the `recursion_limit=40` so if each tool call takes multiple minutes, the entire thing can take hours. I'm also not sure if the LangGraph agent might be catching and suppressing some errors internally, leading to extra long waits. 
Overall, I think we shouldn't have calls that could take more multiple minutes so I'm opening this up as a discussion PR where we can see if there's anything better we can do here.