### PR TITLE
Add shared parsed git diff substrate

### DIFF
--- a/repo_utils/change_detector.py
+++ b/repo_utils/change_detector.py
@@ -7,7 +7,8 @@ This module provides enhanced change detection that properly tracks:
 - Added/deleted files
 - Copy detection
 
-Uses `git diff --name-status -M -C` for accurate rename tracking.
+Uses a shared `git diff --raw -U3 -M -C` parse for accurate rename tracking
+and downstream hunk reuse.
 """
 
 import logging
@@ -15,6 +16,8 @@ import subprocess
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
+
+from repo_utils.parsed_diff import ParsedDiffFile, ParsedGitDiff, load_parsed_git_diff
 
 logger = logging.getLogger(__name__)
 
@@ -60,6 +63,7 @@ class ChangeSet:
     changes: list[DetectedChange] = field(default_factory=list)
     base_ref: str = ""
     target_ref: str = "HEAD"
+    parsed_diff: ParsedGitDiff | None = None
 
     @property
     def renames(self) -> dict[str, str]:
@@ -109,6 +113,7 @@ def detect_changes(
     target_ref: str = "HEAD",
     exclude_patterns: list[str] | None = None,
     fetch_missing_refs: bool = True,
+    parsed_diff: ParsedGitDiff | None = None,
 ) -> ChangeSet:
     """
     Detect file changes between two refs using rename-aware git diff.
