### PR TITLE
Dont overwrite env

### DIFF
--- a/install.py
+++ b/install.py
@@ -329,6 +329,9 @@ def init_dot_env_file():
     print("Step: .env file creation started")
 
     env_file_path = Path(".env")
+    if env_file_path.exists():
+        print("Step: .env file creation finished: skipped - .env already exists")
+        return
 
     # Get the absolute path to the project root
     project_root = Path.cwd().resolve()


### PR DESCRIPTION
This is so much nicer to avoid having to copy paste the .env before rerunning install.

So u now need to delete your .env file to generate a new one (we rarely update the .env file so I think this is justified).