### PR TITLE
Improve CLI install docs (fixes #256)

### DIFF
--- a/PYPI.md
+++ b/PYPI.md
@@ -14,11 +14,25 @@
 
 ---
 
+## Requirements
+
+- **Python 3.12 or 3.13** — other versions are currently not supported.
+
 ## Installation
+
+The recommended way to install the CLI is with [pipx](https://pipx.pypa.io), which automatically creates an isolated environment:
+
+```bash
+pipx install codeboarding
+```
+
+Alternatively, install into an existing virtual environment with pip:
 
 ```bash
 pip install codeboarding
 ```
+
+> Installing into the global Python environment with `pip` is not recommended — it can cause dependency conflicts and will fail if the system Python is not 3.12 or 3.13.
 
 Language server binaries are downloaded automatically on first use. To pre-install them explicitly (useful in CI or restricted environments):
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,16 @@ python main.py --local /path/to/repo
 
 ### Use the packaged CLI
 
+Requires **Python 3.12 or 3.13**. The recommended install method is [pipx](https://pipx.pypa.io), which keeps the CLI in its own isolated environment:
+
+```bash
+pipx install codeboarding
+codeboarding-setup
+codeboarding --local /path/to/repo
+```
+
+Or, if you prefer pip, install into a virtual environment (not the global Python):
+
 ```bash
 pip install codeboarding
 codeboarding-setup


### PR DESCRIPTION
Explicitly states the Python requirements and installation recommendations for the CLI package.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/codeboarding/codeboarding/pull/259" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Python version requirements (3.12 or 3.13 only)
  * Added pipx as the recommended installation method for isolated environments
  * Included warning against installing to system Python environment due to potential conflicts
  * Enhanced installation guidance with multiple approaches and best practices

<!-- end of auto-generated comment: release notes by coderabbit.ai -->