### PR TITLE
Update the dependency configuration setup and add pipeline for external tools

### DIFF
--- a/.github/workflows/build-tools.yml
+++ b/.github/workflows/build-tools.yml
@@ -1,0 +1,120 @@
+name: Build Tool Binaries
+
+on:
+  workflow_dispatch:
+    inputs:
+      tokei_version:
+        description: "Tokei git tag (e.g. v14.0.0)"
+        required: true
+      gopls_version:
+        description: "Gopls version (e.g. v0.21.1)"
+        required: true
+      tools_tag:
+        description: "Release tag for CodeBoarding/tools (e.g. tools-2026.04.05)"
+        required: true
+      dry_run:
+        description: "Build without publishing"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  build-tokei:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            platform_suffix: linux
+            binary_name: tokei
+          - os: macos-latest
+            platform_suffix: macos
+            binary_name: tokei
+          - os: windows-latest
+            platform_suffix: windows.exe
+            binary_name: tokei.exe
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout tokei
+        uses: actions/checkout@v4
+        with:
+          repository: XAMPPRocky/tokei
+          ref: ${{ inputs.tokei_version }}
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build tokei
+        run: cargo build --release
+
+      - name: Rename binary
+        shell: bash
+        run: cp target/release/${{ matrix.binary_name }} tokei-${{ matrix.platform_suffix }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: tokei-${{ matrix.platform_suffix }}
+          path: tokei-${{ matrix.platform_suffix }}
+
+  build-gopls:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            platform_suffix: linux
+            binary_name: gopls
+          - os: macos-latest
+            platform_suffix: macos
+            binary_name: gopls
+          - os: windows-latest
+            platform_suffix: windows.exe
+            binary_name: gopls.exe
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "stable"
+
+      - name: Build gopls
+        run: go install golang.org/x/tools/gopls@${{ inputs.gopls_version }}
+
+      - name: Rename binary
+        shell: bash
+        run: cp "$(go env GOPATH)/bin/${{ matrix.binary_name }}" gopls-${{ matrix.platform_suffix }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: gopls-${{ matrix.platform_suffix }}
+          path: gopls-${{ matrix.platform_suffix }}
+
+  publish-release:
+    needs: [build-tokei, build-gopls]
+    if: ${{ inputs.dry_run != true }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Generate checksums
+        working-directory: artifacts
+        run: sha256sum tokei-* gopls-* > checksums.sha256
+
+      - name: Display checksums
+        run: cat artifacts/checksums.sha256
+
+      - name: Create release on CodeBoarding/tools
+        env:
+          GH_TOKEN: ${{ secrets.TOOLS_REPO_TOKEN }}
+        run: |
+          gh release create "${{ inputs.tools_tag }}" \
+            --repo CodeBoarding/tools \
+            --title "Tools ${{ inputs.tools_tag }}" \
+            --notes "Built from tokei ${{ inputs.tokei_version }}, gopls ${{ inputs.gopls_version }}" \
+            artifacts/*

--- a/.github/workflows/build-tools.yml
+++ b/.github/workflows/build-tools.yml
@@ -2,20 +2,11 @@ name: Build Tool Binaries
 
 on:
   workflow_dispatch:
-    inputs:
-      tokei_version:
-        description: "Tokei git tag (e.g. v14.0.0)"
-        required: true
-      gopls_version:
-        description: "Gopls version (e.g. v0.21.1)"
-        required: true
-      tools_tag:
-        description: "Release tag for CodeBoarding/tools (e.g. tools-2026.04.05)"
-        required: true
-      dry_run:
-        description: "Build without publishing"
-        type: boolean
-        default: false
+
+env:
+  TOKEI_VERSION: "v14.0.0"
+  GOPLS_VERSION: "v0.21.1"
+  TOOLS_TAG: "tools-2026.04.05"
 
 permissions:
   contents: read
@@ -40,7 +31,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: XAMPPRocky/tokei
-          ref: ${{ inputs.tokei_version }}
+          ref: ${{ env.TOKEI_VERSION }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -79,7 +70,8 @@ jobs:
           go-version: "stable"
 
       - name: Build gopls
-        run: go install golang.org/x/tools/gopls@${{ inputs.gopls_version }}
+        shell: bash
+        run: go install "golang.org/x/tools/gopls@${GOPLS_VERSION}"
 
       - name: Rename binary
         shell: bash
@@ -93,7 +85,6 @@ jobs:
 
   publish-release:
     needs: [build-tokei, build-gopls]
-    if: ${{ inputs.dry_run != true }}
     runs-on: ubuntu-latest
     steps:
       - name: Download all artifacts
@@ -113,8 +104,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.TOOLS_REPO_TOKEN }}
         run: |
-          gh release create "${{ inputs.tools_tag }}" \
+          gh release create "$TOOLS_TAG" \
             --repo CodeBoarding/tools \
-            --title "Tools ${{ inputs.tools_tag }}" \
-            --notes "Built from tokei ${{ inputs.tokei_version }}, gopls ${{ inputs.gopls_version }}" \
+            --title "Tools $TOOLS_TAG" \
+            --notes "Built from tokei $TOKEI_VERSION, gopls $GOPLS_VERSION" \
             artifacts/*

--- a/install.py
+++ b/install.py
@@ -11,13 +11,11 @@ from enum import StrEnum
 from pathlib import Path
 
 import requests
-
 from tool_registry import (
     TOOL_REGISTRY,
     ProgressCallback,
     ToolKind,
     _acquire_lock,
-    _write_manifest,
     get_servers_dir,
     install_archive_tool,
     install_native_tools,
@@ -27,6 +25,7 @@ from tool_registry import (
     platform_bin_dir,
     preferred_node_path,
     preferred_npm_command,
+    write_manifest,
 )
 from user_config import ensure_config_template
 
@@ -562,7 +561,7 @@ def ensure_tools(
             auto_install_vcpp=auto_install_vcpp,
             on_progress=on_progress,
         )
-        _write_manifest()
+        write_manifest()
 
 
 def run_install(
@@ -585,7 +584,7 @@ def run_install(
     ensure_config_template()
 
     # Compute a unified total so the caller sees a single progress stream.
-    native_count = sum(1 for d in TOOL_REGISTRY if d.kind is ToolKind.NATIVE and d.github_asset_template)
+    native_count = sum(1 for d in TOOL_REGISTRY if d.kind is ToolKind.NATIVE and d.source)
     node_deps = [d for d in TOOL_REGISTRY if d.kind is ToolKind.NODE]
     archive_count = sum(1 for d in TOOL_REGISTRY if d.kind is ToolKind.ARCHIVE)
     npm_available = resolve_npm_availability(auto_install_npm=auto_install_npm, target_dir=target)
@@ -623,7 +622,7 @@ def main() -> None:
 
     run_install(auto_install_npm=args.auto_install_npm, auto_install_vcpp=args.auto_install_vcpp)
 
-    _write_manifest()
+    write_manifest()
 
     print("\n" + "=" * 40)
     print("Setup complete!")

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -14,6 +14,7 @@ from tool_registry import (
     ToolKind,
     UpstreamToolSource,
     _asset_url,
+    _npm_specs_fingerprint,
     _tools_fingerprint,
     download_asset,
     install_node_tools,
@@ -193,7 +194,7 @@ class TestManifest(unittest.TestCase):
     def test_needs_install_triggers_on_tools_change(self, mock_version, mock_manifest, mock_tools):
         mock_manifest.return_value = {
             "version": "1.0.0",
-            "npm_specs": "",
+            "npm_specs": _npm_specs_fingerprint(),
             "tools": "old-fingerprint",
         }
         self.assertTrue(needs_install())

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -1,10 +1,26 @@
+import hashlib
+import json
 import os
 import tempfile
 import unittest
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
-from tool_registry import TOOL_REGISTRY, ToolKind, install_node_tools, resolve_config
+from tool_registry import (
+    TOOL_REGISTRY,
+    TOOLS_REPO,
+    TOOLS_TAG,
+    GitHubToolSource,
+    ToolKind,
+    UpstreamToolSource,
+    _asset_url,
+    _tools_fingerprint,
+    download_asset,
+    install_node_tools,
+    needs_install,
+    resolve_config,
+    write_manifest,
+)
 
 
 class TestToolRegistry(unittest.TestCase):
@@ -88,6 +104,110 @@ class TestToolRegistry(unittest.TestCase):
             first_command = mock_run.call_args_list[0].args[0]
             self.assertEqual(first_command[0], "/vscode/node")
             self.assertEqual(first_command[1], str(npm_cli))
+
+
+class TestToolSource(unittest.TestCase):
+    def test_asset_url_github_repo(self):
+        source = GitHubToolSource(
+            tag="tools-2026.01.01", repo="CodeBoarding/tools", asset_template="tokei-{platform_suffix}"
+        )
+        url = _asset_url(source, "tokei-linux")
+        self.assertEqual(url, "https://github.com/CodeBoarding/tools/releases/download/tools-2026.01.01/tokei-linux")
+
+    def test_asset_url_direct_upstream(self):
+        source = UpstreamToolSource(
+            tag="1.44.0-202501301522",
+            url_template="https://download.eclipse.org/jdtls/milestones/{version}/jdt-language-server-{version}.tar.gz",
+        )
+        url = _asset_url(source, "ignored")
+        self.assertIn("1.44.0-202501301522", url)
+        self.assertTrue(url.startswith("https://download.eclipse.org/"))
+
+    @patch("tool_registry.requests.get")
+    def test_download_asset_verifies_sha256(self, mock_get):
+        content = b"binary content"
+        expected_hash = hashlib.sha256(content).hexdigest()
+
+        mock_response = MagicMock()
+        mock_response.iter_content.return_value = [content]
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        with tempfile.TemporaryDirectory() as tmp:
+            dest = Path(tmp) / "binary"
+
+            # Correct hash succeeds
+            result = download_asset("https://example.com/binary", dest, expected_sha256=expected_hash)
+            self.assertTrue(result)
+            self.assertTrue(dest.exists())
+
+            # Wrong hash raises
+            dest.unlink()
+            with self.assertRaises(ValueError) as ctx:
+                download_asset("https://example.com/binary", dest, expected_sha256="badhash")
+            self.assertIn("SHA256 mismatch", str(ctx.exception))
+            self.assertFalse(dest.exists())
+
+    @patch("tool_registry.requests.get")
+    def test_download_asset_no_hash_skips_verification(self, mock_get):
+        content = b"binary content"
+        mock_response = MagicMock()
+        mock_response.iter_content.return_value = [content]
+        mock_response.raise_for_status = MagicMock()
+        mock_get.return_value = mock_response
+
+        with tempfile.TemporaryDirectory() as tmp:
+            dest = Path(tmp) / "binary"
+            result = download_asset("https://example.com/binary", dest)
+            self.assertTrue(result)
+            self.assertTrue(dest.exists())
+
+
+class TestManifest(unittest.TestCase):
+    def test_tools_fingerprint_includes_sources(self):
+        fp = _tools_fingerprint()
+        self.assertIn("tokei:", fp)
+        self.assertIn(TOOLS_REPO, fp)
+        self.assertIn(TOOLS_TAG, fp)
+
+    def test_tools_fingerprint_changes_on_version_bump(self):
+        fp1 = _tools_fingerprint()
+        self.assertIsInstance(fp1, str)
+        self.assertTrue(len(fp1) > 0)
+        # The fingerprint is deterministic
+        fp2 = _tools_fingerprint()
+        self.assertEqual(fp1, fp2)
+
+    @patch("tool_registry.get_servers_dir")
+    def test_write_manifest_includes_tools(self, mock_servers_dir):
+        with tempfile.TemporaryDirectory() as tmp:
+            mock_servers_dir.return_value = Path(tmp)
+            write_manifest()
+            manifest = json.loads((Path(tmp) / "installed.json").read_text())
+            self.assertIn("tools", manifest)
+            self.assertEqual(manifest["tools"], _tools_fingerprint())
+
+    @patch("tool_registry.has_required_tools", return_value=True)
+    @patch("tool_registry._read_manifest")
+    @patch("tool_registry._installed_version", return_value="1.0.0")
+    def test_needs_install_triggers_on_tools_change(self, mock_version, mock_manifest, mock_tools):
+        mock_manifest.return_value = {
+            "version": "1.0.0",
+            "npm_specs": "",
+            "tools": "old-fingerprint",
+        }
+        self.assertTrue(needs_install())
+
+    def test_registry_native_tools_have_source(self):
+        for dep in TOOL_REGISTRY:
+            if dep.kind is ToolKind.NATIVE:
+                self.assertIsNotNone(dep.source, f"{dep.key} should have a source")
+
+    def test_registry_archive_tools_have_source(self):
+        for dep in TOOL_REGISTRY:
+            if dep.kind is ToolKind.ARCHIVE:
+                self.assertIsNotNone(dep.source, f"{dep.key} should have a source")
+                self.assertTrue(dep.archive_subdir, f"{dep.key} should have archive_subdir")
 
 
 if __name__ == "__main__":

--- a/tool_registry.py
+++ b/tool_registry.py
@@ -11,6 +11,7 @@ Adding a new language/tool:
     That's it — install, resolve, and wrapper pick it up automatically.
 """
 
+import hashlib
 import importlib.metadata
 import json
 import logging
@@ -34,7 +35,6 @@ else:
     import fcntl
 
 import requests
-
 from vscode_constants import VSCODE_CONFIG, find_runnable
 
 logger = logging.getLogger(__name__)
@@ -42,7 +42,11 @@ logger = logging.getLogger(__name__)
 # Callback type for reporting download progress: (tool_name, current_step, total_steps)
 ProgressCallback = Callable[[str, int, int], None]
 
-GITHUB_REPO = "CodeBoarding/CodeBoarding"
+TOOLS_REPO = "CodeBoarding/tools"
+TOOLS_TAG = "tools-2026.04.05"
+
+JDTLS_VERSION = "1.44.0-202501301522"
+JDTLS_URL_TEMPLATE = "https://download.eclipse.org/jdtls/milestones/{version}/jdt-language-server-{version}.tar.gz"
 
 _PLATFORM_SUFFIX = {
     "Darwin": "macos",
@@ -76,6 +80,39 @@ class ConfigSection(StrEnum):
 
 
 @dataclass(frozen=True)
+class ToolSource:
+    """Base class describing where to download a tool from."""
+
+    tag: str
+
+
+@dataclass(frozen=True)
+class GitHubToolSource(ToolSource):
+    """Tool binary hosted on a GitHub release (built by our pipeline).
+
+    Attributes:
+        repo: GitHub ``owner/repo`` (e.g. ``CodeBoarding/tools``).
+        asset_template: Asset filename with ``{platform_suffix}`` placeholder.
+        sha256: Per-platform SHA256 hashes keyed by platform suffix.
+    """
+
+    repo: str = ""
+    asset_template: str = ""
+    sha256: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class UpstreamToolSource(ToolSource):
+    """Tool downloaded directly from an upstream provider (e.g. Eclipse).
+
+    Attributes:
+        url_template: Full download URL with a ``{version}`` placeholder.
+    """
+
+    url_template: str = ""
+
+
+@dataclass(frozen=True)
 class ToolDependency:
     """Declarative description of an external tool dependency.
 
@@ -84,9 +121,8 @@ class ToolDependency:
         binary_name: Executable name on disk (e.g. "tokei", "pyright-langserver").
         kind: How the tool is distributed — native binary, npm package, or archive.
         config_section: Top-level key in get_config() — "tools" or "lsp_servers".
-        github_asset_template: Asset name with {platform_suffix} placeholder for native binaries.
+        source: Download source for native/archive tools (None for npm-only tools).
         npm_packages: npm packages to install for node tools.
-        archive_asset: Asset name for archive tools (e.g. "jdtls.tar.gz").
         archive_subdir: Subdirectory name under bin/ for archive extraction.
         js_entry_file: JS entry point filename for Windows direct execution (e.g. "cli.mjs").
         js_entry_parent: Parent directory substring to locate the entry point (e.g. "typescript-language-server").
@@ -96,9 +132,8 @@ class ToolDependency:
     binary_name: str
     kind: ToolKind
     config_section: ConfigSection
-    github_asset_template: str = ""
+    source: ToolSource | None = None
     npm_packages: list[str] = field(default_factory=list)
-    archive_asset: str = ""
     archive_subdir: str = ""
     js_entry_file: str = ""
     js_entry_parent: str = ""
@@ -110,14 +145,24 @@ TOOL_REGISTRY: list[ToolDependency] = [
         binary_name="tokei",
         kind=ToolKind.NATIVE,
         config_section=ConfigSection.TOOLS,
-        github_asset_template="tokei-{platform_suffix}",
+        source=GitHubToolSource(
+            tag=TOOLS_TAG,
+            repo=TOOLS_REPO,
+            asset_template="tokei-{platform_suffix}",
+            sha256={},
+        ),
     ),
     ToolDependency(
         key="go",
         binary_name="gopls",
         kind=ToolKind.NATIVE,
         config_section=ConfigSection.LSP_SERVERS,
-        github_asset_template="gopls-{platform_suffix}",
+        source=GitHubToolSource(
+            tag=TOOLS_TAG,
+            repo=TOOLS_REPO,
+            asset_template="gopls-{platform_suffix}",
+            sha256={},
+        ),
     ),
     ToolDependency(
         key="python",
@@ -151,7 +196,10 @@ TOOL_REGISTRY: list[ToolDependency] = [
         binary_name="java",
         kind=ToolKind.ARCHIVE,
         config_section=ConfigSection.LSP_SERVERS,
-        archive_asset="jdtls.tar.gz",
+        source=UpstreamToolSource(
+            tag=JDTLS_VERSION,
+            url_template=JDTLS_URL_TEMPLATE,
+        ),
         archive_subdir="jdtls",
     ),
 ]
@@ -282,12 +330,30 @@ def _npm_specs_fingerprint() -> str:
     return ",".join(specs)
 
 
-def _write_manifest() -> None:
+def _tools_fingerprint() -> str:
+    """Deterministic fingerprint of all pinned tool sources.
+
+    Changes whenever a tool version or source in TOOL_REGISTRY is updated,
+    causing ``needs_install()`` to trigger a reinstall.
+    """
+    parts: list[str] = []
+    for dep in TOOL_REGISTRY:
+        if dep.source:
+            repo = dep.source.repo if isinstance(dep.source, GitHubToolSource) else ""
+            parts.append(f"{dep.key}:{repo}:{dep.source.tag}")
+    return ",".join(sorted(parts))
+
+
+def write_manifest() -> None:
     p = _manifest_path()
     p.parent.mkdir(parents=True, exist_ok=True)
     p.write_text(
         json.dumps(
-            {"version": _installed_version(), "npm_specs": _npm_specs_fingerprint()},
+            {
+                "version": _installed_version(),
+                "npm_specs": _npm_specs_fingerprint(),
+                "tools": _tools_fingerprint(),
+            },
             indent=2,
         )
     )
@@ -299,6 +365,8 @@ def needs_install() -> bool:
     if manifest.get("version") != _installed_version():
         return True
     if manifest.get("npm_specs") != _npm_specs_fingerprint():
+        return True
+    if manifest.get("tools") != _tools_fingerprint():
         return True
     return not has_required_tools(get_servers_dir())
 
@@ -477,22 +545,28 @@ def platform_bin_dir(base: Path) -> Path:
     return base / "bin" / subdir
 
 
-def get_latest_release_tag() -> str:
-    """Fetch the latest release tag from the GitHub repository."""
-    response = requests.get(f"https://api.github.com/repos/{GITHUB_REPO}/releases/latest", timeout=30)
-    response.raise_for_status()
-    return response.json()["tag_name"]
+def _asset_url(source: ToolSource, asset_name: str) -> str:
+    """Construct the download URL for a tool asset.
+
+    For GitHub-hosted tools, builds a releases URL from repo/tag/asset.
+    For upstream sources, the url_template is the full URL with a ``{version}`` placeholder.
+    """
+    if isinstance(source, UpstreamToolSource):
+        return source.url_template.format(version=source.tag)
+    if isinstance(source, GitHubToolSource):
+        return f"https://github.com/{source.repo}/releases/download/{source.tag}/{asset_name}"
+    raise TypeError(f"Unknown source type: {type(source)}")
 
 
-def download_asset(tag: str, asset_name: str, destination: Path) -> bool:
-    """Download a GitHub release asset to destination. Returns True on success.
+def download_asset(url: str, destination: Path, expected_sha256: str | None = None) -> bool:
+    """Download a file from *url* to *destination*. Returns True on success.
 
     Writes to a temp file first, then atomically renames to prevent
-    corrupt binaries if the download is interrupted.
+    corrupt binaries if the download is interrupted.  When *expected_sha256*
+    is provided the downloaded content is verified against it.
     """
     destination.parent.mkdir(parents=True, exist_ok=True)
     temp_dest = destination.with_suffix(destination.suffix + ".download")
-    url = f"https://github.com/{GITHUB_REPO}/releases/download/{tag}/{asset_name}"
     try:
         response = requests.get(url, stream=True, timeout=300, allow_redirects=True)
         response.raise_for_status()
@@ -500,11 +574,16 @@ def download_asset(tag: str, asset_name: str, destination: Path) -> bool:
             for chunk in response.iter_content(chunk_size=32768):
                 if chunk:
                     f.write(chunk)
-        if temp_dest.stat().st_size > 0:
-            os.replace(temp_dest, destination)
-            return True
-        temp_dest.unlink(missing_ok=True)
-        return False
+        if temp_dest.stat().st_size == 0:
+            temp_dest.unlink(missing_ok=True)
+            return False
+        if expected_sha256:
+            actual = hashlib.sha256(temp_dest.read_bytes()).hexdigest()
+            if actual != expected_sha256:
+                temp_dest.unlink(missing_ok=True)
+                raise ValueError(f"SHA256 mismatch for {destination.name}: expected {expected_sha256}, got {actual}")
+        os.replace(temp_dest, destination)
+        return True
     except Exception:
         temp_dest.unlink(missing_ok=True)
         raise
@@ -515,7 +594,7 @@ def install_native_tools(
     deps: list[ToolDependency],
     on_progress: ProgressCallback | None = None,
 ) -> None:
-    """Download native binaries from GitHub releases."""
+    """Download native binaries from their configured sources."""
     system = platform.system()
     suffix = _PLATFORM_SUFFIX.get(system)
     if suffix is None:
@@ -525,14 +604,7 @@ def install_native_tools(
     bin_dir = platform_bin_dir(target_dir)
     bin_dir.mkdir(parents=True, exist_ok=True)
 
-    try:
-        tag = get_latest_release_tag()
-        logger.info("Using release: %s", tag)
-    except Exception:
-        logger.exception("Could not determine latest release")
-        return
-
-    downloadable = [d for d in deps if d.github_asset_template]
+    downloadable = [d for d in deps if isinstance(d.source, GitHubToolSource)]
     for i, dep in enumerate(downloadable, 1):
         if on_progress:
             on_progress(dep.binary_name, i, len(downloadable))
@@ -540,9 +612,13 @@ def install_native_tools(
         if binary_path.exists():
             logger.info("  %s: already installed, skipping", dep.binary_name)
             continue
-        asset_name = dep.github_asset_template.format(platform_suffix=suffix)
+        source = dep.source
+        assert isinstance(source, GitHubToolSource)
+        asset_name = source.asset_template.format(platform_suffix=suffix)
+        url = _asset_url(source, asset_name)
+        expected_hash = source.sha256.get(suffix)
         try:
-            if download_asset(tag, asset_name, binary_path):
+            if download_asset(url, binary_path, expected_sha256=expected_hash):
                 if system != "Windows":
                     os.chmod(binary_path, 0o755)
                 logger.info("  %s: downloaded successfully", dep.binary_name)
@@ -603,7 +679,7 @@ def install_archive_tool(
     on_progress: ProgressCallback | None = None,
 ) -> None:
     """Download and extract an archive tool."""
-    assert dep.archive_asset, f"{dep.key}: archive_asset required for archive tools"
+    assert dep.source, f"{dep.key}: source required for archive tools"
     assert dep.archive_subdir, f"{dep.key}: archive_subdir required for archive tools"
 
     if on_progress:
@@ -616,11 +692,12 @@ def install_archive_tool(
 
     logger.info("Downloading %s...", dep.key)
     extract_dir.mkdir(parents=True, exist_ok=True)
-    archive_path = target_dir / "bin" / dep.archive_asset
+    archive_path = target_dir / "bin" / f"{dep.archive_subdir}.tar.gz"
 
+    url = _asset_url(dep.source, "")
+    expected_hash = dep.source.sha256.get("") if isinstance(dep.source, GitHubToolSource) else None
     try:
-        tag = get_latest_release_tag()
-        if not download_asset(tag, dep.archive_asset, archive_path):
+        if not download_asset(url, archive_path, expected_sha256=expected_hash):
             logger.warning("%s download failed (empty file)", dep.key)
             return
 
@@ -629,7 +706,5 @@ def install_archive_tool(
         archive_path.unlink()
         logger.info("%s installed successfully", dep.key)
     except Exception:
-        logger.exception("%s installation failed", dep.key)
-        archive_path.unlink(missing_ok=True)
         logger.exception("%s installation failed", dep.key)
         archive_path.unlink(missing_ok=True)


### PR DESCRIPTION
Decoupled tool binary management from the main release cycle. Native binaries (tokei, gopls) are now downloaded from a separate `CodeBoarding/tools` GitHub releases repo, while JDTLS is downloaded directly from Eclipse's upstream mirrors, eliminating the need to re-attach unchanged binaries to every CodeBoarding release.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/codeboarding/codeboarding/pull/282" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated build-and-release workflow for tool binaries (multi-OS artifacts).

* **Improvements**
  * SHA256 verification for downloaded tools to ensure integrity.
  * Deterministic tool fingerprinting and improved manifest handling for more reliable install detection.

* **Tests**
  * Expanded test coverage for tool download verification, manifest behavior, and registry integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->