### PR TITLE
Remove _latest.log and use the last created one

### DIFF
--- a/logging_config.py
+++ b/logging_config.py
@@ -1,8 +1,6 @@
 import io
 import logging
 import logging.config
-import os
-import shutil
 from datetime import datetime
 from pathlib import Path
 
@@ -18,7 +16,6 @@ def setup_logging(
     Configure:
       - Console output at INFO level
       - Rotating file handler at DEBUG level writing into timestamped log files in logs directory
-      - Updates a '_latest.log' symlink to point to the current log file
     """
     # Define both handlers from the beginning
     handlers = ["console", "file"]
@@ -100,20 +97,3 @@ def setup_logging(
                 handler.stream = io.TextIOWrapper(
                     stream.buffer, encoding=stream.encoding, errors="replace", line_buffering=stream.line_buffering
                 )
-
-    # Handle _latest.log symlink
-    latest_log_path = logs_dir / "_latest.log"
-    try:
-        if latest_log_path.exists() or latest_log_path.is_symlink():
-            latest_log_path.unlink()
-
-        # Try to create a symlink (works on Unix and Windows with Developer Mode)
-        # Use relative path for portability
-        os.symlink(filename, latest_log_path)
-    except (OSError, AttributeError):
-        # Fallback to copying the file if symlinking fails
-        try:
-            shutil.copy2(log_file_path, latest_log_path)
-        except Exception:
-            # We don't want to crash the whole app if _latest.log fails
-            pass

--- a/tests/agents/test_validation.py
+++ b/tests/agents/test_validation.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 
 from agents.validation import (
@@ -395,6 +396,14 @@ class TestValidateFileClassifications(unittest.TestCase):
 
     def test_path_normalization_with_repo_dir(self):
         """Test path normalization when repo_dir is provided."""
+        # Use platform-appropriate absolute paths so is_absolute() works on Windows too
+        if os.name == "nt":
+            repo_dir = "C:\\repo"
+            abs_file = "C:\\repo\\src\\file1.py"
+        else:
+            repo_dir = "/repo"
+            abs_file = "/repo/src/file1.py"
+
         component_files = ComponentFiles(
             file_paths=[
                 FileClassification(file_path="src/file1.py", component_name="ComponentA"),
@@ -402,14 +411,14 @@ class TestValidateFileClassifications(unittest.TestCase):
         )
 
         context = ValidationContext(
-            expected_files={"/repo/src/file1.py"},  # Absolute path
+            expected_files={abs_file},  # Absolute path
             valid_component_names={"ComponentA"},
-            repo_dir="/repo",
+            repo_dir=repo_dir,
         )
 
         result = validate_file_classifications(component_files, context)
 
-        self.assertTrue(result.is_valid)  # Should normalize /repo/src/file1.py to src/file1.py
+        self.assertTrue(result.is_valid)  # Should normalize absolute path to src/file1.py
 
     def test_truncate_long_error_lists(self):
         """Test that long error lists are truncated."""

--- a/tests/health/test_runner.py
+++ b/tests/health/test_runner.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 
 from health.models import HealthCheckConfig, StandardCheckSummary
@@ -184,23 +185,32 @@ class TestHealthRunner(unittest.TestCase):
 
     def test_relative_paths_when_repo_path_provided(self):
         """Test that file paths are relative to repo_path when provided."""
+        if os.name == "nt":
+            project_root = "C:\\home\\user\\project"
+            src_mod = "C:\\home\\user\\project\\src\\mod.py"
+            lib_utils = "C:\\home\\user\\project\\lib\\utils.py"
+        else:
+            project_root = "/home/user/project"
+            src_mod = "/home/user/project/src/mod.py"
+            lib_utils = "/home/user/project/lib/utils.py"
+
         graph = CallGraph(language="python")
-        graph.add_node(_make_node("mod.func1", "/home/user/project/src/mod.py", 0, 120))
-        graph.add_node(_make_node("mod.func2", "/home/user/project/src/mod.py", 120, 250))
-        graph.add_node(_make_node("utils.helper", "/home/user/project/lib/utils.py", 0, 10))
+        graph.add_node(_make_node("mod.func1", src_mod, 0, 120))
+        graph.add_node(_make_node("mod.func2", src_mod, 120, 250))
+        graph.add_node(_make_node("utils.helper", lib_utils, 0, 10))
 
         results = StaticAnalysisResults()
         results.add_cfg("python", graph)
         results.add_references("python", list(graph.nodes.values()))
         results.add_source_files(
             "python",
-            ["/home/user/project/src/mod.py", "/home/user/project/lib/utils.py"],
+            [src_mod, lib_utils],
         )
 
         config = HealthCheckConfig(
             function_size_max=100,
         )
-        report = run_health_checks(results, "test", config=config, repo_path="/home/user/project")
+        report = run_health_checks(results, "test", config=config, repo_path=project_root)
         assert report is not None
 
         # All file paths in findings should be relative
@@ -210,7 +220,7 @@ class TestHealthRunner(unittest.TestCase):
                     for entity in group.entities:
                         if entity.file_path is not None:
                             self.assertFalse(
-                                entity.file_path.startswith("/home/user/project"),
+                                entity.file_path.startswith(project_root),
                                 f"Expected relative path, got: {entity.file_path}",
                             )
 

--- a/tests/static_analyzer/lsp_client/test_java_client.py
+++ b/tests/static_analyzer/lsp_client/test_java_client.py
@@ -2,6 +2,7 @@
 Tests for Java LSP client.
 """
 
+import os
 import tempfile
 import unittest
 from pathlib import Path
@@ -633,7 +634,7 @@ class TestJavaClient(unittest.TestCase):
                 jdtls_root = client._find_jdtls_root()
 
                 self.assertIsNotNone(jdtls_root)
-                self.assertTrue(str(jdtls_root).endswith("/.jdtls"))
+                self.assertTrue(str(jdtls_root).endswith(os.sep + ".jdtls"))
 
     def test_find_jdtls_root_not_found(self):
         """Test when JDTLS root is not found."""

--- a/tests/static_analyzer/test_java_config_scanner.py
+++ b/tests/static_analyzer/test_java_config_scanner.py
@@ -47,7 +47,7 @@ class TestJavaProjectConfig(unittest.TestCase):
         repr_str = repr(config)
 
         self.assertIn("JavaProjectConfig", repr_str)
-        self.assertIn("/project", repr_str)
+        self.assertIn(str(Path("/project")), repr_str)
         self.assertIn("gradle", repr_str)
         self.assertIn("False", repr_str)
 

--- a/tests/static_analyzer/test_java_utils.py
+++ b/tests/static_analyzer/test_java_utils.py
@@ -469,7 +469,7 @@ class TestCreateJdtlsCommand(unittest.TestCase):
         command = create_jdtls_command(jdtls_root, workspace_dir, java_home=custom_java)
 
         # Should use custom Java home
-        self.assertIn("/custom/java-21/bin/java", command[0])
+        self.assertIn(str(Path("/custom/java-21/bin/java")), command[0])
         # Should not call find_java_21_or_later
         mock_java.assert_not_called()
 

--- a/tests/static_analyzer/test_reference_resolve_mixin.py
+++ b/tests/static_analyzer/test_reference_resolve_mixin.py
@@ -205,7 +205,7 @@ class TestReferenceResolverMixin(unittest.TestCase):
         # Should find the directory path
         self.assertIsNotNone(reference.reference_file)
         assert reference.reference_file is not None
-        self.assertTrue(reference.reference_file.endswith("nested/deep/module"))
+        self.assertTrue(reference.reference_file.endswith(os.path.join("nested", "deep", "module")))
 
     def test_relative_paths_conversion(self):
         """Test conversion of absolute paths to relative paths"""

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -1,7 +1,6 @@
 import codecs
 import io
 import logging
-import os
 import tempfile
 import unittest
 from pathlib import Path
@@ -107,19 +106,11 @@ class TestLoggingConfig(unittest.TestCase):
 
             logs_dir = temp_path / "logs"
             log_files = list(logs_dir.glob("*.log"))
-            # Filter out _latest.log
-            timestamped_files = [f for f in log_files if f.name != "_latest.log"]
 
-            self.assertEqual(len(timestamped_files), 1)
-            filename = timestamped_files[0].name
+            self.assertEqual(len(log_files), 1)
+            filename = log_files[0].name
             # Expected format: YYYYMMDD_HHMMSS.log
             self.assertEqual(len(filename), len("YYYYMMDD_HHMMSS.log"))
-
-            # Check _latest.log
-            latest_log = logs_dir / "_latest.log"
-            self.assertTrue(latest_log.exists())
-            if latest_log.is_symlink():
-                self.assertEqual(os.readlink(latest_log), filename)
 
             self._clean_logging_handlers()
 
@@ -130,11 +121,9 @@ class TestLoggingConfig(unittest.TestCase):
 
             logs_dir = temp_path / "logs"
             log_files = list(logs_dir.glob("*.log"))
-            # Filter out _latest.log
-            timestamped_files = [f for f in log_files if f.name != "_latest.log"]
 
-            self.assertEqual(len(timestamped_files), 1)
-            self.assertEqual(len(timestamped_files[0].name), len("YYYYMMDD_HHMMSS.log"))
+            self.assertEqual(len(log_files), 1)
+            self.assertEqual(len(log_files[0].name), len("YYYYMMDD_HHMMSS.log"))
 
             self._clean_logging_handlers()
 
@@ -151,8 +140,7 @@ class TestLoggingConfig(unittest.TestCase):
             self.assertFalse((logs_path / "logs").exists())
             # But the log file should be inside logs_path
             log_files = list(logs_path.glob("*.log"))
-            timestamped_files = [f for f in log_files if f.name != "_latest.log"]
-            self.assertEqual(len(timestamped_files), 1)
+            self.assertEqual(len(log_files), 1)
 
             self._clean_logging_handlers()
 

--- a/tests/test_windows_encoding.py
+++ b/tests/test_windows_encoding.py
@@ -20,7 +20,7 @@ class TestWindowsEncoding(unittest.TestCase):
             rel = py_file.relative_to(repo_root)
             parts = rel.parts
             if any(
-                p.startswith(".") or p in ("__pycache__", ".venv", "venv", "node_modules", "build", "dist")
+                p.startswith(".") or p in ("__pycache__", ".venv", "venv", "node_modules", "build", "dist", "repos")
                 for p in parts
             ):
                 continue


### PR DESCRIPTION
On Windows, symlinks don't work and the _latest.log is basically empty. Removing it and only using the last created log.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/codeboarding/codeboarding/pull/234" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced cross-platform path compatibility across test suites to ensure consistent behavior on Windows, macOS, and Linux.

* **Chores**
  * Simplified logging configuration by removing symlink-based fallback mechanism.
  * Improved test robustness through platform-specific path handling.
  * Extended test exclusions for better directory filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->