### PR TITLE
Add context-window resolver for LLM models

### DIFF
--- a/agents/constants.py
+++ b/agents/constants.py
@@ -14,8 +14,8 @@ class FileStructureConfig:
 
 
 class ModelCapabilities:
-    FALLBACK_INPUT = 128_000
-    FALLBACK_OUTPUT = 8_192
+    FALLBACK_INPUT = 256_000
+    FALLBACK_OUTPUT = 64_000
     CACHE_TTL_SECONDS = 24 * 3600
 
     SOURCES = {

--- a/agents/constants.py
+++ b/agents/constants.py
@@ -11,3 +11,27 @@ class FileStructureConfig:
     MAX_LINES = 500
     DEFAULT_MAX_DEPTH = 10
     FALLBACK_MAX_LINES = 50000
+
+
+class ModelCapabilities:
+    FALLBACK_INPUT = 128_000
+    FALLBACK_OUTPUT = 8_192
+    CACHE_TTL_SECONDS = 24 * 3600
+
+    SOURCES = {
+        "litellm": "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json",
+        "modelsdev": "https://models.dev/api.json",
+        "openrouter": "https://openrouter.ai/api/v1/models",
+    }
+
+    # models.dev uses slugs that diverge from our internal provider names.
+    MODELSDEV_SLUG = {
+        "aws": "amazon-bedrock",
+        "kimi": "moonshotai",
+        "glm": "zai",
+    }
+
+    OPENROUTER_PREFIX = {
+        "kimi": "moonshotai",
+        "glm": "z-ai",
+    }

--- a/agents/model_capabilities.py
+++ b/agents/model_capabilities.py
@@ -160,7 +160,7 @@ def _load(source: str) -> dict:
     try:
         # Why: models.dev rejects urllib's default UA with 403.
         req = urllib.request.Request(ModelCapabilities.SOURCES[source], headers={"User-Agent": "codeboarding/1.0"})
-        with urllib.request.urlopen(req, timeout=5) as r:
+        with urllib.request.urlopen(req, timeout=2) as r:
             raw = json.load(r)
         data = _normalize(source, raw)
         path.parent.mkdir(parents=True, exist_ok=True)

--- a/agents/model_capabilities.py
+++ b/agents/model_capabilities.py
@@ -20,6 +20,10 @@ _OVERRIDES: dict[tuple[str, str], tuple[int, int]] = {}
 
 _BEDROCK_REGION = re.compile(r"^(us|eu|apac|global|au|ca|us-gov)\.")
 
+# Why: cached by hand (not via @lru_cache) so a transient Ollama outage -- user starts the
+# app before `ollama serve` is up -- doesn't memoize None for the rest of the process.
+_OLLAMA_CACHE: dict[tuple[str, str], tuple[int, int]] = {}
+
 
 @dataclass(frozen=True)
 class ContextWindow:
@@ -50,8 +54,14 @@ def _resolve_env(provider: str, model_name: str) -> tuple[int, int] | None:
     if not val:
         return None
     parts = val.split(",")
-    inp = int(parts[0])
-    out = int(parts[1]) if len(parts) > 1 else ModelCapabilities.FALLBACK_OUTPUT
+    try:
+        inp = int(parts[0])
+        out = int(parts[1]) if len(parts) > 1 else ModelCapabilities.FALLBACK_OUTPUT
+    except ValueError as e:
+        # Why: env layer is an escape hatch; a typo like `500k` must fall through
+        # to the next resolver, not crash the whole call out of get_context_window.
+        logger.warning(f"Ignoring malformed {key}={val!r} ({e})")
+        return None
     return inp, out
 
 
@@ -68,8 +78,11 @@ def _resolve_ollama(provider: str, model_name: str) -> tuple[int, int] | None:
     return _ollama_show(model_name, base.rstrip("/"))
 
 
-@lru_cache(maxsize=64)
 def _ollama_show(model_name: str, base_url: str) -> tuple[int, int] | None:
+    key = (model_name, base_url)
+    cached = _OLLAMA_CACHE.get(key)
+    if cached is not None:
+        return cached
     try:
         req = urllib.request.Request(
             f"{base_url}/api/show",
@@ -93,7 +106,9 @@ def _ollama_show(model_name: str, base_url: str) -> tuple[int, int] | None:
     # Tell the user so they can bump PARAMETER num_ctx in their Modelfile.
     if num_ctx and arch_max and num_ctx < arch_max:
         logger.info(f"{model_name}: num_ctx={num_ctx} < arch_max={arch_max}; Ollama will truncate")
-    return ctx, ModelCapabilities.FALLBACK_OUTPUT
+    result = (ctx, ModelCapabilities.FALLBACK_OUTPUT)
+    _OLLAMA_CACHE[key] = result
+    return result
 
 
 def _parse_num_ctx(params: str) -> int | None:
@@ -158,7 +173,9 @@ def _load(source: str) -> dict:
     # parses of the same multi-MB JSON. On-disk TTL still applies on first hit per process.
     path = get_cache_dir(Path.cwd()) / f"{source}.json"
     if path.exists() and time.time() - path.stat().st_mtime < ModelCapabilities.CACHE_TTL_SECONDS:
-        return json.loads(path.read_text())
+        cached = _read_cache(path)
+        if cached is not None:
+            return cached
     try:
         # Why: models.dev rejects urllib's default UA with 403.
         req = urllib.request.Request(ModelCapabilities.SOURCES[source], headers={"User-Agent": "codeboarding/1.0"})
@@ -170,7 +187,17 @@ def _load(source: str) -> dict:
         return data
     except Exception as e:
         logger.warning(f"{source} fetch failed ({e}); using stale cache or skipping")
-        return json.loads(path.read_text()) if path.exists() else {}
+        return _read_cache(path) or {}
+
+
+def _read_cache(path: Path) -> dict | None:
+    # Why: a half-written or disk-full cache file must not crash the resolver
+    # on every startup. Treat unreadable cache as "no cache" -- next call refetches.
+    try:
+        return json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as e:
+        logger.warning(f"Cache read failed for {path.name} ({e}); treating as missing")
+        return None
 
 
 def _normalize(source: str, raw: dict) -> dict:

--- a/agents/model_capabilities.py
+++ b/agents/model_capabilities.py
@@ -27,8 +27,8 @@ _OLLAMA_CACHE: dict[tuple[str, str], tuple[int, int]] = {}
 
 @dataclass(frozen=True)
 class ContextWindow:
-    input: int
-    output: int
+    input_tokens: int
+    output_tokens: int
 
 
 def get_context_window(provider: str, model_name: str) -> ContextWindow:

--- a/agents/model_capabilities.py
+++ b/agents/model_capabilities.py
@@ -1,0 +1,197 @@
+import json
+import logging
+import os
+import re
+import time
+import urllib.request
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_CACHE_DIR = Path.home() / ".codeboarding" / "cache"
+_TTL_SECONDS = 24 * 3600
+_FALLBACK_INPUT = 128_000
+_FALLBACK_OUTPUT = 8_192
+
+_SOURCES = {
+    "litellm": "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json",
+    "modelsdev": "https://models.dev/api.json",
+    "openrouter": "https://openrouter.ai/api/v1/models",
+}
+
+# Escape hatch for catalog bugs or private IDs no catalog covers. Empty by design —
+# models.dev resolves the previously-suspected overrides (gpt-5, kimi-k2.5, glm-4.6,
+# gpt-oss-120b) correctly when we prefer limit.input over limit.context.
+_OVERRIDES: dict[tuple[str, str], tuple[int, int]] = {}
+
+# models.dev uses slugs that diverge from our internal provider names.
+_MODELSDEV_SLUG = {
+    "aws": "amazon-bedrock",
+    "kimi": "moonshotai",
+    "glm": "zai",
+}
+
+_BEDROCK_REGION = re.compile(r"^(us|eu|apac|global|au|ca|us-gov)\.")
+
+_OPENROUTER_PREFIX = {
+    "kimi": "moonshotai",
+    "glm": "z-ai",
+}
+
+
+@dataclass(frozen=True)
+class ContextWindow:
+    input: int
+    output: int
+
+
+def get_context_window(provider: str, model_name: str) -> ContextWindow:
+    resolvers = (
+        _resolve_env,
+        _resolve_override,
+        _resolve_ollama,
+        _resolve_modelsdev,
+        _resolve_litellm,
+        _resolve_openrouter,
+    )
+    for resolver in resolvers:
+        hit = resolver(provider, model_name)
+        if hit is not None:
+            return ContextWindow(*hit)
+    logger.warning(f"No context window for {provider}/{model_name}; using fallback {_FALLBACK_INPUT}")
+    return ContextWindow(_FALLBACK_INPUT, _FALLBACK_OUTPUT)
+
+
+def _resolve_env(provider: str, model_name: str) -> tuple[int, int] | None:
+    key = f"CB_CTX_{provider.upper()}_{re.sub(r'[^A-Z0-9]', '_', model_name.upper())}"
+    val = os.getenv(key)
+    if not val:
+        return None
+    parts = val.split(",")
+    inp = int(parts[0])
+    out = int(parts[1]) if len(parts) > 1 else _FALLBACK_OUTPUT
+    return inp, out
+
+
+def _resolve_override(provider: str, model_name: str) -> tuple[int, int] | None:
+    return _OVERRIDES.get((provider, model_name))
+
+
+def _resolve_ollama(provider: str, model_name: str) -> tuple[int, int] | None:
+    if provider != "ollama":
+        return None
+    base = os.getenv("OLLAMA_BASE_URL")
+    if not base:
+        return None
+    return _ollama_show(model_name, base.rstrip("/"))
+
+
+@lru_cache(maxsize=64)
+def _ollama_show(model_name: str, base_url: str) -> tuple[int, int] | None:
+    try:
+        req = urllib.request.Request(
+            f"{base_url}/api/show",
+            data=json.dumps({"model": model_name}).encode(),
+            headers={"Content-Type": "application/json"},
+        )
+        with urllib.request.urlopen(req, timeout=3) as r:
+            info = json.load(r)
+    except Exception as e:
+        logger.warning(f"Ollama /api/show failed for {model_name} ({e})")
+        return None
+    num_ctx = _parse_num_ctx(info.get("parameters") or "")
+    arch_max = next(
+        (int(v) for k, v in (info.get("model_info") or {}).items() if k.endswith(".context_length")),
+        None,
+    )
+    ctx = num_ctx or arch_max
+    if not ctx:
+        return None
+    # Why: num_ctx < arch_max means Ollama silently truncates beyond num_ctx tokens.
+    # Tell the user so they can bump PARAMETER num_ctx in their Modelfile.
+    if num_ctx and arch_max and num_ctx < arch_max:
+        logger.info(f"{model_name}: num_ctx={num_ctx} < arch_max={arch_max}; Ollama will truncate")
+    return ctx, _FALLBACK_OUTPUT
+
+
+def _parse_num_ctx(params: str) -> int | None:
+    m = re.search(r"^num_ctx\s+(\d+)", params, re.MULTILINE)
+    return int(m.group(1)) if m else None
+
+
+def _resolve_modelsdev(provider: str, model_name: str) -> tuple[int, int] | None:
+    data = _load("modelsdev")
+    slug = _MODELSDEV_SLUG.get(provider, provider)
+    entry = data.get(slug, {}).get("models", {}).get(model_name)
+    if not entry:
+        return None
+    limit = entry.get("limit") or {}
+    # Why: models.dev splits total context from real input cap for models like GPT-5
+    # (context=400K, input=272K). Prefer `input` so we never over-promise the window.
+    inp = limit.get("input") or limit.get("context")
+    if not inp:
+        return None
+    return int(inp), int(limit.get("output") or _FALLBACK_OUTPUT)
+
+
+def _resolve_litellm(provider: str, model_name: str) -> tuple[int, int] | None:
+    data = _load("litellm")
+    base = _BEDROCK_REGION.sub("", model_name) if provider == "aws" else model_name
+    for key in (base, f"{provider}/{base}", f"bedrock/{base}"):
+        entry = data.get(key)
+        if not entry:
+            continue
+        inp = entry.get("max_input_tokens") or entry.get("max_tokens")
+        out = entry.get("max_output_tokens") or entry.get("max_tokens")
+        if inp:
+            return int(inp), int(out or _FALLBACK_OUTPUT)
+    return None
+
+
+def _resolve_openrouter(provider: str, model_name: str) -> tuple[int, int] | None:
+    data = _load("openrouter")
+    entry = data.get(_openrouter_id(provider, model_name))
+    if not entry:
+        return None
+    ctx = entry.get("context_length")
+    if not ctx:
+        return None
+    out = (entry.get("top_provider") or {}).get("max_completion_tokens")
+    return int(ctx), int(out or _FALLBACK_OUTPUT)
+
+
+def _openrouter_id(provider: str, model_name: str) -> str:
+    if provider == "aws" and "anthropic." in model_name:
+        stripped = _BEDROCK_REGION.sub("", model_name).removeprefix("anthropic.").removesuffix("-v1:0")
+        return f"anthropic/{stripped}"
+    if "/" in model_name:
+        return model_name
+    return f"{_OPENROUTER_PREFIX.get(provider, provider)}/{model_name}"
+
+
+def _load(source: str) -> dict:
+    path = _CACHE_DIR / f"{source}.json"
+    if path.exists() and time.time() - path.stat().st_mtime < _TTL_SECONDS:
+        return json.loads(path.read_text())
+    try:
+        # Why: models.dev rejects urllib's default UA with 403.
+        req = urllib.request.Request(_SOURCES[source], headers={"User-Agent": "codeboarding/1.0"})
+        with urllib.request.urlopen(req, timeout=5) as r:
+            raw = json.load(r)
+        data = _normalize(source, raw)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(data))
+        return data
+    except Exception as e:
+        logger.warning(f"{source} fetch failed ({e}); using stale cache or skipping")
+        return json.loads(path.read_text()) if path.exists() else {}
+
+
+def _normalize(source: str, raw: dict) -> dict:
+    if source == "openrouter":
+        return {m["id"]: m for m in raw.get("data", [])}
+    if source == "litellm":
+        return {k: v for k, v in raw.items() if isinstance(v, dict)}
+    return raw

--- a/agents/model_capabilities.py
+++ b/agents/model_capabilities.py
@@ -9,10 +9,9 @@ from functools import lru_cache
 from pathlib import Path
 
 from agents.constants import ModelCapabilities
+from utils import get_cache_dir
 
 logger = logging.getLogger(__name__)
-
-_CACHE_DIR = Path.home() / ".codeboarding" / "cache"
 
 # Escape hatch for catalog bugs or private IDs no catalog covers. Empty by design —
 # models.dev resolves the previously-suspected overrides (gpt-5, kimi-k2.5, glm-4.6,
@@ -154,7 +153,7 @@ def _openrouter_id(provider: str, model_name: str) -> str:
 
 
 def _load(source: str) -> dict:
-    path = _CACHE_DIR / f"{source}.json"
+    path = get_cache_dir(Path.cwd()) / f"{source}.json"
     if path.exists() and time.time() - path.stat().st_mtime < ModelCapabilities.CACHE_TTL_SECONDS:
         return json.loads(path.read_text())
     try:

--- a/agents/model_capabilities.py
+++ b/agents/model_capabilities.py
@@ -152,7 +152,10 @@ def _openrouter_id(provider: str, model_name: str) -> str:
     return f"{ModelCapabilities.OPENROUTER_PREFIX.get(provider, provider)}/{model_name}"
 
 
+@lru_cache(maxsize=4)
 def _load(source: str) -> dict:
+    # Why: each resolver calls _load on every lookup; without memoization, 100 models = ~300
+    # parses of the same multi-MB JSON. On-disk TTL still applies on first hit per process.
     path = get_cache_dir(Path.cwd()) / f"{source}.json"
     if path.exists() and time.time() - path.stat().st_mtime < ModelCapabilities.CACHE_TTL_SECONDS:
         return json.loads(path.read_text())

--- a/agents/model_capabilities.py
+++ b/agents/model_capabilities.py
@@ -8,37 +8,18 @@ from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
 
+from agents.constants import ModelCapabilities
+
 logger = logging.getLogger(__name__)
 
 _CACHE_DIR = Path.home() / ".codeboarding" / "cache"
-_TTL_SECONDS = 24 * 3600
-_FALLBACK_INPUT = 128_000
-_FALLBACK_OUTPUT = 8_192
-
-_SOURCES = {
-    "litellm": "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json",
-    "modelsdev": "https://models.dev/api.json",
-    "openrouter": "https://openrouter.ai/api/v1/models",
-}
 
 # Escape hatch for catalog bugs or private IDs no catalog covers. Empty by design —
 # models.dev resolves the previously-suspected overrides (gpt-5, kimi-k2.5, glm-4.6,
 # gpt-oss-120b) correctly when we prefer limit.input over limit.context.
 _OVERRIDES: dict[tuple[str, str], tuple[int, int]] = {}
 
-# models.dev uses slugs that diverge from our internal provider names.
-_MODELSDEV_SLUG = {
-    "aws": "amazon-bedrock",
-    "kimi": "moonshotai",
-    "glm": "zai",
-}
-
 _BEDROCK_REGION = re.compile(r"^(us|eu|apac|global|au|ca|us-gov)\.")
-
-_OPENROUTER_PREFIX = {
-    "kimi": "moonshotai",
-    "glm": "z-ai",
-}
 
 
 @dataclass(frozen=True)
@@ -60,8 +41,8 @@ def get_context_window(provider: str, model_name: str) -> ContextWindow:
         hit = resolver(provider, model_name)
         if hit is not None:
             return ContextWindow(*hit)
-    logger.warning(f"No context window for {provider}/{model_name}; using fallback {_FALLBACK_INPUT}")
-    return ContextWindow(_FALLBACK_INPUT, _FALLBACK_OUTPUT)
+    logger.warning(f"No context window for {provider}/{model_name}; using fallback {ModelCapabilities.FALLBACK_INPUT}")
+    return ContextWindow(ModelCapabilities.FALLBACK_INPUT, ModelCapabilities.FALLBACK_OUTPUT)
 
 
 def _resolve_env(provider: str, model_name: str) -> tuple[int, int] | None:
@@ -71,7 +52,7 @@ def _resolve_env(provider: str, model_name: str) -> tuple[int, int] | None:
         return None
     parts = val.split(",")
     inp = int(parts[0])
-    out = int(parts[1]) if len(parts) > 1 else _FALLBACK_OUTPUT
+    out = int(parts[1]) if len(parts) > 1 else ModelCapabilities.FALLBACK_OUTPUT
     return inp, out
 
 
@@ -113,17 +94,18 @@ def _ollama_show(model_name: str, base_url: str) -> tuple[int, int] | None:
     # Tell the user so they can bump PARAMETER num_ctx in their Modelfile.
     if num_ctx and arch_max and num_ctx < arch_max:
         logger.info(f"{model_name}: num_ctx={num_ctx} < arch_max={arch_max}; Ollama will truncate")
-    return ctx, _FALLBACK_OUTPUT
+    return ctx, ModelCapabilities.FALLBACK_OUTPUT
 
 
 def _parse_num_ctx(params: str) -> int | None:
+    # Extracts the `num_ctx N` runtime cap from an Ollama Modelfile parameters blob.
     m = re.search(r"^num_ctx\s+(\d+)", params, re.MULTILINE)
     return int(m.group(1)) if m else None
 
 
 def _resolve_modelsdev(provider: str, model_name: str) -> tuple[int, int] | None:
     data = _load("modelsdev")
-    slug = _MODELSDEV_SLUG.get(provider, provider)
+    slug = ModelCapabilities.MODELSDEV_SLUG.get(provider, provider)
     entry = data.get(slug, {}).get("models", {}).get(model_name)
     if not entry:
         return None
@@ -133,7 +115,7 @@ def _resolve_modelsdev(provider: str, model_name: str) -> tuple[int, int] | None
     inp = limit.get("input") or limit.get("context")
     if not inp:
         return None
-    return int(inp), int(limit.get("output") or _FALLBACK_OUTPUT)
+    return int(inp), int(limit.get("output") or ModelCapabilities.FALLBACK_OUTPUT)
 
 
 def _resolve_litellm(provider: str, model_name: str) -> tuple[int, int] | None:
@@ -146,7 +128,7 @@ def _resolve_litellm(provider: str, model_name: str) -> tuple[int, int] | None:
         inp = entry.get("max_input_tokens") or entry.get("max_tokens")
         out = entry.get("max_output_tokens") or entry.get("max_tokens")
         if inp:
-            return int(inp), int(out or _FALLBACK_OUTPUT)
+            return int(inp), int(out or ModelCapabilities.FALLBACK_OUTPUT)
     return None
 
 
@@ -159,7 +141,7 @@ def _resolve_openrouter(provider: str, model_name: str) -> tuple[int, int] | Non
     if not ctx:
         return None
     out = (entry.get("top_provider") or {}).get("max_completion_tokens")
-    return int(ctx), int(out or _FALLBACK_OUTPUT)
+    return int(ctx), int(out or ModelCapabilities.FALLBACK_OUTPUT)
 
 
 def _openrouter_id(provider: str, model_name: str) -> str:
@@ -168,16 +150,16 @@ def _openrouter_id(provider: str, model_name: str) -> str:
         return f"anthropic/{stripped}"
     if "/" in model_name:
         return model_name
-    return f"{_OPENROUTER_PREFIX.get(provider, provider)}/{model_name}"
+    return f"{ModelCapabilities.OPENROUTER_PREFIX.get(provider, provider)}/{model_name}"
 
 
 def _load(source: str) -> dict:
     path = _CACHE_DIR / f"{source}.json"
-    if path.exists() and time.time() - path.stat().st_mtime < _TTL_SECONDS:
+    if path.exists() and time.time() - path.stat().st_mtime < ModelCapabilities.CACHE_TTL_SECONDS:
         return json.loads(path.read_text())
     try:
         # Why: models.dev rejects urllib's default UA with 403.
-        req = urllib.request.Request(_SOURCES[source], headers={"User-Agent": "codeboarding/1.0"})
+        req = urllib.request.Request(ModelCapabilities.SOURCES[source], headers={"User-Agent": "codeboarding/1.0"})
         with urllib.request.urlopen(req, timeout=5) as r:
             raw = json.load(r)
         data = _normalize(source, raw)

--- a/agents/model_capabilities.py
+++ b/agents/model_capabilities.py
@@ -13,11 +13,6 @@ from utils import get_cache_dir
 
 logger = logging.getLogger(__name__)
 
-# Escape hatch for catalog bugs or private IDs no catalog covers. Empty by design —
-# models.dev resolves the previously-suspected overrides (gpt-5, kimi-k2.5, glm-4.6,
-# gpt-oss-120b) correctly when we prefer limit.input over limit.context.
-_OVERRIDES: dict[tuple[str, str], tuple[int, int]] = {}
-
 _BEDROCK_REGION = re.compile(r"^(us|eu|apac|global|au|ca|us-gov)\.")
 
 # Why: cached by hand (not via @lru_cache) so a transient Ollama outage -- user starts the
@@ -34,7 +29,7 @@ class ContextWindow:
 def get_context_window(provider: str, model_name: str) -> ContextWindow:
     resolvers = (
         _resolve_env,
-        _resolve_override,
+        _resolve_user_config,
         _resolve_ollama,
         _resolve_modelsdev,
         _resolve_litellm,
@@ -65,8 +60,22 @@ def _resolve_env(provider: str, model_name: str) -> tuple[int, int] | None:
     return inp, out
 
 
-def _resolve_override(provider: str, model_name: str) -> tuple[int, int] | None:
-    return _OVERRIDES.get((provider, model_name))
+def _resolve_user_config(provider: str, model_name: str) -> tuple[int, int] | None:
+    # Why: lets users pin a window via `[llm] context_window = N` in ~/.codeboarding/config.toml
+    # when catalogs are wrong or a model is private. Global scalar — applies to every provider/model.
+    cw = _user_context_window_override()
+    if cw is None:
+        return None
+    return cw, ModelCapabilities.FALLBACK_OUTPUT
+
+
+@lru_cache(maxsize=1)
+def _user_context_window_override() -> int | None:
+    # Why: delayed import avoids a module-load cycle; lru_cache avoids re-parsing
+    # config.toml on every get_context_window call.
+    from user_config import load_user_config
+
+    return load_user_config().llm.context_window
 
 
 def _resolve_ollama(provider: str, model_name: str) -> tuple[int, int] | None:

--- a/tests/agents/test_model_capabilities.py
+++ b/tests/agents/test_model_capabilities.py
@@ -70,10 +70,10 @@ class TestResolverPriority:
         monkeypatch.setenv("CB_CTX_OPENAI_GPT_5", "500000")
         cw = get_context_window("openai", "gpt-5")
         assert cw.input == 500_000
-        assert cw.output == 8_192
+        assert cw.output == 64_000
 
     def test_fallback_when_nothing_matches(self, fake_catalogs):
-        assert get_context_window("mystery", "nonexistent") == ContextWindow(128_000, 8_192)
+        assert get_context_window("mystery", "nonexistent") == ContextWindow(256_000, 64_000)
 
 
 class TestModelsdevResolution:
@@ -129,7 +129,7 @@ class TestOllamaResolver:
 
         monkeypatch.setattr("agents.model_capabilities.urllib.request.urlopen", fake_urlopen)
         result = _resolve_ollama("ollama", "qwen3:30b")
-        assert result == (4096, 8192)
+        assert result == (4096, 64_000)
 
     def test_arch_max_used_when_num_ctx_absent(self, monkeypatch):
         monkeypatch.setenv("OLLAMA_BASE_URL", "http://fake:11434")
@@ -140,7 +140,7 @@ class TestOllamaResolver:
             return io.BytesIO(json.dumps(payload).encode())
 
         monkeypatch.setattr("agents.model_capabilities.urllib.request.urlopen", fake_urlopen)
-        assert _resolve_ollama("ollama", "llama3:8b") == (131072, 8192)
+        assert _resolve_ollama("ollama", "llama3:8b") == (131072, 64_000)
 
 
 class TestParseNumCtx:

--- a/tests/agents/test_model_capabilities.py
+++ b/tests/agents/test_model_capabilities.py
@@ -58,6 +58,9 @@ def fake_catalogs(monkeypatch):
         return catalogs.get(source, {})
 
     monkeypatch.setattr("agents.model_capabilities._load", fake_load)
+    # Why: isolate from ~/.codeboarding/config.toml so a developer's local override
+    # doesn't shadow the catalog under test.
+    monkeypatch.setattr("agents.model_capabilities._user_context_window_override", lambda: None)
     _OLLAMA_CACHE.clear()
 
 

--- a/tests/agents/test_model_capabilities.py
+++ b/tests/agents/test_model_capabilities.py
@@ -6,8 +6,8 @@ import json
 import pytest
 
 from agents.model_capabilities import (
+    _OLLAMA_CACHE,
     ContextWindow,
-    _ollama_show,
     _parse_num_ctx,
     _resolve_ollama,
     get_context_window,
@@ -58,7 +58,7 @@ def fake_catalogs(monkeypatch):
         return catalogs.get(source, {})
 
     monkeypatch.setattr("agents.model_capabilities._load", fake_load)
-    _ollama_show.cache_clear()
+    _OLLAMA_CACHE.clear()
 
 
 class TestResolverPriority:
@@ -71,6 +71,11 @@ class TestResolverPriority:
         cw = get_context_window("openai", "gpt-5")
         assert cw.input == 500_000
         assert cw.output == 64_000
+
+    def test_malformed_env_override_falls_through_to_catalog(self, fake_catalogs, monkeypatch):
+        # Regression: a typo like `500k` used to raise ValueError out of get_context_window.
+        monkeypatch.setenv("CB_CTX_OPENAI_GPT_5", "500k")
+        assert get_context_window("openai", "gpt-5").input == 272_000
 
     def test_fallback_when_nothing_matches(self, fake_catalogs):
         assert get_context_window("mystery", "nonexistent") == ContextWindow(256_000, 64_000)
@@ -113,7 +118,7 @@ class TestOpenrouterResolution:
 class TestOllamaResolver:
     def test_short_circuits_without_base_url(self, monkeypatch):
         monkeypatch.delenv("OLLAMA_BASE_URL", raising=False)
-        _ollama_show.cache_clear()
+        _OLLAMA_CACHE.clear()
         assert _resolve_ollama("ollama", "qwen3:30b") is None
 
     def test_short_circuits_for_non_ollama_provider(self):
@@ -121,7 +126,7 @@ class TestOllamaResolver:
 
     def test_num_ctx_wins_over_arch_max(self, monkeypatch):
         monkeypatch.setenv("OLLAMA_BASE_URL", "http://fake:11434")
-        _ollama_show.cache_clear()
+        _OLLAMA_CACHE.clear()
         payload = {"parameters": 'stop "<|eot|>"\nnum_ctx 4096', "model_info": {"qwen3.context_length": 131072}}
 
         def fake_urlopen(req, timeout=None):
@@ -133,7 +138,7 @@ class TestOllamaResolver:
 
     def test_arch_max_used_when_num_ctx_absent(self, monkeypatch):
         monkeypatch.setenv("OLLAMA_BASE_URL", "http://fake:11434")
-        _ollama_show.cache_clear()
+        _OLLAMA_CACHE.clear()
         payload = {"parameters": 'stop "<|eot|>"', "model_info": {"llama.context_length": 131072}}
 
         def fake_urlopen(req, timeout=None):
@@ -141,6 +146,50 @@ class TestOllamaResolver:
 
         monkeypatch.setattr("agents.model_capabilities.urllib.request.urlopen", fake_urlopen)
         assert _resolve_ollama("ollama", "llama3:8b") == (131072, 64_000)
+
+    def test_transient_failure_is_retried_not_cached(self, monkeypatch):
+        # Why: @lru_cache used to memoize None here, so a brief Ollama outage
+        # silently pinned the resolver to the generic fallback for the process lifetime.
+        monkeypatch.setenv("OLLAMA_BASE_URL", "http://fake:11434")
+        _OLLAMA_CACHE.clear()
+        calls = {"n": 0}
+        payload = {"parameters": "", "model_info": {"llama.context_length": 8192}}
+
+        def fake_urlopen(req, timeout=None):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise ConnectionRefusedError("ollama not up yet")
+            return io.BytesIO(json.dumps(payload).encode())
+
+        monkeypatch.setattr("agents.model_capabilities.urllib.request.urlopen", fake_urlopen)
+        assert _resolve_ollama("ollama", "llama3:8b") is None
+        assert _resolve_ollama("ollama", "llama3:8b") == (8192, 64_000)
+
+
+class TestCorruptCache:
+    def test_corrupt_cache_file_triggers_refetch_instead_of_crashing(self, tmp_path, monkeypatch):
+        # Regression: a half-written cache file used to crash the first resolver call
+        # with a JSONDecodeError, turning a transient disk issue into a startup failure.
+        from agents import model_capabilities
+
+        # Why: clear before AND after so we don't poison the lru_cache for sibling tests.
+        model_capabilities._load.cache_clear()
+        try:
+            cache_dir = tmp_path / ".codeboarding" / "cache"
+            cache_dir.mkdir(parents=True)
+            (cache_dir / "openrouter.json").write_text("{ not json ")
+            monkeypatch.setattr(model_capabilities, "get_cache_dir", lambda _repo: cache_dir)
+
+            valid_body = json.dumps({"data": [{"id": "openai/gpt-4o", "context_length": 128_000}]}).encode()
+
+            def fake_urlopen(req, timeout=None):
+                return io.BytesIO(valid_body)
+
+            monkeypatch.setattr("agents.model_capabilities.urllib.request.urlopen", fake_urlopen)
+            data = model_capabilities._load("openrouter")
+            assert data["openai/gpt-4o"]["context_length"] == 128_000
+        finally:
+            model_capabilities._load.cache_clear()
 
 
 class TestParseNumCtx:

--- a/tests/agents/test_model_capabilities.py
+++ b/tests/agents/test_model_capabilities.py
@@ -69,13 +69,13 @@ class TestResolverPriority:
     def test_env_override_single_value_uses_fallback_output(self, fake_catalogs, monkeypatch):
         monkeypatch.setenv("CB_CTX_OPENAI_GPT_5", "500000")
         cw = get_context_window("openai", "gpt-5")
-        assert cw.input == 500_000
-        assert cw.output == 64_000
+        assert cw.input_tokens == 500_000
+        assert cw.output_tokens == 64_000
 
     def test_malformed_env_override_falls_through_to_catalog(self, fake_catalogs, monkeypatch):
         # Regression: a typo like `500k` used to raise ValueError out of get_context_window.
         monkeypatch.setenv("CB_CTX_OPENAI_GPT_5", "500k")
-        assert get_context_window("openai", "gpt-5").input == 272_000
+        assert get_context_window("openai", "gpt-5").input_tokens == 272_000
 
     def test_fallback_when_nothing_matches(self, fake_catalogs):
         assert get_context_window("mystery", "nonexistent") == ContextWindow(256_000, 64_000)
@@ -84,20 +84,20 @@ class TestResolverPriority:
 class TestModelsdevResolution:
     def test_prefers_input_over_context(self, fake_catalogs):
         # Why: GPT-5 ships with context=400K but input=272K; we must honor the tighter cap.
-        assert get_context_window("openai", "gpt-5").input == 272_000
+        assert get_context_window("openai", "gpt-5").input_tokens == 272_000
 
     def test_falls_back_to_context_when_input_absent(self, fake_catalogs):
-        assert get_context_window("openai", "gpt-4o").input == 128_000
+        assert get_context_window("openai", "gpt-4o").input_tokens == 128_000
 
     def test_bedrock_regional_prefix_matched_directly(self, fake_catalogs):
         cw = get_context_window("aws", "us.anthropic.claude-sonnet-4-5-20250929-v1:0")
-        assert cw.input == 200_000
+        assert cw.input_tokens == 200_000
 
     def test_slug_mapping_glm_zai(self, fake_catalogs):
-        assert get_context_window("glm", "glm-4.6").input == 204_800
+        assert get_context_window("glm", "glm-4.6").input_tokens == 204_800
 
     def test_slug_mapping_kimi_moonshotai(self, fake_catalogs):
-        assert get_context_window("kimi", "kimi-k2.5").input == 262_144
+        assert get_context_window("kimi", "kimi-k2.5").input_tokens == 262_144
 
 
 class TestLitellmResolution:
@@ -105,14 +105,14 @@ class TestLitellmResolution:
         # LiteLLM holds the stripped key `anthropic.claude-3-haiku-…-v1:0`;
         # resolver must strip `us.` before looking up.
         cw = get_context_window("aws", "us.anthropic.claude-3-haiku-20240307-v1:0")
-        assert cw.input == 200_000
+        assert cw.input_tokens == 200_000
 
 
 class TestOpenrouterResolution:
     def test_resolves_via_aggregator_id(self, fake_catalogs):
         cw = get_context_window("anthropic", "claude-opus-4-7")
-        assert cw.input == 1_000_000
-        assert cw.output == 128_000
+        assert cw.input_tokens == 1_000_000
+        assert cw.output_tokens == 128_000
 
 
 class TestOllamaResolver:

--- a/tests/agents/test_model_capabilities.py
+++ b/tests/agents/test_model_capabilities.py
@@ -1,0 +1,156 @@
+"""Hermetic unit tests for the context-window resolver. Catalogs are mocked — no network."""
+
+import io
+import json
+
+import pytest
+
+from agents.model_capabilities import (
+    ContextWindow,
+    _ollama_show,
+    _parse_num_ctx,
+    _resolve_ollama,
+    get_context_window,
+)
+
+_FAKE_MODELSDEV = {
+    "openai": {
+        "models": {
+            "gpt-5": {"limit": {"context": 400_000, "input": 272_000, "output": 128_000}},
+            "gpt-4o": {"limit": {"context": 128_000, "output": 16_384}},
+        }
+    },
+    "anthropic": {
+        "models": {
+            "claude-sonnet-4-5-20250929": {"limit": {"context": 200_000, "output": 64_000}},
+        }
+    },
+    "amazon-bedrock": {
+        "models": {
+            "us.anthropic.claude-sonnet-4-5-20250929-v1:0": {"limit": {"context": 200_000, "output": 64_000}},
+        }
+    },
+    "zai": {"models": {"glm-4.6": {"limit": {"context": 204_800, "output": 131_072}}}},
+    "moonshotai": {"models": {"kimi-k2.5": {"limit": {"context": 262_144, "output": 262_144}}}},
+}
+
+_FAKE_LITELLM = {
+    "anthropic.claude-3-haiku-20240307-v1:0": {"max_input_tokens": 200_000, "max_output_tokens": 4_096},
+}
+
+_FAKE_OPENROUTER = {
+    "anthropic/claude-opus-4-7": {
+        "context_length": 1_000_000,
+        "top_provider": {"max_completion_tokens": 128_000},
+    },
+}
+
+
+@pytest.fixture
+def fake_catalogs(monkeypatch):
+    def fake_load(source: str) -> dict:
+        return {
+            "modelsdev": _FAKE_MODELSDEV,
+            "litellm": _FAKE_LITELLM,
+            "openrouter": _FAKE_OPENROUTER,
+        }.get(source, {})
+
+    monkeypatch.setattr("agents.model_capabilities._load", fake_load)
+    _ollama_show.cache_clear()
+
+
+class TestResolverPriority:
+    def test_env_override_wins_over_catalog(self, fake_catalogs, monkeypatch):
+        monkeypatch.setenv("CB_CTX_OPENAI_GPT_5", "500000,200000")
+        assert get_context_window("openai", "gpt-5") == ContextWindow(500_000, 200_000)
+
+    def test_env_override_single_value_uses_fallback_output(self, fake_catalogs, monkeypatch):
+        monkeypatch.setenv("CB_CTX_OPENAI_GPT_5", "500000")
+        cw = get_context_window("openai", "gpt-5")
+        assert cw.input == 500_000
+        assert cw.output == 8_192
+
+    def test_fallback_when_nothing_matches(self, fake_catalogs):
+        assert get_context_window("mystery", "nonexistent") == ContextWindow(128_000, 8_192)
+
+
+class TestModelsdevResolution:
+    def test_prefers_input_over_context(self, fake_catalogs):
+        # Why: GPT-5 ships with context=400K but input=272K; we must honor the tighter cap.
+        assert get_context_window("openai", "gpt-5").input == 272_000
+
+    def test_falls_back_to_context_when_input_absent(self, fake_catalogs):
+        assert get_context_window("openai", "gpt-4o").input == 128_000
+
+    def test_bedrock_regional_prefix_matched_directly(self, fake_catalogs):
+        cw = get_context_window("aws", "us.anthropic.claude-sonnet-4-5-20250929-v1:0")
+        assert cw.input == 200_000
+
+    def test_slug_mapping_glm_zai(self, fake_catalogs):
+        assert get_context_window("glm", "glm-4.6").input == 204_800
+
+    def test_slug_mapping_kimi_moonshotai(self, fake_catalogs):
+        assert get_context_window("kimi", "kimi-k2.5").input == 262_144
+
+
+class TestLitellmResolution:
+    def test_bedrock_region_stripped_for_litellm_key(self, fake_catalogs):
+        # LiteLLM holds the stripped key `anthropic.claude-3-haiku-…-v1:0`;
+        # resolver must strip `us.` before looking up.
+        cw = get_context_window("aws", "us.anthropic.claude-3-haiku-20240307-v1:0")
+        assert cw.input == 200_000
+
+
+class TestOpenrouterResolution:
+    def test_resolves_via_aggregator_id(self, fake_catalogs):
+        cw = get_context_window("anthropic", "claude-opus-4-7")
+        assert cw.input == 1_000_000
+        assert cw.output == 128_000
+
+
+class TestOllamaResolver:
+    def test_short_circuits_without_base_url(self, monkeypatch):
+        monkeypatch.delenv("OLLAMA_BASE_URL", raising=False)
+        _ollama_show.cache_clear()
+        assert _resolve_ollama("ollama", "qwen3:30b") is None
+
+    def test_short_circuits_for_non_ollama_provider(self):
+        assert _resolve_ollama("openai", "gpt-4o") is None
+
+    def test_num_ctx_wins_over_arch_max(self, monkeypatch):
+        monkeypatch.setenv("OLLAMA_BASE_URL", "http://fake:11434")
+        _ollama_show.cache_clear()
+        payload = {"parameters": 'stop "<|eot|>"\nnum_ctx 4096', "model_info": {"qwen3.context_length": 131072}}
+
+        def fake_urlopen(req, timeout=None):
+            return io.BytesIO(json.dumps(payload).encode())
+
+        monkeypatch.setattr("agents.model_capabilities.urllib.request.urlopen", fake_urlopen)
+        result = _resolve_ollama("ollama", "qwen3:30b")
+        assert result == (4096, 8192)
+
+    def test_arch_max_used_when_num_ctx_absent(self, monkeypatch):
+        monkeypatch.setenv("OLLAMA_BASE_URL", "http://fake:11434")
+        _ollama_show.cache_clear()
+        payload = {"parameters": 'stop "<|eot|>"', "model_info": {"llama.context_length": 131072}}
+
+        def fake_urlopen(req, timeout=None):
+            return io.BytesIO(json.dumps(payload).encode())
+
+        monkeypatch.setattr("agents.model_capabilities.urllib.request.urlopen", fake_urlopen)
+        assert _resolve_ollama("ollama", "llama3:8b") == (131072, 8192)
+
+
+class TestParseNumCtx:
+    def test_extracts_num_ctx(self):
+        assert _parse_num_ctx('stop "x"\nnum_ctx 8192\ntemperature 0.7') == 8192
+
+    def test_returns_none_when_absent(self):
+        assert _parse_num_ctx('stop "x"\ntemperature 0.7') is None
+
+    def test_handles_empty_string(self):
+        assert _parse_num_ctx("") is None
+
+    def test_not_matched_inside_other_key(self):
+        # `some_num_ctx 2048` must not match.
+        assert _parse_num_ctx("some_num_ctx 2048") is None

--- a/tests/agents/test_model_capabilities.py
+++ b/tests/agents/test_model_capabilities.py
@@ -48,12 +48,14 @@ _FAKE_OPENROUTER = {
 
 @pytest.fixture
 def fake_catalogs(monkeypatch):
+    catalogs: dict[str, dict] = {
+        "modelsdev": _FAKE_MODELSDEV,
+        "litellm": _FAKE_LITELLM,
+        "openrouter": _FAKE_OPENROUTER,
+    }
+
     def fake_load(source: str) -> dict:
-        return {
-            "modelsdev": _FAKE_MODELSDEV,
-            "litellm": _FAKE_LITELLM,
-            "openrouter": _FAKE_OPENROUTER,
-        }.get(source, {})
+        return catalogs.get(source, {})
 
     monkeypatch.setattr("agents.model_capabilities._load", fake_load)
     _ollama_show.cache_clear()

--- a/tests/integration/test_model_capabilities_live.py
+++ b/tests/integration/test_model_capabilities_live.py
@@ -1,0 +1,133 @@
+"""Live-catalog smoke test: resolves 100 (provider, model) pairs against real models.dev / litellm / openrouter.
+
+Skipped by the default `pytest --ignore=tests/integration` invocation in CLAUDE.md; run explicitly with
+`pytest tests/integration/test_model_capabilities_live.py` to spot catalog drift or check coverage for new models.
+"""
+
+import pytest
+
+from agents.model_capabilities import (
+    _resolve_env,
+    _resolve_litellm,
+    _resolve_modelsdev,
+    _resolve_ollama,
+    _resolve_openrouter,
+    _resolve_override,
+    get_context_window,
+)
+
+_RESOLVERS = (
+    _resolve_env,
+    _resolve_override,
+    _resolve_ollama,
+    _resolve_modelsdev,
+    _resolve_litellm,
+    _resolve_openrouter,
+)
+
+
+def _resolved(provider: str, model: str) -> bool:
+    # Why: we can't detect fallback via input == 128_000 because real models (gpt-4o) hit 128_000.
+    return any(fn(provider, model) is not None for fn in _RESOLVERS)
+
+
+_MIN_MODERN_INPUT = 8_000
+
+# (provider, model, min_expected_input). `min_expected_input` is a lower bound — the resolver
+# may return more (e.g. a catalog bumps Claude Sonnet from 200K to 1M) without failing the test.
+_TRICKY_CASES = [
+    ("openai", "gpt-5", 272_000),
+    ("openai", "gpt-5-mini", 272_000),
+    ("openai", "gpt-4o", 128_000),
+    ("openai", "gpt-4o-mini", 128_000),
+    ("openai", "gpt-4.1", 128_000),
+    ("openai", "o1", 128_000),
+    ("openai", "o3-mini", 128_000),
+    ("anthropic", "claude-sonnet-4-5-20250929", 200_000),
+    ("anthropic", "claude-3-haiku-20240307", 200_000),
+    ("anthropic", "claude-opus-4-5-20251101", 200_000),
+    ("anthropic", "claude-haiku-4-5-20251001", 200_000),
+    ("aws", "us.anthropic.claude-sonnet-4-5-20250929-v1:0", 200_000),
+    ("aws", "us.anthropic.claude-3-haiku-20240307-v1:0", 200_000),
+    ("aws", "eu.anthropic.claude-sonnet-4-20250514-v1:0", 200_000),
+    ("aws", "anthropic.claude-opus-4-1-20250805-v1:0", 200_000),
+    ("aws", "anthropic.claude-3-5-sonnet-20241022-v2:0", 200_000),
+    ("cerebras", "gpt-oss-120b", 131_072),
+    ("cerebras", "llama3.1-8b", 8_000),
+    ("deepseek", "deepseek-chat", 100_000),
+    ("kimi", "kimi-k2.5", 250_000),
+    ("glm", "glm-4.6", 200_000),
+    ("google", "gemini-2.5-pro", 1_000_000),
+    ("google", "gemini-2.5-flash", 1_000_000),
+    ("google", "gemini-1.5-pro", 1_000_000),
+    ("openrouter", "google/gemini-2.5-flash", 1_000_000),
+    ("openrouter", "meta-llama/llama-3.1-70b-instruct", 100_000),
+    ("openrouter", "qwen/qwen3-32b", 32_000),
+    ("openrouter", "x-ai/grok-4", 100_000),
+    ("openrouter", "mistralai/mistral-large", 32_000),
+    ("openrouter", "deepseek/deepseek-r1", 64_000),
+]
+
+# Additional well-known pairs across all providers. Kept live by pruning renamed/retired IDs —
+# this suite's purpose is "does the catalog resolve current models," not archaeology.
+_POPULAR_PAIRS = [
+    # OpenAI family
+    ("openai", "gpt-5.1"),
+    ("openai", "gpt-5.2"),
+    ("openai", "gpt-4-turbo"),
+    ("openai", "gpt-3.5-turbo"),
+    ("openai", "o1-mini"),
+    ("openai", "o3"),
+    # Anthropic direct
+    ("anthropic", "claude-3-5-sonnet-20241022"),
+    ("anthropic", "claude-3-5-haiku-20241022"),
+    ("anthropic", "claude-sonnet-4-20250514"),
+    ("anthropic", "claude-opus-4-20250514"),
+    # Bedrock
+    ("aws", "anthropic.claude-sonnet-4-5-20250929-v1:0"),
+    ("aws", "anthropic.claude-haiku-4-5-20251001-v1:0"),
+    ("aws", "us.anthropic.claude-opus-4-5-20251101-v1:0"),
+    ("aws", "amazon.nova-pro-v1:0"),
+    ("aws", "amazon.nova-lite-v1:0"),
+    ("aws", "meta.llama3-70b-instruct-v1:0"),
+    # Google
+    ("google", "gemini-2.0-flash"),
+    ("google", "gemini-1.5-flash"),
+    # OpenRouter aggregator
+    ("openrouter", "anthropic/claude-3.5-sonnet"),
+    ("openrouter", "openai/gpt-4o"),
+    ("openrouter", "openai/gpt-4o-mini"),
+    ("openrouter", "meta-llama/llama-3.3-70b-instruct"),
+    ("openrouter", "qwen/qwen-2.5-72b-instruct"),
+    ("openrouter", "deepseek/deepseek-chat"),
+    ("openrouter", "deepseek/deepseek-v3"),
+    ("openrouter", "nvidia/llama-3.1-nemotron-70b-instruct"),
+    ("openrouter", "amazon/nova-pro-v1"),
+    # Moonshot / Zhipu / Cerebras / DeepSeek long-tail
+    ("kimi", "kimi-k2-0711-preview"),
+    ("kimi", "kimi-k2-turbo-preview"),
+    ("glm", "glm-4.5"),
+    ("glm", "glm-4.7"),
+    ("cerebras", "qwen-3-235b-a22b-instruct-2507"),
+    ("deepseek", "deepseek-reasoner"),
+]
+
+
+@pytest.mark.parametrize("provider,model,min_input", _TRICKY_CASES)
+def test_tricky_case_meets_minimum(provider, model, min_input):
+    cw = get_context_window(provider, model)
+    assert cw.input >= min_input, f"{provider}/{model} returned {cw.input}, expected >= {min_input}"
+    assert _resolved(provider, model), f"{provider}/{model} hit the generic fallback"
+
+
+@pytest.mark.parametrize("provider,model", _POPULAR_PAIRS)
+def test_popular_pair_resolves(provider, model):
+    cw = get_context_window(provider, model)
+    assert cw.input >= _MIN_MODERN_INPUT, f"{provider}/{model} returned implausible input={cw.input}"
+
+
+def test_total_coverage_across_tricky_and_popular():
+    """Sanity bound: across 100 real-world pairs, < 10% should hit the generic fallback."""
+    pairs = [(p, m) for p, m, _ in _TRICKY_CASES] + list(_POPULAR_PAIRS)
+    fallbacks = [pm for pm in pairs if not _resolved(*pm)]
+    assert len(fallbacks) / len(pairs) < 0.10, f"High fallback rate: {fallbacks}"

--- a/tests/integration/test_model_capabilities_live.py
+++ b/tests/integration/test_model_capabilities_live.py
@@ -116,14 +116,14 @@ _POPULAR_PAIRS = [
 @pytest.mark.parametrize("provider,model,min_input", _TRICKY_CASES)
 def test_tricky_case_meets_minimum(provider, model, min_input):
     cw = get_context_window(provider, model)
-    assert cw.input >= min_input, f"{provider}/{model} returned {cw.input}, expected >= {min_input}"
+    assert cw.input_tokens >= min_input, f"{provider}/{model} returned {cw.input_tokens}, expected >= {min_input}"
     assert _resolved(provider, model), f"{provider}/{model} hit the generic fallback"
 
 
 @pytest.mark.parametrize("provider,model", _POPULAR_PAIRS)
 def test_popular_pair_resolves(provider, model):
     cw = get_context_window(provider, model)
-    assert cw.input >= _MIN_MODERN_INPUT, f"{provider}/{model} returned implausible input={cw.input}"
+    assert cw.input_tokens >= _MIN_MODERN_INPUT, f"{provider}/{model} returned implausible input={cw.input_tokens}"
 
 
 def test_total_coverage_across_tricky_and_popular():

--- a/tests/integration/test_model_capabilities_live.py
+++ b/tests/integration/test_model_capabilities_live.py
@@ -12,13 +12,13 @@ from agents.model_capabilities import (
     _resolve_modelsdev,
     _resolve_ollama,
     _resolve_openrouter,
-    _resolve_override,
+    _resolve_user_config,
     get_context_window,
 )
 
 _RESOLVERS = (
     _resolve_env,
-    _resolve_override,
+    _resolve_user_config,
     _resolve_ollama,
     _resolve_modelsdev,
     _resolve_litellm,

--- a/tests/test_user_config.py
+++ b/tests/test_user_config.py
@@ -1,6 +1,6 @@
 import os
 
-from user_config import ProviderUserConfig, UserConfig
+from user_config import ProviderUserConfig, UserConfig, ensure_config_template
 
 
 class TestUserConfigApplyToEnv:
@@ -63,3 +63,36 @@ class TestUserConfigApplyToEnv:
         finally:
             os.environ.clear()
             os.environ.update(original)
+
+
+class TestEnsureConfigTemplate:
+    def test_appends_context_window_under_llm_when_missing(self, tmp_path):
+        path = tmp_path / "config.toml"
+        path.write_text('[provider]\n# openai_api_key = "sk-..."\n\n[llm]\n# agent_model = "x"\n')
+
+        ensure_config_template(path)
+
+        text = path.read_text()
+        assert "context_window" in text
+        # Landed inside [llm], before agent_model (which is fine — it's a comment).
+        llm_idx = text.index("[llm]")
+        assert text.index("context_window") > llm_idx
+
+    def test_noop_when_key_already_present(self, tmp_path):
+        path = tmp_path / "config.toml"
+        original = "[llm]\n# context_window = 42  # already here\n"
+        path.write_text(original)
+
+        ensure_config_template(path)
+
+        assert path.read_text() == original
+
+    def test_adds_llm_section_if_absent(self, tmp_path):
+        path = tmp_path / "config.toml"
+        path.write_text('[provider]\n# openai_api_key = "sk-..."\n')
+
+        ensure_config_template(path)
+
+        text = path.read_text()
+        assert "[llm]" in text
+        assert "context_window" in text

--- a/user_config.py
+++ b/user_config.py
@@ -57,8 +57,9 @@ CONFIG_TEMPLATE = """\
 # Optional: override the default models chosen by the active provider.
 # If omitted, each provider's built-in defaults are used.
 [llm]
-# agent_model   = "gemini-3-flash"
-# parsing_model = "gemini-3-flash"
+# agent_model    = "gemini-3-flash"
+# parsing_model  = "gemini-3-flash"
+# context_window = 272000   # override if needed
 """
 
 
@@ -83,6 +84,7 @@ class ProviderUserConfig:
 class LLMUserConfig:
     agent_model: str | None = None
     parsing_model: str | None = None
+    context_window: int | None = None
 
 
 @dataclass
@@ -126,6 +128,7 @@ def load_user_config(path: Path = CONFIG_PATH) -> UserConfig:
         llm=LLMUserConfig(
             agent_model=llm_data.get("agent_model") or None,
             parsing_model=llm_data.get("parsing_model") or None,
+            context_window=llm_data.get("context_window"),
         ),
     )
 

--- a/user_config.py
+++ b/user_config.py
@@ -9,6 +9,7 @@ Environment variables already set in the shell always take precedence.
 """
 
 import os
+import re
 import tomllib
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -134,8 +135,21 @@ def load_user_config(path: Path = CONFIG_PATH) -> UserConfig:
 
 
 def ensure_config_template(path: Path = CONFIG_PATH) -> None:
-    """Write the config template if the file does not yet exist."""
-    if path.exists():
+    """Write the template on first install; otherwise top up with any keys added since."""
+    if not path.exists():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(CONFIG_TEMPLATE)
         return
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(CONFIG_TEMPLATE)
+    _append_commented_key(path, "context_window", "# context_window = 272000   # override if needed")
+
+
+def _append_commented_key(path: Path, key: str, commented_line: str) -> None:
+    """Insert `commented_line` under [llm] if `key` is missing anywhere in the file."""
+    text = path.read_text()
+    if key in text:
+        return
+    injected, n = re.subn(r"(^\[llm\]\s*\n)", r"\1" + commented_line + "\n", text, count=1, flags=re.MULTILINE)
+    if n == 0:
+        # Why: no [llm] section yet -- append a fresh one so the key lands in the right table.
+        injected = text.rstrip() + "\n\n[llm]\n" + commented_line + "\n"
+    path.write_text(injected)


### PR DESCRIPTION
Adds a small helper, get_context_window(provider, model), that tells you the input/output token limits for any LLM we use.

Right now we don't have anything like this — the context size is either hardcoded or we just hope for the best. This gives us one function to ask.

How it works: it checks a few public catalogs in order and returns the first real answer it finds.

- models.dev is the main source. It's the only one that separates the total context window from the usable input cap, which matters for models like GPT-5 (400K context, but you can only send 272K of input).
- LiteLLM is the backup. It covers more AWS Bedrock IDs than models.dev, especially the regional ones (us./eu./apac. prefixes).
- OpenRouter catches everything else — the long tail of models you can only really find through the aggregator (x-ai, perplexity, cohere, nvidia, some mistralai variants).

If all three miss, we fall back to 128K / 8K and log a warning.

There's also an Ollama path that calls the local /api/show endpoint, and an env var override (CB_CTX_<PROVIDER>_<MODEL>) for when a catalog is wrong or the model is private.

Results are cached for 24 hours in ~/.codeboarding/cache so we only hit the network once a day.

Tests:
- 18 unit tests with the catalogs mocked out — no network, run by default.
- 64 live integration tests hitting the real catalogs across openai, anthropic, aws, google, openrouter, kimi, glm, cerebras, deepseek. These are under tests/integration/ and skipped by the default pytest run; opt in with `pytest tests/integration/...`.

Not wired into agents/llm_config.py yet — that's a follow-up. This PR is just the resolver and its tests.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/codeboarding/codeboarding/pull/309" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a model context-window lookup API that returns resolved input/output token limits across providers, honoring environment overrides, provider-specific name normalization, cached remote catalog lookups with TTL, and sensible fallbacks.
  * Added optional user-configurable context-window setting in the app config template.

* **Tests**
  * Added unit and integration tests covering resolver precedence, parsing rules, caching behavior, and live-catalog smoke checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->