### PR TITLE
Skip failed LSPs for multi-language projects

### DIFF
--- a/static_analyzer/__init__.py
+++ b/static_analyzer/__init__.py
@@ -122,6 +122,7 @@ class StaticAnalyzer:
         self._engine_clients: list[tuple[LanguageAdapter, Path, LSPClient]] = []
         self.collected_diagnostics: dict[str, FileDiagnosticsMap] = {}
         self._clients_started: bool = False
+        self._failed_languages: list[str] = []
         self._cached_results: StaticAnalysisResults | None = None
 
     def __enter__(self) -> "StaticAnalyzer":
@@ -136,13 +137,21 @@ class StaticAnalyzer:
 
         Call once before invoking analyze() or analyze_with_cluster_changes().
         Idempotent — safe to call even if clients are already running.
+
+        A failing client is skipped and recorded in ``_failed_languages``;
+        ``RuntimeError`` is raised only when every configured client fails.
         """
         if self._clients_started:
             logger.info(f"Clients already started for {self.repository_path}, skipping start.")
             return
 
         started: list[tuple[LanguageAdapter, Path, LSPClient]] = []
+        attempted: list[str] = []
+        self._failed_languages = []
+
         for adapter, project_path in self._engine_configs:
+            attempted.append(adapter.language)
+            engine_client: LSPClient | None = None
             try:
                 logger.info(f"Starting engine LSP client for {adapter.language} at {project_path}")
                 t_start = time.monotonic()
@@ -168,15 +177,30 @@ class StaticAnalyzer:
                     engine_client.wait_for_server_ready()
                     logger.info(f"{adapter.language} project import: {time.monotonic() - t_lsp_started:.1f}s")
 
-            except Exception as e:
-                logger.exception(f"Failed to start engine LSP client for {adapter.language}")
-                for _, _, client in reversed(started):
+            except Exception:
+                logger.exception(
+                    f"Failed to start engine LSP client for {adapter.language}; "
+                    f"skipping this language and continuing"
+                )
+                self._failed_languages.append(adapter.language)
+                if engine_client is not None:
                     try:
-                        client.shutdown()
+                        engine_client.shutdown()
                     except Exception:
-                        logger.exception("Error shutting down engine client during cleanup")
-                self._clients_started = False
-                raise RuntimeError(f"Failed to start engine LSP client for {adapter.language}") from e
+                        logger.exception(
+                            f"Error shutting down partially-started {adapter.language} client during cleanup"
+                        )
+
+        if not started:
+            self._clients_started = False
+            raise RuntimeError(f"Failed to start any engine LSP client (attempted: {', '.join(attempted) or 'none'})")
+
+        if self._failed_languages:
+            logger.warning(
+                f"Proceeding with partial LSP coverage. "
+                f"Failed: {', '.join(self._failed_languages)}. "
+                f"Started: {', '.join(a.language for a, _, _ in started)}"
+            )
 
         self._engine_clients = started
         self._clients_started = True

--- a/static_analyzer/__init__.py
+++ b/static_analyzer/__init__.py
@@ -144,6 +144,12 @@ class StaticAnalyzer:
             logger.info(f"Clients already started for {self.repository_path}, skipping start.")
             return
 
+        if not self._engine_configs:
+            logger.info(f"No supported languages detected in {self.repository_path}; no LSP clients to start.")
+            self._engine_clients = []
+            self._clients_started = True
+            return
+
         started: list[tuple[LanguageAdapter, Path, LSPClient]] = []
         attempted: list[str] = []
         failed_languages: list[str] = []

--- a/static_analyzer/__init__.py
+++ b/static_analyzer/__init__.py
@@ -122,7 +122,6 @@ class StaticAnalyzer:
         self._engine_clients: list[tuple[LanguageAdapter, Path, LSPClient]] = []
         self.collected_diagnostics: dict[str, FileDiagnosticsMap] = {}
         self._clients_started: bool = False
-        self._failed_languages: list[str] = []
         self._cached_results: StaticAnalysisResults | None = None
 
     def __enter__(self) -> "StaticAnalyzer":
@@ -138,8 +137,8 @@ class StaticAnalyzer:
         Call once before invoking analyze() or analyze_with_cluster_changes().
         Idempotent — safe to call even if clients are already running.
 
-        A failing client is skipped and recorded in ``_failed_languages``;
-        ``RuntimeError`` is raised only when every configured client fails.
+        A failing client is skipped and logged; ``RuntimeError`` is raised
+        only when every configured client fails.
         """
         if self._clients_started:
             logger.info(f"Clients already started for {self.repository_path}, skipping start.")
