### PR TITLE
Make meta agent faster

### DIFF
--- a/agents/agent.py
+++ b/agents/agent.py
@@ -42,7 +42,9 @@ MONITORING_CALLBACK = MonitoringCallback(stats_container=RunStats())
 class CodeBoardingAgent(ReferenceResolverMixin, MonitoringMixin):
     _parsing_llm: Optional[BaseChatModel] = None
 
-    def __init__(self, repo_dir: Path, static_analysis: StaticAnalysisResults, system_message: str, llm: BaseChatModel):
+    def __init__(
+        self, repo_dir: Path, static_analysis: StaticAnalysisResults | None, system_message: str, llm: BaseChatModel
+    ):
         ReferenceResolverMixin.__init__(self, repo_dir, static_analysis)
         MonitoringMixin.__init__(self)
         self.llm = llm
@@ -526,7 +528,7 @@ class CodeBoardingAgent(ReferenceResolverMixin, MonitoringMixin):
 
 
 class LargeModelAgent(CodeBoardingAgent):
-    def __init__(self, repo_dir: Path, static_analysis: StaticAnalysisResults, system_message: str):
+    def __init__(self, repo_dir: Path, static_analysis: StaticAnalysisResults | None, system_message: str):
         agent_model = os.getenv("AGENT_MODEL")
         llm, model_name = self._static_initialize_llm(model_override=agent_model, is_parsing=False)
         super().__init__(repo_dir, static_analysis, system_message, llm)

--- a/agents/meta_agent.py
+++ b/agents/meta_agent.py
@@ -1,4 +1,8 @@
 import logging
+import hashlib
+import json
+import os
+from datetime import datetime, timezone
 from pathlib import Path
 
 from langchain_core.prompts import PromptTemplate
@@ -14,10 +18,37 @@ logger = logging.getLogger(__name__)
 
 
 class MetaAgent(LargeModelAgent):
+    _DOC_SUFFIXES = {".md", ".rst", ".txt", ".html"}
+    _DEPENDENCY_FILES = {
+        "requirements.txt",
+        "requirements-dev.txt",
+        "requirements-test.txt",
+        "dev-requirements.txt",
+        "test-requirements.txt",
+        "setup.py",
+        "setup.cfg",
+        "Pipfile",
+        "environment.yml",
+        "environment.yaml",
+        "conda.yml",
+        "conda.yaml",
+        "pixi.toml",
+        "uv.lock",
+        "package.json",
+        "package-lock.json",
+        "yarn.lock",
+        "pnpm-lock.yaml",
+        "bun.lockb",
+        "tsconfig.json",
+    }
+    _DEPENDENCY_DIRS = {"requirements", "deps", "dependencies", "env"}
+    _DEPENDENCY_DIR_SUFFIXES = {".txt", ".yml", ".yaml", ".toml"}
 
-    def __init__(self, repo_dir: Path, static_analysis: StaticAnalysisResults, project_name: str):
+    def __init__(self, repo_dir: Path, static_analysis: StaticAnalysisResults | None, project_name: str):
         super().__init__(repo_dir, static_analysis, get_system_meta_analysis_message())
         self.project_name = project_name
