### PR TITLE
Remove CODEBOARDING_MODEL environment variable

### DIFF
--- a/agents/agent.py
+++ b/agents/agent.py
@@ -106,7 +106,7 @@ class CodeBoardingAgent(ReferenceResolverMixin, MonitoringMixin):
         """Shared access to the small model for parsing tasks."""
         if cls._parsing_llm is None:
 
-            parsing_model = os.getenv("PARSING_MODEL", None) or os.getenv("CODEBOARDING_MODEL")
+            parsing_model = os.getenv("PARSING_MODEL", None)
             cls._parsing_llm, _ = cls._static_initialize_llm(model_override=parsing_model, is_parsing=True)
         return cls._parsing_llm
 

--- a/tests/agents/test_agent.py
+++ b/tests/agents/test_agent.py
@@ -37,9 +37,7 @@ class TestCodeBoardingAgent(unittest.TestCase):
         self.mock_analysis.references = []
 
         # Mock environment variables
-        self.env_patcher = patch.dict(
-            os.environ, {"OPENAI_API_KEY": "test_key", "CODEBOARDING_MODEL": "gpt-4o"}, clear=True
-        )
+        self.env_patcher = patch.dict(os.environ, {"OPENAI_API_KEY": "test_key", "PARSING_MODEL": "gpt-4o"}, clear=True)
         self.env_patcher.start()
 
         # Set up monitoring context


### PR DESCRIPTION
`CODEBOARDING_MODEL` isn't used anymore so we can remove it to simplify things. 