@@ -147,7 +146,7 @@ class StaticAnalyzer:
 
         started: list[tuple[LanguageAdapter, Path, LSPClient]] = []
         attempted: list[str] = []
-        self._failed_languages = []
+        failed_languages: list[str] = []
 
         for adapter, project_path in self._engine_configs:
             attempted.append(adapter.language)
@@ -183,7 +182,7 @@ class StaticAnalyzer:
                     f"Failed to start engine LSP client for {adapter.language}; "
                     f"skipping this language and continuing"
                 )
-                self._failed_languages.append(adapter.language)
+                failed_languages.append(adapter.language)
                 if engine_client is not None:
                     try:
                         engine_client.shutdown()
@@ -196,10 +195,10 @@ class StaticAnalyzer:
             self._clients_started = False
             raise RuntimeError(f"Failed to start any engine LSP client (attempted: {', '.join(attempted) or 'none'})")
 
-        if self._failed_languages:
+        if failed_languages:
             logger.warning(
                 f"Proceeding with partial LSP coverage. "
-                f"Failed: {', '.join(self._failed_languages)}. "
+                f"Failed: {', '.join(failed_languages)}. "
                 f"Started: {', '.join(a.language for a, _, _ in started)}"
             )
 

--- a/static_analyzer/__init__.py
+++ b/static_analyzer/__init__.py
@@ -170,12 +170,13 @@ class StaticAnalyzer:
                 engine_client.start()
                 t_lsp_started = time.monotonic()
                 logger.info(f"{adapter.language} LSP start: {t_lsp_started - t_start:.1f}s")
-                started.append((adapter, project_path, engine_client))
 
                 # For Java, wait for JDTLS to finish importing
                 if adapter.language.lower() == "java":
                     engine_client.wait_for_server_ready()
                     logger.info(f"{adapter.language} project import: {time.monotonic() - t_lsp_started:.1f}s")