+        self.meta_cache_enabled = os.getenv("CODEBOARDING_META_CACHE", "true").lower() in {"1", "true", "yes"}
+        self.meta_cache_path = self.repo_dir / ".codeboarding" / "cache" / "meta_analysis_cache.json"
 
         self.meta_analysis_prompt = PromptTemplate(
             template=get_meta_information_prompt(), input_variables=["project_name"]
@@ -33,8 +64,112 @@ class MetaAgent(LargeModelAgent):
         """Analyze project metadata to provide architectural context and bias."""
         logger.info(f"[MetaAgent] Analyzing metadata for project: {self.project_name}")
 
+        cache_key = None
+        if self.meta_cache_enabled:
+            try:
+                cache_key = self._compute_meta_cache_key()
+                cached = self._load_cached_meta(cache_key)
+                if cached is not None:
+                    logger.info("[MetaAgent] Using cached metadata analysis")
+                    return cached
+            except Exception as e:
+                logger.warning(f"[MetaAgent] Failed to read meta cache, proceeding without cache: {e}")
+
         prompt = self.meta_analysis_prompt.format(project_name=self.project_name)
         analysis = self._parse_invoke(prompt, MetaAnalysisInsights)
 
+        if self.meta_cache_enabled and cache_key is not None:
+            try:
+                self._save_cached_meta(cache_key, analysis)
+            except Exception as e:
+                logger.warning(f"[MetaAgent] Failed to write meta cache: {e}")
+
         logger.info(f"[MetaAgent] Completed metadata analysis for project: {analysis.llm_str()}")
         return analysis
+
+    def _compute_meta_cache_key(self) -> str:
+        hasher = hashlib.sha256()
+
+        hasher.update(f"project_name:{self.project_name}\n".encode("utf-8"))
+        hasher.update(f"system_prompt:{get_system_meta_analysis_message()}\n".encode("utf-8"))
+        hasher.update(f"meta_prompt:{get_meta_information_prompt()}\n".encode("utf-8"))
+
+        model_hint = (
+            getattr(self.llm, "model_name", None)
+            or getattr(self.llm, "model", None)
+            or getattr(self.llm, "model_id", None)
+            or self.llm.__class__.__name__
+        )
+        hasher.update(f"model_hint:{model_hint}\n".encode("utf-8"))
+
+        files = self.toolkit.read_docs.context.get_files()
+        dirs = self.toolkit.read_docs.context.get_directories()
+
+        rel_dirs = sorted(str(d.relative_to(self.repo_dir)) for d in dirs if d != self.repo_dir)
+        rel_files = sorted(str(f.relative_to(self.repo_dir)) for f in files)
+
+        for rel_dir in rel_dirs:
+            hasher.update(f"D:{rel_dir}\n".encode("utf-8"))
+        for rel_file in rel_files:
+            hasher.update(f"F:{rel_file}\n".encode("utf-8"))
+
+        meta_content_files = self._select_meta_content_files(files)
+        for file_path in meta_content_files:
+            rel_path = str(file_path.relative_to(self.repo_dir))
+            hasher.update(f"C:{rel_path}\n".encode("utf-8"))
+            try:
+                content_hash = hashlib.sha256(file_path.read_bytes()).hexdigest()
+                hasher.update(content_hash.encode("utf-8"))
+            except Exception:
+                stat = file_path.stat()
+                hasher.update(f"STAT:{stat.st_size}:{int(stat.st_mtime)}\n".encode("utf-8"))
+
+        return hasher.hexdigest()
+
+    def _select_meta_content_files(self, files: list[Path]) -> list[Path]:
+        selected: list[Path] = []
+        for file_path in files:
+            rel_parts = file_path.relative_to(self.repo_dir).parts
+            suffix = file_path.suffix.lower()
+            name = file_path.name
+
+            is_doc = suffix in self._DOC_SUFFIXES and "tests" not in rel_parts and "test" not in name.lower()
+            is_root_dep = name in self._DEPENDENCY_FILES
+            is_dep_dir_file = (
+                len(rel_parts) > 1 and rel_parts[0] in self._DEPENDENCY_DIRS and suffix in self._DEPENDENCY_DIR_SUFFIXES
+            )
+
+            if is_doc or is_root_dep or is_dep_dir_file:
+                selected.append(file_path)
+
+        return sorted(set(selected))
+
+    def _load_cached_meta(self, cache_key: str) -> MetaAnalysisInsights | None:
+        if not self.meta_cache_path.exists():
+            return None
+
+        payload = json.loads(self.meta_cache_path.read_text(encoding="utf-8"))
+        entry = payload.get("entries", {}).get(cache_key)
+        if not entry:
+            return None
+
+        return MetaAnalysisInsights.model_validate(entry["analysis"])
+
+    def _save_cached_meta(self, cache_key: str, analysis: MetaAnalysisInsights) -> None:
+        self.meta_cache_path.parent.mkdir(parents=True, exist_ok=True)
+
+        payload: dict = {"version": 1, "entries": {}}
+        if self.meta_cache_path.exists():
+            payload = json.loads(self.meta_cache_path.read_text(encoding="utf-8"))
+            payload.setdefault("version", 1)
+            payload.setdefault("entries", {})
+
+        payload["entries"][cache_key] = {
+            "project_name": self.project_name,
+            "cached_at": datetime.now(timezone.utc).isoformat(),
+            "analysis": analysis.model_dump(mode="json"),
+        }
+
+        temp_file = self.meta_cache_path.with_suffix(".tmp")
+        temp_file.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        temp_file.replace(self.meta_cache_path)

--- a/diagram_analysis/incremental/reexpansion.py
+++ b/diagram_analysis/incremental/reexpansion.py
@@ -114,6 +114,7 @@ def reexpand_components(
     component_names: set[str],
     repo_dir: Path,
     context: ReexpansionContext,
+    project_name: str,
 ) -> list[str]:
     """Re-run DetailsAgent for components needing sub-analysis regeneration.
 
@@ -131,14 +132,14 @@ def reexpand_components(
     # Initialize agents using existing static analysis
     meta_agent = MetaAgent(
         repo_dir=repo_dir,
-        project_name=repo_dir.name,
-        static_analysis=context.static_analysis,
+        project_name=project_name,
+        static_analysis=None,
     )
     meta_context = meta_agent.analyze_project_metadata()
 
     details_agent = DetailsAgent(
         repo_dir=repo_dir,
-        project_name=repo_dir.name,
+        project_name=project_name,
         static_analysis=context.static_analysis,
         meta_context=meta_context,
     )

--- a/diagram_analysis/incremental/scoped_analysis.py
+++ b/diagram_analysis/incremental/scoped_analysis.py
@@ -85,6 +85,7 @@ def handle_scoped_component_update(
     output_dir: Path,
     static_analysis: StaticAnalysisResults | None,
     repo_dir: Path,
+    project_name: str,
 ) -> None:
     """Apply scoped impact decisions for expanded components.
 
@@ -143,14 +144,14 @@ def handle_scoped_component_update(
 
         meta_agent = MetaAgent(
             repo_dir=repo_dir,
-            project_name=repo_dir.name,
-            static_analysis=static_analysis,
+            project_name=project_name,
+            static_analysis=None,
         )
         meta_context = meta_agent.analyze_project_metadata()
 
         details_agent = DetailsAgent(
             repo_dir=repo_dir,
-            project_name=repo_dir.name,
+            project_name=project_name,
             static_analysis=static_analysis,
             meta_context=meta_context,
         )
@@ -193,6 +194,7 @@ def run_scoped_component_impacts(
     output_dir: Path,
     static_analysis: StaticAnalysisResults | None,
     repo_dir: Path,
+    project_name: str,
 ) -> None:
     """Run impact analysis inside each component scope and log summaries.
 
@@ -227,4 +229,5 @@ def run_scoped_component_impacts(
                 output_dir=output_dir,
                 static_analysis=static_analysis,
                 repo_dir=repo_dir,
+                project_name=project_name,
             )

--- a/diagram_analysis/incremental/updater.py
+++ b/diagram_analysis/incremental/updater.py
@@ -60,11 +60,13 @@ class IncrementalUpdater:
         output_dir: Path,
         static_analysis: StaticAnalysisResults | None = None,
         force_full: bool = False,
+        project_name: str | None = None,
     ):
         self.repo_dir = repo_dir
         self.output_dir = output_dir
         self.static_analysis = static_analysis
         self.force_full = force_full
+        self.project_name = project_name or repo_dir.name
 
         self.manifest: AnalysisManifest | None = None
         self.analysis: AnalysisInsights | None = None
@@ -330,7 +332,12 @@ class IncrementalUpdater:
                 impact=self.impact,
                 static_analysis=self.static_analysis,
             )
-            reexpanded_components = reexpand_components(components_to_reexpand, self.repo_dir, context)
+            reexpanded_components = reexpand_components(
+                components_to_reexpand,
+                self.repo_dir,
+                context,
+                self.project_name,
+            )
 
         # Step 5a: Sanity check
         for comp_name in reexpanded_components:
@@ -347,6 +354,7 @@ class IncrementalUpdater:
             self.output_dir,
             self.static_analysis,
             self.repo_dir,
+            self.project_name,
         )
 
         # Step 6: Patch components that don't need full re-expansion


### PR DESCRIPTION
This is an aggresive approach to improving the iterative analysis. First, we cache it - since for iterative analysis we now run it despite often not needing it. I know we might get a cache hit at the provider, but I think there's no guarantee. For this however, we can use local caching with langchain (with a tiny database) as it may not need an update. Here I also think we should look at edit distance of e.g. README.md (but wanted to hear ur guys' opinion) since two characters diff in readme should not re-trigger the meta agent.

Also, in Python I hate having multiple threads that convolutes log messages, but none the less I went ahead. Since meta agent and static analysis is not dependant on eachother, we let them run in parallell. Conceptually makes sense, in practice looks not super nice :D 

Since LLM is biggest part to why iterative is slow I think this is one way to start