### PR TITLE
Improve the installation setup and requirement errors for C# and Go

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -167,23 +167,6 @@ jobs:
         with:
           dotnet-version: '9.0.x'
 
-      - name: Install csharp-ls
-        if: matrix.language == 'csharp'
-        # csharp-ls 0.21.0+ ships a malformed NuGet package
-        # (DotnetToolSettings.xml missing); pin to 0.20.0 until upstream
-        # publishes a fixed release.
-        run: dotnet tool install --global csharp-ls --version 0.20.0
-
-      - name: Add dotnet tools to PATH (unix)
-        if: matrix.language == 'csharp' && runner.os != 'Windows'
-        run: echo "$HOME/.dotnet/tools" >> $GITHUB_PATH
-
-      - name: Add dotnet tools to PATH (windows)
-        if: matrix.language == 'csharp' && runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          "$env:USERPROFILE\.dotnet\tools" | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
-
       - name: Install PHP (linux)
         if: matrix.language == 'php' && runner.os == 'Linux'
         run: |

--- a/install.py
+++ b/install.py
@@ -634,7 +634,7 @@ def _language_checks_from_registry(target_dir: Path) -> list[LanguageSupportChec
         for lang in languages:
             checks.append(
                 LanguageSupportCheck(
-                    language=Language(lang).display_label,
+                    language=Language(lang).value,
                     paths=list(paths),
                     requires_npm=requires_npm,
                     fallback_available=fallback_available,

--- a/install.py
+++ b/install.py
@@ -501,6 +501,9 @@ def install_package_manager_lsp_servers(target_dir: Path, on_progress: ProgressC
     install_package_manager_tools(target_dir, pm_deps, on_progress=on_progress)
     for dep in pm_deps:
         binary_path = package_manager_tool_path(target_dir, dep)
+        if binary_path is None:
+            print(f"  {dep.binary_name}: not installed (unsupported platform)")
+            continue
         if binary_path.exists():
             print(f"  {dep.binary_name}: installed")
         else:
@@ -558,7 +561,13 @@ def _language_checks_from_registry(target_dir: Path) -> list[LanguageSupportChec
     ``typescript`` entry covers both TypeScript and JavaScript).
     """
     target_dir = target_dir.resolve()
-    platform_bin_dir = get_platform_bin_dir(target_dir)
+    # native/package-manager installers already warn-and-skip on unsupported
+    # hosts; the summary should mirror that instead of crashing when the host has
+    # no ``platform_bin_dir`` layout.
+    try:
+        platform_bin_dir: Path | None = get_platform_bin_dir(target_dir)
+    except RuntimeError:
+        platform_bin_dir = None
     is_win = platform.system() == "Windows"
     node_ext = ".cmd" if is_win else ""
     native_ext = ".exe" if is_win else ""
@@ -582,7 +591,11 @@ def _language_checks_from_registry(target_dir: Path) -> list[LanguageSupportChec
         reason_binary = f"{dep.binary_name} binary not found"
 
         if dep.kind is ToolKind.NATIVE:
-            paths.append(platform_bin_dir / f"{dep.binary_name}{native_ext}")
+            if platform_bin_dir is not None:
+                paths.append(platform_bin_dir / f"{dep.binary_name}{native_ext}")
+            else:
+                reason_requirement = f"{dep.binary_name} unavailable on this platform"
+                reason_binary = reason_requirement
         elif dep.kind is ToolKind.NODE:
             requires_npm = True
             reason_requirement = npm_missing
@@ -606,11 +619,16 @@ def _language_checks_from_registry(target_dir: Path) -> list[LanguageSupportChec
                 fallback_available = bool(find_java_21_or_later())
                 reason_binary = "jdtls or Java 21+ not found"
         elif dep.kind is ToolKind.PACKAGE_MANAGER:
-            paths.append(package_manager_tool_path(target_dir, dep))
+            pm_path = package_manager_tool_path(target_dir, dep)
+            if pm_path is not None:
+                paths.append(pm_path)
             manager = (
                 dep.source.manager_binary if isinstance(dep.source, PackageManagerToolSource) else "package manager"
             )
-            reason_requirement = f"{dep.binary_name} not installed ({manager} unavailable or install failed)"
+            if pm_path is None:
+                reason_requirement = f"{dep.binary_name} unavailable on this platform"
+            else:
+                reason_requirement = f"{dep.binary_name} not installed ({manager} unavailable or install failed)"
             reason_binary = reason_requirement
 
         for lang in languages:

--- a/install.py
+++ b/install.py
@@ -23,13 +23,18 @@ from tool_registry import (
     install_embedded_node,
     install_native_tools,
     install_node_tools,
+    install_package_manager_tools,
     needs_install,
     npm_subprocess_env,
+    package_manager_tool_path,
     platform_bin_dir,
     preferred_node_path,
     preferred_npm_command,
     write_manifest,
 )
+from tool_registry.registry import ConfigSection, PackageManagerToolSource
+from vscode_constants import VSCODE_CONFIG
+from static_analyzer.constants import Language
 from user_config import ensure_config_template
 
 
@@ -483,6 +488,29 @@ def download_jdtls(target_dir: Path, on_progress: ProgressCallback | None = None
     return True
 
 
+def install_package_manager_lsp_servers(target_dir: Path, on_progress: ProgressCallback | None = None) -> None:
+    """Install LSP servers distributed via user-provided package managers.
+
+    Skips cleanly when the package manager itself is absent — the adapter raises a meaningful error
+    at analysis time.
+    """
+    pm_deps = [d for d in TOOL_REGISTRY if d.kind is ToolKind.PACKAGE_MANAGER]
+    if not pm_deps:
+        return
+    print("Step: Package-manager tool installation started")
+    install_package_manager_tools(target_dir, pm_deps, on_progress=on_progress)
+    for dep in pm_deps:
+        binary_path = package_manager_tool_path(target_dir, dep)
+        if binary_path.exists():
+            print(f"  {dep.binary_name}: installed")
+        else:
+            manager = (
+                dep.source.manager_binary if isinstance(dep.source, PackageManagerToolSource) else "package manager"
+            )
+            print(f"  {dep.binary_name}: not installed ({manager} unavailable or install failed)")
+    print("Step: Package-manager tool installation finished")
+
+
 def install_pre_commit_hooks():
     """Install pre-commit hooks for code formatting and linting (optional for contributors)."""
     pre_commit_config = Path(".pre-commit-config.yaml")
@@ -521,71 +549,88 @@ def install_pre_commit_hooks():
         pass
 
 
-def print_language_support_summary(npm_available: bool, target_dir: Path):
-    """Print which language analyses are currently available based on installed tools."""
-    print("Step: Language support summary")
+def _language_checks_from_registry(target_dir: Path) -> list[LanguageSupportCheck]:
+    """Build one LanguageSupportCheck per LSP language listed in VSCODE_CONFIG.
 
+    Data-driven so adding a language to TOOL_REGISTRY + VSCODE_CONFIG
+    automatically flows to the setup summary — no second list to keep in sync.
+    Each tool dep can surface multiple display languages (e.g. the
+    ``typescript`` entry covers both TypeScript and JavaScript).
+    """
     target_dir = target_dir.resolve()
     platform_bin_dir = get_platform_bin_dir(target_dir)
     is_win = platform.system() == "Windows"
     node_ext = ".cmd" if is_win else ""
-
-    ts_path = target_dir / "node_modules" / ".bin" / f"typescript-language-server{node_ext}"
-    php_path = target_dir / "node_modules" / ".bin" / f"intelephense{node_ext}"
-    py_node_path = target_dir / "node_modules" / ".bin" / f"pyright-langserver{node_ext}"
-    py_env_path = shutil.which("pyright-langserver") or shutil.which("pyright-python-langserver")
-    go_path = platform_bin_dir / ("gopls.exe" if is_win else "gopls")
-    java_path = target_dir / "bin" / "jdtls"
-
+    native_ext = ".exe" if is_win else ""
     npm_missing = "npm not available"
-    pyright_missing = "pyright-langserver not found in node_modules or active environment"
-    typescript_missing = "typescript-language-server binary not found"
 
-    language_checks: list[LanguageSupportCheck] = [
-        LanguageSupportCheck(
-            language="Python",
-            paths=[py_node_path],
-            fallback_available=bool(py_env_path),
-            reason_if_requirement_missing=pyright_missing,
-            reason_if_binary_missing=pyright_missing,
-        ),
-        LanguageSupportCheck(
-            language="TypeScript",
-            paths=[ts_path],
-            requires_npm=True,
-            reason_if_requirement_missing=npm_missing,
-            reason_if_binary_missing=typescript_missing,
-        ),
-        LanguageSupportCheck(
-            language="JavaScript",
-            paths=[ts_path],
-            requires_npm=True,
-            reason_if_requirement_missing=npm_missing,
-            reason_if_binary_missing=typescript_missing,
-        ),
-        LanguageSupportCheck(
-            language="PHP",
-            paths=[php_path],
-            requires_npm=True,
-            reason_if_requirement_missing=npm_missing,
-            reason_if_binary_missing="intelephense binary not found",
-        ),
-        LanguageSupportCheck(
-            language="Go",
-            paths=[go_path],
-            reason_if_requirement_missing="gopls binary not found",
-            reason_if_binary_missing="gopls binary not found",
-        ),
-        LanguageSupportCheck(
-            language="Java",
-            paths=[java_path],
-            fallback_available=bool(find_java_21_or_later()),
-            reason_if_requirement_missing="jdtls installation not found",
-            reason_if_binary_missing="jdtls or Java 21+ not found",
-        ),
-    ]
+    checks: list[LanguageSupportCheck] = []
+    lsp_servers = VSCODE_CONFIG.get("lsp_servers", {})
 
-    for check in language_checks:
+    for dep in TOOL_REGISTRY:
+        if dep.config_section != ConfigSection.LSP_SERVERS:
+            continue
+        config_entry = lsp_servers.get(dep.key)
+        if config_entry is None:
+            continue
+        languages: list[str] = list(config_entry.get("languages", []) or [dep.key])
+
+        paths: list[Path] = []
+        fallback_available = False
+        requires_npm = False
+        reason_requirement = f"{dep.binary_name} not installed"
+        reason_binary = f"{dep.binary_name} binary not found"
+
+        if dep.kind is ToolKind.NATIVE:
+            paths.append(platform_bin_dir / f"{dep.binary_name}{native_ext}")
+        elif dep.kind is ToolKind.NODE:
+            requires_npm = True
+            reason_requirement = npm_missing
+            paths.append(target_dir / "node_modules" / ".bin" / f"{dep.binary_name}{node_ext}")
+            # Python pyright also resolves from the active environment.
+            if dep.key == "python":
+                env_path = shutil.which("pyright-langserver") or shutil.which("pyright-python-langserver")
+                fallback_available = bool(env_path)
+                reason_requirement = "pyright-langserver not found in node_modules or active environment"
+                reason_binary = reason_requirement
+        elif dep.kind is ToolKind.ARCHIVE:
+            # JDTLS is validated by directory presence (+ plugins/ subdir),
+            # mirroring has_required_tools.
+            subdir = dep.archive_subdir or dep.key
+            paths.append(target_dir / "bin" / subdir)
+            reason_requirement = f"{subdir} installation not found"
+            reason_binary = reason_requirement
+            # Java analysis can still proceed when a system Java 21+ is available
+            # (jdtls's bundled JRE is the default, but not strictly required).
+            if dep.key == "java":
+                fallback_available = bool(find_java_21_or_later())
+                reason_binary = "jdtls or Java 21+ not found"
+        elif dep.kind is ToolKind.PACKAGE_MANAGER:
+            paths.append(package_manager_tool_path(target_dir, dep))
+            manager = (
+                dep.source.manager_binary if isinstance(dep.source, PackageManagerToolSource) else "package manager"
+            )
+            reason_requirement = f"{dep.binary_name} not installed ({manager} unavailable or install failed)"
+            reason_binary = reason_requirement
+
+        for lang in languages:
+            checks.append(
+                LanguageSupportCheck(
+                    language=Language(lang).display_label,
+                    paths=list(paths),
+                    requires_npm=requires_npm,
+                    fallback_available=fallback_available,
+                    reason_if_requirement_missing=reason_requirement,
+                    reason_if_binary_missing=reason_binary,
+                )
+            )
+    return checks
+
+
+def print_language_support_summary(npm_available: bool, target_dir: Path):
+    """Print which language analyses are currently available based on installed tools."""
+    print("Step: Language support summary")
+    for check in _language_checks_from_registry(target_dir):
         is_available, reason = check.evaluate(npm_available)
         print(f"  - {check.language}: {'yes' if is_available else 'no'}")
         if reason:
@@ -654,8 +699,9 @@ def run_install(
     native_count = sum(1 for d in TOOL_REGISTRY if d.kind is ToolKind.NATIVE and d.source)
     node_deps = [d for d in TOOL_REGISTRY if d.kind is ToolKind.NODE]
     archive_count = sum(1 for d in TOOL_REGISTRY if d.kind is ToolKind.ARCHIVE)
+    pm_count = sum(1 for d in TOOL_REGISTRY if d.kind is ToolKind.PACKAGE_MANAGER)
     npm_available = resolve_npm_availability(auto_install_npm=auto_install_npm, target_dir=target)
-    total_steps = native_count + (1 if npm_available and node_deps else 0) + archive_count
+    total_steps = native_count + (1 if npm_available and node_deps else 0) + archive_count + pm_count
 
     step = 0
 
@@ -672,6 +718,7 @@ def run_install(
 
     download_binaries(target, auto_install_vcpp=auto_install_vcpp, on_progress=tracker)
     download_jdtls(target, on_progress=tracker)
+    install_package_manager_lsp_servers(target, on_progress=tracker)
     install_pre_commit_hooks()
     print_language_support_summary(npm_available, target)
 

--- a/static_analyzer/constants.py
+++ b/static_analyzer/constants.py
@@ -29,8 +29,8 @@ class Language(StrEnum):
     def display_label(self) -> str:
         """Human-readable label for UI / setup summary output.
 
-        Defaults to ``value.capitalize()``; overridden for acronyms
-        (PHP) and mixed-case names (CSharp, TypeScript, JavaScript)
+        Defaults to ``value.capitalize()``; overridden for acronyms (PHP),
+        punctuated names (C#), and mixed-case names (TypeScript, JavaScript)
         that ``capitalize()`` would mangle.
         """
         return _LANGUAGE_DISPLAY_LABELS.get(self, self.value.capitalize())
@@ -39,7 +39,7 @@ class Language(StrEnum):
 # Populated after the class body because values reference Language members.
 _LANGUAGE_DISPLAY_LABELS: dict["Language", str] = {
     Language.PHP: "PHP",
-    Language.CSHARP: "CSharp",
+    Language.CSHARP: "C#",
     Language.TYPESCRIPT: "TypeScript",
     Language.JAVASCRIPT: "JavaScript",
 }

--- a/static_analyzer/constants.py
+++ b/static_analyzer/constants.py
@@ -25,6 +25,25 @@ class Language(StrEnum):
     CSHARP = "csharp"
     CPP = "cpp"
 
+    @property
+    def display_label(self) -> str:
+        """Human-readable label for UI / setup summary output.
+
+        Defaults to ``value.capitalize()``; overridden for acronyms
+        (PHP) and mixed-case names (CSharp, TypeScript, JavaScript)
+        that ``capitalize()`` would mangle.
+        """
+        return _LANGUAGE_DISPLAY_LABELS.get(self, self.value.capitalize())
+
+
+# Populated after the class body because values reference Language members.
+_LANGUAGE_DISPLAY_LABELS: dict["Language", str] = {
+    Language.PHP: "PHP",
+    Language.CSHARP: "CSharp",
+    Language.TYPESCRIPT: "TypeScript",
+    Language.JAVASCRIPT: "JavaScript",
+}
+
 
 class ClusteringConfig:
     """Configuration constants for graph clustering algorithms.

--- a/static_analyzer/constants.py
+++ b/static_analyzer/constants.py
@@ -25,25 +25,6 @@ class Language(StrEnum):
     CSHARP = "csharp"
     CPP = "cpp"
 
-    @property
-    def display_label(self) -> str:
-        """Human-readable label for UI / setup summary output.
-
-        Defaults to ``value.capitalize()``; overridden for acronyms (PHP),
-        punctuated names (C#), and mixed-case names (TypeScript, JavaScript)
-        that ``capitalize()`` would mangle.
-        """
-        return _LANGUAGE_DISPLAY_LABELS.get(self, self.value.capitalize())
-
-
-# Populated after the class body because values reference Language members.
-_LANGUAGE_DISPLAY_LABELS: dict["Language", str] = {
-    Language.PHP: "PHP",
-    Language.CSHARP: "C#",
-    Language.TYPESCRIPT: "TypeScript",
-    Language.JAVASCRIPT: "JavaScript",
-}
-
 
 class ClusteringConfig:
     """Configuration constants for graph clustering algorithms.

--- a/static_analyzer/engine/adapters/csharp_adapter.py
+++ b/static_analyzer/engine/adapters/csharp_adapter.py
@@ -35,17 +35,19 @@ class CSharpAdapter(LanguageAdapter):
         return "csharp"
 
     def get_lsp_command(self, project_root: Path) -> list[str]:
-        """Resolve csharp-ls, checking ~/.dotnet/tools if not on PATH."""
-        cmd = super().get_lsp_command(project_root)
-        binary = cmd[0]
-        # If the binary resolves on PATH, use as-is
-        if shutil.which(binary):
-            return cmd
-        # Fallback: dotnet global tools directory
-        home_tool = Path.home() / ".dotnet" / "tools" / binary
-        if home_tool.is_file():
-            return [str(home_tool)] + cmd[1:]
-        return cmd
+        """Fail fast if the .NET SDK is missing.
+
+        csharp-ls is a ``dotnet tool`` and needs the .NET runtime + MSBuild
+        to load the Roslyn workspace. We mirror Rust's pattern of requiring
+        a user-installed toolchain rather than bundling a ~200MB runtime.
+        """
+        if shutil.which("dotnet") is None:
+            raise RuntimeError(
+                ".NET SDK not found on PATH. csharp-ls requires the .NET SDK "
+                "(9.0 or later) to index C# projects. Install it from "
+                "https://dotnet.microsoft.com/download and re-run the analysis."
+            )
+        return super().get_lsp_command(project_root)
 
     def build_qualified_name(
         self,

--- a/static_analyzer/engine/adapters/csharp_adapter.py
+++ b/static_analyzer/engine/adapters/csharp_adapter.py
@@ -35,16 +35,11 @@ class CSharpAdapter(LanguageAdapter):
         return "csharp"
 
     def get_lsp_command(self, project_root: Path) -> list[str]:
-        """Fail fast if the .NET SDK is missing.
-
-        csharp-ls is a ``dotnet tool`` and needs the .NET runtime + MSBuild
-        to load the Roslyn workspace. We mirror Rust's pattern of requiring
-        a user-installed toolchain rather than bundling a ~200MB runtime.
-        """
+        """Fail fast if the .NET SDK is missing — csharp-ls needs dotnet+MSBuild to load Roslyn."""
         if shutil.which("dotnet") is None:
             raise RuntimeError(
                 ".NET SDK not found on PATH. csharp-ls requires the .NET SDK "
-                "(9.0 or later) to index C# projects. Install it from "
+                "to index C# projects. Install it from "
                 "https://dotnet.microsoft.com/download and re-run the analysis."
             )
         return super().get_lsp_command(project_root)

--- a/static_analyzer/engine/adapters/go_adapter.py
+++ b/static_analyzer/engine/adapters/go_adapter.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import re
+import shutil
 from pathlib import Path
 
 from repo_utils.ignore import RepoIgnoreManager, _ALWAYS_IGNORED_DIRS
@@ -85,6 +86,20 @@ class GoAdapter(LanguageAdapter):
     @property
     def language_id(self) -> str:
         return "go"
+
+    def get_lsp_command(self, project_root: Path) -> list[str]:
+        """Fail fast if the Go toolchain is missing.
+
+        gopls needs ``go`` on PATH to resolve modules and stdlib — without
+        it, indexing silently returns empty results. Mirrors Rust's check.
+        """
+        if shutil.which("go") is None:
+            raise RuntimeError(
+                "Go toolchain not found on PATH. gopls requires Go to "
+                "resolve modules and the standard library. Install one via "
+                "https://go.dev/dl/ and re-run the analysis."
+            )
+        return super().get_lsp_command(project_root)
 
     def build_qualified_name(
         self,

--- a/tests/integration/test_static_analysis_consistency.py
+++ b/tests/integration/test_static_analysis_consistency.py
@@ -143,7 +143,8 @@ METRIC_TOLERANCE = 0.025
 # Minimum absolute tolerance for small numbers (e.g., 20 vs 19 is 5% diff, but only 1 unit)
 MIN_ABSOLUTE_TOLERANCE = 2
 
-# Tolerance percentage for execution time comparisons (15% = 0.15)
+# Upper-bound tolerance for execution time (15% slower than baseline is still a pass).
+# Faster runs never fail; hardware gets quicker, so we only gate on slowdowns.
 EXECUTION_TIME_TOLERANCE = 0.15
 
 # Minimum absolute tolerance for execution-time comparisons; the larger
@@ -279,10 +280,16 @@ class TestStaticAnalysisConsistency:
             if metric_name == "execution_time_seconds":
                 tolerance = EXECUTION_TIME_TOLERANCE
                 min_absolute = MIN_EXECUTION_TIME_TOLERANCE
+                # Faster-than-baseline runs are a win, not a regression — only
+                # flag when ``actual`` exceeds the upper tolerance bound.
+                upper_only = True
             else:
                 tolerance = METRIC_TOLERANCE
                 min_absolute = MIN_ABSOLUTE_TOLERANCE
-            is_pass, diff_info = self._check_metric_within_tolerance(actual, expected_val, tolerance, min_absolute)
+                upper_only = False
+            is_pass, diff_info = self._check_metric_within_tolerance(
+                actual, expected_val, tolerance, min_absolute, upper_only=upper_only
+            )
             results.append(
                 {
                     "metric": metric_name,
@@ -320,8 +327,13 @@ class TestStaticAnalysisConsistency:
         expected: int | float,
         tolerance: float,
         min_absolute: int | float = MIN_ABSOLUTE_TOLERANCE,
+        upper_only: bool = False,
     ) -> tuple[bool, str]:
         """Check if actual value is within tolerance of expected.
+
+        When ``upper_only`` is True, ``actual < expected`` is always a pass —
+        used for metrics (e.g. execution time) where beating the baseline
+        is a win rather than a regression.
 
         Returns:
             Tuple of (is_pass, diff_info_string)
@@ -329,10 +341,16 @@ class TestStaticAnalysisConsistency:
         if expected == 0:
             if actual == 0:
                 return True, "match"
+            if upper_only and actual < 0:
+                return True, f"faster than baseline ({actual})"
             return False, f"expected 0, got {actual}"
 
-        relative_diff = abs(actual - expected) / expected
-        absolute_diff = abs(actual - expected)
+        diff = actual - expected
+        absolute_diff = abs(diff)
+        relative_diff = absolute_diff / expected
+
+        if upper_only and actual < expected:
+            return True, f"faster than baseline (-{relative_diff * 100:.1f}%)"
 
         # For small numbers, use absolute tolerance; for large numbers, use percentage
         # Whichever is more generous
@@ -342,7 +360,6 @@ class TestStaticAnalysisConsistency:
         if relative_diff <= tolerance:
             return True, f"±{relative_diff * 100:.1f}%"
 
-        diff = actual - expected
         diff_str = f"{diff:+.0f}" if isinstance(diff, int) or diff == int(diff) else f"{diff:+.2f}"
         return (
             False,

--- a/tests/static_analyzer/test_csharp_adapter.py
+++ b/tests/static_analyzer/test_csharp_adapter.py
@@ -1,11 +1,49 @@
 """Tests for the C# language adapter."""
 
+import shutil
 import subprocess
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
+
+import pytest
 
 from static_analyzer.engine.adapters.csharp_adapter import CSharpAdapter
 from static_analyzer.constants import NodeType
+
+
+class TestGetLspCommandDotnetCheck:
+    """``get_lsp_command`` must reject hosts without the .NET SDK.
+
+    csharp-ls is a ``dotnet tool`` and cannot run without the runtime,
+    so a missing ``dotnet`` produces a silently broken analysis. We
+    surface that as a clear RuntimeError at LSP-launch, mirroring how
+    ``RustAdapter`` enforces a cargo toolchain.
+    """
+
+    def test_raises_when_dotnet_missing(self, tmp_path: Path) -> None:
+        real_which = shutil.which
+
+        def selective(name: str) -> str | None:
+            if name == "dotnet":
+                return None
+            return real_which(name)
+
+        with patch("static_analyzer.engine.adapters.csharp_adapter.shutil.which", side_effect=selective):
+            with pytest.raises(RuntimeError, match=r"\.NET SDK not found.*dotnet\.microsoft\.com"):
+                CSharpAdapter().get_lsp_command(tmp_path)
+
+    def test_returns_command_when_dotnet_present(self, tmp_path: Path) -> None:
+        real_which = shutil.which
+
+        def selective(name: str) -> str | None:
+            if name == "dotnet":
+                return "/usr/local/bin/dotnet"
+            return real_which(name)
+
+        with patch("static_analyzer.engine.adapters.csharp_adapter.shutil.which", side_effect=selective):
+            cmd = CSharpAdapter().get_lsp_command(tmp_path)
+        assert cmd
+        assert any("csharp-ls" in part for part in cmd)
 
 
 class TestCSharpAdapterProperties:

--- a/tests/static_analyzer/test_csharp_adapter.py
+++ b/tests/static_analyzer/test_csharp_adapter.py
@@ -7,8 +7,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from static_analyzer.engine.adapters.csharp_adapter import CSharpAdapter
 from static_analyzer.constants import NodeType
+from static_analyzer.engine.adapters.csharp_adapter import CSharpAdapter
 
 
 class TestGetLspCommandDotnetCheck:
@@ -40,10 +40,15 @@ class TestGetLspCommandDotnetCheck:
                 return "/usr/local/bin/dotnet"
             return real_which(name)
 
-        with patch("static_analyzer.engine.adapters.csharp_adapter.shutil.which", side_effect=selective):
+        resolved = "/opt/codeboarding/pm-tools/csharp/csharp-ls"
+        lsp_servers = {"csharp": {"command": [resolved]}}
+
+        with (
+            patch("static_analyzer.engine.adapters.csharp_adapter.shutil.which", side_effect=selective),
+            patch("static_analyzer.engine.language_adapter.get_config", return_value=lsp_servers),
+        ):
             cmd = CSharpAdapter().get_lsp_command(tmp_path)
-        assert cmd
-        assert any("csharp-ls" in part for part in cmd)
+        assert cmd[0] == resolved
 
 
 class TestCSharpAdapterProperties:

--- a/tests/static_analyzer/test_go_adapter.py
+++ b/tests/static_analyzer/test_go_adapter.py
@@ -1,10 +1,48 @@
 """Tests for the Go language adapter."""
 
+import shutil
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
+
+import pytest
 
 from static_analyzer.engine.adapters.go_adapter import GoAdapter, _directory_filters_from_ignore_manager
 from repo_utils.ignore import RepoIgnoreManager
+
+
+class TestGetLspCommandGoCheck:
+    """``get_lsp_command`` must reject hosts without the Go toolchain.
+
+    gopls silently indexes nothing when ``go`` is missing — symbol and
+    reference queries return empty, producing a zero-edge call graph.
+    We surface that as a clear RuntimeError at LSP-launch, mirroring
+    ``RustAdapter``'s cargo check.
+    """
+
+    def test_raises_when_go_missing(self, tmp_path: Path) -> None:
+        real_which = shutil.which
+
+        def selective(name: str) -> str | None:
+            if name == "go":
+                return None
+            return real_which(name)
+
+        with patch("static_analyzer.engine.adapters.go_adapter.shutil.which", side_effect=selective):
+            with pytest.raises(RuntimeError, match=r"Go toolchain not found.*go\.dev/dl"):
+                GoAdapter().get_lsp_command(tmp_path)
+
+    def test_returns_command_when_go_present(self, tmp_path: Path) -> None:
+        real_which = shutil.which
+
+        def selective(name: str) -> str | None:
+            if name == "go":
+                return "/usr/local/bin/go"
+            return real_which(name)
+
+        with patch("static_analyzer.engine.adapters.go_adapter.shutil.which", side_effect=selective):
+            cmd = GoAdapter().get_lsp_command(tmp_path)
+        assert cmd
+        assert any("gopls" in part for part in cmd)
 
 
 class TestBuildTagFiltering:

--- a/tests/test_registry_coverage.py
+++ b/tests/test_registry_coverage.py
@@ -1,0 +1,396 @@
+"""Guard-rail tests ensuring language support is wired end-to-end.
+
+These tests fail loudly when a new language or tool kind is added to
+``TOOL_REGISTRY`` without also wiring it into the downstream integration
+points (install orchestrator, validation, VSCODE_CONFIG, adapters,
+Language enum). Adding a language touches a handful of parallel lists
+across the codebase; without these guards regressions hide until an
+end-to-end CI run fails on a specific OS/language matrix cell.
+
+Each test targets one specific integration point so a failure tells
+you *which* list is out of sync.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import install
+from static_analyzer.constants import Language
+from static_analyzer.engine.adapters import ADAPTER_REGISTRY
+from tool_registry import TOOL_REGISTRY, ToolKind, has_required_tools, needs_install
+from tool_registry.registry import ConfigSection, PackageManagerToolSource
+from vscode_constants import VSCODE_CONFIG
+
+# Sample LSP adapter imported just so test #4 can prove import ordering
+# doesn't hide a missing adapter. Each adapter's own tests exercise it
+# functionally — this file only checks structural consistency.
+
+
+class TestInstallOrchestratorCoversEveryKind(unittest.TestCase):
+    """``run_install`` must invoke an installer for every ``ToolKind`` that
+    has at least one entry in ``TOOL_REGISTRY``.
+
+    Regression this guards: adding a new ToolKind, plumbing it into
+    registry + installers, but forgetting to wire it into ``install.py``'s
+    per-kind step list. That's exactly how PACKAGE_MANAGER shipped silently
+    broken on the first CI run — the installer existed but ``run_install``
+    never called it.
+    """
+
+    # Map ToolKind -> install.py function name that must be invoked.
+    # Kinds present in the registry but absent from this map will cause
+    # the test below to fail — force the author to decide where to wire
+    # the new kind in.
+    _INSTALLER_FOR_KIND: dict[ToolKind, str] = {
+        ToolKind.NATIVE: "download_binaries",
+        ToolKind.NODE: "install_node_servers",
+        ToolKind.ARCHIVE: "download_jdtls",
+        ToolKind.PACKAGE_MANAGER: "install_package_manager_lsp_servers",
+    }
+
+    def test_every_tool_kind_in_registry_has_a_mapped_installer(self):
+        kinds_in_registry = {dep.kind for dep in TOOL_REGISTRY}
+        unmapped = kinds_in_registry - self._INSTALLER_FOR_KIND.keys()
+        self.assertFalse(
+            unmapped,
+            f"ToolKind(s) {unmapped} are in TOOL_REGISTRY but not mapped "
+            f"to an installer function in this test. Add them to both "
+            f"``_INSTALLER_FOR_KIND`` here and to ``install.run_install``.",
+        )
+
+    def test_run_install_invokes_installer_for_every_kind_in_registry(self):
+        """Patch each installer and assert it was called at least once for
+        kinds present in the registry. Uses a throwaway target dir; the
+        patches keep the test fast and filesystem-safe.
+        """
+        kinds_in_registry = {dep.kind for dep in TOOL_REGISTRY}
+
+        with tempfile.TemporaryDirectory() as tmp:
+            target = Path(tmp)
+
+            # npm availability stubbed True so the node installer branch runs;
+            # the embedded Node bootstrap is stubbed so we don't actually
+            # download ~30MB of runtime during a unit test.
+            patches = [
+                patch("install.download_binaries"),
+                patch("install.install_node_servers"),
+                patch("install.download_jdtls"),
+                patch("install.install_package_manager_lsp_servers"),
+                patch("install.install_pre_commit_hooks"),
+                patch("install.ensure_node_runtime"),
+                patch("install.resolve_npm_availability", return_value=True),
+                patch("install.print_language_support_summary"),
+            ]
+            mocks = [p.start() for p in patches]
+            try:
+                install.run_install(target_dir=target)
+            finally:
+                for p in patches:
+                    p.stop()
+
+            # Keyed by the same names as _INSTALLER_FOR_KIND so a mismatch
+            # produces an immediately readable assertion message.
+            called_by_name = {
+                "download_binaries": mocks[0].called,
+                "install_node_servers": mocks[1].called,
+                "download_jdtls": mocks[2].called,
+                "install_package_manager_lsp_servers": mocks[3].called,
+            }
+            for kind in kinds_in_registry:
+                fn_name = self._INSTALLER_FOR_KIND[kind]
+                self.assertTrue(
+                    called_by_name[fn_name],
+                    f"run_install did not call {fn_name}(), but {kind} deps "
+                    f"exist in TOOL_REGISTRY. Wire the installer into run_install.",
+                )
+
+
+class TestHasRequiredToolsCoversEveryKind(unittest.TestCase):
+    """``has_required_tools`` must validate every kind present in the registry.
+
+    Regression this guards: adding a new kind without adding a validation
+    branch makes ``needs_install`` loop forever (install succeeds,
+    validation says "still missing", repeat). Or the opposite: the check
+    silently returns True when the artifact is actually absent, so the
+    LSP launch fails at analysis time with a cryptic FileNotFoundError
+    (which is exactly the bug this PR fixed for PACKAGE_MANAGER).
+    """
+
+    def test_missing_artifact_is_detected_for_every_kind(self):
+        """For each kind present in the registry, populate everything, then
+        remove one representative artifact of that kind and assert
+        ``has_required_tools`` returns False.
+        """
+        # Lazy import: the helper lives in the test_tool_registry module
+        # so we don't duplicate the per-kind fixture setup.
+        from tests.test_tool_registry import _populate_complete_servers_dir
+        from tool_registry.paths import exe_suffix, platform_bin_dir
+
+        kinds_in_registry = {dep.kind for dep in TOOL_REGISTRY}
+
+        for kind in kinds_in_registry:
+            dep = next(d for d in TOOL_REGISTRY if d.kind is kind)
+            with self.subTest(kind=kind, dep=dep.key):
+                with tempfile.TemporaryDirectory() as tmp:
+                    base = Path(tmp)
+                    _populate_complete_servers_dir(base)
+                    self.assertTrue(
+                        has_required_tools(base),
+                        f"Populated dir should pass has_required_tools but didn't — "
+                        f"did _populate_complete_servers_dir get a new branch for {kind}?",
+                    )
+
+                    bin_dir = platform_bin_dir(base)
+                    if kind is ToolKind.NATIVE:
+                        (bin_dir / f"{dep.binary_name}{exe_suffix()}").unlink()
+                    elif kind is ToolKind.NODE and dep.js_entry_file:
+                        import shutil as _shutil
+
+                        _shutil.rmtree(base / "node_modules" / dep.js_entry_parent)
+                    elif kind is ToolKind.ARCHIVE and dep.archive_subdir:
+                        import shutil as _shutil
+
+                        _shutil.rmtree(base / "bin" / dep.archive_subdir)
+                    elif kind is ToolKind.PACKAGE_MANAGER:
+                        subdir = dep.archive_subdir or dep.key
+                        (bin_dir / "pm-tools" / subdir / f"{dep.binary_name}{exe_suffix()}").unlink()
+                    else:
+                        self.skipTest(f"Kind {kind} has no deletion rule in this test — extend the match.")
+
+                    self.assertFalse(
+                        has_required_tools(base),
+                        f"has_required_tools should return False after deleting "
+                        f"the {kind} artifact for {dep.key} — the validation branch "
+                        f"for this kind is likely missing or wrong.",
+                    )
+
+    def test_needs_install_does_not_loop_when_pm_manager_missing(self):
+        """PACKAGE_MANAGER deps must be skipped by ``has_required_tools``
+        when their ``manager_binary`` is unavailable — otherwise
+        ``needs_install`` returns True forever on hosts without that
+        toolchain and re-triggers the installer every run.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            # Deliberately populate only non-PM artifacts.
+            from tests.test_tool_registry import _populate_complete_servers_dir
+            from tool_registry.paths import exe_suffix, platform_bin_dir
+
+            _populate_complete_servers_dir(base)
+            # Delete every PM artifact so the only way for has_required_tools
+            # to return True is via the "manager missing -> skip" branch.
+            for dep in TOOL_REGISTRY:
+                if dep.kind is ToolKind.PACKAGE_MANAGER:
+                    subdir = dep.archive_subdir or dep.key
+                    p = platform_bin_dir(base) / "pm-tools" / subdir / f"{dep.binary_name}{exe_suffix()}"
+                    if p.exists():
+                        p.unlink()
+
+            with patch("tool_registry.manifest.shutil.which", return_value=None):
+                self.assertTrue(has_required_tools(base))
+
+    def test_needs_install_public_contract(self):
+        """Smoke check: ``needs_install`` is callable and returns a bool
+        even for a populated dir — protects against signature changes
+        that silently break the top-level call in install.py.
+        """
+        self.assertIsInstance(needs_install(), bool)
+
+
+class TestRegistryAndVscodeConfigParity(unittest.TestCase):
+    """``VSCODE_CONFIG`` and ``TOOL_REGISTRY`` are two parallel lists —
+    adding a tool to one without the other produces a silent misconfig
+    (resolve_config has nothing to map into, or VSCODE_CONFIG entries
+    that never get an absolute path). Enforce parity.
+    """
+
+    def test_every_registry_entry_has_matching_vscode_config_entry(self):
+        for dep in TOOL_REGISTRY:
+            with self.subTest(dep=dep.key):
+                section = dep.config_section.value
+                self.assertIn(
+                    section,
+                    VSCODE_CONFIG,
+                    f"VSCODE_CONFIG has no section '{section}' for {dep.key}.",
+                )
+                self.assertIn(
+                    dep.key,
+                    VSCODE_CONFIG[section],
+                    f"TOOL_REGISTRY entry '{dep.key}' has no matching "
+                    f"VSCODE_CONFIG[{section!r}][{dep.key!r}] entry. "
+                    f"Add it to vscode_constants.py.",
+                )
+                entry = VSCODE_CONFIG[section][dep.key]
+                self.assertIn(
+                    "command",
+                    entry,
+                    f"VSCODE_CONFIG[{section!r}][{dep.key!r}] is missing 'command'.",
+                )
+                cmd = entry["command"]
+                self.assertTrue(
+                    isinstance(cmd, list) and cmd,
+                    f"VSCODE_CONFIG[{section!r}][{dep.key!r}]['command'] must be a non-empty list.",
+                )
+                # cmd[0] must reference either the registry ``binary_name``
+                # (NATIVE/ARCHIVE/PM) or the ``js_entry_file`` (NODE). Any
+                # other value means ``resolve_config`` has no path to fill in.
+                acceptable = {dep.binary_name}
+                if dep.js_entry_file:
+                    acceptable.add(dep.js_entry_file)
+                self.assertIn(
+                    cmd[0],
+                    acceptable,
+                    f"VSCODE_CONFIG['command'][0] is {cmd[0]!r} but TOOL_REGISTRY "
+                    f"declares binary_name={dep.binary_name!r} / js_entry_file="
+                    f"{dep.js_entry_file!r}. resolve_config won't know which slot "
+                    f"to rewrite unless one of these matches.",
+                )
+
+    def test_every_vscode_config_entry_has_matching_registry_entry(self):
+        registry_keys_by_section: dict[str, set[str]] = {}
+        for dep in TOOL_REGISTRY:
+            registry_keys_by_section.setdefault(dep.config_section.value, set()).add(dep.key)
+        for section_name, section in VSCODE_CONFIG.items():
+            for key in section:
+                with self.subTest(section=section_name, key=key):
+                    self.assertIn(
+                        key,
+                        registry_keys_by_section.get(section_name, set()),
+                        f"VSCODE_CONFIG[{section_name!r}][{key!r}] has no matching "
+                        f"TOOL_REGISTRY entry. Either add one, or remove the orphan "
+                        f"config block — codeboarding-setup won't know how to install it.",
+                    )
+
+
+class TestLspAdapterAndLanguageEnumParity(unittest.TestCase):
+    """Every LSP registered in ``TOOL_REGISTRY`` must have:
+    1. A ``LanguageAdapter`` subclass in ``ADAPTER_REGISTRY`` that can index it.
+    2. A corresponding value in the ``Language`` enum.
+
+    Regression this guards: registering an LSP but forgetting to add the
+    adapter means the tool downloads but nothing ever spawns it; omitting
+    the enum value means detection can't route files to the new language.
+    """
+
+    # Map from VSCODE_CONFIG language id (lowercase, e.g. "csharp") to
+    # ADAPTER_REGISTRY key (e.g. "CSharp"). The adapter registry key is
+    # the PascalCase form produced by ``LanguageAdapter.language``.
+    _LANGUAGE_ID_TO_ADAPTER_KEY: dict[str, str] = {
+        "python": "Python",
+        "typescript": "TypeScript",
+        "javascript": "JavaScript",
+        "go": "Go",
+        "php": "PHP",
+        "csharp": "CSharp",
+        "java": "Java",
+        "rust": "Rust",
+    }
+
+    def test_every_lsp_tool_has_an_adapter_per_supported_language(self):
+        for dep in TOOL_REGISTRY:
+            if dep.config_section != ConfigSection.LSP_SERVERS:
+                continue
+            config_entry = VSCODE_CONFIG["lsp_servers"].get(dep.key, {})
+            languages = config_entry.get("languages") or [dep.key]
+            for lang in languages:
+                with self.subTest(dep=dep.key, language=lang):
+                    adapter_key = self._LANGUAGE_ID_TO_ADAPTER_KEY.get(lang)
+                    self.assertIsNotNone(
+                        adapter_key,
+                        f"Language id {lang!r} (from VSCODE_CONFIG[{dep.key!r}]['languages']) "
+                        f"is not mapped to an ADAPTER_REGISTRY key here. Add the mapping "
+                        f"and the matching adapter.",
+                    )
+                    self.assertIn(
+                        adapter_key,
+                        ADAPTER_REGISTRY,
+                        f"ADAPTER_REGISTRY has no adapter {adapter_key!r} for "
+                        f"LSP dep {dep.key!r}. Register the adapter in "
+                        f"static_analyzer/engine/adapters/__init__.py.",
+                    )
+
+    def test_every_lsp_language_is_in_the_language_enum(self):
+        language_values = {lang.value for lang in Language}
+        for dep in TOOL_REGISTRY:
+            if dep.config_section != ConfigSection.LSP_SERVERS:
+                continue
+            config_entry = VSCODE_CONFIG["lsp_servers"].get(dep.key, {})
+            languages = config_entry.get("languages") or [dep.key]
+            for lang in languages:
+                with self.subTest(dep=dep.key, language=lang):
+                    self.assertIn(
+                        lang,
+                        language_values,
+                        f"Language id {lang!r} from VSCODE_CONFIG has no matching "
+                        f"entry in the Language enum (static_analyzer/constants.py). "
+                        f"File detection won't be able to route to this language.",
+                    )
+
+
+class TestPackageManagerSourceInvariants(unittest.TestCase):
+    """Structural checks for every ``PackageManagerToolSource`` in the
+    registry. Catches copy-paste errors on the next PM-installed tool
+    (pipx, cargo install, gem install, ...).
+    """
+
+    def _pm_deps(self):
+        return [d for d in TOOL_REGISTRY if d.kind is ToolKind.PACKAGE_MANAGER]
+
+    def test_registry_has_at_least_one_pm_dep(self):
+        """If this ever fails, either PM support was removed (delete this
+        whole test class) or the csharp entry regressed to NATIVE.
+        """
+        self.assertTrue(self._pm_deps(), "No PACKAGE_MANAGER deps in TOOL_REGISTRY.")
+
+    def test_every_pm_dep_has_a_package_manager_source(self):
+        for dep in self._pm_deps():
+            with self.subTest(dep=dep.key):
+                self.assertIsInstance(
+                    dep.source,
+                    PackageManagerToolSource,
+                    f"{dep.key}: kind=PACKAGE_MANAGER but source is {type(dep.source).__name__}.",
+                )
+
+    def test_every_pm_dep_declares_manager_and_install_args(self):
+        for dep in self._pm_deps():
+            source = dep.source
+            assert isinstance(source, PackageManagerToolSource)
+            with self.subTest(dep=dep.key):
+                self.assertTrue(
+                    source.manager_binary,
+                    f"{dep.key}: PackageManagerToolSource.manager_binary is empty — "
+                    f"the installer wouldn't know which executable to invoke.",
+                )
+                self.assertTrue(
+                    source.install_args,
+                    f"{dep.key}: PackageManagerToolSource.install_args is empty — "
+                    f"the installer would run a bare {source.manager_binary!r}.",
+                )
+
+    def test_every_pm_dep_has_exactly_one_tool_path_placeholder(self):
+        """The installer substitutes ``{tool_path}`` with the managed install
+        dir. Zero placeholders means the tool lands in the package manager's
+        default location (polluting the user's global namespace, and
+        ``has_required_tools`` won't find it). Multiple placeholders is a
+        copy-paste bug.
+        """
+        for dep in self._pm_deps():
+            source = dep.source
+            assert isinstance(source, PackageManagerToolSource)
+            with self.subTest(dep=dep.key):
+                placeholder_count = sum(arg.count("{tool_path}") for arg in source.install_args)
+                self.assertEqual(
+                    placeholder_count,
+                    1,
+                    f"{dep.key}: expected exactly one '{{tool_path}}' placeholder in "
+                    f"install_args, found {placeholder_count}. "
+                    f"install_args={list(source.install_args)!r}",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -43,7 +43,13 @@ from tool_registry import (
     tools_fingerprint,
     write_manifest,
 )
-from tool_registry.installers import _extract_compressed_binary, resolve_native_asset_name
+from tool_registry import PackageManagerToolSource
+from tool_registry.installers import (
+    _extract_compressed_binary,
+    install_package_manager_tools,
+    package_manager_tool_dir,
+    resolve_native_asset_name,
+)
 from tool_registry.registry import ConfigSection, ToolDependency, ToolSource
 
 
@@ -955,7 +961,8 @@ def _populate_complete_servers_dir(base_dir: Path) -> None:
     NATIVE -> platform_bin_dir/<name><exe>;
     NODE -> node_modules/<js_entry_parent>/lib/<js_entry_file>
     (find_runnable does a substring match on parent dir);
-    ARCHIVE -> bin/<archive_subdir>/plugins/
+    ARCHIVE -> bin/<archive_subdir>/plugins/;
+    PACKAGE_MANAGER -> platform_bin_dir/pm-tools/<subdir>/<name><exe>
     """
     bin_dir = platform_bin_dir(base_dir)
     bin_dir.mkdir(parents=True, exist_ok=True)
@@ -968,6 +975,11 @@ def _populate_complete_servers_dir(base_dir: Path) -> None:
             (entry_dir / dep.js_entry_file).write_text("// stub\n")
         elif dep.kind is ToolKind.ARCHIVE and dep.archive_subdir:
             (base_dir / "bin" / dep.archive_subdir / "plugins").mkdir(parents=True, exist_ok=True)
+        elif dep.kind is ToolKind.PACKAGE_MANAGER:
+            subdir = dep.archive_subdir or dep.key
+            pm_dir = bin_dir / "pm-tools" / subdir
+            pm_dir.mkdir(parents=True, exist_ok=True)
+            (pm_dir / f"{dep.binary_name}{exe_suffix()}").write_text("#!/bin/sh\n")
 
 
 class TestHasRequiredTools(unittest.TestCase):
@@ -1524,6 +1536,109 @@ class TestRustRegistryEntry(unittest.TestCase):
         rust = next(d for d in TOOL_REGISTRY if d.key == "rust")
         assert isinstance(rust.source, GitHubToolSource)
         self.assertIn(rust.source.tag, tools_fingerprint())
+
+
+class TestInstallPackageManagerTools(unittest.TestCase):
+    """``install_package_manager_tools`` invokes a user-provided package
+    manager (e.g. ``dotnet tool install``) and must degrade gracefully
+    when the manager itself is missing."""
+
+    def _csharp_dep(self) -> ToolDependency:
+        return ToolDependency(
+            key="csharp",
+            binary_name="csharp-ls",
+            kind=ToolKind.PACKAGE_MANAGER,
+            config_section=ConfigSection.LSP_SERVERS,
+            source=PackageManagerToolSource(
+                tag="0.20.0",
+                manager_binary="dotnet",
+                install_args=("tool", "install", "csharp-ls", "--tool-path", "{tool_path}"),
+            ),
+            archive_subdir="csharp-ls",
+        )
+
+    def test_skips_when_manager_binary_missing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            with (
+                patch("tool_registry.installers.shutil.which", return_value=None),
+                patch("tool_registry.installers.subprocess.run") as mock_run,
+            ):
+                install_package_manager_tools(base, [self._csharp_dep()])
+            mock_run.assert_not_called()
+
+    def test_invokes_manager_with_substituted_tool_path(self):
+        dep = self._csharp_dep()
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            install_dir = package_manager_tool_dir(base, dep)
+            binary_path = install_dir / f"csharp-ls{exe_suffix()}"
+
+            def fake_run(cmd, **_kwargs):
+                # Simulate ``dotnet tool install`` dropping the binary.
+                binary_path.parent.mkdir(parents=True, exist_ok=True)
+                binary_path.write_text("fake csharp-ls")
+                result = MagicMock()
+                result.returncode = 0
+                result.stdout = ""
+                result.stderr = ""
+                return result
+
+            with (
+                patch("tool_registry.installers.shutil.which", return_value="/usr/bin/dotnet"),
+                patch("tool_registry.installers.subprocess.run", side_effect=fake_run) as mock_run,
+            ):
+                install_package_manager_tools(base, [dep])
+
+            self.assertEqual(mock_run.call_count, 1)
+            invoked_cmd = mock_run.call_args.args[0]
+            self.assertEqual(invoked_cmd[0], "dotnet")
+            # --tool-path placeholder must be substituted with the real install dir.
+            self.assertIn(str(install_dir), invoked_cmd)
+            self.assertNotIn("{tool_path}", invoked_cmd)
+            self.assertTrue(binary_path.exists())
+
+    def test_idempotent_when_binary_already_present(self):
+        dep = self._csharp_dep()
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            install_dir = package_manager_tool_dir(base, dep)
+            install_dir.mkdir(parents=True, exist_ok=True)
+            (install_dir / f"csharp-ls{exe_suffix()}").write_text("pre-existing")
+
+            with (
+                patch("tool_registry.installers.shutil.which", return_value="/usr/bin/dotnet"),
+                patch("tool_registry.installers.subprocess.run") as mock_run,
+            ):
+                install_package_manager_tools(base, [dep])
+            mock_run.assert_not_called()
+
+    def test_reports_failure_when_manager_exits_nonzero(self):
+        dep = self._csharp_dep()
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            install_dir = package_manager_tool_dir(base, dep)
+
+            failed = MagicMock()
+            failed.returncode = 1
+            failed.stdout = ""
+            failed.stderr = "boom"
+
+            with (
+                patch("tool_registry.installers.shutil.which", return_value="/usr/bin/dotnet"),
+                patch("tool_registry.installers.subprocess.run", return_value=failed),
+            ):
+                install_package_manager_tools(base, [dep])
+
+            self.assertFalse((install_dir / f"csharp-ls{exe_suffix()}").exists())
+
+    def test_fingerprint_changes_with_version_tag(self):
+        """Bumping the pinned tag must invalidate manifests (same guarantee
+        as GitHub-sourced tools).
+        """
+        csharp = next(d for d in TOOL_REGISTRY if d.key == "csharp")
+        assert isinstance(csharp.source, PackageManagerToolSource)
+        self.assertIn(csharp.source.tag, tools_fingerprint())
 
 
 if __name__ == "__main__":

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -1552,7 +1552,7 @@ class TestInstallPackageManagerTools(unittest.TestCase):
             source=PackageManagerToolSource(
                 tag="0.20.0",
                 manager_binary="dotnet",
-                install_args=("tool", "install", "csharp-ls", "--tool-path", "{tool_path}"),
+                install_args=("tool", "install", "csharp-ls", "--version", "{tag}", "--tool-path", "{tool_path}"),
             ),
             archive_subdir="csharp-ls",
         )
@@ -1593,9 +1593,11 @@ class TestInstallPackageManagerTools(unittest.TestCase):
             self.assertEqual(mock_run.call_count, 1)
             invoked_cmd = mock_run.call_args.args[0]
             self.assertEqual(invoked_cmd[0], "dotnet")
-            # --tool-path placeholder must be substituted with the real install dir.
+            # Placeholders must be substituted: {tool_path} -> install dir, {tag} -> source.tag.
             self.assertIn(str(install_dir), invoked_cmd)
+            self.assertIn("0.20.0", invoked_cmd)
             self.assertNotIn("{tool_path}", invoked_cmd)
+            self.assertNotIn("{tag}", invoked_cmd)
             self.assertTrue(binary_path.exists())
 
     def test_idempotent_when_binary_already_present(self):

--- a/tool_registry/__init__.py
+++ b/tool_registry/__init__.py
@@ -64,6 +64,9 @@ from .installers import (  # noqa: F401
     install_embedded_node,
     install_native_tools,
     install_node_tools,
+    install_package_manager_tools,
     install_tools,
     nodeenv_needs_unofficial_builds,
+    package_manager_tool_dir,
 )
+from .manifest import package_manager_tool_path  # noqa: F401

--- a/tool_registry/__init__.py
+++ b/tool_registry/__init__.py
@@ -14,6 +14,7 @@ from .registry import (  # noqa: F401
     TOOLS_TAG,
     ConfigSection,
     GitHubToolSource,
+    PackageManagerToolSource,
     ProgressCallback,
     ToolDependency,
     ToolKind,

--- a/tool_registry/installers.py
+++ b/tool_registry/installers.py
@@ -31,6 +31,7 @@ from .registry import (
     PLATFORM_SUFFIX,
     TOOL_REGISTRY,
     GitHubToolSource,
+    PackageManagerToolSource,
     ProgressCallback,
     ToolDependency,
     ToolKind,
@@ -254,6 +255,84 @@ def install_native_tools(
             binary_path.unlink(missing_ok=True)
 
 
+# -- Package-manager installer (dotnet tool, cargo install, ...) --------------
+
+
+def package_manager_tool_dir(target_dir: Path, dep: ToolDependency) -> Path:
+    """Managed install directory for a PACKAGE_MANAGER tool.
+
+    Layout: ``<target_dir>/bin/<platform>/pm-tools/<subdir>/``. Using a
+    per-tool subdir keeps multiple pm-tools from clobbering each other.
+    """
+    subdir = dep.archive_subdir or dep.key
+    return platform_bin_dir(target_dir) / "pm-tools" / subdir
+
+
+def install_package_manager_tools(
+    target_dir: Path,
+    deps: list[ToolDependency],
+    on_progress: ProgressCallback | None = None,
+) -> None:
+    """Install each dep by invoking its declared package manager.
+
+    Warn-and-skip when the package manager binary is absent — the LSP
+    adapter's ``get_lsp_command`` surfaces the actionable error at
+    analysis time (mirrors the ``install_node_tools`` npm-missing path).
+    """
+    pm_deps = [d for d in deps if isinstance(d.source, PackageManagerToolSource)]
+    for i, dep in enumerate(pm_deps, 1):
+        if on_progress:
+            on_progress(dep.binary_name, i, len(pm_deps))
+        source = dep.source
+        assert isinstance(source, PackageManagerToolSource)
+        if not shutil.which(source.manager_binary):
+            logger.warning(
+                "  %s: %s not found on PATH; skipping install. " "Users must install it before running analysis.",
+                dep.binary_name,
+                source.manager_binary,
+            )
+            continue
+        install_dir = package_manager_tool_dir(target_dir, dep)
+        binary_path = install_dir / f"{dep.binary_name}{exe_suffix()}"
+        if binary_path.exists():
+            logger.info("  %s: already installed, skipping", dep.binary_name)
+            continue
+        install_dir.mkdir(parents=True, exist_ok=True)
+        args = [arg.format(tool_path=str(install_dir)) for arg in source.install_args]
+        try:
+            result = subprocess.run(
+                [source.manager_binary, *args],
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=600,
+            )
+            if result.returncode != 0:
+                logger.warning(
+                    "  %s: %s install failed (exit %d): %s",
+                    dep.binary_name,
+                    source.manager_binary,
+                    result.returncode,
+                    (result.stderr or result.stdout)[-500:],
+                )
+                continue
+            if not binary_path.exists():
+                logger.warning(
+                    "  %s: %s install reported success but %s is missing",
+                    dep.binary_name,
+                    source.manager_binary,
+                    binary_path,
+                )
+                continue
+            if platform.system() != "Windows":
+                os.chmod(binary_path, 0o755)
+            logger.info("  %s: installed via %s", dep.binary_name, source.manager_binary)
+        except subprocess.TimeoutExpired:
+            logger.warning("  %s: %s install timed out after 600s", dep.binary_name, source.manager_binary)
+        except OSError:
+            logger.exception("  %s: %s install could not be invoked", dep.binary_name, source.manager_binary)
+
+
 # -- Node / npm installer -----------------------------------------------------
 
 
@@ -356,6 +435,7 @@ def install_tools(target_dir: Path) -> None:
     native_deps = [d for d in TOOL_REGISTRY if d.kind is ToolKind.NATIVE]
     node_deps = [d for d in TOOL_REGISTRY if d.kind is ToolKind.NODE]
     archive_deps = [d for d in TOOL_REGISTRY if d.kind is ToolKind.ARCHIVE]
+    pm_deps = [d for d in TOOL_REGISTRY if d.kind is ToolKind.PACKAGE_MANAGER]
 
     if native_deps:
         install_native_tools(target_dir, native_deps)
@@ -363,6 +443,8 @@ def install_tools(target_dir: Path) -> None:
         install_node_tools(target_dir, node_deps)
     for dep in archive_deps:
         install_archive_tool(target_dir, dep)
+    if pm_deps:
+        install_package_manager_tools(target_dir, pm_deps)
 
 
 # -- Embedded Node.js runtime bootstrap ---------------------------------------

--- a/tool_registry/installers.py
+++ b/tool_registry/installers.py
@@ -316,6 +316,10 @@ def install_package_manager_tools(
                 timeout=600,
             )
             if result.returncode != 0:
+                # A failed install can leave partial files that would
+                # make the next run skip install and report a
+                # stale binary as healthy.
+                shutil.rmtree(install_dir, ignore_errors=True)
                 logger.warning(
                     "  %s: %s install failed (exit %d): %s",
                     dep.binary_name,
@@ -325,6 +329,7 @@ def install_package_manager_tools(
                 )
                 continue
             if not binary_path.exists():
+                shutil.rmtree(install_dir, ignore_errors=True)
                 logger.warning(
                     "  %s: %s install reported success but %s is missing",
                     dep.binary_name,

--- a/tool_registry/installers.py
+++ b/tool_registry/installers.py
@@ -13,7 +13,7 @@ import subprocess
 import tarfile
 import zipfile
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import requests
 
@@ -280,25 +280,33 @@ def install_package_manager_tools(
     analysis time (mirrors the ``install_node_tools`` npm-missing path).
     """
     pm_deps = [d for d in deps if isinstance(d.source, PackageManagerToolSource)]
+    try:
+        pm_root = platform_bin_dir(target_dir) / "pm-tools"
+    except RuntimeError:
+        logger.warning(
+            "Unsupported platform %s/%s; skipping package-manager tool installation.",
+            platform.system(),
+            platform.machine(),
+        )
+        return
     for i, dep in enumerate(pm_deps, 1):
         if on_progress:
             on_progress(dep.binary_name, i, len(pm_deps))
-        source = dep.source
-        assert isinstance(source, PackageManagerToolSource)
+        source = cast(PackageManagerToolSource, dep.source)
         if not shutil.which(source.manager_binary):
             logger.warning(
-                "  %s: %s not found on PATH; skipping install. " "Users must install it before running analysis.",
+                "  %s: %s not found on PATH; skipping install. Users must install it before running analysis.",
                 dep.binary_name,
                 source.manager_binary,
             )
             continue
-        install_dir = package_manager_tool_dir(target_dir, dep)
+        install_dir = pm_root / (dep.archive_subdir or dep.key)
         binary_path = install_dir / f"{dep.binary_name}{exe_suffix()}"
         if binary_path.exists():
             logger.info("  %s: already installed, skipping", dep.binary_name)
             continue
         install_dir.mkdir(parents=True, exist_ok=True)
-        args = [arg.format(tool_path=str(install_dir)) for arg in source.install_args]
+        args = [arg.format(tool_path=str(install_dir), tag=source.tag) for arg in source.install_args]
         try:
             result = subprocess.run(
                 [source.manager_binary, *args],

--- a/tool_registry/installers.py
+++ b/tool_registry/installers.py
@@ -341,8 +341,10 @@ def install_package_manager_tools(
                 os.chmod(binary_path, 0o755)
             logger.info("  %s: installed via %s", dep.binary_name, source.manager_binary)
         except subprocess.TimeoutExpired:
+            shutil.rmtree(install_dir, ignore_errors=True)
             logger.warning("  %s: %s install timed out after 600s", dep.binary_name, source.manager_binary)
         except OSError:
+            shutil.rmtree(install_dir, ignore_errors=True)
             logger.exception("  %s: %s install could not be invoked", dep.binary_name, source.manager_binary)
 
 

--- a/tool_registry/manifest.py
+++ b/tool_registry/manifest.py
@@ -186,9 +186,18 @@ def build_config() -> dict[str, Any]:
     return config
 
 
-def package_manager_tool_path(base_dir: Path, dep: ToolDependency) -> Path:
-    """Absolute path to a PACKAGE_MANAGER tool's installed binary."""
-    return package_manager_tool_dir(base_dir, dep) / f"{dep.binary_name}{exe_suffix()}"
+def package_manager_tool_path(base_dir: Path, dep: ToolDependency) -> Path | None:
+    """Absolute path to a PACKAGE_MANAGER tool's installed binary.
+
+    Returns ``None`` on hosts where ``platform_bin_dir`` has no layout —
+    the native installer path already skips unsupported OSes, so the
+    summary and config resolution need a matching signal rather than a
+    hard crash.
+    """
+    try:
+        return package_manager_tool_dir(base_dir, dep) / f"{dep.binary_name}{exe_suffix()}"
+    except RuntimeError:
+        return None
 
 
 def resolve_config(base_dir: Path) -> dict[str, Any]:
@@ -211,7 +220,7 @@ def resolve_config(base_dir: Path) -> dict[str, Any]:
 
         elif dep.kind is ToolKind.PACKAGE_MANAGER:
             binary_path = package_manager_tool_path(base_dir, dep)
-            if binary_path.exists():
+            if binary_path is not None and binary_path.exists():
                 cmd = cast(list[str], config[dep.config_section][dep.key]["command"])
                 cmd[0] = str(binary_path)
 
@@ -304,6 +313,9 @@ def has_required_tools(base_dir: Path) -> bool:
                 )
                 continue
             binary_path = package_manager_tool_path(base_dir, dep)
+            if binary_path is None:
+                logger.info("has_required_tools: %s unsupported on this host; skipping check", dep.key)
+                continue
             if not binary_path.exists():
                 logger.info("has_required_tools: %s missing at %s", dep.key, binary_path)
                 return False

--- a/tool_registry/manifest.py
+++ b/tool_registry/manifest.py
@@ -24,6 +24,8 @@ from .registry import (
     PINNED_NODE_VERSION,
     TOOL_REGISTRY,
     GitHubToolSource,
+    PackageManagerToolSource,
+    ToolDependency,
     ToolKind,
     UpstreamToolSource,
 )
@@ -80,6 +82,8 @@ def tools_fingerprint() -> str:
                 parts.append(f"{dep.key}:{dep.source.repo}:{dep.source.tag}")
             elif isinstance(dep.source, UpstreamToolSource):
                 parts.append(f"{dep.key}::{dep.source.tag}-{dep.source.build}")
+            elif isinstance(dep.source, PackageManagerToolSource):
+                parts.append(f"{dep.key}:{dep.source.manager_binary}:{dep.source.tag}")
     return ",".join(sorted(parts))
 
 
@@ -178,6 +182,15 @@ def build_config() -> dict[str, Any]:
     return config
 
 
+def package_manager_tool_path(base_dir: Path, dep: ToolDependency) -> Path:
+    """Absolute path to a PACKAGE_MANAGER tool's installed binary.
+
+    Kept in sync with ``installers.package_manager_tool_dir``.
+    """
+    subdir = dep.archive_subdir or dep.key
+    return platform_bin_dir(base_dir) / "pm-tools" / subdir / f"{dep.binary_name}{exe_suffix()}"
+
+
 def resolve_config(base_dir: Path) -> dict[str, Any]:
     """Scan base_dir for installed tools and return a config dict.
 
@@ -192,6 +205,12 @@ def resolve_config(base_dir: Path) -> dict[str, Any]:
     for dep in TOOL_REGISTRY:
         if dep.kind is ToolKind.NATIVE:
             binary_path = bin_dir / f"{dep.binary_name}{native_ext}"
+            if binary_path.exists():
+                cmd = cast(list[str], config[dep.config_section][dep.key]["command"])
+                cmd[0] = str(binary_path)
+
+        elif dep.kind is ToolKind.PACKAGE_MANAGER:
+            binary_path = package_manager_tool_path(base_dir, dep)
             if binary_path.exists():
                 cmd = cast(list[str], config[dep.config_section][dep.key]["command"])
                 cmd[0] = str(binary_path)
@@ -227,7 +246,7 @@ def resolve_config_from_path() -> dict[str, Any]:
 
     for dep in TOOL_REGISTRY:
         path = None
-        if dep.kind in (ToolKind.NATIVE, ToolKind.NODE):
+        if dep.kind in (ToolKind.NATIVE, ToolKind.NODE, ToolKind.PACKAGE_MANAGER):
             path = shutil.which(dep.binary_name)
         if path:
             cmd = cast(list[str], config[dep.config_section][dep.key]["command"])
@@ -261,17 +280,30 @@ def has_required_tools(base_dir: Path) -> bool:
 
     for dep in TOOL_REGISTRY:
         if dep.kind is ToolKind.NATIVE:
-            # Native tools with no source are installed externally (e.g. csharp-ls
-            # via ``dotnet tool install``) — the adapter resolves them from PATH,
-            # so there's nothing to verify inside ``base_dir``.
-            if dep.source is None:
-                continue
             # Skip the check when the installer would also skip the download,
             # otherwise ``needs_install`` loops forever on unsupported hosts.
             if not dep.is_available_on_host():
                 logger.info("has_required_tools: %s unavailable on this host; skipping check", dep.key)
                 continue
             binary_path = platform_bin_dir(base_dir) / f"{dep.binary_name}{exe_suffix()}"
+            if not binary_path.exists():
+                logger.info("has_required_tools: %s missing at %s", dep.key, binary_path)
+                return False
+
+        elif dep.kind is ToolKind.PACKAGE_MANAGER:
+            # Skip when the package manager itself is missing — the installer
+            # also skips, and the adapter raises a meaningful error at
+            # analysis time. Without this skip, ``needs_install`` loops on
+            # machines without the user-provided toolchain.
+            source = dep.source
+            if isinstance(source, PackageManagerToolSource) and not shutil.which(source.manager_binary):
+                logger.info(
+                    "has_required_tools: %s unavailable (%s missing); skipping check",
+                    dep.key,
+                    source.manager_binary,
+                )
+                continue
+            binary_path = package_manager_tool_path(base_dir, dep)
             if not binary_path.exists():
                 logger.info("has_required_tools: %s missing at %s", dep.key, binary_path)
                 return False

--- a/tool_registry/manifest.py
+++ b/tool_registry/manifest.py
@@ -19,6 +19,7 @@ else:
 
 from vscode_constants import VSCODE_CONFIG, find_runnable
 
+from .installers import package_manager_tool_dir
 from .paths import exe_suffix, get_servers_dir, platform_bin_dir, preferred_node_path
 from .registry import (
     PINNED_NODE_VERSION,
@@ -83,7 +84,10 @@ def tools_fingerprint() -> str:
             elif isinstance(dep.source, UpstreamToolSource):
                 parts.append(f"{dep.key}::{dep.source.tag}-{dep.source.build}")
             elif isinstance(dep.source, PackageManagerToolSource):
-                parts.append(f"{dep.key}:{dep.source.manager_binary}:{dep.source.tag}")
+                # ``install_args`` is included: flag changes (pinned version, channel) must invalidate the manifest.
+                parts.append(
+                    f"{dep.key}:{dep.source.manager_binary}:{dep.source.tag}:{'|'.join(dep.source.install_args)}"
+                )
     return ",".join(sorted(parts))
 
 
@@ -183,12 +187,8 @@ def build_config() -> dict[str, Any]:
 
 
 def package_manager_tool_path(base_dir: Path, dep: ToolDependency) -> Path:
-    """Absolute path to a PACKAGE_MANAGER tool's installed binary.
-
-    Kept in sync with ``installers.package_manager_tool_dir``.
-    """
-    subdir = dep.archive_subdir or dep.key
-    return platform_bin_dir(base_dir) / "pm-tools" / subdir / f"{dep.binary_name}{exe_suffix()}"
+    """Absolute path to a PACKAGE_MANAGER tool's installed binary."""
+    return package_manager_tool_dir(base_dir, dep) / f"{dep.binary_name}{exe_suffix()}"
 
 
 def resolve_config(base_dir: Path) -> dict[str, Any]:

--- a/tool_registry/registry.py
+++ b/tool_registry/registry.py
@@ -59,6 +59,9 @@ class ToolKind(StrEnum):
     NATIVE = "native"  # Pre-built binary downloaded from GitHub releases
     NODE = "node"  # npm package installed via `npm install`
     ARCHIVE = "archive"  # Tarball downloaded and extracted from GitHub releases
+    PACKAGE_MANAGER = (
+        "package_manager"  # Installed by invoking a user-provided package manager (e.g. `dotnet tool install`)
+    )
 
 
 class ConfigSection(StrEnum):
@@ -106,6 +109,25 @@ class UpstreamToolSource(ToolSource):
 
     url_template: str = ""  # with ``{version}`` / optional ``{build}``
     build: str = ""
+
+
+@dataclass(frozen=True)
+class PackageManagerToolSource(ToolSource):
+    """Tool installed by invoking a user-provided package manager.
+
+    Why: some LSPs (e.g. csharp-ls) are distributed only through a
+    language package manager (``dotnet tool``, ``cargo install``) and
+    ship no standalone binaries. We run the package manager at setup
+    time into a CodeBoarding-owned directory so the install is
+    self-contained and version-pinned. ``manager_binary`` absence at
+    install time is a non-fatal skip (mirrors ``install_node_tools``
+    when npm is missing); the LSP adapter surfaces the meaningful
+    error at analysis time (mirrors ``RustAdapter``).
+    """
+
+    manager_binary: str = ""  # e.g. "dotnet"
+    # Placeholder ``{tool_path}`` in any arg is substituted with the managed install dir.
+    install_args: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -197,14 +219,30 @@ TOOL_REGISTRY: list[ToolDependency] = [
         js_entry_file="intelephense.js",
         js_entry_parent="intelephense",
     ),
-    # No source: csharp-ls is resolved from PATH or
-    # ~/.dotnet/tools (see CSharpAdapter.get_lsp_command fallback).
-    # Install: dotnet tool install --global csharp-ls
+    # csharp-ls ships no prebuilt binaries (upstream release assets are
+    # empty), only a NuGet dotnet-tool package. We install it via
+    # ``dotnet tool install --tool-path <managed-dir>`` at setup time.
+    # The .NET SDK is a user prerequisite — CSharpAdapter raises a
+    # meaningful error when ``dotnet`` is missing at analysis time.
     ToolDependency(
         key="csharp",
         binary_name="csharp-ls",
-        kind=ToolKind.NATIVE,
+        kind=ToolKind.PACKAGE_MANAGER,
         config_section=ConfigSection.LSP_SERVERS,
+        source=PackageManagerToolSource(
+            tag="0.20.0",
+            manager_binary="dotnet",
+            install_args=(
+                "tool",
+                "install",
+                "csharp-ls",
+                "--version",
+                "0.20.0",
+                "--tool-path",
+                "{tool_path}",
+            ),
+        ),
+        archive_subdir="csharp-ls",
     ),
     ToolDependency(
         key="java",

--- a/tool_registry/registry.py
+++ b/tool_registry/registry.py
@@ -113,20 +113,13 @@ class UpstreamToolSource(ToolSource):
 
 @dataclass(frozen=True)
 class PackageManagerToolSource(ToolSource):
-    """Tool installed by invoking a user-provided package manager.
+    """Tool installed by invoking a user-provided package manager (e.g. ``dotnet tool install``).
 
-    Why: some LSPs (e.g. csharp-ls) are distributed only through a
-    language package manager (``dotnet tool``, ``cargo install``) and
-    ship no standalone binaries. We run the package manager at setup
-    time into a CodeBoarding-owned directory so the install is
-    self-contained and version-pinned. ``manager_binary`` absence at
-    install time is a non-fatal skip (mirrors ``install_node_tools``
-    when npm is missing); the LSP adapter surfaces the meaningful
-    error at analysis time (mirrors ``RustAdapter``).
+    Why: some LSPs ship only as language-package-manager packages, not as standalone binaries.
     """
 
     manager_binary: str = ""  # e.g. "dotnet"
-    # Placeholder ``{tool_path}`` in any arg is substituted with the managed install dir.
+    # Placeholders substituted at install time: ``{tool_path}`` -> managed install dir; ``{tag}`` -> source.tag.
     install_args: tuple[str, ...] = ()
 
 
@@ -219,11 +212,10 @@ TOOL_REGISTRY: list[ToolDependency] = [
         js_entry_file="intelephense.js",
         js_entry_parent="intelephense",
     ),
-    # csharp-ls ships no prebuilt binaries (upstream release assets are
-    # empty), only a NuGet dotnet-tool package. We install it via
-    # ``dotnet tool install --tool-path <managed-dir>`` at setup time.
-    # The .NET SDK is a user prerequisite — CSharpAdapter raises a
-    # meaningful error when ``dotnet`` is missing at analysis time.
+    # csharp-ls ships only as a NuGet dotnet-tool; installed via ``dotnet tool install``.
+    # Pinned 0.20.0: 0.21.0+ has a malformed NuGet upstream.
+    # ``--framework net9.0`` is required — 0.20.0 ships only a net9.0 target, and without
+    # the flag ``--tool-path`` emits a misleading "DotnetToolSettings.xml not found" error.
     ToolDependency(
         key="csharp",
         binary_name="csharp-ls",
@@ -237,7 +229,9 @@ TOOL_REGISTRY: list[ToolDependency] = [
                 "install",
                 "csharp-ls",
                 "--version",
-                "0.20.0",
+                "{tag}",
+                "--framework",
+                "net9.0",
                 "--tool-path",
                 "{tool_path}",
             ),

--- a/vscode_constants.py
+++ b/vscode_constants.py
@@ -109,7 +109,9 @@ VSCODE_CONFIG = {
             "command": ["csharp-ls"],
             "languages": ["csharp"],
             "file_extensions": [".cs"],
-            "install_commands": "dotnet tool install --global csharp-ls",
+            # csharp-ls is installed via `dotnet tool install --tool-path` by
+            # tool_registry; requires the .NET SDK 9.0+ on PATH.
+            "install_commands": "codeboarding-setup (installs csharp-ls automatically; requires .NET SDK 9.0+)",
         },
         "java": {
             "name": "Eclipse JDT Language Server",


### PR DESCRIPTION
I noticed C# was not properly installing the csharp-ls and I'm fixing this here. For go, we also didn't have a clear message when go is not installed, which I added here too. 
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/codeboarding/codeboarding/pull/295" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Package-manager based installation for language servers with per-tool install locations and orchestrated installer steps.

* **Improvements**
  * Runtime preflight checks for Go and .NET toolchains with clear guidance when missing.
  * Installer-driven language-support reporting and data-driven setup summary.
  * Human-friendly language labels and updated installation guidance for C# tooling.

* **Tests**
  * Broad test suite additions covering registry/install parity, package-manager installs, adapters, and end-to-end invariants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->