### PR TITLE
Fix Vercel API

### DIFF
--- a/agents/agent.py
+++ b/agents/agent.py
@@ -90,17 +90,6 @@ class CodeBoardingAgent(ReferenceResolverMixin, MonitoringMixin):
     def external_deps_tool(self):
         return self.toolkit.external_deps
 
-    def _setup_env_vars(self):
-        load_dotenv()
-        self.openai_api_key = os.getenv("OPENAI_API_KEY")
-        self.openai_base_url = os.getenv("OPENAI_BASE_URL")
-        self.anthropic_api_key = os.getenv("ANTHROPIC_API_KEY")
-        self.google_api_key = os.getenv("GOOGLE_API_KEY")
-        self.aws_bearer_token = os.getenv("AWS_BEARER_TOKEN_BEDROCK")
-        self.aws_region = os.getenv("AWS_DEFAULT_REGION", "us-east-1")
-        self.cerebras_api_key = os.getenv("CEREBRAS_API_KEY")
-        self.ollama_base_url = os.getenv("OLLAMA_BASE_URL")
-
     @classmethod
     def get_parsing_llm(cls) -> BaseChatModel:
         """Shared access to the small model for parsing tasks."""

--- a/agents/llm_config.py
+++ b/agents/llm_config.py
@@ -70,7 +70,7 @@ LLM_PROVIDERS = {
     "vercel": LLMConfig(
         chat_class=ChatOpenAI,
         api_key_env="VERCEL_API_KEY",
-        agent_model="gemini-3-flash-preview",
+        agent_model="gemini-2.5-flash",
         parsing_model="gemini-2.5-flash-lite",
         alt_env_vars=["VERCEL_BASE_URL"],
         extra_args={
@@ -94,7 +94,7 @@ LLM_PROVIDERS = {
     "google": LLMConfig(
         chat_class=ChatGoogleGenerativeAI,
         api_key_env="GOOGLE_API_KEY",
-        agent_model="gemini-3-flash-preview",
+        agent_model="gemini-2.5-flash",
         parsing_model="gemini-2.5-flash",
         extra_args={
             "max_tokens": None,


### PR DESCRIPTION
https://github.com/vercel/ai/issues/10344

The issue is google is using a new signature method. In my mind, OpenAI (that is our python wrapper for vercel) is only using a REST API to send to Vercel.

We should try to test and upgrade `langchain-openai`. Problem there is it breaks our other dependencies.

For now let's downgrade to `gemini-2.5-flash`