### PR TITLE
Fix code reference lines

### DIFF
--- a/static_analyzer/engine/symbol_table.py
+++ b/static_analyzer/engine/symbol_table.py
@@ -88,9 +88,9 @@ class SymbolTable:
             end = range_info.get("end", {})
             sel_start = sel_range.get("start", start)
 
-            start_line = sel_start.get("line", 0)
+            start_line = sel_start.get("line", 0) + 1  # LSP lines are 0-based, convert to 1-based
             start_char = sel_start.get("character", 0)
-            end_line = end.get("line", 0)
+            end_line = end.get("line", 0) + 1  # LSP lines are 0-based, convert to 1-based
             end_char = end.get("character", 0)
 
             file_key = str(file_path)


### PR DESCRIPTION
I noticed that the references were agian 1 line off after the LSP changes. This PR fixes it.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/codeboarding/codeboarding/pull/241" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected line coordinate handling to ensure accurate symbol positioning in the editor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->