### PR TITLE
Fix windows issues

### DIFF
--- a/static_analyzer/lsp_client/client.py
+++ b/static_analyzer/lsp_client/client.py
@@ -778,6 +778,7 @@ class LSPClient(ABC):
             }
 
             # Collect results as they complete
+            files_done = 0
             with tqdm(total=total_files, desc="[Unified Analysis] Processing files") as pbar:
                 for future in as_completed(future_to_file):
                     file_path = future_to_file[future]
@@ -789,9 +790,6 @@ class LSPClient(ABC):
                             logger.error(f"Error processing {file_path}: {result.error}")
                         else:
                             successful_results.append(result)
-                        completed = len(successful_results)
-                        if completed % 10 == 0 or completed == total_files:
-                            logger.info(f"Static analysis progress: {completed}/{total_files} files processed")
                     except TimeoutError:
                         logger.error(
                             f"Timeout (300s) processing {file_path} - worker thread may be hung on LSP request"
@@ -799,7 +797,10 @@ class LSPClient(ABC):
                     except Exception as e:
                         logger.error(f"Exception processing {file_path}: {e}")
                     finally:
+                        files_done += 1
                         pbar.update(1)
+                        if files_done % 10 == 0 or files_done == total_files:
+                            logger.info(f"Static analysis progress: {files_done}/{total_files} files done")
 
         logger.info(f"Successfully processed {len(successful_results)} files")
 

--- a/tool_registry.py
+++ b/tool_registry.py
@@ -24,11 +24,10 @@ from dataclasses import dataclass, field
 from enum import StrEnum
 from pathlib import Path
 from typing import Any, cast
-from vscode_constants import find_runnable
 
 import requests
 
-from vscode_constants import VSCODE_CONFIG
+from vscode_constants import VSCODE_CONFIG, find_runnable
 
 logger = logging.getLogger(__name__)
 
@@ -215,11 +214,16 @@ def build_config() -> dict[str, Any]:
     servers = get_servers_dir()
     config = resolve_config(servers)
     path_config = resolve_config_from_path()
-    # For any entry still pointing to a bare name (not found in servers dir), try system PATH
+    # For any entry still pointing to a bare name (not found in servers dir), try system PATH.
+    # Skip entries where resolve_config() already resolved the tool (e.g. on Windows, Node tools
+    # use [node, /absolute/path/to/entry.mjs, ...] — cmd[0] is "node" but cmd[1] is absolute).
     for section in ("lsp_servers", "tools"):
         for key, entry in config[section].items():
             cmd = entry.get("command", [])
-            if cmd and not Path(cmd[0]).is_absolute():
+            if not cmd:
+                continue
+            has_absolute = any(Path(c).is_absolute() for c in cmd)
+            if not has_absolute:
                 path_cmd = path_config[section][key].get("command", [])
                 if path_cmd and Path(path_cmd[0]).is_absolute():
                     entry["command"] = list(path_cmd)
@@ -306,7 +310,20 @@ def resolve_config_from_path() -> dict[str, Any]:
             path = shutil.which(dep.binary_name)
         if path:
             cmd = cast(list[str], config[dep.config_section][dep.key]["command"])
-            cmd[0] = path
+            if platform.system() == "Windows" and dep.kind is ToolKind.NODE and dep.js_entry_file:
+                # On Windows, bypass .cmd wrappers found on PATH — same rationale
+                # as resolve_config(): .cmd wrappers cause pipe buffering issues.
+                # Walk up from the resolved binary to find the JS entry point.
+                bin_dir = str(Path(path).parent.parent)  # .../node_modules/.bin -> .../node_modules/..
+                js_entry = find_runnable(bin_dir, dep.js_entry_file, dep.js_entry_parent or dep.binary_name)
+                if js_entry:
+                    node_path = os.environ.get("CODEBOARDING_NODE_PATH", "node")
+                    cmd[0] = js_entry
+                    cmd.insert(0, node_path)
+                else:
+                    cmd[0] = path
+            else:
+                cmd[0] = path
 
     return config
 


### PR DESCRIPTION
Fix 1: Wrong LSP server command on Windows
When `tool_registry.py` was introduced, `resolve_config()` started resolving Node-based tools (TypeScript, Pyright, Intelephense) to their .cmd wrapper scripts on Windows (e.g. typescript-language-server.cmd). These `.cmd` wrappers go through `cmd.exe`, which causes pipe buffering issues with `subprocess.Popen(stdin=PIPE, stdout=PIPE)`. The old `vscode_constants.py` correctly bypassed this by finding the actual `.mjs/.js` entry point and running it directly with Node.js via CODEBOARDING_NODE_PATH.

The fix adds `js_entry_file` and `js_entry_parent` fields to ToolDependency, and on Windows, `resolve_config()` now finds the JS entry point directly and prepends the Node executable, matching the old behavior.

Fix 2: Pipe buffer deadlock with concurrent workers
`build_static_analysis()` spawns `cpu_count - 1` worker threads, all writing didOpen + LSP requests to the same stdin pipe simultaneously. On Windows (4KB pipe buffer), this fills the buffer. If the LSP server then sends a request back (e.g. workspace/configuration) before reading more stdin, it blocks waiting for our response — but we can't write the response because the pipe is full. Classic deadlock.

The fix limits the ThreadPoolExecutor to 1 worker on Windows (for now to unblock others). A separate _stdin_lock was also introduced to decouple stdin writes from the main _lock (used for response tracking), preventing a secondary contention path where the reader thread couldn't store responses while a worker held the lock during a blocking write.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/codeboarding/codeboarding/pull/232" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added periodic progress logging during static analysis for better visibility.

* **Improvements**
  * Improved I/O serialization to prevent blocking and reduce interference with analysis.
  * Platform-aware concurrency tuning (reduced workers on Windows) for stability and performance.
  * Enhanced Windows execution paths for Node-based development tools for more reliable tool invocation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->