### PR TITLE
Fix unused code diagnostics

### DIFF
--- a/static_analyzer/lsp_client/diagnostics.py
+++ b/static_analyzer/lsp_client/diagnostics.py
@@ -33,13 +33,25 @@ class LSPDiagnostic:
     tags: list[int] = field(default_factory=list)
     range: DiagnosticRange = field(default_factory=DiagnosticRange)
 
+    @staticmethod
+    def _extract_code(raw_code: object) -> str:
+        """Extract the diagnostic code string.
+
+        LSP servers may send ``code`` as a plain string/int or as an object
+        ``{"value": "<code>", "target": "<url>"}``.  Newer versions of pyright
+        (>= 1.1.3xx) use the object form.
+        """
+        if isinstance(raw_code, dict):
+            return str(raw_code.get("value", ""))
+        return str(raw_code)
+
     @classmethod
     def from_lsp_dict(cls, data: dict) -> "LSPDiagnostic":
         range_info = data.get("range", {})
         start = range_info.get("start", {})
         end = range_info.get("end", {})
         return cls(
-            code=str(data.get("code", "")),
+            code=cls._extract_code(data.get("code", "")),
             message=data.get("message", ""),
             severity=data.get("severity", 1),
             tags=data.get("tags", []),

--- a/tests/health/test_unused_code_diagnostics.py
+++ b/tests/health/test_unused_code_diagnostics.py
@@ -55,6 +55,40 @@ class TestDeadCodeCategory:
         assert DeadCodeCategory.UNKNOWN.value == "unknown"
 
 
+class TestLSPDiagnosticCodeExtraction:
+    """Tests for LSPDiagnostic.from_lsp_dict handling of code formats."""
+
+    def test_string_code_preserved(self):
+        """Plain string codes (older LSP servers) are preserved as-is."""
+        diag = LSPDiagnostic.from_lsp_dict(
+            {"code": "reportUnusedImport", "message": "unused", "range": {"start": {"line": 0}, "end": {"line": 0}}}
+        )
+        assert diag.code == "reportUnusedImport"
+
+    def test_dict_code_extracts_value(self):
+        """Object-form codes (e.g. pyright >= 1.1.3xx) extract the 'value' key."""
+        diag = LSPDiagnostic.from_lsp_dict(
+            {
+                "code": {"value": "reportUnusedImport", "target": "https://docs.example.com"},
+                "message": "unused",
+                "range": {"start": {"line": 0}, "end": {"line": 0}},
+            }
+        )
+        assert diag.code == "reportUnusedImport"
+
+    def test_int_code_converted_to_string(self):
+        """Integer codes (e.g. TypeScript error numbers) are converted to strings."""
+        diag = LSPDiagnostic.from_lsp_dict(
+            {"code": 6133, "message": "unused", "range": {"start": {"line": 0}, "end": {"line": 0}}}
+        )
+        assert diag.code == "6133"
+
+    def test_missing_code_defaults_to_empty(self):
+        """Missing code field defaults to empty string."""
+        diag = LSPDiagnostic.from_lsp_dict({"message": "unused", "range": {"start": {"line": 0}, "end": {"line": 0}}})
+        assert diag.code == ""
+
+
 class TestLSPDiagnosticsCollector:
     """Tests for LSPDiagnosticsCollector class."""
 


### PR DESCRIPTION
There were some issues with the newer versions of Pyright for detecting unused code. This PR should address them.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/codeboarding/codeboarding/pull/247" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed diagnostic code value extraction to properly handle codes received in multiple formats (strings, integers, or objects) from language servers, ensuring consistent normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->