### PR TITLE
Raise a proper failure when tokei fails to produce output for the repository

### DIFF
--- a/static_analyzer/scanner.py
+++ b/static_analyzer/scanner.py
@@ -28,6 +28,15 @@ class ProjectScanner:
         commands = get_config("tools")["tokei"]["command"]
         result = subprocess.run(commands, cwd=self.repo_location, capture_output=True, text=True, check=True)
 
+        if not result.stdout:
+            stderr_msg = result.stderr.strip() if result.stderr else "no stderr output"
+            raise RuntimeError(
+                f"Tokei produced no output for repository '{self.repo_location}'. "
+                f"stderr: {stderr_msg}. "
+                f"This may indicate a tokei installation issue (e.g. Windows binary invoked inside WSL). "
+                f"Verify that 'tokei -o json' works in your terminal."
+            )
+
         server_config = get_config("lsp_servers")
         builder = ProgrammingLanguageBuilder(server_config)
 

--- a/tests/static_analyzer/test_project_scanner.py
+++ b/tests/static_analyzer/test_project_scanner.py
@@ -1,0 +1,52 @@
+import unittest
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+from static_analyzer.scanner import ProjectScanner
+
+
+class TestProjectScanner(unittest.TestCase):
+    def setUp(self):
+        self.scanner = ProjectScanner(Path("/fake/repo"))
+
+    @patch("static_analyzer.scanner.get_config")
+    @patch("static_analyzer.scanner.subprocess.run")
+    def test_scan_raises_on_empty_stdout(self, mock_run, mock_get_config):
+        mock_get_config.return_value = {"tokei": {"command": ["tokei", "-o", "json"]}}
+        mock_run.return_value = MagicMock(stdout="", stderr="some warning")
+
+        with self.assertRaises(RuntimeError) as ctx:
+            self.scanner.scan()
+
+        self.assertIn("Tokei produced no output", str(ctx.exception))
+        self.assertIn("some warning", str(ctx.exception))
+
+    @patch("static_analyzer.scanner.get_config")
+    @patch("static_analyzer.scanner.subprocess.run")
+    def test_scan_raises_on_none_stdout(self, mock_run, mock_get_config):
+        mock_get_config.return_value = {"tokei": {"command": ["tokei", "-o", "json"]}}
+        mock_run.return_value = MagicMock(stdout=None, stderr="")
+
+        with self.assertRaises(RuntimeError) as ctx:
+            self.scanner.scan()
+
+        self.assertIn("Tokei produced no output", str(ctx.exception))
+
+    @patch("static_analyzer.scanner.get_config")
+    @patch("static_analyzer.scanner.subprocess.run")
+    def test_scan_succeeds_with_valid_output(self, mock_run, mock_get_config):
+        mock_get_config.side_effect = [
+            {"tokei": {"command": ["tokei", "-o", "json"]}},
+            {"python": {"command": ["pyright-langserver", "--stdio"]}},
+        ]
+        mock_run.return_value = MagicMock(
+            stdout='{"Python": {"code": 100, "reports": [{"name": "main.py"}]}, "Total": {"code": 100}}'
+        )
+
+        result = self.scanner.scan()
+
+        self.assertIsInstance(result, list)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR should at least tell the user if something is off with their setup when tokei fails (as reported on Discord). 
Ideally we should be able to support WSL but till then, we can at least improve the error handling. 
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/codeboarding/codeboarding/pull/252" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling for code analysis operations. The scanner now detects when the analysis tool fails to produce output and provides a clear error message instead of silently failing.

* **Tests**
  * Added comprehensive unit tests for the project scanner to verify proper error handling in edge cases and successful analysis scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->