+
+                started.append((adapter, project_path, engine_client))
 
             except Exception:
                 logger.exception(

--- a/tests/static_analyzer/test_static_analyzer_start_clients.py
+++ b/tests/static_analyzer/test_static_analyzer_start_clients.py
@@ -1,0 +1,101 @@
+"""Tests for ``StaticAnalyzer.start_clients`` graceful-degradation behavior.
+
+Covers the failure-mode contract introduced for issue #280: a single
+language's LSP client failing to start must not tear down the other
+clients, and a total failure must raise a ``RuntimeError`` listing all
+attempted languages.
+"""
+
+from pathlib import Path
+from typing import cast
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from static_analyzer import StaticAnalyzer
+from static_analyzer.engine.language_adapter import LanguageAdapter
+
+
+def _make_adapter(language: str) -> LanguageAdapter:
+    adapter = MagicMock(name=f"{language}Adapter")
+    adapter.language = language
+    adapter.get_lsp_command.return_value = [f"{language.lower()}-lsp"]
+    adapter.get_lsp_init_options.return_value = {}
+    adapter.get_lsp_env.return_value = {}
+    adapter.get_workspace_settings.return_value = {}
+    return cast(LanguageAdapter, adapter)
+
+
+@pytest.fixture
+def analyzer(tmp_path: Path) -> StaticAnalyzer:
+    # Bypass ProjectScanner / config discovery — we inject _engine_configs directly.
+    with patch("static_analyzer.ProjectScanner") as scanner_cls:
+        scanner_cls.return_value.scan.return_value = []
+        sa = StaticAnalyzer(tmp_path)
+    return sa
+
+
+class TestStartClientsGracefulDegradation:
+    def test_partial_failure_skips_failing_language_and_continues(
+        self, analyzer: StaticAnalyzer, tmp_path: Path
+    ) -> None:
+        py_adapter = _make_adapter("Python")
+        cs_adapter = _make_adapter("CSharp")
+        ts_adapter = _make_adapter("TypeScript")
+        analyzer._engine_configs = [
+            (py_adapter, tmp_path),
+            (cs_adapter, tmp_path),
+            (ts_adapter, tmp_path),
+        ]
+
+        good_client_py = MagicMock(name="PythonClient")
+        bad_client_cs = MagicMock(name="CSharpClient")
+        bad_client_cs.start.side_effect = TimeoutError("OmniSharp timed out")
+        good_client_ts = MagicMock(name="TypeScriptClient")
+
+        with patch(
+            "static_analyzer.LSPClient",
+            side_effect=[good_client_py, bad_client_cs, good_client_ts],
+        ):
+            analyzer.start_clients()
+
+        assert analyzer._clients_started is True
+        assert [a.language for a, _, _ in analyzer._engine_clients] == ["Python", "TypeScript"]
+        assert analyzer._failed_languages == ["CSharp"]
+        # Healthy clients must NOT be shut down because a sibling failed.
+        good_client_py.shutdown.assert_not_called()
+        good_client_ts.shutdown.assert_not_called()
+        # Failing client gets a best-effort shutdown for partial-state cleanup.
+        bad_client_cs.shutdown.assert_called_once()
+
+    def test_total_failure_raises_runtime_error_listing_attempted_languages(
+        self, analyzer: StaticAnalyzer, tmp_path: Path
+    ) -> None:
+        py_adapter = _make_adapter("Python")
+        cs_adapter = _make_adapter("CSharp")
+        analyzer._engine_configs = [(py_adapter, tmp_path), (cs_adapter, tmp_path)]
+
+        bad_py = MagicMock()
+        bad_py.start.side_effect = RuntimeError("pyright missing")
+        bad_cs = MagicMock()
+        bad_cs.start.side_effect = TimeoutError("omnisharp timed out")
+
+        with patch("static_analyzer.LSPClient", side_effect=[bad_py, bad_cs]):
+            with pytest.raises(RuntimeError, match=r"attempted:.*Python.*CSharp"):
+                analyzer.start_clients()
+
+        assert analyzer._clients_started is False
+        assert analyzer._engine_clients == []
+        assert analyzer._failed_languages == ["Python", "CSharp"]
+
+    def test_all_success_records_no_failures(self, analyzer: StaticAnalyzer, tmp_path: Path) -> None:
+        py_adapter = _make_adapter("Python")
+        ts_adapter = _make_adapter("TypeScript")
+        analyzer._engine_configs = [(py_adapter, tmp_path), (ts_adapter, tmp_path)]
+
+        with patch("static_analyzer.LSPClient", side_effect=[MagicMock(), MagicMock()]):
+            analyzer.start_clients()
+
+        assert analyzer._clients_started is True
+        assert analyzer._failed_languages == []
+        assert len(analyzer._engine_clients) == 2

--- a/tests/static_analyzer/test_static_analyzer_start_clients.py
+++ b/tests/static_analyzer/test_static_analyzer_start_clients.py
@@ -61,7 +61,6 @@ class TestStartClientsGracefulDegradation:
 
         assert analyzer._clients_started is True
         assert [a.language for a, _, _ in analyzer._engine_clients] == ["Python", "TypeScript"]
-        assert analyzer._failed_languages == ["CSharp"]
         # Healthy clients must NOT be shut down because a sibling failed.
         good_client_py.shutdown.assert_not_called()
         good_client_ts.shutdown.assert_not_called()
@@ -86,7 +85,6 @@ class TestStartClientsGracefulDegradation:
 
         assert analyzer._clients_started is False
         assert analyzer._engine_clients == []
-        assert analyzer._failed_languages == ["Python", "CSharp"]
 
     def test_all_success_records_no_failures(self, analyzer: StaticAnalyzer, tmp_path: Path) -> None:
         py_adapter = _make_adapter("Python")
@@ -97,5 +95,4 @@ class TestStartClientsGracefulDegradation:
             analyzer.start_clients()
 
         assert analyzer._clients_started is True
-        assert analyzer._failed_languages == []
         assert len(analyzer._engine_clients) == 2


### PR DESCRIPTION
This PR fixes the all-or-nothing LSP startup so that a single failing language server no longer crashes the whole analysis. Failing languages are skipped and logged, a hard error is raised only when every client fails. 
Files of skipped languages are counted as not-analyzed. 

Closes #280 
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/codeboarding/codeboarding/pull/290" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Analyzer now detects "no supported languages" immediately, tolerates individual language client startup failures (continues starting others), keeps successfully started clients active, emits a warning for partial failures, and only errors if no clients start.
* **Tests**
  * Added tests for partial-start, total-failure, and all-success scenarios to verify startup resilience and shutdown behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->