@@ -130,83 +135,42 @@ def detect_changes(
         for rename_old, rename_new in changes.renames.items():
             logger.info(f"Renamed: {rename_old} -> {rename_new}")
     """
-    changes: list[DetectedChange] = []
     target_ref_value = target_ref
 
     # Default exclusions for analysis output directories
     if exclude_patterns is None:
         exclude_patterns = [".codeboarding/", ".codeboarding\\"]
 
-    cmd = [
-        "git",
-        "diff",
-        "--name-status",
-        "-M",
-        "-C",
-        "--find-renames=50%",
+    diff_data = parsed_diff or load_parsed_git_diff(
+        repo_dir,
         base_ref,
-    ]
-    if target_ref:
-        cmd.append(target_ref)
+        target_ref,
+        fetch_missing_refs=fetch_missing_refs,
+    )
 
-    def _run_diff() -> subprocess.CompletedProcess:
-        return subprocess.run(
-            cmd,
-            cwd=repo_dir,
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-
-    try:
-        result = _run_diff()
-    except subprocess.CalledProcessError as e:
-        stderr_lower = (e.stderr or "").lower()
-        if fetch_missing_refs and "bad object" in stderr_lower:
-            logger.warning("Git diff failed due to missing ref (%s); fetching refs and retrying once", e.stderr.strip())
-            try:
-                subprocess.run(
-                    ["git", "fetch", "--all", "--prune", "--tags"],
-                    cwd=repo_dir,
-                    capture_output=True,
-                    text=True,
-                    check=True,
-                )
-                result = _run_diff()
-            except subprocess.CalledProcessError as fetch_err:
-                logger.error(f"Git fetch/diff retry failed: {fetch_err.stderr}")
-                return ChangeSet(changes=changes, base_ref=base_ref, target_ref=target_ref_value)
-        else:
-            logger.error(f"Git diff failed: {e.stderr}")
-            return ChangeSet(changes=changes, base_ref=base_ref, target_ref=target_ref_value)
-    except FileNotFoundError:
-        logger.error("Git not found in PATH")
-        return ChangeSet(changes=changes, base_ref=base_ref, target_ref=target_ref_value)
-
-    for line in result.stdout.strip().split("\n"):
-        if not line:
+    changes: list[DetectedChange] = []
+    for file_diff in diff_data.files:
+        change = _detected_change_from_parsed_diff(file_diff)
+        if change is None:
             continue
 
-        change = _parse_status_line(line)
-        if change:
-            # Skip excluded patterns
-            should_skip = False
-            for pattern in exclude_patterns:
-                if change.file_path.startswith(pattern):
-                    should_skip = True
-                    break
-                if change.old_path and change.old_path.startswith(pattern):
-                    should_skip = True
-                    break
+        should_skip = False
+        for pattern in exclude_patterns:
+            if change.file_path.startswith(pattern):
+                should_skip = True
+                break
+            if change.old_path and change.old_path.startswith(pattern):
+                should_skip = True
+                break
 
-            if should_skip:
-                logger.debug(f"Skipping excluded path: {change.file_path}")
-                continue
+        if should_skip:
+            logger.debug(f"Skipping excluded path: {change.file_path}")
+            continue
 
-            changes.append(change)
-            logger.debug(f"Detected change: {change.change_type.name} {change.file_path}")
+        changes.append(change)
+        logger.debug(f"Detected change: {change.change_type.name} {change.file_path}")
 
-    return ChangeSet(changes=changes, base_ref=base_ref, target_ref=target_ref_value)
+    return ChangeSet(changes=changes, base_ref=base_ref, target_ref=target_ref_value, parsed_diff=diff_data)
 
 
 def detect_changes_from_commit(repo_dir: Path, base_commit: str) -> ChangeSet:
@@ -276,6 +240,21 @@ def _parse_status_line(line: str) -> DetectedChange | None:
     return DetectedChange(
         change_type=change_type,
         file_path=parts[1],
+    )
+
+
+def _detected_change_from_parsed_diff(file_diff: ParsedDiffFile) -> DetectedChange | None:
+    status = file_diff.status_code.upper()
+    if status not in {change.value for change in ChangeType}:
+        logger.warning("Unknown git status: %s", status)
+        return None
+
+    change_type = ChangeType(status)
+    return DetectedChange(
+        change_type=change_type,
+        file_path=file_diff.file_path,
+        old_path=file_diff.old_path,
+        similarity=file_diff.similarity,
     )
 
 

--- a/repo_utils/method_diff.py
+++ b/repo_utils/method_diff.py
@@ -7,57 +7,14 @@ on MethodEntry and the ``file_status`` field on FileMethodGroup.
 """
 
 import logging
-import re
-import subprocess
 from pathlib import Path
 
 from agents.agent_responses import FileEntry, MethodEntry
 from agents.change_status import ChangeStatus
 from repo_utils.change_detector import ChangeSet
+from repo_utils.parsed_diff import classify_new_file_ranges, ParsedGitDiff
 
 logger = logging.getLogger(__name__)
-
-
-def _parse_hunk_side(side: str) -> tuple[int, int]:
-    """Parse one hunk side like ``+12,3`` or ``-8`` into (start, count)."""
-    m = re.match(r"^[+-](\d+)(?:,(\d+))?$", side)
-    if m is None:
-        return 0, 0
-    start = int(m.group(1))
-    count = int(m.group(2) or "1")
-    return start, count
-
-
-def _parse_diff_hunks(repo_dir: Path, base_ref: str, file_path: str) -> list[tuple[int, int, int, int]]:
-    """Return parsed hunk tuples: (old_start, old_count, new_start, new_count).
-
-    Uses ``git diff -U0`` to get exact changed line ranges without context lines.
-    """
-    try:
-        result = subprocess.run(
-            ["git", "diff", "-U0", base_ref, "--", file_path],
-            cwd=repo_dir,
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        return []
-
-    hunks: list[tuple[int, int, int, int]] = []
-    for line in result.stdout.splitlines():
-        if not line.startswith("@@"):
-            continue
-        # Parse header like: @@ -3,2 +4,5 @@
-        parts = line.split()
-        if len(parts) < 3:
-            continue
-        old_start, old_count = _parse_hunk_side(parts[1])
-        new_start, new_count = _parse_hunk_side(parts[2])
-        if old_start == 0 and new_start == 0:
-            continue
-        hunks.append((old_start, old_count, new_start, new_count))
-    return hunks
 
 
 def _method_overlaps_ranges(method: MethodEntry, changed_ranges: list[tuple[int, int]]) -> bool:
@@ -120,27 +77,9 @@ def get_method_statuses_for_file(
         return file_status
 
     if file_status == ChangeStatus.MODIFIED:
-        hunks = _parse_diff_hunks(repo_dir, changes.base_ref, file_path)
-        if hunks:
-            added_ranges: list[tuple[int, int]] = []
-            changed_ranges: list[tuple[int, int]] = []
-            deletion_points: list[tuple[int, int]] = []
-            for _old_start, old_count, new_start, new_count in hunks:
-                if new_count <= 0:
-                    # Deletion-only hunk: lines were removed at this point in the
-                    # new file.  Any method that spans the deletion point was
-                    # modified.  new_start is the line *before* which the deletion
-                    # occurred, so the affected region in the new file is the
-                    # single line at new_start (the line right after the gap).
-                    if new_start > 0:
-                        deletion_points.append((new_start, new_start))
-                    continue
-                new_range = (new_start, new_start + new_count - 1)
-                if old_count == 0:
-                    added_ranges.append(new_range)
-                else:
-                    changed_ranges.append(new_range)
-
+        diff_file = _get_diff_file(changes.parsed_diff, file_path)
+        if diff_file is not None and diff_file.hunks:
+            added_ranges, changed_ranges, deletion_points = classify_new_file_ranges(diff_file.hunks)
             for method in methods:
                 if _method_overlaps_ranges(method, changed_ranges):
                     method.status = ChangeStatus.MODIFIED
@@ -175,3 +114,9 @@ def apply_method_diffs_to_file_index(
         file_entry.file_status = get_method_statuses_for_file(file_entry.methods, file_path, changes, repo_dir)
 
     return files
+
+
+def _get_diff_file(parsed_diff: ParsedGitDiff | None, file_path: str):
+    if parsed_diff is None:
+        return None
+    return parsed_diff.get_file(file_path)

--- a/repo_utils/parsed_diff.py
+++ b/repo_utils/parsed_diff.py
@@ -1,0 +1,279 @@
+"""Shared git diff parsing for incremental analysis.
+
+Loads a single rename-aware patch diff and exposes both file-level metadata and
+parsed hunk content for downstream consumers.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_HUNK_SIDE_RE = re.compile(r"^[+-](\d+)(?:,(\d+))?$")
+
+
+@dataclass
+class ParsedDiffHunk:
+    """One unified-diff hunk with its body lines."""
+
+    old_start: int
+    old_count: int
+    new_start: int
+    new_count: int
+    lines: list[str] = field(default_factory=list)
+
+
+@dataclass
+class ParsedDiffFile:
+    """Parsed diff data for one file."""
+
+    status_code: str
+    file_path: str
+    old_path: str | None = None
+    similarity: int | None = None
+    patch_text: str = ""
+    hunks: list[ParsedDiffHunk] = field(default_factory=list)
+
+
+@dataclass
+class ParsedGitDiff:
+    """Container for a parsed `git diff` invocation."""
+
+    base_ref: str
+    target_ref: str
+    files: list[ParsedDiffFile] = field(default_factory=list)
+
+    def get_file(self, file_path: str) -> ParsedDiffFile | None:
+        for file_diff in self.files:
+            if file_diff.file_path == file_path:
+                return file_diff
+        return None
+
+
+def _parse_hunk_side(side: str) -> tuple[int, int]:
+    """Parse one hunk side like ``+12,3`` or ``-8`` into ``(start, count)``."""
+    match = _HUNK_SIDE_RE.match(side)
+    if match is None:
+        return 0, 0
+    start = int(match.group(1))
+    count = int(match.group(2) or "1")
+    return start, count
+
+
+def _parse_raw_line(line: str) -> ParsedDiffFile | None:
+    if not line.startswith(":"):
+        return None
+
+    parts = line.split("\t")
+    if len(parts) < 2:
+        return None
+
+    meta = parts[0].split()
+    if len(meta) < 5:
+        return None
+
+    status = meta[4]
+    status_code = status[0].upper()
+    similarity = None
+    if len(status) > 1 and status[1:].isdigit():
+        similarity = int(status[1:])
+
+    if status_code in {"R", "C"}:
+        if len(parts) < 3:
+            return None
+        return ParsedDiffFile(
+            status_code=status_code,
+            file_path=parts[2],
+            old_path=parts[1],
+            similarity=similarity,
+        )
+
+    return ParsedDiffFile(
+        status_code=status_code,
+        file_path=parts[1],
+        similarity=similarity,
+    )
+
+
+def _parse_patch_text(patch_text: str) -> list[ParsedDiffHunk]:
+    hunks: list[ParsedDiffHunk] = []
+    current_hunk: ParsedDiffHunk | None = None
+
+    for line in patch_text.splitlines():
+        if line.startswith("@@"):
+            parts = line.split()
+            if len(parts) < 3:
+                continue
+            old_start, old_count = _parse_hunk_side(parts[1])
+            new_start, new_count = _parse_hunk_side(parts[2])
+            if old_start == 0 and new_start == 0:
+                continue
+            current_hunk = ParsedDiffHunk(
+                old_start=old_start,
+                old_count=old_count,
+                new_start=new_start,
+                new_count=new_count,
+            )
+            hunks.append(current_hunk)
+            continue
+
+        if current_hunk is not None:
+            current_hunk.lines.append(line)
+
+    return hunks
+
+
+def _finalize_file_diff(file_diff: ParsedDiffFile | None, patch_lines: list[str]) -> ParsedDiffFile | None:
+    if file_diff is None:
+        return None
+
+    file_diff.patch_text = "\n".join(patch_lines).strip()
+    file_diff.hunks = _parse_patch_text(file_diff.patch_text)
+    return file_diff
+
+
+def _parse_diff_output(output: str, base_ref: str, target_ref: str) -> ParsedGitDiff:
+    files: list[ParsedDiffFile] = []
+    current_file: ParsedDiffFile | None = None
+    patch_lines: list[str] = []
+
+    for line in output.splitlines():
+        if line.startswith(":"):
+            finalized = _finalize_file_diff(current_file, patch_lines)
+            if finalized is not None:
+                files.append(finalized)
+
+            current_file = _parse_raw_line(line)
+            patch_lines = []
+            continue
+
+        if current_file is not None:
+            patch_lines.append(line)
+
+    finalized = _finalize_file_diff(current_file, patch_lines)
+    if finalized is not None:
+        files.append(finalized)
+
+    return ParsedGitDiff(base_ref=base_ref, target_ref=target_ref, files=files)
+
+
+def load_parsed_git_diff(
+    repo_dir: Path,
+    base_ref: str,
+    target_ref: str = "HEAD",
+    context_lines: int = 3,
+    fetch_missing_refs: bool = True,
+) -> ParsedGitDiff:
+    """Load a parsed diff with both raw status data and patch hunks."""
+    target_ref_value = target_ref
+    cmd = [
+        "git",
+        "diff",
+        "--raw",
+        f"-U{context_lines}",
+        "-M",
+        "-C",
+        "--find-renames=50%",
+        base_ref,
+    ]
+    if target_ref:
+        cmd.append(target_ref)
+
+    def _run_diff() -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            cmd,
+            cwd=repo_dir,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+    try:
+        result = _run_diff()
+    except subprocess.CalledProcessError as exc:
+        stderr_lower = (exc.stderr or "").lower()
+        if fetch_missing_refs and "bad object" in stderr_lower:
+            logger.warning(
+                "Git diff failed due to missing ref (%s); fetching refs and retrying once", exc.stderr.strip()
+            )
+            try:
+                subprocess.run(
+                    ["git", "fetch", "--all", "--prune", "--tags"],
+                    cwd=repo_dir,
+                    capture_output=True,
+                    text=True,
+                    check=True,
+                )
+                result = _run_diff()
+            except subprocess.CalledProcessError as fetch_err:
+                logger.error("Git fetch/diff retry failed: %s", fetch_err.stderr)
+                return ParsedGitDiff(base_ref=base_ref, target_ref=target_ref_value)
+        else:
+            logger.error("Git diff failed: %s", exc.stderr)
+            return ParsedGitDiff(base_ref=base_ref, target_ref=target_ref_value)
+    except FileNotFoundError:
+        logger.error("Git not found in PATH")
+        return ParsedGitDiff(base_ref=base_ref, target_ref=target_ref_value)
+
+    return _parse_diff_output(result.stdout, base_ref, target_ref_value)
+
+
+def classify_new_file_ranges(
+    hunks: list[ParsedDiffHunk],
+) -> tuple[list[tuple[int, int]], list[tuple[int, int]], list[tuple[int, int]]]:
+    """Return exact new-file line ranges for additions, modifications, and deletions."""
+    added_ranges: list[tuple[int, int]] = []
+    changed_ranges: list[tuple[int, int]] = []
+    deletion_points: list[tuple[int, int]] = []
+
+    for hunk in hunks:
+        new_line = hunk.new_start
+        segment_new_start: int | None = None
+        plus_count = 0
+        minus_count = 0
+
+        def _flush_segment() -> None:
+            nonlocal segment_new_start, plus_count, minus_count
+
+            if plus_count and segment_new_start is not None:
+                new_range = (segment_new_start, segment_new_start + plus_count - 1)
+                if minus_count:
+                    changed_ranges.append(new_range)
+                else:
+                    added_ranges.append(new_range)
+            elif minus_count and new_line > 0:
+                deletion_points.append((new_line, new_line))
+
+            segment_new_start = None
+            plus_count = 0
+            minus_count = 0
+
+        for line in hunk.lines:
+            if not line:
+                _flush_segment()
+                continue
+
+            prefix = line[0]
+            if prefix == " ":
+                _flush_segment()
+                new_line += 1
+            elif prefix == "-":
+                minus_count += 1
+            elif prefix == "+":
+                if segment_new_start is None:
+                    segment_new_start = new_line
+                plus_count += 1
+                new_line += 1
+            elif prefix == "\\":
+                continue
+            else:
+                _flush_segment()
+
+        _flush_segment()
+
+    return added_ranges, changed_ranges, deletion_points

--- a/tests/repo_utils/test_change_detector.py
+++ b/tests/repo_utils/test_change_detector.py
@@ -1,61 +1,40 @@
 from pathlib import Path
-from subprocess import CompletedProcess
 from unittest.mock import patch
 
 from repo_utils.change_detector import ChangeType, detect_changes_from_commit, detect_uncommitted_changes
+from repo_utils.parsed_diff import ParsedDiffFile, ParsedGitDiff
 
 
 def test_detect_uncommitted_changes_uses_working_tree_diff():
     with patch(
-        "repo_utils.change_detector.subprocess.run",
-        return_value=CompletedProcess(
-            args=["git", "diff"],
-            returncode=0,
-            stdout="M\tpyproject.toml\n",
-            stderr="",
+        "repo_utils.change_detector.load_parsed_git_diff",
+        return_value=ParsedGitDiff(
+            base_ref="HEAD",
+            target_ref="",
+            files=[ParsedDiffFile(status_code="M", file_path="pyproject.toml")],
         ),
-    ) as run_mock:
+    ) as load_mock:
         changes = detect_uncommitted_changes(Path("/tmp/repo"))
 
-    run_mock.assert_called_once()
-    command = run_mock.call_args.args[0]
-    assert command == [
-        "git",
-        "diff",
-        "--name-status",
-        "-M",
-        "-C",
-        "--find-renames=50%",
-        "HEAD",
-    ]
+    load_mock.assert_called_once_with(Path("/tmp/repo"), "HEAD", "", fetch_missing_refs=True)
     assert len(changes.changes) == 1
     assert changes.changes[0].change_type == ChangeType.MODIFIED
     assert changes.changes[0].file_path == "pyproject.toml"
+    assert changes.parsed_diff is not None
 
 
 def test_detect_changes_from_commit_uses_working_tree_target():
     with patch(
-        "repo_utils.change_detector.subprocess.run",
-        return_value=CompletedProcess(
-            args=["git", "diff"],
-            returncode=0,
-            stdout="A\trequirements/base.txt\n",
-            stderr="",
+        "repo_utils.change_detector.load_parsed_git_diff",
+        return_value=ParsedGitDiff(
+            base_ref="abc123",
+            target_ref="",
+            files=[ParsedDiffFile(status_code="A", file_path="requirements/base.txt")],
         ),
-    ) as run_mock:
+    ) as load_mock:
         changes = detect_changes_from_commit(Path("/tmp/repo"), "abc123")
 
-    run_mock.assert_called_once()
-    command = run_mock.call_args.args[0]
-    assert command == [
-        "git",
-        "diff",
-        "--name-status",
-        "-M",
-        "-C",
-        "--find-renames=50%",
-        "abc123",
-    ]
+    load_mock.assert_called_once_with(Path("/tmp/repo"), "abc123", "", fetch_missing_refs=True)
     assert len(changes.changes) == 1
     assert changes.changes[0].change_type == ChangeType.ADDED
     assert changes.changes[0].file_path == "requirements/base.txt"

--- a/tests/repo_utils/test_method_diff.py
+++ b/tests/repo_utils/test_method_diff.py
@@ -1,100 +1,47 @@
-"""Tests for repo_utils.method_diff - method-level diff status classification."""
-
-import pytest
-from unittest.mock import patch
+from pathlib import Path
 
 from agents.agent_responses import MethodEntry
 from agents.change_status import ChangeStatus
 from repo_utils.change_detector import ChangeSet, ChangeType, DetectedChange
 from repo_utils.method_diff import get_method_statuses_for_file
-
-from pathlib import Path
-
-
-def _make_changeset(*, modified: list[str] | None = None, base_ref: str = "HEAD~1") -> ChangeSet:
-    changes: list[DetectedChange] = []
-    for f in modified or []:
-        changes.append(DetectedChange(change_type=ChangeType.MODIFIED, file_path=f))
-    return ChangeSet(changes=changes, base_ref=base_ref)
+from repo_utils.parsed_diff import ParsedDiffFile, ParsedGitDiff, _parse_patch_text
 
 
-class TestNewFunctionInMixedHunk:
-    """Reproduce: a hunk that modifies a few existing lines AND adds many new
-    lines should mark a brand-new function (fully inside the added portion) as
-    ADDED, not MODIFIED.
+def test_get_method_statuses_uses_exact_changed_lines_from_context_diff():
+    patch_text = """\
+diff --git a/src/mod.py b/src/mod.py
+index abcdef0..1234567 100644
+--- a/src/mod.py
++++ b/src/mod.py
+@@ -1,7 +1,7 @@
+ def alpha():
+     step_one()
+-    old_call()
++    new_call()
+ 
+ def beta():
+     return 2
+"""
 
-    Real-world example: ``static_analyzer/cluster_helpers.py`` had a hunk
-    ``@@ -42,10 +69,367 @@`` which modified 10 old lines into 367 new lines.
-    ``merge_clusters`` (lines 385-424) is entirely new code, but the current
-    logic puts the whole 69-435 range into ``changed_ranges`` (because
-    ``old_count=10 > 0``), so the function is classified as MODIFIED.
-    """
+    parsed_file = ParsedDiffFile(
+        status_code="M",
+        file_path="src/mod.py",
+        patch_text=patch_text,
+        hunks=_parse_patch_text(patch_text),
+    )
+    changes = ChangeSet(
+        changes=[DetectedChange(change_type=ChangeType.MODIFIED, file_path="src/mod.py")],
+        base_ref="HEAD",
+        target_ref="",
+        parsed_diff=ParsedGitDiff(base_ref="HEAD", target_ref="", files=[parsed_file]),
+    )
+    methods = [
+        MethodEntry(qualified_name="mod.alpha", start_line=1, end_line=3, node_type="FUNCTION"),
+        MethodEntry(qualified_name="mod.beta", start_line=5, end_line=6, node_type="FUNCTION"),
+    ]
 
-    @pytest.fixture
-    def file_path(self) -> str:
-        return "static_analyzer/cluster_helpers.py"
+    file_status = get_method_statuses_for_file(methods, "src/mod.py", changes, Path("/tmp/repo"))
 
-    @pytest.fixture
-    def changes(self, file_path: str) -> ChangeSet:
-        return _make_changeset(modified=[file_path])
-
-    @pytest.fixture
-    def hunks(self) -> list[tuple[int, int, int, int]]:
-        # Mimics @@ -42,10 +69,367 @@
-        return [(42, 10, 69, 367)]
-
-    @pytest.fixture
-    def methods(self) -> list[MethodEntry]:
-        return [
-            # Existing function that was modified (overlaps with the old 10 lines)
-            MethodEntry(
-                qualified_name="cluster_helpers.build_all_cluster_results",
-                start_line=69,
-                end_line=110,
-                node_type="FUNCTION",
-            ),
-            # Brand-new function, fully inside the added portion of the hunk
-            MethodEntry(
-                qualified_name="cluster_helpers.merge_clusters",
-                start_line=385,
-                end_line=424,
-                node_type="FUNCTION",
-            ),
-            # Unchanged function outside the hunk
-            MethodEntry(
-                qualified_name="cluster_helpers.get_all_cluster_ids",
-                start_line=440,
-                end_line=450,
-                node_type="FUNCTION",
-            ),
-        ]
-
-    @patch("repo_utils.method_diff._parse_diff_hunks")
-    @pytest.mark.skip(reason="Temporarily ignored until mixed-hunk method classification is fixed")
-    def test_new_function_in_mixed_hunk_is_added(self, mock_parse, methods, file_path, changes, hunks):
-        mock_parse.return_value = hunks
-
-        get_method_statuses_for_file(methods, file_path, changes, Path("/fake/repo"))
-
-        by_name = {m.qualified_name: m.status for m in methods}
-        # merge_clusters is entirely new code – it should be ADDED
-        assert by_name["cluster_helpers.merge_clusters"] == ChangeStatus.ADDED
-
-    @patch("repo_utils.method_diff._parse_diff_hunks")
-    def test_modified_function_in_mixed_hunk_is_modified(self, mock_parse, methods, file_path, changes, hunks):
-        mock_parse.return_value = hunks
-
-        get_method_statuses_for_file(methods, file_path, changes, Path("/fake/repo"))
-
-        by_name = {m.qualified_name: m.status for m in methods}
-        # build_all_cluster_results overlaps the replaced portion – should be MODIFIED
-        assert by_name["cluster_helpers.build_all_cluster_results"] == ChangeStatus.MODIFIED
-
-    @patch("repo_utils.method_diff._parse_diff_hunks")
-    def test_unchanged_function_outside_hunk(self, mock_parse, methods, file_path, changes, hunks):
-        mock_parse.return_value = hunks
-
-        get_method_statuses_for_file(methods, file_path, changes, Path("/fake/repo"))
-
-        by_name = {m.qualified_name: m.status for m in methods}
-        assert by_name["cluster_helpers.get_all_cluster_ids"] == ChangeStatus.UNCHANGED
+    assert file_status == ChangeStatus.MODIFIED
+    assert methods[0].status == ChangeStatus.MODIFIED
+    assert methods[1].status == ChangeStatus.UNCHANGED

--- a/tests/repo_utils/test_parsed_diff.py
+++ b/tests/repo_utils/test_parsed_diff.py
@@ -1,0 +1,64 @@
+from pathlib import Path
+from subprocess import CompletedProcess
+from unittest.mock import patch
+
+from repo_utils.parsed_diff import load_parsed_git_diff
+
+
+def test_load_parsed_git_diff_uses_single_command():
+    diff_output = """\
+:100644 100644 abcdef0 1234567 M\tsrc/mod.py
+diff --git a/src/mod.py b/src/mod.py
+index abcdef0..1234567 100644
+--- a/src/mod.py
++++ b/src/mod.py
+@@ -1,3 +1,3 @@
+ def alpha():
+-    old_call()
++    new_call()
+     return 1
+"""
+
+    with patch(
+        "repo_utils.parsed_diff.subprocess.run",
+        return_value=CompletedProcess(args=["git", "diff"], returncode=0, stdout=diff_output, stderr=""),
+    ) as run_mock:
+        parsed = load_parsed_git_diff(Path("/tmp/repo"), "HEAD", "")
+
+    run_mock.assert_called_once()
+    command = run_mock.call_args.args[0]
+    assert command == [
+        "git",
+        "diff",
+        "--raw",
+        "-U3",
+        "-M",
+        "-C",
+        "--find-renames=50%",
+        "HEAD",
+    ]
+    assert len(parsed.files) == 1
+    assert parsed.files[0].file_path == "src/mod.py"
+    assert parsed.files[0].status_code == "M"
+    assert len(parsed.files[0].hunks) == 1
+
+
+def test_load_parsed_git_diff_tracks_rename_metadata():
+    diff_output = """\
+:100644 100644 abcdef0 1234567 R100\told.py\tnew.py
+diff --git a/old.py b/new.py
+similarity index 100%
+rename from old.py
+rename to new.py
+"""
+
+    with patch(
+        "repo_utils.parsed_diff.subprocess.run",
+        return_value=CompletedProcess(args=["git", "diff"], returncode=0, stdout=diff_output, stderr=""),
+    ):
+        parsed = load_parsed_git_diff(Path("/tmp/repo"), "HEAD~1", "HEAD")
+
+    assert len(parsed.files) == 1
+    assert parsed.files[0].file_path == "new.py"
+    assert parsed.files[0].old_path == "old.py"
+    assert parsed.files[0].similarity == 100


### PR DESCRIPTION
## Summary
Shared parsed git diff substrate for rename-aware change analysis.

## Testing
uv run pytest tests/repo_utils/test_change_detector.py tests/repo_utils/test_method_diff.py tests/repo_utils/test_parsed_diff.py -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved change detection reliability by automatically fetching missing git references when needed.

* **Improvements**
  * Enhanced detection and tracking of file rename and copy operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->