### PR TITLE
Add Rust language support via rust-analyzer

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -16,6 +16,7 @@ on:
           - typescript
           - php
           - javascript
+          - rust
 
   push:
     branches: [main]
@@ -42,7 +43,7 @@ on:
 
 jobs:
   # Emit the matrix.include list, event-driven:
-  #   schedule / workflow_dispatch → full 6 langs x 3 OSes minus skipped pairs.
+  #   schedule / workflow_dispatch → full 7 langs x 3 OSes minus skipped pairs.
   #   push / pull_request         → Windows all langs (except java) + java on
   #                                 Linux/mac (java's dev platforms).
   # workflow_dispatch honors the optional ``language`` input to narrow
@@ -72,7 +73,7 @@ jobs:
           event = os.environ.get("EVENT_NAME", "")
           dispatch_lang = os.environ.get("DISPATCH_LANG", "").strip()
 
-          all_langs = ["python", "java", "go", "typescript", "php", "javascript"]
+          all_langs = ["python", "java", "go", "typescript", "php", "javascript", "rust"]
           all_os = ["ubuntu-latest", "macos-latest", "windows-latest"]
           skip = {("macos-latest", "go"), ("windows-latest", "java")}  # see job-level note
 
@@ -147,6 +148,17 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
+
+      - name: Install Rust toolchain
+        if: matrix.language == 'rust'
+        # rust-analyzer comes from ``codeboarding-setup`` (tool_registry)
+        # but cargo must be on PATH for ``cargo metadata`` to succeed —
+        # without it, RustAdapter.get_lsp_command raises. Same pattern as
+        # the JDK requirement for Java/JDTLS.
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          components: ''
 
       - name: Install PHP (linux)
         if: matrix.language == 'php' && runner.os == 'Linux'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,14 +58,14 @@ Adding language support requires changes across several files. Use [PR #276 (Rus
 |------|-------------|
 | `static_analyzer/engine/adapters/<lang>_adapter.py` | **New file.** Adapter class extending `LanguageAdapter`. Handles language-specific qualified name construction, reference keys, and any special rules (e.g. `mod.rs` collapsing for Rust). |
 | `static_analyzer/engine/adapters/__init__.py` | Import the adapter and add it to `ADAPTER_REGISTRY`. |
-| `static_analyzer/constants.py` | Add a value to the `Language` enum and an entry in `ClusteringConfig.DELIMITER_MAP` (most languages use `"."`). |
+| `static_analyzer/constants.py` | Add a value to the `Language` enum. Qualified names use the universal `.` delimiter defined in `ClusteringConfig.QUALIFIED_NAME_DELIMITER`. |
 | `static_analyzer/__init__.py` | Add a mapping in `_lang_to_adapter_name()` from the `ProgrammingLanguage` name to the adapter registry key. |
 | `vscode_constants.py` | Add an LSP server config entry to `VSCODE_CONFIG["lsp_servers"]` with the server name, command, languages, file extensions, and install command. |
-| `tool_registry.py` | Add a `ToolDependency` entry to `TOOL_REGISTRY` (see below). |
+| `tool_registry/registry.py` | Add a `ToolDependency` entry to `TOOL_REGISTRY` (see below). |
 
 ### 5b) Registering the LSP server dependency
 
-The LSP server must be registered in `tool_registry.py` so it gets installed automatically. The `ToolDependency` entry depends on how the server is distributed:
+The LSP server must be registered in `tool_registry/registry.py` so it gets installed automatically. The `ToolDependency` entry depends on how the server is distributed:
 
 **npm package** (e.g. pyright, typescript-language-server) — no pipeline update needed:
 ```python

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Install the extension from Open VSX.
 [![Python](https://img.shields.io/badge/Python-3776AB?style=flat-square&logo=python&logoColor=white)](https://www.python.org/)
 [![Go](https://img.shields.io/badge/Go-00ADD8?style=flat-square&logo=go&logoColor=white)](https://go.dev/)
 [![PHP](https://img.shields.io/badge/PHP-777BB4?style=flat-square&logo=php&logoColor=white)](https://www.php.net/)
+[![Rust](https://img.shields.io/badge/Rust-000000?style=flat-square&logo=rust&logoColor=white)](https://www.rust-lang.org/)
 
 ## Few use cases:
 
@@ -141,7 +142,7 @@ python main.py https://github.com/pytorch/pytorch
 
 ## Supported stack
 
-- Languages: Python, TypeScript, JavaScript, Java, Go, PHP.
+- Languages: Python, TypeScript, JavaScript, Java, Go, PHP, Rust.
 - LLM providers: OpenAI, Anthropic, Google, Vercel AI Gateway, AWS Bedrock, Ollama, OpenRouter, and more.
 
 ## Examples

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,4 +119,5 @@ markers = [
     "typescript_lang: marks tests for TypeScript language",
     "php_lang: marks tests for PHP language",
     "javascript_lang: marks tests for JavaScript language",
+    "rust_lang: marks tests for Rust language",
 ]

--- a/repo_utils/ignore.py
+++ b/repo_utils/ignore.py
@@ -28,7 +28,10 @@ venv/
 env/
 *.egg-info/
 
-# Java (Maven/Gradle) build output
+# Java (Maven/Gradle) and Rust (Cargo) build output. Both ecosystems
+# produce a top-level ``target/`` directory full of compiled artifacts —
+# kept here as well as in ``_ALWAYS_IGNORED_DIRS`` so users who customize
+# their ``.codeboardingignore`` continue to skip it even after edits.
 target/
 bin/
 out/
@@ -145,11 +148,12 @@ _ALWAYS_IGNORED_DIRS = {
     ".codeboarding",
     # Dependency installs
     "node_modules",
-    # Compiled / build output
+    # Compiled / build output (universal across ecosystems — never source)
     "__pycache__",
     "build",
     "dist",
     "coverage",
+    "target",  # Java (Maven), Rust (Cargo)
 }
 
 

--- a/static_analyzer/__init__.py
+++ b/static_analyzer/__init__.py
@@ -169,6 +169,7 @@ class StaticAnalyzer:
                 # a Node-less host the embedded runtime's dir must be on PATH.
                 ensure_node_on_path(command, extra_env)
                 workspace_settings = adapter.get_workspace_settings()
+                extra_capabilities = getattr(adapter, "extra_client_capabilities", {}) or {}
                 engine_client = LSPClient(
                     command=command,
                     project_root=project_path,
@@ -176,15 +177,20 @@ class StaticAnalyzer:
                     collect_diagnostics=True,
                     extra_env=extra_env,
                     workspace_settings=workspace_settings,
+                    extra_client_capabilities=extra_capabilities,
                 )
                 engine_client.start()
                 t_lsp_started = time.monotonic()
                 logger.info(f"{adapter.language} LSP start: {t_lsp_started - t_start:.1f}s")
 
-                # For Java, wait for JDTLS to finish importing
-                if adapter.language.lower() == "java":
+                # Some LSP servers (JDTLS, rust-analyzer) load workspace
+                # metadata asynchronously and only respond to cross-file
+                # queries once that's complete. Adapters opt in via
+                # ``wait_for_workspace_ready`` so the language-name check
+                # doesn't keep growing.
+                if getattr(adapter, "wait_for_workspace_ready", False):
                     engine_client.wait_for_server_ready()
-                    logger.info(f"{adapter.language} project import: {time.monotonic() - t_lsp_started:.1f}s")
+                    logger.info(f"{adapter.language} workspace ready: {time.monotonic() - t_lsp_started:.1f}s")
 
                 started.append((adapter, project_path, engine_client))
 

--- a/static_analyzer/__init__.py
+++ b/static_analyzer/__init__.py
@@ -108,6 +108,7 @@ def _lang_to_adapter_name(language: str) -> str | None:
         "go": "Go",
         "java": "Java",
         "php": "PHP",
+        "rust": "Rust",
     }
     return mapping.get(language.lower())
 

--- a/static_analyzer/constants.py
+++ b/static_analyzer/constants.py
@@ -21,6 +21,7 @@ class Language(StrEnum):
     GO = "go"
     JAVA = "java"
     PHP = "php"
+    RUST = "rust"
     CPP = "cpp"
 
 
@@ -50,6 +51,7 @@ class ClusteringConfig:
         Language.TYPESCRIPT: ".",
         Language.JAVASCRIPT: ".",
         Language.JAVA: ".",
+        Language.RUST: ".",
     }
 
     # Deterministic seed for clustering algorithms

--- a/static_analyzer/constants.py
+++ b/static_analyzer/constants.py
@@ -42,17 +42,12 @@ class ClusteringConfig:
     # Display limits
     MAX_DISPLAY_CLUSTERS = 55  # Maximum clusters to show in output (readability limit)
 
-    # Language-specific delimiters for qualified names
-    DEFAULT_DELIMITER = "."  # Works for Python, Java, C#
-    DELIMITER_MAP = {
-        Language.PYTHON: ".",
-        Language.GO: ".",
-        Language.PHP: "\\",  # PHP uses backslash for namespaces
-        Language.TYPESCRIPT: ".",
-        Language.JAVASCRIPT: ".",
-        Language.JAVA: ".",
-        Language.RUST: ".",
-    }
+    # Separator used by every ``LanguageAdapter.build_qualified_name``.
+    # A future per-language switch (e.g. Rust to ``::``) would need both a
+    # per-adapter override and updates to consumers that hardcode
+    # ``.split(".")`` (``language_adapter.extract_package``,
+    # ``cluster_methods_mixin.py``, ``diagnose_relations.py``).
+    QUALIFIED_NAME_DELIMITER = "."
 
     # Deterministic seed for clustering algorithms
     CLUSTERING_SEED = 42

--- a/static_analyzer/engine/adapters/__init__.py
+++ b/static_analyzer/engine/adapters/__init__.py
@@ -7,6 +7,7 @@ from static_analyzer.engine.adapters.go_adapter import GoAdapter
 from static_analyzer.engine.adapters.java_adapter import JavaAdapter
 from static_analyzer.engine.adapters.php_adapter import PHPAdapter
 from static_analyzer.engine.adapters.python_adapter import PythonAdapter
+from static_analyzer.engine.adapters.rust_adapter import RustAdapter
 from static_analyzer.engine.adapters.typescript_adapter import JavaScriptAdapter, TypeScriptAdapter
 
 ADAPTER_REGISTRY: dict[str, type[LanguageAdapter]] = {
@@ -16,6 +17,7 @@ ADAPTER_REGISTRY: dict[str, type[LanguageAdapter]] = {
     "Go": GoAdapter,
     "Java": JavaAdapter,
     "PHP": PHPAdapter,
+    "Rust": RustAdapter,
 }
 
 

--- a/static_analyzer/engine/adapters/java_adapter.py
+++ b/static_analyzer/engine/adapters/java_adapter.py
@@ -40,6 +40,20 @@ class JavaAdapter(LanguageAdapter):
     def language_id(self) -> str:
         return "java"
 
+    @property
+    def wait_for_workspace_ready(self) -> bool:
+        """JDTLS sends ``language/status`` notifications during project import
+        and is not ready to serve cross-file queries until ``ProjectStatus OK``
+        arrives. Block on it before Phase 2.
+
+        Replaces the ``adapter.language.lower() == "java"`` special-case that
+        ``StaticAnalyzer.start_clients`` previously used to drive the same
+        wait — keeping it here lets new adapters with the same need
+        (rust-analyzer, csharp-ls) opt in declaratively instead of growing
+        the language-name string check.
+        """
+        return True
+
     def get_lsp_command(self, project_root: Path) -> list[str]:
         """Build the full JDTLS launch command.
 

--- a/static_analyzer/engine/adapters/java_adapter.py
+++ b/static_analyzer/engine/adapters/java_adapter.py
@@ -42,15 +42,9 @@ class JavaAdapter(LanguageAdapter):
 
     @property
     def wait_for_workspace_ready(self) -> bool:
-        """JDTLS sends ``language/status`` notifications during project import
-        and is not ready to serve cross-file queries until ``ProjectStatus OK``
-        arrives. Block on it before Phase 2.
-
-        Replaces the ``adapter.language.lower() == "java"`` special-case that
-        ``StaticAnalyzer.start_clients`` previously used to drive the same
-        wait — keeping it here lets new adapters with the same need
-        (rust-analyzer, csharp-ls) opt in declaratively instead of growing
-        the language-name string check.
+        """JDTLS finishes project import asynchronously and only signals
+        readiness via ``language/status`` (``ProjectStatus OK``); cross-file
+        queries return empty until then.
         """
         return True
 

--- a/static_analyzer/engine/adapters/rust_adapter.py
+++ b/static_analyzer/engine/adapters/rust_adapter.py
@@ -1,0 +1,57 @@
+"""Rust language adapter using rust-analyzer."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from static_analyzer.engine.language_adapter import LanguageAdapter
+
+
+class RustAdapter(LanguageAdapter):
+
+    @property
+    def language(self) -> str:
+        return "Rust"
+
+    @property
+    def file_extensions(self) -> tuple[str, ...]:
+        return (".rs",)
+
+    @property
+    def lsp_command(self) -> list[str]:
+        return ["rust-analyzer"]
+
+    @property
+    def language_id(self) -> str:
+        return "rust"
+
+    def build_qualified_name(
+        self,
+        file_path: Path,
+        symbol_name: str,
+        symbol_kind: int,
+        parent_chain: list[tuple[str, int]],
+        project_root: Path,
+        detail: str = "",
+    ) -> str:
+        """Build a qualified name, collapsing ``mod.rs`` into its parent directory.
+
+        In Rust, ``src/models/mod.rs`` defines the ``models`` module — the
+        ``mod`` file stem is an implementation detail, not part of the
+        logical module path.  Stripping it produces
+        ``src.models.User`` instead of ``src.models.mod.User``.
+        """
+        rel = file_path.relative_to(project_root)
+        parts = list(rel.with_suffix("").parts)
+        if parts and parts[-1] == "mod":
+            parts.pop()
+        module = ".".join(parts) if parts else rel.stem
+
+        if parent_chain:
+            parents = ".".join(name for name, _ in parent_chain)
+            return f"{module}.{parents}.{symbol_name}"
+        return f"{module}.{symbol_name}"
+
+    def build_reference_key(self, qualified_name: str) -> str:
+        """Preserve original casing for Rust qualified names."""
+        return qualified_name

--- a/static_analyzer/engine/adapters/rust_adapter.py
+++ b/static_analyzer/engine/adapters/rust_adapter.py
@@ -2,16 +2,68 @@
 
 from __future__ import annotations
 
+import shutil
 from pathlib import Path
 
+from repo_utils.ignore import RepoIgnoreManager
 from static_analyzer.engine.language_adapter import LanguageAdapter
+
+# File stems implicit in the module path: ``mod.rs`` (directory module
+# entry), ``lib.rs`` (library crate root), ``main.rs`` (binary crate root).
+_IMPLICIT_MODULE_STEMS = {"mod", "lib", "main"}
+
+
+def _normalize_parent(name: str) -> str:
+    """Strip the ``impl `` prefix and ``impl X for Y`` wrapper from a
+    rust-analyzer documentSymbol parent name, leaving just the implementing
+    type (e.g. ``"impl Speaker for Cat"`` becomes ``"Cat"``). Generics are
+    stripped so consumers can ``.split(".")``. Non-impl names pass through.
+    """
+    name = name.strip()
+    if not name.startswith("impl "):
+        return name
+    body = name[len("impl ") :].strip()
+    for_idx = body.find(" for ")
+    if for_idx != -1:
+        body = body[for_idx + len(" for ") :].strip()
+    angle_idx = body.find("<")
+    if angle_idx != -1:
+        body = body[:angle_idx].strip()
+    return body or name
 
 
 class RustAdapter(LanguageAdapter):
+    """Static-analysis adapter for Rust projects backed by rust-analyzer."""
 
     @property
     def language(self) -> str:
         return "Rust"
+
+    @property
+    def references_per_query_timeout(self) -> int:
+        """Non-zero gates the Phase-1.5 warmup probe so rust-analyzer builds
+        its ``ide_db::search`` index before Phase 2 fans out queries."""
+        return 60
+
+    @property
+    def wait_for_workspace_ready(self) -> bool:
+        """Block on ``experimental/serverStatus`` quiescent before Phase 2.
+
+        rust-analyzer's cross-file queries return empty until ``cargo metadata``
+        finishes loading the workspace.
+        """
+        return True
+
+    @property
+    def extra_client_capabilities(self) -> dict:
+        """Opt into rust-analyzer's ``experimental/serverStatus`` notifications.
+
+        Required: without this advertisement rust-analyzer never emits the
+        ``quiescent`` notification and ``wait_for_server_ready`` times out
+        (verified empirically). Confined to this adapter so other LSPs
+        don't see vendor-specific keys.
+        """
+        return {"experimental": {"serverStatusNotification": True}}
 
     @property
     def file_extensions(self) -> tuple[str, ...]:
@@ -25,6 +77,35 @@ class RustAdapter(LanguageAdapter):
     def language_id(self) -> str:
         return "rust"
 
+    def get_lsp_command(self, project_root: Path) -> list[str]:
+        """Fail fast if cargo is missing.
+
+        rust-analyzer needs ``cargo metadata`` to index any Cargo workspace
+        and the toolchain is too large to bundle, so we mirror Java's
+        pattern of requiring a user-installed toolchain.
+        """
+        if shutil.which("cargo") is None:
+            raise RuntimeError(
+                "cargo not found on PATH. rust-analyzer requires a Rust "
+                "toolchain to index Cargo projects. Install one via "
+                "https://rustup.rs/ and re-run the analysis."
+            )
+        return super().get_lsp_command(project_root)
+
+    def get_lsp_init_options(self, ignore_manager: RepoIgnoreManager | None = None) -> dict:
+        """Tune rust-analyzer for batch analysis: enable build scripts and
+        proc macros (so generated code is indexed) and the full target graph;
+        disable ``checkOnSave`` (slow and unused).
+        """
+        return {
+            "cargo": {
+                "buildScripts": {"enable": True},
+                "allTargets": True,
+            },
+            "procMacro": {"enable": True},
+            "checkOnSave": False,
+        }
+
     def build_qualified_name(
         self,
         file_path: Path,
@@ -34,24 +115,19 @@ class RustAdapter(LanguageAdapter):
         project_root: Path,
         detail: str = "",
     ) -> str:
-        """Build a qualified name, collapsing ``mod.rs`` into its parent directory.
-
-        In Rust, ``src/models/mod.rs`` defines the ``models`` module — the
-        ``mod`` file stem is an implementation detail, not part of the
-        logical module path.  Stripping it produces
-        ``src.models.User`` instead of ``src.models.mod.User``.
+        """Collapse implicit module stems (``mod.rs``/``lib.rs``/``main.rs``)
+        when building dotted qualified names. ``src/models/mod.rs::User``
+        becomes ``src.models.User``, not ``src.models.mod.User``. Falls back
+        to the file stem if stripping would leave no module parts (e.g. a
+        bare ``mod.rs`` at the project root).
         """
         rel = file_path.relative_to(project_root)
         parts = list(rel.with_suffix("").parts)
-        if parts and parts[-1] == "mod":
+        if parts and parts[-1] in _IMPLICIT_MODULE_STEMS:
             parts.pop()
         module = ".".join(parts) if parts else rel.stem
 
         if parent_chain:
-            parents = ".".join(name for name, _ in parent_chain)
+            parents = ".".join(_normalize_parent(name) for name, _ in parent_chain)
             return f"{module}.{parents}.{symbol_name}"
         return f"{module}.{symbol_name}"
-
-    def build_reference_key(self, qualified_name: str) -> str:
-        """Preserve original casing for Rust qualified names."""
-        return qualified_name

--- a/static_analyzer/engine/adapters/rust_adapter.py
+++ b/static_analyzer/engine/adapters/rust_adapter.py
@@ -13,22 +13,57 @@ from static_analyzer.engine.language_adapter import LanguageAdapter
 _IMPLICIT_MODULE_STEMS = {"mod", "lib", "main"}
 
 
+def _skip_angle_block(s: str, start: int) -> int:
+    """Return the index just past a balanced ``<...>`` block starting at *start*.
+
+    Handles nested generics (``<T: Iterator<Item = u8>>``). Returns *start*
+    unchanged if the block is malformed.
+    """
+    if start >= len(s) or s[start] != "<":
+        return start
+    depth = 0
+    for i in range(start, len(s)):
+        if s[i] == "<":
+            depth += 1
+        elif s[i] == ">":
+            depth -= 1
+            if depth == 0:
+                return i + 1
+    return start
+
+
 def _normalize_parent(name: str) -> str:
-    """Strip the ``impl `` prefix and ``impl X for Y`` wrapper from a
-    rust-analyzer documentSymbol parent name, leaving just the implementing
-    type (e.g. ``"impl Speaker for Cat"`` becomes ``"Cat"``). Generics are
-    stripped so consumers can ``.split(".")``. Non-impl names pass through.
+    """Reduce a rust-analyzer documentSymbol parent to a clean type name.
+
+    Handles every impl header shape rust-analyzer emits:
+    ``impl T``, ``impl<T> Foo<T>``, ``impl<T> Trait for Foo<T>``,
+    ``impl<T: Bound> Foo<T> where ...``. Returns the implementing type
+    with all generics and where clauses stripped so consumers can
+    ``.split(".")``. Non-impl names pass through unchanged.
     """
     name = name.strip()
-    if not name.startswith("impl "):
+    if not name.startswith("impl"):
         return name
-    body = name[len("impl ") :].strip()
+    # ``impl`` must be a standalone token: either followed by whitespace
+    # (``impl Foo``) or by ``<`` for impl-level generics (``impl<T> Foo``).
+    after_impl = name[len("impl") :]
+    if after_impl and after_impl[0] not in (" ", "\t", "<"):
+        return name
+    # Skip the impl-level ``<...>`` block if present, then any whitespace.
+    cursor = len("impl")
+    cursor = _skip_angle_block(name, cursor)
+    while cursor < len(name) and name[cursor].isspace():
+        cursor += 1
+    body = name[cursor:].strip()
+    # Trait impls put the implementing type after ``for``.
     for_idx = body.find(" for ")
     if for_idx != -1:
         body = body[for_idx + len(" for ") :].strip()
-    angle_idx = body.find("<")
-    if angle_idx != -1:
-        body = body[:angle_idx].strip()
+    # Strip type-level generics and where clauses.
+    for terminator in ("<", " where "):
+        idx = body.find(terminator)
+        if idx != -1:
+            body = body[:idx].strip()
     return body or name
 
 
@@ -56,12 +91,8 @@ class RustAdapter(LanguageAdapter):
 
     @property
     def extra_client_capabilities(self) -> dict:
-        """Opt into rust-analyzer's ``experimental/serverStatus`` notifications.
-
-        Required: without this advertisement rust-analyzer never emits the
-        ``quiescent`` notification and ``wait_for_server_ready`` times out
-        (verified empirically). Confined to this adapter so other LSPs
-        don't see vendor-specific keys.
+        """Opt into rust-analyzer's ``experimental/serverStatus`` notifications,
+        which it only emits when the client advertises this capability.
         """
         return {"experimental": {"serverStatusNotification": True}}
 

--- a/static_analyzer/engine/language_adapter.py
+++ b/static_analyzer/engine/language_adapter.py
@@ -207,6 +207,22 @@ class LanguageAdapter(ABC):
         return EdgeStrategy.REFERENCES
 
     @property
+    def wait_for_workspace_ready(self) -> bool:
+        """Override to ``True`` for LSPs (JDTLS, rust-analyzer) that load
+        project metadata async and return empty results until ready. Per-file
+        indexers (pyright, gopls, tsserver, intelephense) keep the default.
+        """
+        return False
+
+    @property
+    def extra_client_capabilities(self) -> dict:
+        """Vendor-specific keys to shallow-merge into the LSP ``initialize``
+        capabilities (e.g. ``{"experimental": {...}}``). Default ``{}`` keeps
+        the shared client free of language-specific opt-ins.
+        """
+        return {}
+
+    @property
     def references_batch_size(self) -> int:
         """Max number of references requests to send in a single batch."""
         return 50

--- a/static_analyzer/engine/lsp_client.py
+++ b/static_analyzer/engine/lsp_client.py
@@ -48,6 +48,7 @@ class LSPClient:
         collect_diagnostics: bool = False,
         extra_env: dict[str, str] | None = None,
         workspace_settings: dict | None = None,
+        extra_client_capabilities: dict | None = None,
     ) -> None:
         self._command = command
         self._project_root = project_root
@@ -56,6 +57,8 @@ class LSPClient:
         self._collect_diagnostics = collect_diagnostics
         self._extra_env = extra_env or {}
         self._workspace_settings = workspace_settings
+        # Adapter-specific keys merged into capabilities at ``initialize`` time.
+        self._extra_client_capabilities = extra_client_capabilities or {}
         self._process: subprocess.Popen | None = None  # type: ignore[type-arg]
         self._stdout_fd: int | None = None
         self._request_id = 0
@@ -123,15 +126,22 @@ class LSPClient:
                 "tagSupport": {"valueSet": [1, 2]},
             }
 
+        capabilities: dict = {"textDocument": text_doc_capabilities}
+        # Shallow-merge adapter extras into the top-level capabilities. On
+        # collision: dicts merge, scalars are overwritten by the adapter.
+        for cap_key, cap_value in self._extra_client_capabilities.items():
+            if cap_key in capabilities and isinstance(capabilities[cap_key], dict) and isinstance(cap_value, dict):
+                capabilities[cap_key] = {**capabilities[cap_key], **cap_value}
+            else:
+                capabilities[cap_key] = cap_value
+
         init_result = self._send_request(
             "initialize",
             {
                 "processId": os.getpid(),
                 "rootUri": root_uri,
                 "rootPath": str(self._project_root),
-                "capabilities": {
-                    "textDocument": text_doc_capabilities,
-                },
+                "capabilities": capabilities,
                 "workspaceFolders": [
                     {"uri": root_uri, "name": self._project_root.name},
                 ],
@@ -662,6 +672,18 @@ class LSPClient:
             elif status_type == "ProjectStatus" and status_message == "OK":
                 self._server_ready.set()
                 logger.info("LSP server: ProjectStatus OK")
+
+        elif method == "experimental/serverStatus":
+            # rust-analyzer's readiness signal. ``quiescent`` flips True once
+            # the initial workspace load completes; we set ready then
+            # regardless of health (a ``warning`` state still has a usable
+            # reference index, just with diagnostics flagged).
+            quiescent = bool(params.get("quiescent", False))
+            health = params.get("health", "")
+            logger.debug("rust-analyzer status: health=%s, quiescent=%s", health, quiescent)
+            if quiescent:
+                self._server_ready.set()
+                logger.info("LSP server: rust-analyzer quiescent (health=%s)", health)
 
     def _read_single_message(self) -> dict | None:
         """Read a single JSON-RPC message from stdout using raw fd I/O."""

--- a/static_analyzer/graph.py
+++ b/static_analyzer/graph.py
@@ -9,7 +9,6 @@ from static_analyzer.constants import (
     ENTITY_LABELS,
     GRAPH_NODE_TYPES,
     ClusteringConfig,
-    Language,
     NodeType,
 )
 from static_analyzer.node import Node
@@ -65,13 +64,9 @@ class CallGraph:
         self.edges = edges if edges is not None else []
         self._edge_set: set[tuple[str, str]] = set()
         self.language = language.lower()
-        # Set delimiter based on language for qualified name parsing
-        # Convert string language to Language enum for lookup using list comprehension
-        lang_key: Language | None = next((lang for lang in Language if lang.value == self.language), None)
-        if lang_key and lang_key in ClusteringConfig.DELIMITER_MAP:
-            self.delimiter = ClusteringConfig.DELIMITER_MAP[lang_key]
-        else:
-            self.delimiter = ClusteringConfig.DEFAULT_DELIMITER
+        # Every adapter currently emits ``.``-separated qualified names; see
+        # ``constants.QUALIFIED_NAME_DELIMITER`` for the language-switch caveat.
+        self.delimiter = ClusteringConfig.QUALIFIED_NAME_DELIMITER
         # Cache for cluster result
         self._cluster_cache: ClusterResult | None = None
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -131,6 +131,21 @@ REPOSITORY_CONFIGS = [
             "lsp_server_key": "typescript",
         },
     ),
+    RepositoryTestConfig(
+        name="clap_rust",
+        repo_url="https://github.com/clap-rs/clap",
+        pinned_commit="v4.5.20",
+        language="Rust",
+        fixture_file="clap_rust.json",
+        mock_language={
+            "language": "Rust",
+            "size": 50000,
+            "percentage": 100.0,
+            "suffixes": [".rs"],
+            "server_commands": ["rust-analyzer"],
+            "lsp_server_key": "rust",
+        },
+    ),
 ]
 
 

--- a/tests/integration/fixtures/edge_cases/rust_edge_cases.json
+++ b/tests/integration/fixtures/edge_cases/rust_edge_cases.json
@@ -1,0 +1,87 @@
+{
+  "language": "Rust",
+  "expected_references": [
+    "src.main",
+    "src.models.base.Entity",
+    "src.models.base.Entity.get_id",
+    "src.models.base.Entity.id",
+    "src.models.base.Entity.new",
+    "src.models.base.Speaker",
+    "src.models.base.Speaker.shout",
+    "src.models.base.Speaker.speak",
+    "src.models.entities.Cat",
+    "src.models.entities.Cat.entity",
+    "src.models.entities.Cat.name",
+    "src.models.entities.Cat.new",
+    "src.models.entities.Cat.speak",
+    "src.models.entities.Dog",
+    "src.models.entities.Dog.entity",
+    "src.models.entities.Dog.name",
+    "src.models.entities.Dog.new",
+    "src.models.entities.Dog.speak",
+    "src.models.entities.Task",
+    "src.models.entities.Task.get_label",
+    "src.models.entities.Task.id",
+    "src.models.entities.Task.new",
+    "src.models.entities.Task.title",
+    "src.services.processor.Summary",
+    "src.services.processor.Summary.count",
+    "src.services.processor.Summary.last_label",
+    "src.services.processor.summarize",
+    "src.utils.helpers.add",
+    "src.utils.helpers.format_label"
+  ],
+  "expected_classes": [
+    "src.models.base.Entity",
+    "src.models.base.Speaker",
+    "src.models.entities.Cat",
+    "src.models.entities.Dog",
+    "src.models.entities.Task",
+    "src.services.processor.Summary"
+  ],
+  "expected_hierarchy": {},
+  "expected_edges": [
+    ["src.main", "src.models.entities.Cat.new"],
+    ["src.main", "src.models.entities.Dog.new"],
+    ["src.main", "src.models.entities.Cat.speak"],
+    ["src.main", "src.models.entities.Dog.speak"],
+    ["src.main", "src.models.base.Speaker.speak"],
+    ["src.main", "src.models.entities.Task.new"],
+    ["src.main", "src.models.entities.Task.get_label"],
+    ["src.main", "src.services.processor.summarize"],
+    ["src.main", "src.utils.helpers.add"],
+    ["src.models.base.Speaker.shout", "src.models.base.Speaker.speak"],
+    ["src.models.entities.Cat.new", "src.models.base.Entity.new"],
+    ["src.models.entities.Dog.new", "src.models.base.Entity.new"],
+    ["src.models.entities.Task.get_label", "src.utils.helpers.format_label"],
+    ["src.services.processor.summarize", "src.models.entities.Task.get_label"]
+  ],
+  "expected_package_deps": {
+    "src": {
+      "imports_contain": ["src.models", "src.services", "src.utils"],
+      "imported_by_contain": []
+    },
+    "src.models": {
+      "imports_contain": ["src.utils"],
+      "imported_by_contain": ["src", "src.services"]
+    },
+    "src.services": {
+      "imports_contain": ["src.models"],
+      "imported_by_contain": ["src"]
+    },
+    "src.utils": {
+      "imports_contain": [],
+      "imported_by_contain": ["src", "src.models"]
+    }
+  },
+  "expected_source_files": [
+    "src/main.rs",
+    "src/models/base.rs",
+    "src/models/entities.rs",
+    "src/models/mod.rs",
+    "src/services/mod.rs",
+    "src/services/processor.rs",
+    "src/utils/helpers.rs",
+    "src/utils/mod.rs"
+  ]
+}

--- a/tests/integration/fixtures/real_projects/clap_rust.json
+++ b/tests/integration/fixtures/real_projects/clap_rust.json
@@ -1,0 +1,32 @@
+{
+  "metadata": {
+    "repo_url": "https://github.com/clap-rs/clap",
+    "pinned_commit": "v4.5.20",
+    "language": "Rust",
+    "generated_at": "2026-04-11T13:45:00+00:00",
+    "codeboarding_version": "0.2.0"
+  },
+  "metrics": {
+    "references_count_by_os": {
+      "Linux": 2242,
+      "Darwin": 2242,
+      "Windows": 2242
+    },
+    "packages_count": 28,
+    "call_graph_nodes": 2930,
+    "call_graph_edges": 3407,
+    "source_files_count": 133,
+    "execution_time_seconds_by_os": {
+      "Linux": 35,
+      "Darwin": 35,
+      "Windows": 60
+    }
+  },
+  "sample_references": [
+    "clap_bench.benches.complex.Args",
+    "clap_bench.benches.complex.Args.args",
+    "clap_bench.benches.complex.Args.fmt",
+    "clap_bench.benches.complex.Args.name",
+    "clap_bench.benches.complex.COMPLEX_ARGS"
+  ]
+}

--- a/tests/integration/projects/rust_edge_cases_project/Cargo.toml
+++ b/tests/integration/projects/rust_edge_cases_project/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "rust_edge_cases"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "rust_edge_cases"
+path = "src/main.rs"

--- a/tests/integration/projects/rust_edge_cases_project/src/main.rs
+++ b/tests/integration/projects/rust_edge_cases_project/src/main.rs
@@ -1,0 +1,36 @@
+// Binary crate root. Exercises:
+//   - main.rs stem collapse (functions here should be `src.main.<name>`)
+//   - cross-module function calls (edges to models, services, utils)
+//   - trait method invocation through dyn dispatch
+
+mod models;
+mod services;
+mod utils;
+
+use models::base::{Entity, Speaker};
+use models::entities::{Cat, Dog, Task};
+use services::processor;
+use utils::helpers;
+
+fn main() {
+    let cat = Cat::new("Whiskers");
+    let dog = Dog::new("Rex");
+
+    println!("{}", cat.speak());
+    println!("{}", dog.speak());
+
+    let speakers: Vec<Box<dyn Speaker>> = vec![Box::new(cat), Box::new(dog)];
+    for s in &speakers {
+        println!("{}", s.speak());
+    }
+
+    let task = Task::new(1, "Write tests");
+    let label = task.get_label();
+    println!("{}", label);
+
+    let summary = processor::summarize(&[task]);
+    println!("count: {}", summary.count);
+
+    let r = helpers::add(2, 3);
+    println!("{}", r);
+}

--- a/tests/integration/projects/rust_edge_cases_project/src/models/base.rs
+++ b/tests/integration/projects/rust_edge_cases_project/src/models/base.rs
@@ -1,0 +1,29 @@
+// Base types for the edge-case project. Exercises:
+//   - struct + impl block
+//   - trait declaration with default method
+//   - trait implementation
+//   - associated function (Entity::new)
+
+pub struct Entity {
+    pub id: u32,
+}
+
+impl Entity {
+    pub fn new(id: u32) -> Self {
+        Entity { id }
+    }
+
+    pub fn get_id(&self) -> u32 {
+        self.id
+    }
+}
+
+pub trait Speaker {
+    fn speak(&self) -> String;
+
+    fn shout(&self) -> String {
+        // Default trait method — exercises trait dispatch on inherited impl
+        let line = self.speak();
+        line.to_uppercase()
+    }
+}

--- a/tests/integration/projects/rust_edge_cases_project/src/models/entities.rs
+++ b/tests/integration/projects/rust_edge_cases_project/src/models/entities.rs
@@ -1,0 +1,66 @@
+// Concrete domain types. Exercises:
+//   - multiple struct definitions
+//   - impl Trait for Struct
+//   - method that calls another method on the same struct
+//   - method that calls a function in a sibling module (utils::helpers::format_label)
+
+use crate::models::base::{Entity, Speaker};
+use crate::utils::helpers;
+
+pub struct Cat {
+    pub entity: Entity,
+    pub name: String,
+}
+
+impl Cat {
+    pub fn new(name: &str) -> Self {
+        Cat {
+            entity: Entity::new(1),
+            name: name.to_string(),
+        }
+    }
+}
+
+impl Speaker for Cat {
+    fn speak(&self) -> String {
+        format!("{} says meow", self.name)
+    }
+}
+
+pub struct Dog {
+    pub entity: Entity,
+    pub name: String,
+}
+
+impl Dog {
+    pub fn new(name: &str) -> Self {
+        Dog {
+            entity: Entity::new(2),
+            name: name.to_string(),
+        }
+    }
+}
+
+impl Speaker for Dog {
+    fn speak(&self) -> String {
+        format!("{} says woof", self.name)
+    }
+}
+
+pub struct Task {
+    pub id: u32,
+    pub title: String,
+}
+
+impl Task {
+    pub fn new(id: u32, title: &str) -> Self {
+        Task {
+            id,
+            title: title.to_string(),
+        }
+    }
+
+    pub fn get_label(&self) -> String {
+        helpers::format_label(self.id, &self.title)
+    }
+}

--- a/tests/integration/projects/rust_edge_cases_project/src/models/mod.rs
+++ b/tests/integration/projects/rust_edge_cases_project/src/models/mod.rs
@@ -1,0 +1,5 @@
+// mod.rs entry point — symbols defined directly here should be
+// addressable as ``src.models.<name>``, not ``src.models.mod.<name>``.
+
+pub mod base;
+pub mod entities;

--- a/tests/integration/projects/rust_edge_cases_project/src/services/mod.rs
+++ b/tests/integration/projects/rust_edge_cases_project/src/services/mod.rs
@@ -1,0 +1,1 @@
+pub mod processor;

--- a/tests/integration/projects/rust_edge_cases_project/src/services/processor.rs
+++ b/tests/integration/projects/rust_edge_cases_project/src/services/processor.rs
@@ -1,0 +1,20 @@
+// Free function + struct in a sibling module — exercises cross-module
+// references and a small "summary" data type.
+
+use crate::models::entities::Task;
+
+pub struct Summary {
+    pub count: usize,
+    pub last_label: String,
+}
+
+pub fn summarize(tasks: &[Task]) -> Summary {
+    let last_label = tasks
+        .last()
+        .map(|t| t.get_label())
+        .unwrap_or_default();
+    Summary {
+        count: tasks.len(),
+        last_label,
+    }
+}

--- a/tests/integration/projects/rust_edge_cases_project/src/utils/helpers.rs
+++ b/tests/integration/projects/rust_edge_cases_project/src/utils/helpers.rs
@@ -1,0 +1,10 @@
+// Free helper functions — exercises function-level references and a
+// dependency that other modules import (Task::get_label calls format_label).
+
+pub fn add(a: i32, b: i32) -> i32 {
+    a + b
+}
+
+pub fn format_label(id: u32, title: &str) -> String {
+    format!("[{}] {}", id, title)
+}

--- a/tests/integration/projects/rust_edge_cases_project/src/utils/mod.rs
+++ b/tests/integration/projects/rust_edge_cases_project/src/utils/mod.rs
@@ -1,0 +1,1 @@
+pub mod helpers;

--- a/tests/integration/test_lsp_analysis_for_edge_cases.py
+++ b/tests/integration/test_lsp_analysis_for_edge_cases.py
@@ -96,6 +96,12 @@ EDGE_CASE_PROJECTS = [
         language="PHP",
         fixture_file="php_edge_cases.json",
     ),
+    EdgeCaseProject(
+        name="rust_edge_cases",
+        project_dir="rust_edge_cases_project",
+        language="Rust",
+        fixture_file="rust_edge_cases.json",
+    ),
 ]
 
 
@@ -111,6 +117,7 @@ _LANGUAGE_MARKERS = {
     "TypeScript": pytest.mark.typescript_lang,
     "PHP": pytest.mark.php_lang,
     "JavaScript": pytest.mark.javascript_lang,
+    "Rust": pytest.mark.rust_lang,
 }
 
 

--- a/tests/integration/test_static_analysis_consistency.py
+++ b/tests/integration/test_static_analysis_consistency.py
@@ -30,22 +30,22 @@ import json
 import platform
 import time
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from git import Repo
-from unittest.mock import patch
 
-from static_analyzer import get_static_analysis
-from static_analyzer.analysis_result import StaticAnalysisResults
 from repo_utils import clone_repository
 from repo_utils.ignore import initialize_codeboardingignore
+from static_analyzer import get_static_analysis
+from static_analyzer.analysis_result import StaticAnalysisResults
 
 from .conftest import (
-    RepositoryTestConfig,
     REPOSITORY_CONFIGS,
+    RepositoryTestConfig,
     create_mock_scanner,
-    load_fixture,
     extract_metrics,
+    load_fixture,
 )
 
 SNAPSHOT_DIR = Path(__file__).parent / "snapshots" / "real_projects"
@@ -137,8 +137,8 @@ def _write_snapshot(static_analysis: StaticAnalysisResults, language: str, confi
     return snapshot_path
 
 
-# Tolerance percentage for metric comparisons (2% = 0.02)
-METRIC_TOLERANCE = 0.02
+# Tolerance percentage for metric comparisons (2.5% = 0.025)
+METRIC_TOLERANCE = 0.025
 
 # Minimum absolute tolerance for small numbers (e.g., 20 vs 19 is 5% diff, but only 1 unit)
 MIN_ABSOLUTE_TOLERANCE = 2

--- a/tests/integration/test_static_analysis_consistency.py
+++ b/tests/integration/test_static_analysis_consistency.py
@@ -162,6 +162,7 @@ def get_language_marker(language: str):
         "TypeScript": pytest.mark.typescript_lang,
         "PHP": pytest.mark.php_lang,
         "JavaScript": pytest.mark.javascript_lang,
+        "Rust": pytest.mark.rust_lang,
     }
     return marker_map.get(language)
 

--- a/tests/static_analyzer/test_lsp_client.py
+++ b/tests/static_analyzer/test_lsp_client.py
@@ -34,6 +34,78 @@ class TestLSPClientInit:
         client = LSPClient(["cmd"], Path("/root"), collect_diagnostics=True)
         assert client._collect_diagnostics is True
 
+    def test_extra_client_capabilities_default_empty(self):
+        client = LSPClient(["cmd"], Path("/root"))
+        assert client._extra_client_capabilities == {}
+
+    def test_extra_client_capabilities_stored(self):
+        caps = {"experimental": {"serverStatusNotification": True}}
+        client = LSPClient(["cmd"], Path("/root"), extra_client_capabilities=caps)
+        assert client._extra_client_capabilities == caps
+
+
+class TestExtraClientCapabilitiesMerge:
+    """Verify ``start()`` merges adapter-supplied capabilities into the
+    initialize request. Adapters that don't supply any keep the bare
+    base capabilities (no vendor-specific fields leak to other LSPs).
+    """
+
+    def _capture_init_request(self, extra_caps: dict | None) -> dict:
+        """Spawn an LSPClient with a fake process and capture the initialize params."""
+        client = LSPClient(["cmd"], Path("/root"), extra_client_capabilities=extra_caps)
+        captured: dict = {}
+
+        def fake_send_request(method, params, timeout=None):
+            if method == "initialize":
+                captured["params"] = params
+            return {}
+
+        # Patch _send_request and _send_notification on the instance so the
+        # real start() body runs the merge logic but doesn't actually spawn a
+        # subprocess. The reader thread is also stubbed.
+        with (
+            patch.object(client, "_send_request", side_effect=fake_send_request),
+            patch.object(client, "_send_notification"),
+            patch("subprocess.Popen") as mock_popen,
+            patch("os.dup", return_value=99),
+            patch("threading.Thread"),
+        ):
+            mock_proc = MagicMock()
+            mock_proc.stdout.fileno.return_value = 5
+            mock_popen.return_value = mock_proc
+            client.start()
+        return captured.get("params", {})
+
+    def test_no_extra_caps_produces_only_text_document(self):
+        params = self._capture_init_request(None)
+        caps = params.get("capabilities", {})
+        assert "textDocument" in caps
+        # No experimental, no window, no vendor-specific fields.
+        assert "experimental" not in caps
+
+    def test_experimental_block_is_merged_at_top_level(self):
+        params = self._capture_init_request({"experimental": {"serverStatusNotification": True}})
+        caps = params.get("capabilities", {})
+        assert caps["experimental"] == {"serverStatusNotification": True}
+        # Base text-document capabilities still present.
+        assert "documentSymbol" in caps["textDocument"]
+
+    def test_overlapping_top_level_dict_keys_are_shallow_merged(self):
+        """If an adapter adds keys under ``textDocument`` they merge with the base."""
+        params = self._capture_init_request({"textDocument": {"semanticTokens": {"requests": {"full": True}}}})
+        caps = params.get("capabilities", {})
+        # Both base and adapter keys are present.
+        assert "documentSymbol" in caps["textDocument"]
+        assert caps["textDocument"]["semanticTokens"] == {"requests": {"full": True}}
+
+    def test_adapter_value_wins_on_scalar_collision(self):
+        """A scalar override (rare) replaces the base value rather than crashing."""
+        params = self._capture_init_request({"textDocument": "broken"})
+        caps = params.get("capabilities", {})
+        # Adapter intentionally clobbered the dict — merge logic falls
+        # back to assignment when types don't match.
+        assert caps["textDocument"] == "broken"
+
 
 class TestWriteMessage:
     def test_writes_json_rpc_with_content_length(self):
@@ -478,6 +550,40 @@ class TestHandleNotification:
         client = LSPClient(["cmd"], Path("/root"))
 
         client._handle_notification("language/status", {"type": "Starting", "message": "loading..."})
+
+        assert not client._server_ready.is_set()
+
+    def test_rust_analyzer_quiescent_ok_marks_ready(self):
+        """rust-analyzer's ``experimental/serverStatus`` with ``quiescent=true`` is the ready signal."""
+        client = LSPClient(["cmd"], Path("/root"))
+        assert not client._server_ready.is_set()
+
+        client._handle_notification(
+            "experimental/serverStatus",
+            {"health": "ok", "quiescent": True},
+        )
+
+        assert client._server_ready.is_set()
+
+    def test_rust_analyzer_quiescent_warning_marks_ready(self):
+        """A ``warning`` health is still ready — it just means diagnostics found something."""
+        client = LSPClient(["cmd"], Path("/root"))
+
+        client._handle_notification(
+            "experimental/serverStatus",
+            {"health": "warning", "quiescent": True},
+        )
+
+        assert client._server_ready.is_set()
+
+    def test_rust_analyzer_non_quiescent_does_not_mark_ready(self):
+        """Status updates during indexing should not unblock waiters."""
+        client = LSPClient(["cmd"], Path("/root"))
+
+        client._handle_notification(
+            "experimental/serverStatus",
+            {"health": "ok", "quiescent": False},
+        )
 
         assert not client._server_ready.is_set()
 

--- a/tests/static_analyzer/test_rust_adapter.py
+++ b/tests/static_analyzer/test_rust_adapter.py
@@ -1,0 +1,131 @@
+"""Tests for the Rust language adapter."""
+
+from pathlib import Path
+
+from static_analyzer.engine.adapters import get_adapter
+from static_analyzer.engine.adapters.rust_adapter import RustAdapter
+
+
+class TestRustAdapterProperties:
+    """Basic adapter property tests."""
+
+    def test_language(self):
+        assert RustAdapter().language == "Rust"
+
+    def test_file_extensions(self):
+        assert RustAdapter().file_extensions == (".rs",)
+
+    def test_lsp_command(self):
+        assert RustAdapter().lsp_command == ["rust-analyzer"]
+
+    def test_language_id(self):
+        assert RustAdapter().language_id == "rust"
+
+    def test_registry_returns_rust_adapter(self):
+        """Adapter registry key 'Rust' resolves to a RustAdapter instance."""
+        adapter = get_adapter("Rust")
+        assert isinstance(adapter, RustAdapter)
+
+
+class TestBuildQualifiedName:
+    """Tests for qualified name building, especially mod.rs collapsing."""
+
+    def setup_method(self):
+        self.adapter = RustAdapter()
+        self.root = Path("/project")
+
+    def test_top_level_function(self):
+        result = self.adapter.build_qualified_name(
+            file_path=Path("/project/src/main.rs"),
+            symbol_name="main",
+            symbol_kind=12,
+            parent_chain=[],
+            project_root=self.root,
+        )
+        assert result == "src.main.main"
+
+    def test_nested_module_function(self):
+        result = self.adapter.build_qualified_name(
+            file_path=Path("/project/src/models/user.rs"),
+            symbol_name="new",
+            symbol_kind=12,
+            parent_chain=[],
+            project_root=self.root,
+        )
+        assert result == "src.models.user.new"
+
+    def test_mod_rs_collapses_into_parent(self):
+        """mod.rs is the module entry point — 'mod' should not appear in the qualified name."""
+        result = self.adapter.build_qualified_name(
+            file_path=Path("/project/src/models/mod.rs"),
+            symbol_name="ModelError",
+            symbol_kind=5,
+            parent_chain=[],
+            project_root=self.root,
+        )
+        assert result == "src.models.ModelError"
+
+    def test_method_in_impl_block(self):
+        """Methods inside impl blocks have the struct as parent."""
+        result = self.adapter.build_qualified_name(
+            file_path=Path("/project/src/models/user.rs"),
+            symbol_name="validate",
+            symbol_kind=6,
+            parent_chain=[("User", 23)],  # 23 = Struct
+            project_root=self.root,
+        )
+        assert result == "src.models.user.User.validate"
+
+    def test_method_in_mod_rs_impl_block(self):
+        """Methods in impl blocks inside mod.rs should collapse the 'mod' stem."""
+        result = self.adapter.build_qualified_name(
+            file_path=Path("/project/src/handlers/mod.rs"),
+            symbol_name="handle_request",
+            symbol_kind=6,
+            parent_chain=[("Router", 23)],
+            project_root=self.root,
+        )
+        assert result == "src.handlers.Router.handle_request"
+
+    def test_deeply_nested_module(self):
+        result = self.adapter.build_qualified_name(
+            file_path=Path("/project/src/api/v2/routes.rs"),
+            symbol_name="list_users",
+            symbol_kind=12,
+            parent_chain=[],
+            project_root=self.root,
+        )
+        assert result == "src.api.v2.routes.list_users"
+
+    def test_lib_rs_at_root(self):
+        result = self.adapter.build_qualified_name(
+            file_path=Path("/project/src/lib.rs"),
+            symbol_name="init",
+            symbol_kind=12,
+            parent_chain=[],
+            project_root=self.root,
+        )
+        assert result == "src.lib.init"
+
+    def test_mod_rs_at_project_root_falls_back_to_stem(self):
+        """A mod.rs directly in the project root is pathological but should not crash."""
+        result = self.adapter.build_qualified_name(
+            file_path=Path("/project/mod.rs"),
+            symbol_name="Setup",
+            symbol_kind=5,
+            parent_chain=[],
+            project_root=self.root,
+        )
+        assert result == "mod.Setup"
+
+
+class TestBuildReferenceKey:
+    """Reference key should preserve original casing."""
+
+    def test_preserves_snake_case(self):
+        adapter = RustAdapter()
+        assert adapter.build_reference_key("src.models.user.find_by_id") == "src.models.user.find_by_id"
+
+    def test_preserves_pascal_case(self):
+        adapter = RustAdapter()
+        assert adapter.build_reference_key("src.models.user.UserConfig") == "src.models.user.UserConfig"

--- a/tests/static_analyzer/test_rust_adapter.py
+++ b/tests/static_analyzer/test_rust_adapter.py
@@ -1,9 +1,12 @@
 """Tests for the Rust language adapter."""
 
 from pathlib import Path
+from unittest.mock import patch
+
+import pytest
 
 from static_analyzer.engine.adapters import get_adapter
-from static_analyzer.engine.adapters.rust_adapter import RustAdapter
+from static_analyzer.engine.adapters.rust_adapter import RustAdapter, _normalize_parent
 
 
 class TestRustAdapterProperties:
@@ -26,15 +29,85 @@ class TestRustAdapterProperties:
         adapter = get_adapter("Rust")
         assert isinstance(adapter, RustAdapter)
 
+    def test_wait_for_workspace_ready_is_true(self):
+        """Rust must opt into the workspace-ready wait so phase 2 references work.
+
+        Without this, ``StaticAnalyzer.start_clients`` skips the
+        ``wait_for_server_ready`` call and ``textDocument/references``
+        queries race the cargo metadata load. Regression guard.
+        """
+        assert RustAdapter().wait_for_workspace_ready is True
+
+    def test_references_per_query_timeout_is_nonzero(self):
+        """A non-zero value gates the Phase-1.5 warmup probe in CallGraphBuilder."""
+        assert RustAdapter().references_per_query_timeout > 0
+
+    def test_extra_client_capabilities_advertises_server_status(self):
+        """rust-analyzer requires this capability to send quiescent notifications.
+
+        Verified by direct probing — without ``serverStatusNotification: true``
+        in the initialize request's experimental block, rust-analyzer never
+        emits ``experimental/serverStatus`` and ``wait_for_server_ready``
+        blocks until timeout.
+        """
+        caps = RustAdapter().extra_client_capabilities
+        assert caps == {"experimental": {"serverStatusNotification": True}}
+
+
+class TestGetLspCommandCargoCheck:
+    """``get_lsp_command`` must reject hosts without a Rust toolchain.
+
+    rust-analyzer needs ``cargo metadata`` to index any Cargo workspace, so
+    a missing ``cargo`` binary produces a silently broken analysis (zero
+    references, zero edges). We surface that as a clear RuntimeError at
+    LSP-launch instead, mirroring how ``JavaAdapter`` enforces a JDK.
+    """
+
+    def test_raises_when_cargo_missing(self, tmp_path: Path) -> None:
+        with patch("static_analyzer.engine.adapters.rust_adapter.shutil.which", return_value=None):
+            with pytest.raises(RuntimeError, match=r"cargo not found.*rustup\.rs"):
+                RustAdapter().get_lsp_command(tmp_path)
+
+    def test_returns_command_when_cargo_present(self, tmp_path: Path) -> None:
+        with patch(
+            "static_analyzer.engine.adapters.rust_adapter.shutil.which",
+            return_value="/usr/local/bin/cargo",
+        ):
+            cmd = RustAdapter().get_lsp_command(tmp_path)
+        # The base resolver consults ``get_config('lsp_servers')`` first
+        # and falls back to ``self.lsp_command`` (`["rust-analyzer"]`) if
+        # the registry has no entry. Either way the command must invoke
+        # ``rust-analyzer``.
+        assert cmd
+        assert any("rust-analyzer" in part for part in cmd)
+
+
+class TestLspInitOptions:
+    """rust-analyzer initialization options."""
+
+    def test_enables_build_scripts_and_proc_macros(self):
+        options = RustAdapter().get_lsp_init_options()
+        assert options["cargo"]["buildScripts"]["enable"] is True
+        assert options["procMacro"]["enable"] is True
+
+    def test_disables_check_on_save(self):
+        # cargo check during indexing significantly slows rust-analyzer
+        # and we don't consume its diagnostics for static analysis.
+        assert RustAdapter().get_lsp_init_options()["checkOnSave"] is False
+
+    def test_enables_all_cargo_targets(self):
+        assert RustAdapter().get_lsp_init_options()["cargo"]["allTargets"] is True
+
 
 class TestBuildQualifiedName:
-    """Tests for qualified name building, especially mod.rs collapsing."""
+    """Tests for qualified name building, especially mod.rs / lib.rs / main.rs collapsing."""
 
     def setup_method(self):
         self.adapter = RustAdapter()
         self.root = Path("/project")
 
-    def test_top_level_function(self):
+    def test_top_level_function_in_main_rs_collapses(self):
+        """main.rs is the binary crate root, so its stem should not appear."""
         result = self.adapter.build_qualified_name(
             file_path=Path("/project/src/main.rs"),
             symbol_name="main",
@@ -42,7 +115,7 @@ class TestBuildQualifiedName:
             parent_chain=[],
             project_root=self.root,
         )
-        assert result == "src.main.main"
+        assert result == "src.main"
 
     def test_nested_module_function(self):
         result = self.adapter.build_qualified_name(
@@ -97,7 +170,8 @@ class TestBuildQualifiedName:
         )
         assert result == "src.api.v2.routes.list_users"
 
-    def test_lib_rs_at_root(self):
+    def test_lib_rs_collapses_as_crate_root(self):
+        """src/lib.rs is the library crate root; ``lib`` stem should be dropped."""
         result = self.adapter.build_qualified_name(
             file_path=Path("/project/src/lib.rs"),
             symbol_name="init",
@@ -105,7 +179,7 @@ class TestBuildQualifiedName:
             parent_chain=[],
             project_root=self.root,
         )
-        assert result == "src.lib.init"
+        assert result == "src.init"
 
     def test_mod_rs_at_project_root_falls_back_to_stem(self):
         """A mod.rs directly in the project root is pathological but should not crash."""
@@ -118,9 +192,128 @@ class TestBuildQualifiedName:
         )
         assert result == "mod.Setup"
 
+    def test_lib_rs_at_project_root_falls_back_to_stem(self):
+        result = self.adapter.build_qualified_name(
+            file_path=Path("/project/lib.rs"),
+            symbol_name="init",
+            symbol_kind=12,
+            parent_chain=[],
+            project_root=self.root,
+        )
+        assert result == "lib.init"
+
+    def test_main_rs_at_project_root_falls_back_to_stem(self):
+        """A bare main.rs at the project root is pathological — fall back to stem.
+
+        Symmetric with the mod.rs and lib.rs cases above; covers the
+        ``parts`` empty branch in ``build_qualified_name`` for completeness.
+        """
+        result = self.adapter.build_qualified_name(
+            file_path=Path("/project/main.rs"),
+            symbol_name="main",
+            symbol_kind=12,
+            parent_chain=[],
+            project_root=self.root,
+        )
+        assert result == "main.main"
+
+    def test_method_in_lib_rs_impl_block(self):
+        """impl blocks inside lib.rs collapse the lib stem just like mod.rs."""
+        result = self.adapter.build_qualified_name(
+            file_path=Path("/project/src/lib.rs"),
+            symbol_name="register",
+            symbol_kind=6,
+            parent_chain=[("Crate", 23)],
+            project_root=self.root,
+        )
+        assert result == "src.Crate.register"
+
+    def test_function_named_main_in_non_main_rs(self):
+        """A function literally named ``main`` in a regular module file is unambiguous.
+
+        Guards against any future refactor that strips ``main`` from symbol
+        names instead of just from file stems.
+        """
+        result = self.adapter.build_qualified_name(
+            file_path=Path("/project/src/utils.rs"),
+            symbol_name="main",
+            symbol_kind=12,
+            parent_chain=[],
+            project_root=self.root,
+        )
+        assert result == "src.utils.main"
+
+
+class TestNormalizeParent:
+    """Cleanup of rust-analyzer parent names so impl blocks contribute the type only."""
+
+    def test_inherent_impl_strips_keyword(self):
+        assert _normalize_parent("impl Entity") == "Entity"
+
+    def test_trait_impl_keeps_implementing_type(self):
+        """``impl Speaker for Cat`` is a trait impl on Cat — the type we want is Cat."""
+        assert _normalize_parent("impl Speaker for Cat") == "Cat"
+
+    def test_generic_type_params_are_stripped(self):
+        """Generic params would otherwise leak ``<T>`` into qualified names."""
+        assert _normalize_parent("impl Repository<T>") == "Repository"
+        assert _normalize_parent("impl Iterator for Vec<u8>") == "Vec"
+
+    def test_non_impl_names_pass_through(self):
+        """Module / struct parents (not impl headers) are returned unchanged."""
+        assert _normalize_parent("models") == "models"
+        assert _normalize_parent("InnerStruct") == "InnerStruct"
+
+    def test_impl_keyword_alone_returns_stripped(self):
+        """Defensive: a malformed ``impl `` with no body falls back to the stripped input."""
+        # ``"impl "`` strips to ``"impl"`` which no longer starts with ``"impl "``
+        # (note the trailing space), so the early-return path applies.
+        assert _normalize_parent("impl ") == "impl"
+
+
+class TestBuildQualifiedNameWithImplBlocks:
+    """build_qualified_name should produce clean names for symbols inside impl blocks."""
+
+    def setup_method(self):
+        self.adapter = RustAdapter()
+        self.root = Path("/project")
+
+    def test_inherent_impl_method(self):
+        """``impl Entity { fn get_id() }`` -> ``models.base.Entity.get_id``."""
+        result = self.adapter.build_qualified_name(
+            file_path=Path("/project/src/models/base.rs"),
+            symbol_name="get_id",
+            symbol_kind=6,
+            parent_chain=[("impl Entity", 5)],
+            project_root=self.root,
+        )
+        assert result == "src.models.base.Entity.get_id"
+
+    def test_trait_impl_method(self):
+        """``impl Speaker for Cat { fn speak() }`` -> ``models.entities.Cat.speak``."""
+        result = self.adapter.build_qualified_name(
+            file_path=Path("/project/src/models/entities.rs"),
+            symbol_name="speak",
+            symbol_kind=6,
+            parent_chain=[("impl Speaker for Cat", 5)],
+            project_root=self.root,
+        )
+        assert result == "src.models.entities.Cat.speak"
+
+    def test_generic_impl_method(self):
+        """Generic parameters in impl headers are stripped, keeping the bare type."""
+        result = self.adapter.build_qualified_name(
+            file_path=Path("/project/src/store.rs"),
+            symbol_name="add",
+            symbol_kind=6,
+            parent_chain=[("impl Repository<T>", 5)],
+            project_root=self.root,
+        )
+        assert result == "src.store.Repository.add"
+
 
 class TestBuildReferenceKey:
-    """Reference key should preserve original casing."""
+    """Reference key should preserve original casing (inherited from base)."""
 
     def test_preserves_snake_case(self):
         adapter = RustAdapter()

--- a/tests/static_analyzer/test_rust_adapter.py
+++ b/tests/static_analyzer/test_rust_adapter.py
@@ -31,11 +31,8 @@ class TestRustAdapterProperties:
         assert isinstance(adapter, RustAdapter)
 
     def test_wait_for_workspace_ready_is_true(self):
-        """Rust must opt into the workspace-ready wait so phase 2 references work.
-
-        Without this, ``StaticAnalyzer.start_clients`` skips the
-        ``wait_for_server_ready`` call and ``textDocument/references``
-        queries race the cargo metadata load. Regression guard.
+        """Rust opts into the workspace-ready wait so Phase 2 references queries
+        run after rust-analyzer has loaded the Cargo workspace.
         """
         assert RustAdapter().wait_for_workspace_ready is True
 
@@ -44,12 +41,8 @@ class TestRustAdapterProperties:
         assert RustAdapter().references_per_query_timeout > 0
 
     def test_extra_client_capabilities_advertises_server_status(self):
-        """rust-analyzer requires this capability to send quiescent notifications.
-
-        Verified by direct probing — without ``serverStatusNotification: true``
-        in the initialize request's experimental block, rust-analyzer never
-        emits ``experimental/serverStatus`` and ``wait_for_server_ready``
-        blocks until timeout.
+        """rust-analyzer only emits ``experimental/serverStatus`` notifications
+        when the client advertises this capability in the initialize request.
         """
         caps = RustAdapter().extra_client_capabilities
         assert caps == {"experimental": {"serverStatusNotification": True}}
@@ -286,10 +279,39 @@ class TestNormalizeParent:
         assert _normalize_parent("InnerStruct") == "InnerStruct"
 
     def test_impl_keyword_alone_returns_stripped(self):
-        """Defensive: a malformed ``impl `` with no body falls back to the stripped input."""
-        # ``"impl "`` strips to ``"impl"`` which no longer starts with ``"impl "``
-        # (note the trailing space), so the early-return path applies.
+        """A malformed ``impl `` with no body returns the stripped token."""
         assert _normalize_parent("impl ") == "impl"
+
+    def test_impl_with_inherent_generics(self):
+        """``impl<T> Foo<T>`` — impl-level generics declared before the type."""
+        assert _normalize_parent("impl<T> Repository<T>") == "Repository"
+        assert _normalize_parent("impl<T, U> Map<T, U>") == "Map"
+
+    def test_impl_with_generic_bounds(self):
+        """Trait bounds in the impl-level generics block must be skipped wholesale."""
+        assert _normalize_parent("impl<T: Clone> Vec<T>") == "Vec"
+        assert _normalize_parent("impl<T: Clone + Send> Repository<T>") == "Repository"
+
+    def test_impl_with_nested_generics_in_bounds(self):
+        """Impl-level generics may themselves contain nested generic types."""
+        assert _normalize_parent("impl<T: Iterator<Item = u8>> Foo<T>") == "Foo"
+
+    def test_generic_trait_impl(self):
+        """``impl<T> Trait for Type<T>`` — the implementing type comes after ``for``."""
+        assert _normalize_parent("impl<T> Iterator for MyIter<T>") == "MyIter"
+
+    def test_impl_with_lifetime(self):
+        """Lifetime parameters in the impl block also need to be skipped."""
+        assert _normalize_parent("impl<'a> Borrow<str> for Owned") == "Owned"
+
+    def test_impl_with_where_clause(self):
+        """``where`` clauses are stripped along with type-level generics."""
+        assert _normalize_parent("impl<T> Foo where T: Clone") == "Foo"
+        assert _normalize_parent("impl Foo where T: Clone") == "Foo"
+
+    def test_implementation_word_passes_through(self):
+        """``implementation`` is not an impl block — must not be touched."""
+        assert _normalize_parent("implementation") == "implementation"
 
 
 class TestBuildQualifiedNameWithImplBlocks:

--- a/tests/static_analyzer/test_rust_adapter.py
+++ b/tests/static_analyzer/test_rust_adapter.py
@@ -1,5 +1,6 @@
 """Tests for the Rust language adapter."""
 
+import shutil
 from pathlib import Path
 from unittest.mock import patch
 
@@ -64,20 +65,40 @@ class TestGetLspCommandCargoCheck:
     """
 
     def test_raises_when_cargo_missing(self, tmp_path: Path) -> None:
-        with patch("static_analyzer.engine.adapters.rust_adapter.shutil.which", return_value=None):
+        # Selective: only ``cargo`` is missing; other binaries pass through
+        # to the real ``shutil.which`` so the base resolver works normally.
+        real_which = shutil.which
+
+        def selective(name: str) -> str | None:
+            if name == "cargo":
+                return None
+            return real_which(name)
+
+        with patch("static_analyzer.engine.adapters.rust_adapter.shutil.which", side_effect=selective):
             with pytest.raises(RuntimeError, match=r"cargo not found.*rustup\.rs"):
                 RustAdapter().get_lsp_command(tmp_path)
 
     def test_returns_command_when_cargo_present(self, tmp_path: Path) -> None:
-        with patch(
-            "static_analyzer.engine.adapters.rust_adapter.shutil.which",
-            return_value="/usr/local/bin/cargo",
-        ):
+        # Selective patch: ``cargo`` resolves to a fake path, every other
+        # binary lookup (including the ``rust-analyzer`` lookup performed
+        # by ``resolve_config_from_path`` in the base resolver) falls
+        # through to the real ``shutil.which``. A blanket patch would be
+        # global (``shutil.which`` is a module attribute), making the
+        # resolver believe rust-analyzer also lives at the fake cargo
+        # path and producing a misleading absolute command.
+        real_which = shutil.which
+
+        def selective(name: str) -> str | None:
+            if name == "cargo":
+                return "/usr/local/bin/cargo"
+            return real_which(name)
+
+        with patch("static_analyzer.engine.adapters.rust_adapter.shutil.which", side_effect=selective):
             cmd = RustAdapter().get_lsp_command(tmp_path)
-        # The base resolver consults ``get_config('lsp_servers')`` first
-        # and falls back to ``self.lsp_command`` (`["rust-analyzer"]`) if
-        # the registry has no entry. Either way the command must invoke
-        # ``rust-analyzer``.
+        # The base resolver returns whatever ``build_config`` produces:
+        # an absolute ``rust-analyzer`` path if installed, otherwise the
+        # bare ``["rust-analyzer"]`` from ``VSCODE_CONFIG``. Both contain
+        # the substring ``rust-analyzer``.
         assert cmd
         assert any("rust-analyzer" in part for part in cmd)
 

--- a/tests/static_analyzer/test_static_analyzer_start_clients.py
+++ b/tests/static_analyzer/test_static_analyzer_start_clients.py
@@ -16,13 +16,14 @@ from static_analyzer import StaticAnalyzer
 from static_analyzer.engine.language_adapter import LanguageAdapter
 
 
-def _make_adapter(language: str) -> LanguageAdapter:
+def _make_adapter(language: str, *, wait_for_workspace_ready: bool = False) -> LanguageAdapter:
     adapter = MagicMock(name=f"{language}Adapter")
     adapter.language = language
     adapter.get_lsp_command.return_value = [f"{language.lower()}-lsp"]
     adapter.get_lsp_init_options.return_value = {}
     adapter.get_lsp_env.return_value = {}
     adapter.get_workspace_settings.return_value = {}
+    adapter.wait_for_workspace_ready = wait_for_workspace_ready
     return cast(LanguageAdapter, adapter)
 
 
@@ -96,3 +97,47 @@ class TestStartClientsGracefulDegradation:
 
         assert analyzer._clients_started is True
         assert len(analyzer._engine_clients) == 2
+
+
+class TestStartClientsWorkspaceReadyDispatch:
+    """``start_clients`` must call ``wait_for_server_ready`` exactly when the
+    adapter opts in via ``wait_for_workspace_ready``.
+
+    Replaces the previous ``adapter.language.lower() == "java"`` special case
+    with a property-based dispatch that lets rust-analyzer (and future
+    workspace-loading LSPs like csharp-ls) hook into the same wait without
+    growing a string check.
+    """
+
+    def test_adapter_opting_in_triggers_wait(self, analyzer: StaticAnalyzer, tmp_path: Path) -> None:
+        rust_adapter = _make_adapter("Rust", wait_for_workspace_ready=True)
+        analyzer._engine_configs = [(rust_adapter, tmp_path)]
+
+        client = MagicMock(name="RustClient")
+        with patch("static_analyzer.LSPClient", return_value=client):
+            analyzer.start_clients()
+
+        client.wait_for_server_ready.assert_called_once()
+
+    def test_adapter_not_opting_in_skips_wait(self, analyzer: StaticAnalyzer, tmp_path: Path) -> None:
+        py_adapter = _make_adapter("Python", wait_for_workspace_ready=False)
+        analyzer._engine_configs = [(py_adapter, tmp_path)]
+
+        client = MagicMock(name="PythonClient")
+        with patch("static_analyzer.LSPClient", return_value=client):
+            analyzer.start_clients()
+
+        client.wait_for_server_ready.assert_not_called()
+
+    def test_mixed_adapters_only_waits_on_opting_in_clients(self, analyzer: StaticAnalyzer, tmp_path: Path) -> None:
+        rust_adapter = _make_adapter("Rust", wait_for_workspace_ready=True)
+        py_adapter = _make_adapter("Python", wait_for_workspace_ready=False)
+        analyzer._engine_configs = [(py_adapter, tmp_path), (rust_adapter, tmp_path)]
+
+        py_client = MagicMock(name="PythonClient")
+        rust_client = MagicMock(name="RustClient")
+        with patch("static_analyzer.LSPClient", side_effect=[py_client, rust_client]):
+            analyzer.start_clients()
+
+        py_client.wait_for_server_ready.assert_not_called()
+        rust_client.wait_for_server_ready.assert_called_once()

--- a/tests/static_analyzer/test_static_analyzer_start_clients.py
+++ b/tests/static_analyzer/test_static_analyzer_start_clients.py
@@ -100,13 +100,8 @@ class TestStartClientsGracefulDegradation:
 
 
 class TestStartClientsWorkspaceReadyDispatch:
-    """``start_clients`` must call ``wait_for_server_ready`` exactly when the
+    """``start_clients`` calls ``wait_for_server_ready`` exactly when the
     adapter opts in via ``wait_for_workspace_ready``.
-
-    Replaces the previous ``adapter.language.lower() == "java"`` special case
-    with a property-based dispatch that lets rust-analyzer (and future
-    workspace-loading LSPs like csharp-ls) hook into the same wait without
-    growing a string check.
     """
 
     def test_adapter_opting_in_triggers_wait(self, analyzer: StaticAnalyzer, tmp_path: Path) -> None:

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -44,7 +44,7 @@ from tool_registry import (
     write_manifest,
 )
 from tool_registry.installers import _extract_compressed_binary, resolve_native_asset_name
-from tool_registry.registry import ToolDependency, ConfigSection
+from tool_registry.registry import ConfigSection, ToolDependency, ToolSource
 
 
 def _write_healthy_embedded_node(base_dir: Path, version: str = PINNED_NODE_VERSION) -> Path:
@@ -734,6 +734,74 @@ class TestEnsureNodeOnPath(unittest.TestCase):
             self.assertTrue(extra_env["PATH"].startswith(str(node_path.parent)))
 
 
+class TestIsAvailableOnHost(unittest.TestCase):
+    """``ToolDependency.is_available_on_host`` keeps the installer and
+    ``has_required_tools`` in sync so unsupported hosts (e.g. rust-analyzer
+    on Linux/riscv64) don't trigger an infinite reinstall loop.
+    """
+
+    def _native_dep(self, source: ToolSource | None) -> ToolDependency:
+        return ToolDependency(
+            key="example",
+            binary_name="example",
+            kind=ToolKind.NATIVE,
+            config_section=ConfigSection.LSP_SERVERS,
+            source=source,
+        )
+
+    def test_non_native_kinds_are_always_available(self):
+        node_dep = ToolDependency(
+            key="ts",
+            binary_name="tsserver",
+            kind=ToolKind.NODE,
+            config_section=ConfigSection.LSP_SERVERS,
+        )
+        self.assertTrue(node_dep.is_available_on_host())
+        archive_dep = ToolDependency(
+            key="java",
+            binary_name="java",
+            kind=ToolKind.ARCHIVE,
+            config_section=ConfigSection.LSP_SERVERS,
+        )
+        self.assertTrue(archive_dep.is_available_on_host())
+
+    def test_native_dep_without_arch_overrides_is_available(self):
+        """Templated-asset deps (tokei, gopls) rely on the whole-OS guard."""
+        source = GitHubToolSource(tag="v1", repo="x/y", asset_template="tokei-{platform_suffix}")
+        self.assertTrue(self._native_dep(source).is_available_on_host())
+
+    def test_arch_aware_dep_available_when_host_in_overrides(self):
+        source = GitHubToolSource(
+            tag="v1",
+            repo="x/y",
+            asset_template="ignored-{platform_suffix}",
+            asset_arch_overrides={
+                ("Linux", "x86_64"): "binary-linux-x86_64.gz",
+                ("Darwin", "arm64"): "binary-macos-arm64.gz",
+            },
+        )
+        with (
+            patch("tool_registry.registry.platform.system", return_value="Linux"),
+            patch("tool_registry.registry.platform.machine", return_value="x86_64"),
+        ):
+            self.assertTrue(self._native_dep(source).is_available_on_host())
+
+    def test_arch_aware_dep_unavailable_when_host_missing_from_overrides(self):
+        source = GitHubToolSource(
+            tag="v1",
+            repo="x/y",
+            asset_template="ignored-{platform_suffix}",
+            asset_arch_overrides={
+                ("Linux", "x86_64"): "binary-linux-x86_64.gz",
+            },
+        )
+        with (
+            patch("tool_registry.registry.platform.system", return_value="Linux"),
+            patch("tool_registry.registry.platform.machine", return_value="riscv64"),
+        ):
+            self.assertFalse(self._native_dep(source).is_available_on_host())
+
+
 class TestToolSource(unittest.TestCase):
     def test_asset_url_github_repo(self):
         source = GitHubToolSource(
@@ -971,6 +1039,39 @@ class TestHasRequiredTools(unittest.TestCase):
                         },
                     ):
                         self.assertTrue(needs_install())
+
+    def test_unavailable_native_dep_does_not_block_required_tools(self):
+        """Regression: rust-analyzer missing on Linux/riscv64 must not make
+        ``has_required_tools`` False — that would loop forever via
+        ``needs_install``.
+        """
+        with (
+            patch("tool_registry.registry.platform.system", return_value="Linux"),
+            patch("tool_registry.registry.platform.machine", return_value="riscv64"),
+        ):
+            with tempfile.TemporaryDirectory() as tmp:
+                base_dir = Path(tmp)
+                _populate_complete_servers_dir(base_dir)
+                # Delete the stubbed rust-analyzer to simulate "installer skipped".
+                rust_path = platform_bin_dir(base_dir) / f"rust-analyzer{exe_suffix()}"
+                if rust_path.exists():
+                    rust_path.unlink()
+                self.assertTrue(has_required_tools(base_dir))
+
+    def test_unavailable_native_dep_still_blocks_when_other_tools_missing(self):
+        """Sanity: the skip rule must not mask a missing tokei (always required)."""
+        with (
+            patch("tool_registry.registry.platform.system", return_value="Linux"),
+            patch("tool_registry.registry.platform.machine", return_value="riscv64"),
+        ):
+            with tempfile.TemporaryDirectory() as tmp:
+                base_dir = Path(tmp)
+                _populate_complete_servers_dir(base_dir)
+                rust_path = platform_bin_dir(base_dir) / f"rust-analyzer{exe_suffix()}"
+                if rust_path.exists():
+                    rust_path.unlink()
+                (platform_bin_dir(base_dir) / f"tokei{exe_suffix()}").unlink()
+                self.assertFalse(has_required_tools(base_dir))
 
 
 class TestResolveNativeAssetName(unittest.TestCase):

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -1,3 +1,4 @@
+import gzip
 import hashlib
 import io
 import json
@@ -7,6 +8,7 @@ import subprocess
 import tarfile
 import tempfile
 import unittest
+import zipfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -29,6 +31,7 @@ from tool_registry import (
     has_required_tools,
     initialize_nodeenv_globals,
     install_embedded_node,
+    install_native_tools,
     install_node_tools,
     needs_install,
     node_is_acceptable,
@@ -40,6 +43,8 @@ from tool_registry import (
     tools_fingerprint,
     write_manifest,
 )
+from tool_registry.installers import _extract_compressed_binary, resolve_native_asset_name
+from tool_registry.registry import ToolDependency, ConfigSection
 
 
 def _write_healthy_embedded_node(base_dir: Path, version: str = PINNED_NODE_VERSION) -> Path:
@@ -966,6 +971,336 @@ class TestHasRequiredTools(unittest.TestCase):
                         },
                     ):
                         self.assertTrue(needs_install())
+
+
+class TestResolveNativeAssetName(unittest.TestCase):
+    """Asset-name resolution for both pre-extracted and compressed sources."""
+
+    def test_templated_lookup_uses_platform_suffix(self):
+        """Sources without arch overrides format ``asset_template`` with the suffix."""
+        source = GitHubToolSource(
+            tag="v1.0",
+            repo="example/tool",
+            asset_template="example-{platform_suffix}",
+        )
+        self.assertEqual(resolve_native_asset_name(source, "linux"), "example-linux")
+        self.assertEqual(resolve_native_asset_name(source, "macos"), "example-macos")
+        self.assertEqual(resolve_native_asset_name(source, "windows.exe"), "example-windows.exe")
+
+    def test_empty_platform_suffix_returns_none(self):
+        """Unsupported host falls through cleanly so the caller can log+skip."""
+        source = GitHubToolSource(
+            tag="v1.0",
+            repo="example/tool",
+            asset_template="example-{platform_suffix}",
+        )
+        self.assertIsNone(resolve_native_asset_name(source, ""))
+
+    def test_arch_overrides_win_when_host_matches(self):
+        """``asset_arch_overrides`` is consulted before the templated path."""
+        source = GitHubToolSource(
+            tag="2026-03-30",
+            repo="rust-lang/rust-analyzer",
+            asset_template="rust-analyzer-{platform_suffix}",
+            asset_arch_overrides={
+                ("Linux", "x86_64"): "rust-analyzer-x86_64-unknown-linux-gnu.gz",
+                ("Darwin", "arm64"): "rust-analyzer-aarch64-apple-darwin.gz",
+            },
+        )
+        with (
+            patch("tool_registry.installers.platform.system", return_value="Linux"),
+            patch("tool_registry.installers.platform.machine", return_value="x86_64"),
+        ):
+            self.assertEqual(
+                resolve_native_asset_name(source, "linux"),
+                "rust-analyzer-x86_64-unknown-linux-gnu.gz",
+            )
+        with (
+            patch("tool_registry.installers.platform.system", return_value="Darwin"),
+            patch("tool_registry.installers.platform.machine", return_value="arm64"),
+        ):
+            self.assertEqual(
+                resolve_native_asset_name(source, "macos"),
+                "rust-analyzer-aarch64-apple-darwin.gz",
+            )
+
+    def test_arch_overrides_unsupported_host_returns_none(self):
+        """If ``asset_arch_overrides`` is set but this host is missing, return None.
+
+        This is intentional — falling through to the templated suffix would
+        download the wrong-arch binary instead of cleanly reporting "no
+        release for this host".
+        """
+        source = GitHubToolSource(
+            tag="2026-03-30",
+            repo="rust-lang/rust-analyzer",
+            asset_template="rust-analyzer-{platform_suffix}",
+            asset_arch_overrides={
+                ("Linux", "x86_64"): "rust-analyzer-x86_64-unknown-linux-gnu.gz",
+            },
+        )
+        with (
+            patch("tool_registry.installers.platform.system", return_value="Linux"),
+            patch("tool_registry.installers.platform.machine", return_value="riscv64"),
+        ):
+            self.assertIsNone(resolve_native_asset_name(source, "linux"))
+
+
+class TestExtractCompressedBinary(unittest.TestCase):
+    """Decompression of gzipped and zipped single-binary release assets.
+
+    Format is inferred from the archive filename suffix (``.gz`` or ``.zip``).
+    """
+
+    def test_gz_writes_decompressed_payload(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            archive = tmp_path / "tool.gz"
+            target = tmp_path / "tool"
+            payload = b"#!/bin/sh\necho rust-analyzer-mock\n" * 100
+            with gzip.open(archive, "wb") as f:
+                f.write(payload)
+
+            _extract_compressed_binary(archive, "", target)
+
+            self.assertTrue(target.exists())
+            self.assertEqual(target.read_bytes(), payload)
+
+    def test_zip_with_single_member_extracts_it(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            archive = tmp_path / "tool.zip"
+            target = tmp_path / "tool.exe"
+            payload = b"MZ\x90\x00\x03\x00\x00\x00mock-exe-bytes"
+            with zipfile.ZipFile(archive, "w") as zf:
+                zf.writestr("rust-analyzer.exe", payload)
+
+            _extract_compressed_binary(archive, "", target)
+
+            self.assertEqual(target.read_bytes(), payload)
+
+    def test_zip_picks_only_exe_member_from_mixed_archive(self):
+        """When a zip has multiple members, prefer the unique .exe candidate."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            archive = tmp_path / "tool.zip"
+            target = tmp_path / "tool.exe"
+            with zipfile.ZipFile(archive, "w") as zf:
+                zf.writestr("README.txt", b"docs")
+                zf.writestr("LICENSE", b"license")
+                zf.writestr("rust-analyzer.exe", b"binary-bytes")
+
+            _extract_compressed_binary(archive, "", target)
+
+            self.assertEqual(target.read_bytes(), b"binary-bytes")
+
+    def test_zip_with_explicit_inner_path(self):
+        """When ``archive_inner_path`` is set the named member is used verbatim."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            archive = tmp_path / "tool.zip"
+            target = tmp_path / "tool"
+            with zipfile.ZipFile(archive, "w") as zf:
+                zf.writestr("nested/dir/binary", b"payload")
+
+            _extract_compressed_binary(archive, "nested/dir/binary", target)
+
+            self.assertEqual(target.read_bytes(), b"payload")
+
+    def test_zip_with_missing_inner_path_raises(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            archive = tmp_path / "tool.zip"
+            with zipfile.ZipFile(archive, "w") as zf:
+                zf.writestr("only-member", b"")
+
+            with self.assertRaises(ValueError) as ctx:
+                _extract_compressed_binary(archive, "missing", tmp_path / "out")
+            self.assertIn("missing", str(ctx.exception))
+
+    def test_zip_ambiguous_members_raises(self):
+        """Multiple non-.exe members with no inner_path is unrecoverable."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            archive = tmp_path / "tool.zip"
+            with zipfile.ZipFile(archive, "w") as zf:
+                zf.writestr("foo", b"a")
+                zf.writestr("bar", b"b")
+
+            with self.assertRaises(ValueError):
+                _extract_compressed_binary(archive, "", tmp_path / "out")
+
+    def test_unknown_suffix_raises(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaises(ValueError):
+                _extract_compressed_binary(Path(tmp) / "x.rar", "", Path(tmp) / "out")
+
+
+class TestInstallNativeToolsCompressed(unittest.TestCase):
+    """End-to-end install path for compressed-asset native tools."""
+
+    def _make_compressed_dep(self, asset_name: str) -> ToolDependency:
+        return ToolDependency(
+            key="rust",
+            binary_name="rust-analyzer",
+            kind=ToolKind.NATIVE,
+            config_section=ConfigSection.LSP_SERVERS,
+            source=GitHubToolSource(
+                tag="2026-03-30",
+                repo="rust-lang/rust-analyzer",
+                asset_template="rust-analyzer-{platform_suffix}",
+                asset_arch_overrides={
+                    ("Linux", "x86_64"): asset_name,
+                },
+            ),
+        )
+
+    def test_gz_asset_is_decompressed_and_chmod_set(self):
+        """A gz dep gets downloaded, decompressed, and marked executable."""
+        dep = self._make_compressed_dep("rust-analyzer-x86_64-unknown-linux-gnu.gz")
+        binary_payload = b"\x7fELF" + b"fake-elf-bytes" * 200
+
+        # The fake "download" writes a gzipped payload to the destination path.
+        def fake_download(url, destination, expected_sha256=None):
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            with gzip.open(destination, "wb") as f:
+                f.write(binary_payload)
+            return True
+
+        # ``installers.platform`` and ``paths.platform`` reference the same
+        # global ``platform`` module, so a single patch on ``platform.system``
+        # affects both call sites. The two patch lines below are equivalent
+        # (both set the same attribute) — kept symmetric for readability.
+        with tempfile.TemporaryDirectory() as tmp:
+            target_dir = Path(tmp)
+            with (
+                patch("tool_registry.installers.platform.system", return_value="Linux"),
+                patch("tool_registry.installers.platform.machine", return_value="x86_64"),
+                patch("tool_registry.paths.platform.system", return_value="Linux"),
+                patch("tool_registry.installers.download_asset", side_effect=fake_download),
+            ):
+                install_native_tools(target_dir, [dep])
+
+                installed = platform_bin_dir(target_dir) / "rust-analyzer"
+                self.assertTrue(installed.exists())
+                self.assertEqual(installed.read_bytes(), binary_payload)
+                # Archive temp file must be cleaned up.
+                archive_leftover = platform_bin_dir(target_dir) / "rust-analyzer-x86_64-unknown-linux-gnu.gz"
+                self.assertFalse(archive_leftover.exists())
+                # On Unix, the binary should be executable.
+                mode = installed.stat().st_mode & 0o777
+                self.assertEqual(mode & 0o111, 0o111)
+
+    def test_zip_asset_is_extracted(self):
+        """Windows zip assets must use the zip extractor, not the gz one.
+
+        Regression: an earlier version stored a single ``archive_format``
+        flag on the source, so a rust entry declaring ``"gz"`` would try to
+        gunzip the Windows ``.zip`` asset and fail. Format is now inferred
+        from the asset filename suffix.
+        """
+        dep = ToolDependency(
+            key="rust",
+            binary_name="rust-analyzer",
+            kind=ToolKind.NATIVE,
+            config_section=ConfigSection.LSP_SERVERS,
+            source=GitHubToolSource(
+                tag="2026-03-30",
+                repo="rust-lang/rust-analyzer",
+                asset_template="rust-analyzer-{platform_suffix}",
+                asset_arch_overrides={
+                    ("Windows", "AMD64"): "rust-analyzer-x86_64-pc-windows-msvc.zip",
+                },
+            ),
+        )
+        binary_payload = b"MZ\x90\x00mock-windows-binary"
+
+        def fake_download(url, destination, expected_sha256=None):
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            with zipfile.ZipFile(destination, "w") as zf:
+                zf.writestr("rust-analyzer.exe", binary_payload)
+            return True
+
+        with tempfile.TemporaryDirectory() as tmp:
+            target_dir = Path(tmp)
+            with (
+                patch("tool_registry.installers.platform.system", return_value="Windows"),
+                patch("tool_registry.installers.platform.machine", return_value="AMD64"),
+                patch("tool_registry.paths.platform.system", return_value="Windows"),
+                patch("tool_registry.installers.download_asset", side_effect=fake_download),
+            ):
+                install_native_tools(target_dir, [dep])
+                installed = platform_bin_dir(target_dir) / "rust-analyzer.exe"
+                self.assertTrue(installed.exists())
+                self.assertEqual(installed.read_bytes(), binary_payload)
+
+    def test_unsupported_arch_skips_cleanly(self):
+        """A host with no arch override is reported and skipped, not crashed."""
+        dep = self._make_compressed_dep("rust-analyzer-x86_64-unknown-linux-gnu.gz")
+        with tempfile.TemporaryDirectory() as tmp:
+            target_dir = Path(tmp)
+            with (
+                patch("tool_registry.installers.platform.system", return_value="Linux"),
+                patch("tool_registry.installers.platform.machine", return_value="riscv64"),
+                patch("tool_registry.installers.download_asset") as mock_download,
+            ):
+                install_native_tools(target_dir, [dep])
+                mock_download.assert_not_called()
+            installed = platform_bin_dir(target_dir) / "rust-analyzer"
+            self.assertFalse(installed.exists())
+
+    def test_unsupported_platform_logs_warning_but_does_not_crash(self):
+        """An unknown ``platform.system()`` (e.g. FreeBSD) logs the top-level
+        warning before ``platform_bin_dir`` raises. Verifies one clear
+        message reaches the user instead of an opaque crash.
+        """
+        compressed_dep = self._make_compressed_dep("rust-analyzer-x86_64-unknown-linux-gnu.gz")
+        with tempfile.TemporaryDirectory() as tmp:
+            target_dir = Path(tmp)
+            with (
+                patch("tool_registry.installers.platform.system", return_value="FreeBSD"),
+                self.assertLogs("tool_registry.installers", level="WARNING") as logs,
+            ):
+                # platform_bin_dir will raise on FreeBSD because the
+                # subdir map doesn't know it. That's expected — we only
+                # care that the top-level "Unsupported platform" warning
+                # was logged before the crash.
+                with self.assertRaises(RuntimeError, msg="platform_bin_dir should reject unknown systems"):
+                    install_native_tools(target_dir, [compressed_dep])
+            warning_text = "\n".join(logs.output)
+            self.assertIn("Unsupported platform FreeBSD", warning_text)
+
+
+class TestRustRegistryEntry(unittest.TestCase):
+    """Smoke tests for the rust-analyzer entry in TOOL_REGISTRY."""
+
+    def test_rust_entry_present(self):
+        rust_deps = [d for d in TOOL_REGISTRY if d.key == "rust"]
+        self.assertEqual(len(rust_deps), 1)
+        self.assertEqual(rust_deps[0].binary_name, "rust-analyzer")
+        self.assertEqual(rust_deps[0].kind, ToolKind.NATIVE)
+
+    def test_rust_source_has_arch_overrides_for_all_three_platforms(self):
+        """Sanity: Linux, macOS, Windows are all covered (at least one arch each)."""
+        rust = next(d for d in TOOL_REGISTRY if d.key == "rust")
+        assert isinstance(rust.source, GitHubToolSource)
+        systems = {key[0] for key in rust.source.asset_arch_overrides}
+        self.assertEqual(systems, {"Linux", "Darwin", "Windows"})
+
+    def test_rust_uses_compressed_assets(self):
+        """Every override in the rust entry must end in .gz or .zip so the
+        installer's suffix-based decompression picks the right format.
+        """
+        rust = next(d for d in TOOL_REGISTRY if d.key == "rust")
+        assert isinstance(rust.source, GitHubToolSource)
+        for asset in rust.source.asset_arch_overrides.values():
+            self.assertTrue(asset.endswith(".gz") or asset.endswith(".zip"), asset)
+
+    def test_rust_fingerprint_includes_tag(self):
+        """Bumping ``RUST_ANALYZER_TAG`` must invalidate manifests."""
+        rust = next(d for d in TOOL_REGISTRY if d.key == "rust")
+        assert isinstance(rust.source, GitHubToolSource)
+        self.assertIn(rust.source.tag, tools_fingerprint())
 
 
 if __name__ == "__main__":

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -1135,6 +1135,48 @@ class TestExtractCompressedBinary(unittest.TestCase):
             with self.assertRaises(ValueError):
                 _extract_compressed_binary(Path(tmp) / "x.rar", "", Path(tmp) / "out")
 
+    def test_extraction_failure_does_not_leave_partial_binary(self):
+        """A failed extraction must NOT publish a half-written file at *target*.
+
+        Atomicity guard: write to a sibling temp file, then ``os.replace``.
+        Without this, a previous run that crashed mid-extract would leave a
+        truncated binary at *target* and the next ``has_required_tools``
+        check would treat it as installed.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            archive = tmp_path / "tool.zip"
+            target = tmp_path / "rust-analyzer"
+            # Build a zip with two ambiguous members so the extractor raises
+            # ValueError BEFORE writing anything.
+            with zipfile.ZipFile(archive, "w") as zf:
+                zf.writestr("foo", b"a")
+                zf.writestr("bar", b"b")
+
+            with self.assertRaises(ValueError):
+                _extract_compressed_binary(archive, "", target)
+
+            # Final binary path must NOT exist.
+            self.assertFalse(target.exists())
+            # Sibling temp file must NOT exist either.
+            self.assertFalse((tmp_path / "rust-analyzer.extract").exists())
+
+    def test_successful_extraction_replaces_existing_target(self):
+        """A repeat install over a stale binary should atomically swap it."""
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            archive = tmp_path / "tool.gz"
+            target = tmp_path / "rust-analyzer"
+            target.write_bytes(b"stale-bytes")
+            payload = b"fresh-binary-bytes" * 50
+            with gzip.open(archive, "wb") as f:
+                f.write(payload)
+
+            _extract_compressed_binary(archive, "", target)
+
+            self.assertEqual(target.read_bytes(), payload)
+            self.assertFalse((tmp_path / "rust-analyzer.extract").exists())
+
 
 class TestInstallNativeToolsCompressed(unittest.TestCase):
     """End-to-end install path for compressed-asset native tools."""
@@ -1190,6 +1232,94 @@ class TestInstallNativeToolsCompressed(unittest.TestCase):
                 # On Unix, the binary should be executable.
                 mode = installed.stat().st_mode & 0o777
                 self.assertEqual(mode & 0o111, 0o111)
+
+    def test_compressed_asset_honors_per_asset_sha256(self):
+        """``sha256[asset_name]`` lets a registry author pin compressed assets."""
+        binary_payload = b"#!/bin/sh\necho rust-analyzer\n" * 10
+        gz_buf = io.BytesIO()
+        with gzip.GzipFile(fileobj=gz_buf, mode="wb") as f:
+            f.write(binary_payload)
+        gz_bytes = gz_buf.getvalue()
+        gz_hash = hashlib.sha256(gz_bytes).hexdigest()
+
+        dep = ToolDependency(
+            key="rust",
+            binary_name="rust-analyzer",
+            kind=ToolKind.NATIVE,
+            config_section=ConfigSection.LSP_SERVERS,
+            source=GitHubToolSource(
+                tag="2026-03-30",
+                repo="rust-lang/rust-analyzer",
+                asset_template="rust-analyzer-{platform_suffix}",
+                sha256={"rust-analyzer-x86_64-unknown-linux-gnu.gz": gz_hash},
+                asset_arch_overrides={
+                    ("Linux", "x86_64"): "rust-analyzer-x86_64-unknown-linux-gnu.gz",
+                },
+            ),
+        )
+
+        def fake_download(url, destination, expected_sha256=None):
+            # Mirror download_asset's verification: write the bytes, then
+            # check the hash matches what the installer passed in.
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            destination.write_bytes(gz_bytes)
+            if expected_sha256 is not None:
+                actual = hashlib.sha256(destination.read_bytes()).hexdigest()
+                if actual != expected_sha256:
+                    raise ValueError(f"hash mismatch: expected={expected_sha256} got={actual}")
+            return True
+
+        with tempfile.TemporaryDirectory() as tmp:
+            target_dir = Path(tmp)
+            with (
+                patch("tool_registry.installers.platform.system", return_value="Linux"),
+                patch("tool_registry.installers.platform.machine", return_value="x86_64"),
+                patch("tool_registry.installers.download_asset", side_effect=fake_download) as mock_dl,
+            ):
+                install_native_tools(target_dir, [dep])
+            # Verify the installer asked download_asset to verify the hash.
+            call_kwargs = mock_dl.call_args.kwargs
+            self.assertEqual(call_kwargs.get("expected_sha256"), gz_hash)
+
+    def test_compressed_asset_falls_through_when_no_per_asset_pin(self):
+        """Without an exact-asset pin, compressed deps still skip verification.
+
+        The per-suffix sha256 map is meant for tools we re-publish ourselves
+        (tokei, gopls), not for upstream-managed compressed releases.
+        """
+        dep = ToolDependency(
+            key="rust",
+            binary_name="rust-analyzer",
+            kind=ToolKind.NATIVE,
+            config_section=ConfigSection.LSP_SERVERS,
+            source=GitHubToolSource(
+                tag="2026-03-30",
+                repo="rust-lang/rust-analyzer",
+                asset_template="rust-analyzer-{platform_suffix}",
+                # Note: a stale per-suffix entry must NOT be applied to the
+                # compressed asset (it would always mismatch).
+                sha256={"linux": "0" * 64},
+                asset_arch_overrides={
+                    ("Linux", "x86_64"): "rust-analyzer-x86_64-unknown-linux-gnu.gz",
+                },
+            ),
+        )
+
+        def fake_download(url, destination, expected_sha256=None):
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            with gzip.open(destination, "wb") as f:
+                f.write(b"\x7fELFmock")
+            return True
+
+        with tempfile.TemporaryDirectory() as tmp:
+            target_dir = Path(tmp)
+            with (
+                patch("tool_registry.installers.platform.system", return_value="Linux"),
+                patch("tool_registry.installers.platform.machine", return_value="x86_64"),
+                patch("tool_registry.installers.download_asset", side_effect=fake_download) as mock_dl,
+            ):
+                install_native_tools(target_dir, [dep])
+            self.assertIsNone(mock_dl.call_args.kwargs.get("expected_sha256"))
 
     def test_zip_asset_is_extracted(self):
         """Windows zip assets must use the zip extractor, not the gz one.
@@ -1249,10 +1379,12 @@ class TestInstallNativeToolsCompressed(unittest.TestCase):
             installed = platform_bin_dir(target_dir) / "rust-analyzer"
             self.assertFalse(installed.exists())
 
-    def test_unsupported_platform_logs_warning_but_does_not_crash(self):
-        """An unknown ``platform.system()`` (e.g. FreeBSD) logs the top-level
-        warning before ``platform_bin_dir`` raises. Verifies one clear
-        message reaches the user instead of an opaque crash.
+    def test_unsupported_platform_logs_warning_and_returns_cleanly(self):
+        """An unknown ``platform.system()`` (e.g. FreeBSD) is caught up front:
+        ``platform_bin_dir`` raises, the installer logs one clear warning,
+        and returns instead of propagating the RuntimeError to the caller.
+        Without this guard, a single FreeBSD user would see an opaque crash
+        in ``codeboarding-setup``.
         """
         compressed_dep = self._make_compressed_dep("rust-analyzer-x86_64-unknown-linux-gnu.gz")
         with tempfile.TemporaryDirectory() as tmp:
@@ -1261,12 +1393,9 @@ class TestInstallNativeToolsCompressed(unittest.TestCase):
                 patch("tool_registry.installers.platform.system", return_value="FreeBSD"),
                 self.assertLogs("tool_registry.installers", level="WARNING") as logs,
             ):
-                # platform_bin_dir will raise on FreeBSD because the
-                # subdir map doesn't know it. That's expected — we only
-                # care that the top-level "Unsupported platform" warning
-                # was logged before the crash.
-                with self.assertRaises(RuntimeError, msg="platform_bin_dir should reject unknown systems"):
-                    install_native_tools(target_dir, [compressed_dep])
+                # Must not raise — the RuntimeError from platform_bin_dir
+                # is caught and turned into a warning + early return.
+                install_native_tools(target_dir, [compressed_dep])
             warning_text = "\n".join(logs.output)
             self.assertIn("Unsupported platform FreeBSD", warning_text)
 

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -1237,12 +1237,9 @@ class TestExtractCompressedBinary(unittest.TestCase):
                 _extract_compressed_binary(Path(tmp) / "x.rar", "", Path(tmp) / "out")
 
     def test_extraction_failure_does_not_leave_partial_binary(self):
-        """A failed extraction must NOT publish a half-written file at *target*.
-
-        Atomicity guard: write to a sibling temp file, then ``os.replace``.
-        Without this, a previous run that crashed mid-extract would leave a
-        truncated binary at *target* and the next ``has_required_tools``
-        check would treat it as installed.
+        """A failed extraction must not publish a half-written file at *target*
+        — ``has_required_tools`` only checks existence, so a truncated binary
+        would be treated as installed.
         """
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)
@@ -1423,12 +1420,8 @@ class TestInstallNativeToolsCompressed(unittest.TestCase):
             self.assertIsNone(mock_dl.call_args.kwargs.get("expected_sha256"))
 
     def test_zip_asset_is_extracted(self):
-        """Windows zip assets must use the zip extractor, not the gz one.
-
-        Regression: an earlier version stored a single ``archive_format``
-        flag on the source, so a rust entry declaring ``"gz"`` would try to
-        gunzip the Windows ``.zip`` asset and fail. Format is now inferred
-        from the asset filename suffix.
+        """Windows ``.zip`` assets must use the zip extractor; the format is
+        inferred from the asset filename suffix per arch override.
         """
         dep = ToolDependency(
             key="rust",
@@ -1481,11 +1474,9 @@ class TestInstallNativeToolsCompressed(unittest.TestCase):
             self.assertFalse(installed.exists())
 
     def test_unsupported_platform_logs_warning_and_returns_cleanly(self):
-        """An unknown ``platform.system()`` (e.g. FreeBSD) is caught up front:
-        ``platform_bin_dir`` raises, the installer logs one clear warning,
-        and returns instead of propagating the RuntimeError to the caller.
-        Without this guard, a single FreeBSD user would see an opaque crash
-        in ``codeboarding-setup``.
+        """An unknown ``platform.system()`` (e.g. FreeBSD) makes
+        ``platform_bin_dir`` raise; the installer must catch it, log one
+        warning, and return rather than propagate the RuntimeError.
         """
         compressed_dep = self._make_compressed_dep("rust-analyzer-x86_64-unknown-linux-gnu.gz")
         with tempfile.TemporaryDirectory() as tmp:
@@ -1494,8 +1485,6 @@ class TestInstallNativeToolsCompressed(unittest.TestCase):
                 patch("tool_registry.installers.platform.system", return_value="FreeBSD"),
                 self.assertLogs("tool_registry.installers", level="WARNING") as logs,
             ):
-                # Must not raise — the RuntimeError from platform_bin_dir
-                # is caught and turned into a warning + early return.
                 install_native_tools(target_dir, [compressed_dep])
             warning_text = "\n".join(logs.output)
             self.assertIn("Unsupported platform FreeBSD", warning_text)

--- a/tool_registry/installers.py
+++ b/tool_registry/installers.py
@@ -193,6 +193,16 @@ def install_native_tools(
     for i, dep in enumerate(downloadable, 1):
         if on_progress:
             on_progress(dep.binary_name, i, len(downloadable))
+        # Mirrored by ``has_required_tools`` so an unsupported host
+        # doesn't loop forever (install skips, check fails, repeat).
+        if not dep.is_available_on_host():
+            logger.warning(
+                "  %s: no release asset for this host (%s/%s); skipping",
+                dep.binary_name,
+                system,
+                platform.machine(),
+            )
+            continue
         binary_path = bin_dir / f"{dep.binary_name}{exe_suffix()}"
         if binary_path.exists():
             logger.info("  %s: already installed, skipping", dep.binary_name)
@@ -201,12 +211,8 @@ def install_native_tools(
         assert isinstance(source, GitHubToolSource)
         asset_name = resolve_native_asset_name(source, suffix or "")
         if asset_name is None:
-            logger.warning(
-                "  %s: no release asset for this host (%s/%s); skipping",
-                dep.binary_name,
-                system,
-                platform.machine(),
-            )
+            # Defensive: should be unreachable via is_available_on_host above.
+            logger.warning("  %s: resolve_native_asset_name returned None", dep.binary_name)
             continue
         url = asset_url(source, asset_name)
         compressed = _is_compressed_asset(asset_name)

--- a/tool_registry/installers.py
+++ b/tool_registry/installers.py
@@ -85,41 +85,52 @@ def _is_compressed_asset(asset_name: str) -> bool:
 
 
 def _extract_compressed_binary(archive_path: Path, inner_path: str, target: Path) -> None:
-    """Decompress *archive_path* (format inferred from suffix) into *target*.
+    """Atomically decompress *archive_path* (format inferred from suffix) into *target*.
 
     ``.gz`` is a single gzipped binary. ``.zip`` extracts ``inner_path`` if
     set, otherwise the only ``.exe`` member or — failing that — the only
     member. Raises ``ValueError`` for unknown suffixes or ambiguous zips.
+
+    The decompressed bytes are written to a sibling ``<target>.extract``
+    temp file and then ``os.replace``-d into place so a crash mid-extract
+    cannot leave a half-written binary at *target*. The temp file is
+    cleaned up on any exception.
     """
     suffix = archive_path.suffix.lower()
-    if suffix == ".gz":
-        with gzip.open(archive_path, "rb") as src, open(target, "wb") as dst:
-            shutil.copyfileobj(src, dst)
-        return
-    if suffix == ".zip":
-        with zipfile.ZipFile(archive_path) as zf:
-            members = zf.namelist()
-            if inner_path:
-                if inner_path not in members:
-                    raise ValueError(
-                        f"{archive_path.name}: archive_inner_path {inner_path!r} not found (members: {members})"
-                    )
-                chosen = inner_path
-            else:
-                exe_members = [m for m in members if m.lower().endswith(".exe")]
-                if len(exe_members) == 1:
-                    chosen = exe_members[0]
-                elif len(members) == 1:
-                    chosen = members[0]
-                else:
-                    raise ValueError(
-                        f"{archive_path.name}: cannot pick a binary automatically "
-                        f"(set archive_inner_path; members: {members})"
-                    )
-            with zf.open(chosen) as src, open(target, "wb") as dst:
+    if suffix not in (".gz", ".zip"):
+        raise ValueError(f"Unsupported archive suffix: {suffix!r}")
+
+    temp_target = target.with_name(target.name + ".extract")
+    try:
+        if suffix == ".gz":
+            with gzip.open(archive_path, "rb") as src, open(temp_target, "wb") as dst:
                 shutil.copyfileobj(src, dst)
-        return
-    raise ValueError(f"Unsupported archive suffix: {suffix!r}")
+        else:  # ".zip"
+            with zipfile.ZipFile(archive_path) as zf:
+                members = zf.namelist()
+                if inner_path:
+                    if inner_path not in members:
+                        raise ValueError(
+                            f"{archive_path.name}: archive_inner_path {inner_path!r} not found " f"(members: {members})"
+                        )
+                    chosen = inner_path
+                else:
+                    exe_members = [m for m in members if m.lower().endswith(".exe")]
+                    if len(exe_members) == 1:
+                        chosen = exe_members[0]
+                    elif len(members) == 1:
+                        chosen = members[0]
+                    else:
+                        raise ValueError(
+                            f"{archive_path.name}: cannot pick a binary automatically "
+                            f"(set archive_inner_path; members: {members})"
+                        )
+                with zf.open(chosen) as src, open(temp_target, "wb") as dst:
+                    shutil.copyfileobj(src, dst)
+        os.replace(temp_target, target)
+    except Exception:
+        temp_target.unlink(missing_ok=True)
+        raise
 
 
 def download_asset(url: str, destination: Path, expected_sha256: str | None = None) -> bool:
@@ -158,24 +169,24 @@ def install_native_tools(
 ) -> None:
     """Download native binaries from their configured sources.
 
-    Supports both pre-extracted binaries (the default — used by tools we
-    re-publish via ``CodeBoarding/tools``) and compressed-binary assets
-    (``archive_format="gz"`` for Unix gzipped binaries; ``"zip"`` for the
-    Windows zips upstream rust-analyzer ships).
+    Supports both pre-extracted binaries (default, e.g. ``tokei``,
+    ``gopls``) and compressed-binary assets (``rust-analyzer``); the
+    archive format is inferred from the asset filename suffix.
     """
     system = platform.system()
     suffix = PLATFORM_SUFFIX.get(system)
-    if suffix is None:
-        # One clear top-level warning, then fall through: arch-aware tools
-        # (those with ``asset_arch_overrides``) may still resolve a binary;
-        # template-based tools get logged + skipped individually below.
+    try:
+        bin_dir = platform_bin_dir(target_dir)
+    except RuntimeError:
+        # ``platform_bin_dir`` raises on hosts not in ``_PLATFORM_BIN_SUBDIR``
+        # (e.g. FreeBSD). Log once and return — without a target directory
+        # we cannot install anything regardless of arch-override status.
         logger.warning(
-            "Unsupported platform %s/%s; only arch-aware tools with explicit overrides can install.",
+            "Unsupported platform %s/%s; skipping native tool installation.",
             system,
             platform.machine(),
         )
-
-    bin_dir = platform_bin_dir(target_dir)
+        return
     bin_dir.mkdir(parents=True, exist_ok=True)
 
     downloadable = [d for d in deps if isinstance(d.source, GitHubToolSource)]
@@ -199,10 +210,20 @@ def install_native_tools(
             continue
         url = asset_url(source, asset_name)
         compressed = _is_compressed_asset(asset_name)
-        # SHA256 pinning only applies to pre-extracted assets — compressed
-        # ones get republished every release and would force a six-entry
-        # update on every bump.
-        expected_hash = source.sha256.get(suffix or "") if not compressed else None
+        # Hash lookup precedence:
+        #   1. ``sha256[asset_name]`` — exact-asset pin (works for any asset
+        #      including compressed; one entry per arch override).
+        #   2. ``sha256[suffix]`` — per-platform pin used by tools we
+        #      republish ourselves (tokei, gopls); only consulted for
+        #      pre-extracted assets so a stale platform-keyed hash doesn't
+        #      get applied to a freshly compressed binary.
+        #   3. ``None`` — no pin, ``download_asset`` skips verification.
+        if asset_name in source.sha256:
+            expected_hash: str | None = source.sha256[asset_name]
+        elif not compressed:
+            expected_hash = source.sha256.get(suffix or "")
+        else:
+            expected_hash = None
         try:
             if compressed:
                 archive_path = bin_dir / asset_name

--- a/tool_registry/installers.py
+++ b/tool_registry/installers.py
@@ -3,6 +3,7 @@
 The only module in the package with filesystem side effects.
 """
 
+import gzip
 import hashlib
 import logging
 import os
@@ -10,6 +11,7 @@ import platform
 import shutil
 import subprocess
 import tarfile
+import zipfile
 from pathlib import Path
 from typing import Any
 
@@ -51,6 +53,75 @@ def asset_url(source: ToolSource, asset_name: str) -> str:
     raise TypeError(f"Unknown source type: {type(source)}")
 
 
+def resolve_native_asset_name(source: GitHubToolSource, platform_suffix: str) -> str | None:
+    """Pick the correct release asset filename for this host's (OS, arch).
+
+    Architecture-aware sources (e.g. rust-analyzer) carry an
+    ``asset_arch_overrides`` dict keyed by ``(platform.system(), platform.machine())``;
+    when the current host has an entry there it wins over the templated name.
+
+    Returns ``None`` when the host is unsupported (no override and no
+    ``platform_suffix``) so the caller can log+skip rather than crash.
+    """
+    if source.asset_arch_overrides:
+        key = (platform.system(), platform.machine())
+        override = source.asset_arch_overrides.get(key)
+        if override:
+            return override
+        # Architecture-aware tool but this host's (system, machine) isn't
+        # listed — return None and let install_native_tools log a clear
+        # "unsupported architecture" warning instead of falling through to
+        # the templated name and downloading the wrong binary.
+        return None
+    if not platform_suffix:
+        return None
+    return source.asset_template.format(platform_suffix=platform_suffix)
+
+
+def _is_compressed_asset(asset_name: str) -> bool:
+    """True if the asset filename indicates it needs decompression."""
+    lower = asset_name.lower()
+    return lower.endswith(".gz") or lower.endswith(".zip")
+
+
+def _extract_compressed_binary(archive_path: Path, inner_path: str, target: Path) -> None:
+    """Decompress *archive_path* (format inferred from suffix) into *target*.
+
+    ``.gz`` is a single gzipped binary. ``.zip`` extracts ``inner_path`` if
+    set, otherwise the only ``.exe`` member or — failing that — the only
+    member. Raises ``ValueError`` for unknown suffixes or ambiguous zips.
+    """
+    suffix = archive_path.suffix.lower()
+    if suffix == ".gz":
+        with gzip.open(archive_path, "rb") as src, open(target, "wb") as dst:
+            shutil.copyfileobj(src, dst)
+        return
+    if suffix == ".zip":
+        with zipfile.ZipFile(archive_path) as zf:
+            members = zf.namelist()
+            if inner_path:
+                if inner_path not in members:
+                    raise ValueError(
+                        f"{archive_path.name}: archive_inner_path {inner_path!r} not found (members: {members})"
+                    )
+                chosen = inner_path
+            else:
+                exe_members = [m for m in members if m.lower().endswith(".exe")]
+                if len(exe_members) == 1:
+                    chosen = exe_members[0]
+                elif len(members) == 1:
+                    chosen = members[0]
+                else:
+                    raise ValueError(
+                        f"{archive_path.name}: cannot pick a binary automatically "
+                        f"(set archive_inner_path; members: {members})"
+                    )
+            with zf.open(chosen) as src, open(target, "wb") as dst:
+                shutil.copyfileobj(src, dst)
+        return
+    raise ValueError(f"Unsupported archive suffix: {suffix!r}")
+
+
 def download_asset(url: str, destination: Path, expected_sha256: str | None = None) -> bool:
     """Download *url* to *destination* via temp-file + rename. Verifies SHA256 if provided."""
     destination.parent.mkdir(parents=True, exist_ok=True)
@@ -85,12 +156,24 @@ def install_native_tools(
     deps: list[ToolDependency],
     on_progress: ProgressCallback | None = None,
 ) -> None:
-    """Download native binaries from their configured sources."""
+    """Download native binaries from their configured sources.
+
+    Supports both pre-extracted binaries (the default — used by tools we
+    re-publish via ``CodeBoarding/tools``) and compressed-binary assets
+    (``archive_format="gz"`` for Unix gzipped binaries; ``"zip"`` for the
+    Windows zips upstream rust-analyzer ships).
+    """
     system = platform.system()
     suffix = PLATFORM_SUFFIX.get(system)
     if suffix is None:
-        logger.error("Unsupported platform: %s", system)
-        return
+        # One clear top-level warning, then fall through: arch-aware tools
+        # (those with ``asset_arch_overrides``) may still resolve a binary;
+        # template-based tools get logged + skipped individually below.
+        logger.warning(
+            "Unsupported platform %s/%s; only arch-aware tools with explicit overrides can install.",
+            system,
+            platform.machine(),
+        )
 
     bin_dir = platform_bin_dir(target_dir)
     bin_dir.mkdir(parents=True, exist_ok=True)
@@ -105,17 +188,40 @@ def install_native_tools(
             continue
         source = dep.source
         assert isinstance(source, GitHubToolSource)
-        asset_name = source.asset_template.format(platform_suffix=suffix)
+        asset_name = resolve_native_asset_name(source, suffix or "")
+        if asset_name is None:
+            logger.warning(
+                "  %s: no release asset for this host (%s/%s); skipping",
+                dep.binary_name,
+                system,
+                platform.machine(),
+            )
+            continue
         url = asset_url(source, asset_name)
-        expected_hash = source.sha256.get(suffix)
+        compressed = _is_compressed_asset(asset_name)
+        # SHA256 pinning only applies to pre-extracted assets — compressed
+        # ones get republished every release and would force a six-entry
+        # update on every bump.
+        expected_hash = source.sha256.get(suffix or "") if not compressed else None
         try:
-            if download_asset(url, binary_path, expected_sha256=expected_hash):
-                if system != "Windows":
-                    os.chmod(binary_path, 0o755)
-                logger.info("  %s: downloaded successfully", dep.binary_name)
+            if compressed:
+                archive_path = bin_dir / asset_name
+                if not download_asset(url, archive_path, expected_sha256=expected_hash):
+                    logger.warning("  %s: download failed (empty file)", dep.binary_name)
+                    archive_path.unlink(missing_ok=True)
+                    continue
+                try:
+                    _extract_compressed_binary(archive_path, source.archive_inner_path, binary_path)
+                finally:
+                    archive_path.unlink(missing_ok=True)
             else:
-                logger.warning("  %s: download failed (empty file)", dep.binary_name)
-                binary_path.unlink(missing_ok=True)
+                if not download_asset(url, binary_path, expected_sha256=expected_hash):
+                    logger.warning("  %s: download failed (empty file)", dep.binary_name)
+                    binary_path.unlink(missing_ok=True)
+                    continue
+            if system != "Windows":
+                os.chmod(binary_path, 0o755)
+            logger.info("  %s: downloaded successfully", dep.binary_name)
         except Exception:
             logger.exception("  %s: download failed", dep.binary_name)
             binary_path.unlink(missing_ok=True)

--- a/tool_registry/manifest.py
+++ b/tool_registry/manifest.py
@@ -261,6 +261,11 @@ def has_required_tools(base_dir: Path) -> bool:
 
     for dep in TOOL_REGISTRY:
         if dep.kind is ToolKind.NATIVE:
+            # Skip the check when the installer would also skip the download,
+            # otherwise ``needs_install`` loops forever on unsupported hosts.
+            if not dep.is_available_on_host():
+                logger.info("has_required_tools: %s unavailable on this host; skipping check", dep.key)
+                continue
             binary_path = platform_bin_dir(base_dir) / f"{dep.binary_name}{exe_suffix()}"
             if not binary_path.exists():
                 logger.info("has_required_tools: %s missing at %s", dep.key, binary_path)

--- a/tool_registry/registry.py
+++ b/tool_registry/registry.py
@@ -6,7 +6,7 @@ Adding a new tool:
        ``ToolKind.NATIVE`` and a ``GitHubToolSource`` with ``asset_template``.
        For native binaries shipped as compressed assets (gzipped on Unix or
        zipped on Windows — e.g. upstream rust-analyzer), additionally set
-       ``archive_format`` and, for arch-specific tools, ``asset_arch_overrides``.
+       ``asset_arch_overrides`` (format is inferred from the asset filename suffix).
     2. Add the entry to ``VSCODE_CONFIG`` in ``vscode_constants.py``.
     3. Add to the ``Language`` enum in ``static_analyzer/constants.py``.
 """

--- a/tool_registry/registry.py
+++ b/tool_registry/registry.py
@@ -11,6 +11,7 @@ Adding a new tool:
     3. Add to the ``Language`` enum in ``static_analyzer/constants.py``.
 """
 
+import platform
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import StrEnum
@@ -120,6 +121,20 @@ class ToolDependency:
     archive_subdir: str = ""
     js_entry_file: str = ""
     js_entry_parent: str = ""
+
+    def is_available_on_host(self) -> bool:
+        """True unless this is an arch-aware NATIVE dep whose override map
+        excludes the running ``(system, machine)`` (e.g. rust-analyzer on
+        Linux/riscv64). Consulted by both the installer and
+        ``has_required_tools`` to keep them in sync.
+        """
+        if self.kind is not ToolKind.NATIVE:
+            return True
+        if not isinstance(self.source, GitHubToolSource):
+            return True
+        if not self.source.asset_arch_overrides:
+            return True
+        return (platform.system(), platform.machine()) in self.source.asset_arch_overrides
 
 
 TOOL_REGISTRY: list[ToolDependency] = [

--- a/tool_registry/registry.py
+++ b/tool_registry/registry.py
@@ -2,6 +2,11 @@
 
 Adding a new tool:
     1. Add a ``ToolDependency`` entry to ``TOOL_REGISTRY`` below.
+       For native binaries hosted as a single pre-extracted file, set
+       ``ToolKind.NATIVE`` and a ``GitHubToolSource`` with ``asset_template``.
+       For native binaries shipped as compressed assets (gzipped on Unix or
+       zipped on Windows — e.g. upstream rust-analyzer), additionally set
+       ``archive_format`` and, for arch-specific tools, ``asset_arch_overrides``.
     2. Add the entry to ``VSCODE_CONFIG`` in ``vscode_constants.py``.
     3. Add to the ``Language`` enum in ``static_analyzer/constants.py``.
 """
@@ -25,6 +30,12 @@ JDTLS_BUILD = "202501221502"
 JDTLS_URL_TEMPLATE = (
     "https://download.eclipse.org/jdtls/milestones/{version}/jdt-language-server-{version}-{build}.tar.gz"
 )
+
+# rust-analyzer is pulled directly from upstream (weekly releases, ~17MB
+# per platform) rather than mirrored. Bumping the tag triggers a reinstall
+# via ``tools_fingerprint()``.
+RUST_ANALYZER_REPO = "rust-lang/rust-analyzer"
+RUST_ANALYZER_TAG = "2026-03-30"
 
 # Pinned Node.js runtime for users without system Node; downloaded to
 # <servers_dir>/nodeenv/ via install_embedded_node(). A bump is folded into
@@ -65,11 +76,27 @@ class ToolSource:
 
 @dataclass(frozen=True)
 class GitHubToolSource(ToolSource):
-    """Tool binary hosted on a GitHub release built by our pipeline."""
+    """Tool binary hosted on a GitHub release.
+
+    Distribution patterns:
+
+    * **Pre-extracted binary** (default, e.g. ``tokei``, ``gopls``): asset
+      downloaded directly to ``bin/<platform>/<binary_name><exe>``.
+    * **Compressed binary** (e.g. ``rust-analyzer``): the installer infers
+      the format from the asset filename suffix (``.gz`` or ``.zip``) and
+      decompresses after download. ``archive_inner_path`` picks a specific
+      member out of a zip; single-member zips can omit it.
+    * **Architecture-aware**: provide ``asset_arch_overrides`` keyed by
+      ``(platform.system(), platform.machine())`` for tools shipping
+      distinct binaries per CPU; the override wins over the
+      ``asset_template`` + ``PLATFORM_SUFFIX`` lookup.
+    """
 
     repo: str = ""
     asset_template: str = ""  # ``{platform_suffix}`` placeholder
     sha256: dict[str, str] = field(default_factory=dict)  # keyed by platform suffix
+    archive_inner_path: str = ""  # path to the binary inside a zip; default = single member
+    asset_arch_overrides: dict[tuple[str, str], str] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -166,5 +193,26 @@ TOOL_REGISTRY: list[ToolDependency] = [
             build=JDTLS_BUILD,
         ),
         archive_subdir="jdtls",
+    ),
+    ToolDependency(
+        key="rust",
+        binary_name="rust-analyzer",
+        kind=ToolKind.NATIVE,
+        config_section=ConfigSection.LSP_SERVERS,
+        source=GitHubToolSource(
+            tag=RUST_ANALYZER_TAG,
+            repo=RUST_ANALYZER_REPO,
+            # ``asset_template`` is unused for arch-aware tools but kept
+            # non-empty so ``tools_fingerprint()`` formatting stays stable.
+            asset_template="rust-analyzer-{platform_suffix}",
+            asset_arch_overrides={
+                ("Linux", "x86_64"): "rust-analyzer-x86_64-unknown-linux-gnu.gz",
+                ("Linux", "aarch64"): "rust-analyzer-aarch64-unknown-linux-gnu.gz",
+                ("Darwin", "x86_64"): "rust-analyzer-x86_64-apple-darwin.gz",
+                ("Darwin", "arm64"): "rust-analyzer-aarch64-apple-darwin.gz",
+                ("Windows", "AMD64"): "rust-analyzer-x86_64-pc-windows-msvc.zip",
+                ("Windows", "ARM64"): "rust-analyzer-aarch64-pc-windows-msvc.zip",
+            },
+        ),
     ),
 ]

--- a/vscode_constants.py
+++ b/vscode_constants.py
@@ -111,6 +111,13 @@ VSCODE_CONFIG = {
             "file_extensions": [".java"],
             "install_commands": "null",
         },
+        "rust": {
+            "name": "rust-analyzer",
+            "command": ["rust-analyzer"],
+            "languages": ["rust"],
+            "file_extensions": [".rs"],
+            "install_commands": "rustup component add rust-analyzer",
+        },
     },
     "tools": {
         "tokei": {

--- a/vscode_constants.py
+++ b/vscode_constants.py
@@ -116,7 +116,10 @@ VSCODE_CONFIG = {
             "command": ["rust-analyzer"],
             "languages": ["rust"],
             "file_extensions": [".rs"],
-            "install_commands": "rustup component add rust-analyzer",
+            # rust-analyzer is downloaded from rust-lang/rust-analyzer releases
+            # by tool_registry; the install_commands string is informational only
+            # and surfaces in error messages when the binary cannot be located.
+            "install_commands": "codeboarding-setup (downloads rust-analyzer automatically)",
         },
     },
     "tools": {


### PR DESCRIPTION
## Summary
- Adds `RustAdapter` extending `LanguageAdapter` with `mod.rs` collapsing in qualified names
- Registers rust-analyzer as a `ToolKind.NATIVE` binary in `TOOL_REGISTRY`
- Adds VSCode config, `Language.RUST` enum, adapter registry entry, and language mapping
- 15 tests at 100% coverage on new code

## Changes
| File | Change |
|------|--------|
| `static_analyzer/engine/adapters/rust_adapter.py` | New `RustAdapter` class |
| `static_analyzer/engine/adapters/__init__.py` | Import + registry entry |
| `static_analyzer/constants.py` | `Language.RUST` + delimiter map |
| `static_analyzer/__init__.py` | Language mapping |
| `vscode_constants.py` | LSP server config |
| `tool_registry.py` | `ToolDependency` for rust-analyzer |
| `tests/static_analyzer/test_rust_adapter.py` | 15 tests |

## Test plan
- [x] `uv run pytest tests/static_analyzer/test_rust_adapter.py -v` — 15/15 pass
- [x] `uv run pytest --ignore=tests/integration` — 1158 passed, 25 skipped
- [x] `uv run mypy` — no issues
- [x] `uv run black --check` — all clean
- [x] `rust_adapter.py` coverage: 100%
- [ ] Integration test with a real Rust repo + rust-analyzer installed

Closes #275

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Rust project analysis with rust-analyzer support and automatic rust-analyzer install entry.

* **Improvements**
  * LSP clients can advertise extra capabilities and clients may wait for workspace readiness before queries.
  * Qualified-name delimiter standardized across languages; Rust build outputs (target/) ignored by default.
  * Native tool installer now robustly handles compressed archives (.gz, .zip) and platform-specific assets.

* **Tests**
  * Expanded unit and integration tests, fixtures, CI matrix, and added a Rust pytest marker.

* **Chores**
  * Updated contributor guide and README to include Rust.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/codeboarding/codeboarding/pull/276" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
