### PR TITLE
Update stale Anthropic model ID and skip 404 retry

### DIFF
--- a/agents/agent.py
+++ b/agents/agent.py
@@ -160,6 +160,11 @@ class CodeBoardingAgent(ReferenceResolverMixin, MonitoringMixin):
                     raise
 
             except Exception as e:
+                # HTTP 404 (e.g. retired model ID) is permanent — retrying won't help.
+                if getattr(e, "status_code", None) == 404:
+                    logger.error(f"Permanent HTTP 404 — not retrying: {type(e).__name__}: {e}")
+                    raise
+
                 # Other errors (network, parsing, etc.) get standard exponential backoff
                 if attempt < max_retries - 1:
                     delay = min(10 * (2**attempt), 120)

--- a/agents/llm_config.py
+++ b/agents/llm_config.py
@@ -136,7 +136,7 @@ LLM_PROVIDERS = {
     "anthropic": LLMConfig(
         chat_class=ChatAnthropic,
         api_key_env="ANTHROPIC_API_KEY",
-        agent_model="claude-3-7-sonnet-20250219",
+        agent_model="claude-sonnet-4-5-20250929",
         parsing_model="claude-3-haiku-20240307",
         llm_type=LLMType.CLAUDE,
         extra_args={
@@ -160,7 +160,7 @@ LLM_PROVIDERS = {
     "aws": LLMConfig(
         chat_class=ChatBedrockConverse,
         api_key_env="AWS_BEARER_TOKEN_BEDROCK",  # Used for existence check
-        agent_model="us.anthropic.claude-3-7-sonnet-20250219-v1:0",
+        agent_model="us.anthropic.claude-sonnet-4-5-20250929-v1:0",
         parsing_model="us.anthropic.claude-3-haiku-20240307-v1:0",
         llm_type=LLMType.CLAUDE,
         extra_args={

--- a/tests/agents/test_agent.py
+++ b/tests/agents/test_agent.py
@@ -367,6 +367,34 @@ class TestCodeBoardingAgent(unittest.TestCase):
         self.assertIsNotNone(agent.external_deps_tool)
 
     @patch("agents.agent.create_agent")
+    @patch("time.sleep")
+    def test_invoke_raises_immediately_on_404(self, mock_sleep, mock_create_agent):
+        """HTTP 404 (e.g. retired model) should raise immediately without retrying."""
+        mock_agent_executor = Mock()
+        mock_create_agent.return_value = mock_agent_executor
+
+        # Simulate a NotFoundError-like exception with status_code=404
+        error = Exception("model not found")
+        error.status_code = 404  # type: ignore[attr-defined]
+        mock_agent_executor.invoke.side_effect = error
+
+        mock_parsing_llm = Mock(spec=BaseChatModel)
+        agent = CodeBoardingAgent(
+            repo_dir=self.repo_dir,
+            static_analysis=self.mock_analysis,
+            system_message="Test",
+            agent_llm=self.mock_llm,
+            parsing_llm=mock_parsing_llm,
+        )
+
+        with self.assertRaises(Exception, msg="model not found"):
+            agent._invoke("Test prompt")
+
+        # Should NOT have retried — only one call
+        self.assertEqual(mock_agent_executor.invoke.call_count, 1)
+        mock_sleep.assert_not_called()
+
+    @patch("agents.agent.create_agent")
     def test_agent_created_with_tools(self, mock_create_agent):
         # Test that agent is created with correct tools
         mock_create_agent.return_value = Mock()

--- a/tests/agents/test_llm_config.py
+++ b/tests/agents/test_llm_config.py
@@ -59,12 +59,14 @@ class TestDetectLLMTypeFromModel:
             "claude-3-sonnet-20240229",
             "claude-3-haiku-20240307",
             "claude-3-7-sonnet-20250219",
+            "claude-sonnet-4-5-20250929",
             "claude-3.5-sonnet-20241022",
             "claude-2.1",
             "claude-instant-1.2",
             "CLAUDE-3-OPUS",  # Uppercase
             "anthropic.claude-3-sonnet-20240229-v1:0",  # Bedrock format
-            "us.anthropic.claude-3-7-sonnet-20250219-v1:0",  # Bedrock with region
+            "us.anthropic.claude-3-7-sonnet-20250219-v1:0",  # Bedrock with region (retired)
+            "us.anthropic.claude-sonnet-4-5-20250929-v1:0",  # Bedrock with region (current)
             "opus",  # Just model family name
             "sonnet",  # Just model family name
             "haiku",  # Just model family name
@@ -127,7 +129,7 @@ class TestDetectLLMTypeFromModel:
         """
         # Vercel can proxy any model, detection should work based on model name
         assert LLMType.from_model_name("gpt-4o") == LLMType.GPT4
-        assert LLMType.from_model_name("claude-3-7-sonnet-20250219") == LLMType.CLAUDE
+        assert LLMType.from_model_name("claude-sonnet-4-5-20250929") == LLMType.CLAUDE
         assert LLMType.from_model_name("gemini-2.5-flash") == LLMType.GEMINI_FLASH
 
     # Future-proofing


### PR DESCRIPTION
claude-3-7-sonnet-20250219 has been retired; update to claude-sonnet-4-5-20250929. Exclude NotFoundError (HTTP 404) from agent retry loop since retired models won't come back.

Closes #278

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * HTTP 404 errors are now treated as permanent failures and handled immediately without automatic retry logic, improving response times for missing resources.

* **Chores**
  * Updated default AI model versions from Claude 3.7 Sonnet to Claude Sonnet 4.5 across both direct and cloud-based provider configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/codeboarding/codeboarding/pull/279" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
