### PR TITLE
Fix scope leakage: filter subgraph by exact method set instead of files

### DIFF
--- a/agents/cluster_methods_mixin.py
+++ b/agents/cluster_methods_mixin.py
@@ -247,11 +247,11 @@ class ClusterMethodsMixin:
             logger.warning(f"Component {component.name} has no assigned files")
             return "No assigned files found for this component.", {}, {}
 
-        # Convert files to absolute paths for comparison
-        assigned_file_set = set()
-        for f in component_files:
-            abs_path = os.path.join(self.repo_dir, f) if not os.path.isabs(f) else f
-            assigned_file_set.add(abs_path)
+        # Collect qualified names for method-level filtering
+        assigned_qnames: set[str] = set()
+        for group in component.file_methods:
+            for method in group.methods:
+                assigned_qnames.add(method.qualified_name)
 
         cluster_results: dict[str, ClusterResult] = {}
         subgraph_cfgs: dict[str, CallGraph] = {}
@@ -259,8 +259,8 @@ class ClusterMethodsMixin:
         for lang in self.static_analysis.get_languages():
             cfg = self.static_analysis.get_cfg(lang)
 
-            # Use strict filtering logic
-            sub_cfg = cfg.filter_by_files(assigned_file_set)
+            # Filter by exact method set to prevent scope leakage
+            sub_cfg = cfg.filter_by_nodes(assigned_qnames)
 
             if sub_cfg.nodes:
                 subgraph_cfgs[lang] = sub_cfg
@@ -299,7 +299,7 @@ class ClusterMethodsMixin:
         result = "".join(result_parts)
 
         if not result.strip():
-            logger.warning(f"No CFG found for component {component.name} with {len(component_files)} files")
+            logger.warning(f"No CFG found for component {component.name} with {len(assigned_qnames)} methods")
             return "No relevant CFG clusters found for this component.", cluster_results, subgraph_cfgs
 
         return result, cluster_results, subgraph_cfgs

--- a/static_analyzer/graph.py
+++ b/static_analyzer/graph.py
@@ -258,6 +258,23 @@ class CallGraph:
 
         return sub_graph
 
+    def filter_by_nodes(self, qualified_names: set[str]) -> "CallGraph":
+        """Create a new CallGraph containing only the specified nodes (by qualified name).
+
+        Only includes edges where both source and target are in the allowed set.
+        """
+        relevant_nodes = {nid: node for nid, node in self.nodes.items() if nid in qualified_names}
+
+        filtered_edges = []
+        for edge in self.edges:
+            if edge.get_source() in relevant_nodes and edge.get_destination() in relevant_nodes:
+                filtered_edges.append(Edge(self.nodes[edge.get_source()], self.nodes[edge.get_destination()]))
+
+        sub_graph = CallGraph(language=self.language)
+        sub_graph.nodes = relevant_nodes
+        sub_graph.edges = filtered_edges
+        return sub_graph
+
     def to_cluster_string(
         self,
         cluster_ids: set[int] | None = None,

--- a/tests/agents/test_details_agent.py
+++ b/tests/agents/test_details_agent.py
@@ -57,8 +57,18 @@ class TestDetailsAgent(unittest.TestCase):
             description="Test component",
             key_entities=[ref],
             file_methods=[
-                FileMethodGroup(file_path="test.py"),
-                FileMethodGroup(file_path="test_utils.py"),
+                FileMethodGroup(
+                    file_path="test.py",
+                    methods=[
+                        MethodEntry(qualified_name="test.func", start_line=1, end_line=10, node_type="FUNCTION"),
+                    ],
+                ),
+                FileMethodGroup(
+                    file_path="test_utils.py",
+                    methods=[
+                        MethodEntry(qualified_name="test_utils.helper", start_line=1, end_line=5, node_type="FUNCTION"),
+                    ],
+                ),
             ],
         )
 
@@ -98,8 +108,8 @@ class TestDetailsAgent(unittest.TestCase):
             parsing_llm=mock_parsing_llm,
             run_id="test-run-id",
         )
-        # Mock StaticAnalysis and CFG behavior
-        abs_assigned = {str(self.repo_dir / fg.file_path) for fg in self.test_component.file_methods}
+        # Build the expected set of qualified names from component's file_methods
+        expected_qnames = {"test.func", "test_utils.helper"}
 
         # Create a mock node with proper attributes for method-level expansion check
         mock_node = MagicMock()
@@ -121,8 +131,7 @@ class TestDetailsAgent(unittest.TestCase):
         mock_subgraph.to_cluster_string.return_value = "Component CFG String"
 
         mock_cfg = MagicMock()
-        # Ensure filter_by_files returns our mock subgraph
-        mock_cfg.filter_by_files.return_value = mock_subgraph
+        mock_cfg.filter_by_nodes.return_value = mock_subgraph
 
         self.mock_static_analysis.get_languages.return_value = ["python"]
         self.mock_static_analysis.get_cfg.return_value = mock_cfg
@@ -135,7 +144,7 @@ class TestDetailsAgent(unittest.TestCase):
         self.assertIn("python", subgraph_cfgs)
         self.assertIs(subgraph_cfgs["python"], mock_subgraph)
         self.mock_static_analysis.get_cfg.assert_called_with("python")
-        mock_cfg.filter_by_files.assert_called_with(abs_assigned)
+        mock_cfg.filter_by_nodes.assert_called_with(expected_qnames)
         mock_subgraph.cluster.assert_called_once()
 
     @patch("agents.details_agent.DetailsAgent._validation_invoke")
@@ -313,7 +322,7 @@ class TestDetailsAgent(unittest.TestCase):
 
         mock_cfg = MagicMock()
         mock_cfg.cluster.return_value = mock_cluster_result
-        mock_cfg.filter_by_files.return_value = mock_subgraph
+        mock_cfg.filter_by_nodes.return_value = mock_subgraph
         # _build_cluster_string calls cfg.to_cluster_string on the original cfg
         mock_cfg.to_cluster_string.return_value = "Cluster 1: method_a, method_b"
 


### PR DESCRIPTION
_create_strict_component_subgraph used filter_by_files which included ALL methods from a file even when the parent component only owned a subset. Re-clustering then assigned extra methods to children, violating the parent's scope boundary.

Added CallGraph.filter_by_nodes() and switched the subgraph creation to use it, ensuring children can only see methods the parent actually owns.

Amp-Thread-ID: https://ampcode.com/threads/T-019d9817-8ee7-724a-aef5-3bd014a00ecf
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/codeboarding/codeboarding/pull/306" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced component analysis precision by switching to granular method-level filtering, reducing scope leakage during subgraph extraction.

* **Tests**
  * Updated test cases to align with new filtering methodology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->