### PR TITLE
Update sha values after tools released

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,7 +126,9 @@ If the LSP server doesn't publish pre-built binaries (like gopls or tokei), you 
 - Write unit tests for the adapter (aim for 100% coverage on new code)
 - Run `uv run pytest --ignore=tests/integration` to verify nothing is broken
 - Run `uv run mypy .` and `uv run black . --check`
-- Add an integration test fixture for a hand-crafted and well-known repo in the added language
+- Add integration test fixtures:
+  - **Edge cases** (`tests/integration/fixtures/edge_cases/<lang>_edge_cases.json`): A hand-crafted small project that exercises language-specific features (interfaces, generics, inheritance, etc.). Lists `expected_references` that the static analysis must find. See `go_edge_cases.json` or `python_edge_cases.json` for the format.
+  - **Real project** (`tests/integration/fixtures/real_projects/<project>_<lang>.json`): A well-known open-source repo pinned to a specific commit, with expected metric counts (references, packages, call graph nodes/edges, source files). See `prometheus_go.json` or `mockito_java.json` for the format.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,9 +48,90 @@ For regular users who just want to run the analysis, use `uv sync --frozen` inst
 
 ---
 
-## 5) How to PR
+## 5) Adding a new language
+
+Adding language support requires changes across several files. Use [PR #276 (Rust support)](https://github.com/CodeBoarding/CodeBoarding/pull/276) as a reference.
+
+### 5a) Code changes (all required)
+
+| File | What to add |
+|------|-------------|
+| `static_analyzer/engine/adapters/<lang>_adapter.py` | **New file.** Adapter class extending `LanguageAdapter`. Handles language-specific qualified name construction, reference keys, and any special rules (e.g. `mod.rs` collapsing for Rust). |
+| `static_analyzer/engine/adapters/__init__.py` | Import the adapter and add it to `ADAPTER_REGISTRY`. |
+| `static_analyzer/constants.py` | Add a value to the `Language` enum and an entry in `ClusteringConfig.DELIMITER_MAP` (most languages use `"."`). |
+| `static_analyzer/__init__.py` | Add a mapping in `_lang_to_adapter_name()` from the `ProgrammingLanguage` name to the adapter registry key. |
+| `vscode_constants.py` | Add an LSP server config entry to `VSCODE_CONFIG["lsp_servers"]` with the server name, command, languages, file extensions, and install command. |
+| `tool_registry.py` | Add a `ToolDependency` entry to `TOOL_REGISTRY` (see below). |
+
+### 5b) Registering the LSP server dependency
+
+The LSP server must be registered in `tool_registry.py` so it gets installed automatically. The `ToolDependency` entry depends on how the server is distributed:
+
+**npm package** (e.g. pyright, typescript-language-server) — no pipeline update needed:
+```python
+ToolDependency(
+    key="python",
+    binary_name="pyright-langserver",
+    kind=ToolKind.NODE,
+    config_section=ConfigSection.LSP_SERVERS,
+    npm_packages=["pyright@1.1.400"],
+    js_entry_file="langserver.index.js",
+    js_entry_parent="pyright",
+)
+```
+
+**Upstream download** (e.g. jdtls from Eclipse) — downloaded directly, no pipeline:
+```python
+ToolDependency(
+    key="java",
+    binary_name="java",
+    kind=ToolKind.ARCHIVE,
+    config_section=ConfigSection.LSP_SERVERS,
+    source=UpstreamToolSource(
+        tag=JDTLS_VERSION,
+        url_template=JDTLS_URL_TEMPLATE,
+        build=JDTLS_BUILD,
+    ),
+    archive_subdir="jdtls",
+)
+```
+
+**Built from source** (e.g. gopls, tokei) — no upstream binaries, needs pipeline:
+```python
+ToolDependency(
+    key="go",
+    binary_name="gopls",
+    kind=ToolKind.NATIVE,
+    config_section=ConfigSection.LSP_SERVERS,
+    source=GitHubToolSource(
+        tag=TOOLS_TAG,
+        repo=TOOLS_REPO,
+        asset_template="gopls-{platform_suffix}",
+        sha256={...},
+    ),
+)
+```
+
+### 5c) Build pipeline (only for `ToolKind.NATIVE` without upstream binaries)
+
+If the LSP server doesn't publish pre-built binaries (like gopls or tokei), you need to update `.github/workflows/build-tools.yml` to build it from source. The workflow is manually triggered and publishes binaries to the [`CodeBoarding/tools`](https://github.com/CodeBoarding/tools) repo:
+
+1. Add a new `build-<tool>` job to `build-tools.yml` with the appropriate toolchain (Go, Rust, etc.)
+2. Add the tool version as a top-level `env:` variable
+3. Add the new artifacts to the `publish-release` job
+4. Run the workflow, then copy the SHA256 hashes from the output into your `ToolDependency`
+
+### 5d) Tests
+
+- Write unit tests for the adapter (aim for 100% coverage on new code)
+- Run `uv run pytest --ignore=tests/integration` to verify nothing is broken
+- Run `uv run mypy .` and `uv run black . --check`
+- Add an integration test fixture for a hand-crafted and well-known repo in the added language
+
+---
+
+## 6) How to PR
 - Fork the repo.
 - Create a branch: `feat/...`, `fix/...`, or `docs/...`.
-- No tests or linters yet (yaaayy)
 - In the PR, explain **WHAT/WHY/HOW**: what changed, why it's useful, and how you tested it.
 - Optional: add a picture of a diagram from your favorite project.

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -117,12 +117,15 @@ class TestToolSource(unittest.TestCase):
 
     def test_asset_url_direct_upstream(self):
         source = UpstreamToolSource(
-            tag="1.44.0-202501301522",
-            url_template="https://download.eclipse.org/jdtls/milestones/{version}/jdt-language-server-{version}.tar.gz",
+            tag="1.44.0",
+            url_template="https://download.eclipse.org/jdtls/milestones/{version}/jdt-language-server-{version}-{build}.tar.gz",
+            build="202501221502",
         )
         url = _asset_url(source, "ignored")
-        self.assertIn("1.44.0-202501301522", url)
-        self.assertTrue(url.startswith("https://download.eclipse.org/"))
+        self.assertEqual(
+            url,
+            "https://download.eclipse.org/jdtls/milestones/1.44.0/jdt-language-server-1.44.0-202501221502.tar.gz",
+        )
 
     @patch("tool_registry.requests.get")
     def test_download_asset_verifies_sha256(self, mock_get):

--- a/tool_registry.py
+++ b/tool_registry.py
@@ -45,8 +45,11 @@ ProgressCallback = Callable[[str, int, int], None]
 TOOLS_REPO = "CodeBoarding/tools"
 TOOLS_TAG = "tools-2026.04.05"
 
-JDTLS_VERSION = "1.44.0-202501301522"
-JDTLS_URL_TEMPLATE = "https://download.eclipse.org/jdtls/milestones/{version}/jdt-language-server-{version}.tar.gz"
+JDTLS_VERSION = "1.44.0"
+JDTLS_BUILD = "202501221502"
+JDTLS_URL_TEMPLATE = (
+    "https://download.eclipse.org/jdtls/milestones/{version}/jdt-language-server-{version}-{build}.tar.gz"
+)
 
 _PLATFORM_SUFFIX = {
     "Darwin": "macos",
@@ -106,10 +109,12 @@ class UpstreamToolSource(ToolSource):
     """Tool downloaded directly from an upstream provider (e.g. Eclipse).
 
     Attributes:
-        url_template: Full download URL with a ``{version}`` placeholder.
+        url_template: Full download URL with ``{version}`` and optional ``{build}`` placeholders.
+        build: Build identifier appended to the version in the download URL.
     """
 
     url_template: str = ""
+    build: str = ""
 
 
 @dataclass(frozen=True)
@@ -149,7 +154,11 @@ TOOL_REGISTRY: list[ToolDependency] = [
             tag=TOOLS_TAG,
             repo=TOOLS_REPO,
             asset_template="tokei-{platform_suffix}",
-            sha256={},
+            sha256={
+                "linux": "e366026993bce6a40d6df19dcac9c1c58e88820268c68304c056cd3878e545e2",
+                "macos": "90ae8a2e979b9658c2616787bcc26f187f14b922fcd0bf61cb3f7fcc2a43634e",
+                "windows.exe": "7db547cb6bfa1722e89ca52a43426fb212aa53603a60256af25fb6e59ca12099",
+            },
         ),
     ),
     ToolDependency(
@@ -161,7 +170,11 @@ TOOL_REGISTRY: list[ToolDependency] = [
             tag=TOOLS_TAG,
             repo=TOOLS_REPO,
             asset_template="gopls-{platform_suffix}",
-            sha256={},
+            sha256={
+                "linux": "76ecc01106266aa03f75c3ea857f6bd6a1da79b00abb6cb5a573b1cd5ecbdcb7",
+                "macos": "a12551ec82e8000c055a8e8e3447cbf22bd7c4b220d4e3802112a569e88a4965",
+                "windows.exe": "b739c89bcd3068257a5ac1be1b9b4978576f7731c7893fdc0b13577927bd6483",
+            },
         ),
     ),
     ToolDependency(
@@ -199,6 +212,7 @@ TOOL_REGISTRY: list[ToolDependency] = [
         source=UpstreamToolSource(
             tag=JDTLS_VERSION,
             url_template=JDTLS_URL_TEMPLATE,
+            build=JDTLS_BUILD,
         ),
         archive_subdir="jdtls",
     ),
@@ -339,8 +353,10 @@ def _tools_fingerprint() -> str:
     parts: list[str] = []
     for dep in TOOL_REGISTRY:
         if dep.source:
-            repo = dep.source.repo if isinstance(dep.source, GitHubToolSource) else ""
-            parts.append(f"{dep.key}:{repo}:{dep.source.tag}")
+            if isinstance(dep.source, GitHubToolSource):
+                parts.append(f"{dep.key}:{dep.source.repo}:{dep.source.tag}")
+            elif isinstance(dep.source, UpstreamToolSource):
+                parts.append(f"{dep.key}::{dep.source.tag}-{dep.source.build}")
     return ",".join(sorted(parts))
 
 
@@ -552,7 +568,7 @@ def _asset_url(source: ToolSource, asset_name: str) -> str:
     For upstream sources, the url_template is the full URL with a ``{version}`` placeholder.
     """
     if isinstance(source, UpstreamToolSource):
-        return source.url_template.format(version=source.tag)
+        return source.url_template.format(version=source.tag, build=source.build)
     if isinstance(source, GitHubToolSource):
         return f"https://github.com/{source.repo}/releases/download/{source.tag}/{asset_name}"
     raise TypeError(f"Unknown source type: {type(source)}")


### PR DESCRIPTION
Now that the build-tools pipeline has been executed and we have the hashes to compare with, update them to make sure we don't re-download binaries unnecessarily.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/codeboarding/codeboarding/pull/283" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded contribution guide with a new "Adding a new language" walkthrough, updated PR guidance, build-pipeline and testing recommendations, and examples for configuring language servers and tool installation.

* **Improvements**
  * Added checksum support for native tool downloads.
  * Enhanced version handling to separate version and build identifiers for more precise tracking.

* **Tests**
  * Updated tests to validate the new version+build handling in tool registry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->