### PR TITLE
Add CFG skip planner to fit cluster prompts in context window

### DIFF
--- a/agents/abstraction_agent.py
+++ b/agents/abstraction_agent.py
@@ -70,8 +70,20 @@ class AbstractionAgent(ClusterMethodsMixin, CodeBoardingAgent):
 
         programming_langs = self.static_analysis.get_languages()
 
-        # Build cluster string using the pre-computed cluster results
-        cluster_str = self._build_cluster_string(programming_langs, cluster_results)
+        # Measure everything that wraps cfg_clusters (system message + rendered
+        # template with an empty slot) so the skip planner can back it out of
+        # the input window before budgeting the cluster string.
+        overhead_chars = len(str(self.system_message.content)) + len(
+            self.prompts["group_clusters"].format(
+                project_name=self.project_name,
+                cfg_clusters="",
+                meta_context=meta_context_str,
+                project_type=project_type,
+            )
+        )
+        cluster_str = self._build_cluster_string(
+            programming_langs, cluster_results, prompt_overhead_chars=overhead_chars
+        )
 
         prompt = self.prompts["group_clusters"].format(
             project_name=self.project_name,

--- a/agents/cluster_budget.py
+++ b/agents/cluster_budget.py
@@ -1,0 +1,21 @@
+from dataclasses import dataclass
+
+from agents.constants import ModelCapabilities
+
+OUTPUT_HEADROOM_TOKENS = 8_000
+CONTEXT_MARGIN = 0.9
+
+
+@dataclass(frozen=True)
+class ClusterPromptBudget:
+    """Character budget for the full rendered ``cfg_clusters`` prompt slot."""
+
+    input_tokens: int
+    output_headroom_tokens: int = OUTPUT_HEADROOM_TOKENS
+    chars_per_token: float = ModelCapabilities.CHARS_PER_TOKEN
+    margin: float = CONTEXT_MARGIN
+
+    def available_chars(self, prompt_overhead_chars: int) -> int:
+        prompt_overhead_tokens = prompt_overhead_chars / self.chars_per_token
+        available_tokens = (self.input_tokens - self.output_headroom_tokens - prompt_overhead_tokens) * self.margin
+        return int(available_tokens * self.chars_per_token)

--- a/agents/cluster_methods_mixin.py
+++ b/agents/cluster_methods_mixin.py
@@ -13,10 +13,11 @@ from agents.agent_responses import (
     FileMethodGroup,
     MethodEntry,
 )
+from agents.constants import ModelCapabilities
 from agents.llm_config import get_current_agent_context_window
 from constants import MIN_CLUSTERS_THRESHOLD
 from static_analyzer.analysis_result import StaticAnalysisResults
-from static_analyzer.cfg_skip_planner import CHARS_PER_TOKEN, plan_skip_set
+from static_analyzer.cfg_skip_planner import ContextBudgetExceededError, plan_skip_set
 from static_analyzer.cluster_helpers import (
     MAX_LLM_CLUSTERS,
     enforce_cross_language_budget,
@@ -102,7 +103,9 @@ class ClusterMethodsMixin:
             cfg = self.static_analysis.get_cfg(lang)
             # Get cluster result for this language
             cluster_result = cluster_results.get(lang)
-            cluster_str = cfg.to_cluster_string(cluster_ids, cluster_result, skip_nodes=per_lang_skip.get(lang))
+            cluster_str = cfg.to_cluster_string(
+                cluster_ids or set(), cluster_result, skip_nodes=per_lang_skip.get(lang, set())
+            )
 
             if cluster_str.strip() and cluster_str not in ("empty", "none", "No clusters found."):
                 header = "Component CFG" if cluster_ids else "Clusters"
@@ -132,16 +135,23 @@ class ClusterMethodsMixin:
         """Compute per-language skip sets so the combined cluster string fits the agent's input window.
 
         Splits the available char budget evenly across languages. Returns an
-        empty dict when nothing needs pruning.
+        empty dict when no language needs pruning.
+
+        Raises:
+            ContextBudgetExceededError: Prompt overhead alone exceeds the
+                input window, or a per-language trim cannot fit its share.
         """
         ctx = get_current_agent_context_window()
-        prompt_overhead_tokens = prompt_overhead_chars / CHARS_PER_TOKEN
+        prompt_overhead_tokens = prompt_overhead_chars / ModelCapabilities.CHARS_PER_TOKEN
         available_tokens = (ctx.input_tokens - OUTPUT_HEADROOM_TOKENS - prompt_overhead_tokens) * CONTEXT_MARGIN
-        if available_tokens <= 0:
-            return {}
-        char_budget = int(available_tokens * CHARS_PER_TOKEN)
+        char_budget = int(available_tokens * ModelCapabilities.CHARS_PER_TOKEN)
         if char_budget <= 0:
-            return {}
+            msg = (
+                f"Prompt overhead ({prompt_overhead_chars} chars) consumes the entire agent input "
+                f"window ({ctx.input_tokens} tokens); no room for cluster renderings."
+            )
+            logger.error("[CFG skip planner] %s", msg)
+            raise ContextBudgetExceededError(msg)
 
         langs_with_clusters = [l for l in programming_langs if cluster_results.get(l)]
         if not langs_with_clusters:

--- a/agents/cluster_methods_mixin.py
+++ b/agents/cluster_methods_mixin.py
@@ -13,8 +13,10 @@ from agents.agent_responses import (
     FileMethodGroup,
     MethodEntry,
 )
+from agents.llm_config import get_current_agent_context_window
 from constants import MIN_CLUSTERS_THRESHOLD
 from static_analyzer.analysis_result import StaticAnalysisResults
+from static_analyzer.cfg_skip_planner import CHARS_PER_TOKEN, plan_skip_set
 from static_analyzer.cluster_helpers import (
     MAX_LLM_CLUSTERS,
     enforce_cross_language_budget,
@@ -30,6 +32,14 @@ from static_analyzer.cluster_relations import (
 from static_analyzer.constants import CALLABLE_TYPES, CLASS_TYPES, NodeType
 from static_analyzer.graph import CallGraph, ClusterResult
 from static_analyzer.node import Node
+
+# Minimum tokens reserved for the model's output (matches Anthropic's default
+# max_tokens=8192 for Sonnet-class models). Tool round-trips, validation
+# retries, and chars-to-tokens variance are absorbed by CONTEXT_MARGIN. The
+# rest of the prompt (system message + rendered template) is measured by the
+# caller and passed in as ``prompt_overhead_chars``.
+OUTPUT_HEADROOM_TOKENS = 8_000
+CONTEXT_MARGIN = 0.9
 
 logger = logging.getLogger(__name__)
 
@@ -61,6 +71,7 @@ class ClusterMethodsMixin:
         programming_langs: list[str],
         cluster_results: dict[str, ClusterResult],
         cluster_ids: set[int] | None = None,
+        prompt_overhead_chars: int = 0,
     ) -> str:
         """
         Build a cluster string for LLM consumption using pre-computed cluster results.
@@ -69,6 +80,11 @@ class ClusterMethodsMixin:
             programming_langs: List of languages to include
             cluster_results: Pre-computed cluster results mapping language -> ClusterResult
             cluster_ids: Optional set of cluster IDs to filter by
+            prompt_overhead_chars: Characters used by everything else in the
+                prompt (system message + rendered template with an empty
+                ``cfg_clusters`` slot). The skip planner subtracts this from
+                the model's input window before computing the char budget for
+                the cluster string.
 
         Returns:
             Formatted cluster string with headers per language
@@ -76,11 +92,17 @@ class ClusterMethodsMixin:
         cluster_lines = []
         all_cluster_ids: set[int] = set()
 
+        # Plan per-language skip sets for full-graph rendering only. DetailsAgent
+        # subgraphs (cluster_ids != None) are already scoped and rarely need pruning.
+        per_lang_skip = (
+            self._plan_skip_sets(programming_langs, cluster_results, prompt_overhead_chars) if not cluster_ids else {}
+        )
+
         for lang in programming_langs:
             cfg = self.static_analysis.get_cfg(lang)
             # Get cluster result for this language
             cluster_result = cluster_results.get(lang)
-            cluster_str = cfg.to_cluster_string(cluster_ids, cluster_result)
+            cluster_str = cfg.to_cluster_string(cluster_ids, cluster_result, skip_nodes=per_lang_skip.get(lang))
 
             if cluster_str.strip() and cluster_str not in ("empty", "none", "No clusters found."):
                 header = "Component CFG" if cluster_ids else "Clusters"
@@ -100,6 +122,40 @@ class ClusterMethodsMixin:
             )
 
         return "".join(cluster_lines)
+
+    def _plan_skip_sets(
+        self,
+        programming_langs: list[str],
+        cluster_results: dict[str, ClusterResult],
+        prompt_overhead_chars: int,
+    ) -> dict[str, set[str]]:
+        """Compute per-language skip sets so the combined cluster string fits the agent's input window.
+
+        Splits the available char budget evenly across languages. Returns an
+        empty dict when nothing needs pruning.
+        """
+        ctx = get_current_agent_context_window()
+        prompt_overhead_tokens = prompt_overhead_chars / CHARS_PER_TOKEN
+        available_tokens = (ctx.input_tokens - OUTPUT_HEADROOM_TOKENS - prompt_overhead_tokens) * CONTEXT_MARGIN
+        if available_tokens <= 0:
+            return {}
+        char_budget = int(available_tokens * CHARS_PER_TOKEN)
+        if char_budget <= 0:
+            return {}
+
+        langs_with_clusters = [l for l in programming_langs if cluster_results.get(l)]
+        if not langs_with_clusters:
+            return {}
+
+        per_lang_budget = char_budget // len(langs_with_clusters)
+        skip_sets: dict[str, set[str]] = {}
+        for lang in langs_with_clusters:
+            cfg = self.static_analysis.get_cfg(lang)
+            cluster_result = cluster_results[lang]
+            skip = plan_skip_set(cfg, cluster_result, per_lang_budget)
+            if skip:
+                skip_sets[lang] = skip
+        return skip_sets
 
     def _ensure_unique_key_entities(self, analysis: AnalysisInsights):
         """

--- a/agents/cluster_methods_mixin.py
+++ b/agents/cluster_methods_mixin.py
@@ -1,7 +1,9 @@
 import logging
 import os
 from collections import defaultdict
+from dataclasses import dataclass
 from pathlib import Path
+from typing import NoReturn
 
 import networkx as nx
 
@@ -13,7 +15,7 @@ from agents.agent_responses import (
     FileMethodGroup,
     MethodEntry,
 )
-from agents.constants import ModelCapabilities
+from agents.cluster_budget import ClusterPromptBudget
 from agents.llm_config import get_current_agent_context_window
 from constants import MIN_CLUSTERS_THRESHOLD
 from static_analyzer.analysis_result import StaticAnalysisResults
@@ -34,15 +36,14 @@ from static_analyzer.constants import CALLABLE_TYPES, CLASS_TYPES, NodeType
 from static_analyzer.graph import CallGraph, ClusterResult
 from static_analyzer.node import Node
 
-# Minimum tokens reserved for the model's output (matches Anthropic's default
-# max_tokens=8192 for Sonnet-class models). Tool round-trips, validation
-# retries, and chars-to-tokens variance are absorbed by CONTEXT_MARGIN. The
-# rest of the prompt (system message + rendered template) is measured by the
-# caller and passed in as ``prompt_overhead_chars``.
-OUTPUT_HEADROOM_TOKENS = 8_000
-CONTEXT_MARGIN = 0.9
-
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class _RenderedClusterString:
+    text: str
+    by_language: dict[str, str]
+    cluster_ids: set[int]
 
 
 class ClusterMethodsMixin:
@@ -90,33 +91,50 @@ class ClusterMethodsMixin:
         Returns:
             Formatted cluster string with headers per language
         """
-        cluster_lines = []
-        all_cluster_ids: set[int] = set()
+        rendered = self._render_cluster_string(programming_langs, cluster_results, cluster_ids, {})
+        if cluster_ids:
+            return rendered.text
 
-        # Plan per-language skip sets for full-graph rendering only. DetailsAgent
-        # subgraphs (cluster_ids != None) are already scoped and rarely need pruning.
-        per_lang_skip = (
-            self._plan_skip_sets(programming_langs, cluster_results, prompt_overhead_chars) if not cluster_ids else {}
+        char_budget = self._cluster_prompt_budget(prompt_overhead_chars)
+        if len(rendered.text) <= char_budget:
+            return rendered.text
+
+        per_lang_skip = self._plan_skip_sets(programming_langs, cluster_results, prompt_overhead_chars)
+        rendered_with_skips = self._render_cluster_string(
+            programming_langs, cluster_results, cluster_ids, per_lang_skip
         )
+        if len(rendered_with_skips.text) > char_budget:
+            self._raise_cluster_budget_error(char_budget, rendered_with_skips, per_lang_skip)
+
+        return rendered_with_skips.text
+
+    def _render_cluster_string(
+        self,
+        programming_langs: list[str],
+        cluster_results: dict[str, ClusterResult],
+        cluster_ids: set[int] | None,
+        skip_sets: dict[str, set[str]],
+    ) -> _RenderedClusterString:
+        cluster_lines: list[str] = []
+        by_language: dict[str, str] = {}
+        all_cluster_ids: set[int] = set()
 
         for lang in programming_langs:
             cfg = self.static_analysis.get_cfg(lang)
-            # Get cluster result for this language
             cluster_result = cluster_results.get(lang)
             cluster_str = cfg.to_cluster_string(
-                cluster_ids or set(), cluster_result, skip_nodes=per_lang_skip.get(lang, set())
+                cluster_ids or set(), cluster_result, skip_nodes=skip_sets.get(lang, set())
             )
 
             if cluster_str.strip() and cluster_str not in ("empty", "none", "No clusters found."):
                 header = "Component CFG" if cluster_ids else "Clusters"
-                cluster_lines.append(f"\n## {lang.capitalize()} - {header}\n")
-                cluster_lines.append(cluster_str)
-                cluster_lines.append("\n")
+                lang_text = f"\n## {lang.capitalize()} - {header}\n{cluster_str}\n"
+                cluster_lines.append(lang_text)
+                by_language[lang] = lang_text
                 if cluster_result:
                     lang_ids = cluster_ids if cluster_ids else cluster_result.get_cluster_ids()
                     all_cluster_ids.update(lang_ids)
 
-        # Add explicit ID checklist so the LLM knows exactly which IDs to assign
         if all_cluster_ids and not cluster_ids:
             sorted_cluster_ids = sorted(all_cluster_ids)
             cluster_lines.append(
@@ -124,7 +142,7 @@ class ClusterMethodsMixin:
                 f"Every one of these IDs: {sorted_cluster_ids} must appear in exactly one group."
             )
 
-        return "".join(cluster_lines)
+        return _RenderedClusterString(text="".join(cluster_lines), by_language=by_language, cluster_ids=all_cluster_ids)
 
     def _plan_skip_sets(
         self,
@@ -132,20 +150,10 @@ class ClusterMethodsMixin:
         cluster_results: dict[str, ClusterResult],
         prompt_overhead_chars: int,
     ) -> dict[str, set[str]]:
-        """Compute per-language skip sets so the combined cluster string fits the agent's input window.
-
-        Splits the available char budget evenly across languages. Returns an
-        empty dict when no language needs pruning.
-
-        Raises:
-            ContextBudgetExceededError: Prompt overhead alone exceeds the
-                input window, or a per-language trim cannot fit its share.
-        """
-        ctx = get_current_agent_context_window()
-        prompt_overhead_tokens = prompt_overhead_chars / ModelCapabilities.CHARS_PER_TOKEN
-        available_tokens = (ctx.input_tokens - OUTPUT_HEADROOM_TOKENS - prompt_overhead_tokens) * CONTEXT_MARGIN
-        char_budget = int(available_tokens * ModelCapabilities.CHARS_PER_TOKEN)
+        """Compute per-language skip sets so the final combined cluster string fits."""
+        char_budget = self._cluster_prompt_budget(prompt_overhead_chars)
         if char_budget <= 0:
+            ctx = get_current_agent_context_window()
             msg = (
                 f"Prompt overhead ({prompt_overhead_chars} chars) consumes the entire agent input "
                 f"window ({ctx.input_tokens} tokens); no room for cluster renderings."
@@ -157,15 +165,94 @@ class ClusterMethodsMixin:
         if not langs_with_clusters:
             return {}
 
-        per_lang_budget = char_budget // len(langs_with_clusters)
         skip_sets: dict[str, set[str]] = {}
-        for lang in langs_with_clusters:
-            cfg = self.static_analysis.get_cfg(lang)
-            cluster_result = cluster_results[lang]
-            skip = plan_skip_set(cfg, cluster_result, per_lang_budget)
-            if skip:
-                skip_sets[lang] = skip
-        return skip_sets
+        rendered = self._render_cluster_string(programming_langs, cluster_results, None, skip_sets)
+        if len(rendered.text) <= char_budget:
+            return skip_sets
+
+        max_iterations = max(1, len(langs_with_clusters) * 5)
+        for _ in range(max_iterations):
+            deficit = len(rendered.text) - char_budget
+            ordered_langs = sorted(
+                langs_with_clusters,
+                key=lambda lang: len(rendered.by_language.get(lang, "")),
+                reverse=True,
+            )
+            progressed = False
+
+            for lang in ordered_langs:
+                lang_text = rendered.by_language.get(lang, "")
+                current_len = len(lang_text)
+                if current_len == 0:
+                    continue
+
+                for target in self._language_budget_targets(current_len, deficit):
+                    try:
+                        skip = plan_skip_set(self.static_analysis.get_cfg(lang), cluster_results[lang], target)
+                    except ContextBudgetExceededError:
+                        continue
+
+                    if skip == skip_sets.get(lang, set()):
+                        continue
+
+                    trial_skip_sets = dict(skip_sets)
+                    if skip:
+                        trial_skip_sets[lang] = skip
+                    else:
+                        trial_skip_sets.pop(lang, None)
+
+                    trial_rendered = self._render_cluster_string(
+                        programming_langs, cluster_results, None, trial_skip_sets
+                    )
+                    if len(trial_rendered.text) >= len(rendered.text):
+                        continue
+
+                    skip_sets = trial_skip_sets
+                    rendered = trial_rendered
+                    progressed = True
+                    break
+
+                if progressed:
+                    break
+
+            if len(rendered.text) <= char_budget:
+                return skip_sets
+            if not progressed:
+                break
+
+        self._raise_cluster_budget_error(char_budget, rendered, skip_sets)
+
+    @staticmethod
+    def _language_budget_targets(current_len: int, deficit: int) -> list[int]:
+        exact_target = max(0, current_len - deficit)
+        targets = {
+            exact_target,
+            int(current_len * 0.9),
+            int(current_len * 0.75),
+            int(current_len * 0.5),
+            0,
+        }
+        return sorted((target for target in targets if target < current_len), reverse=True)
+
+    @staticmethod
+    def _raise_cluster_budget_error(
+        char_budget: int,
+        rendered: _RenderedClusterString,
+        skip_sets: dict[str, set[str]],
+    ) -> NoReturn:
+        per_lang_sizes = {lang: len(text) for lang, text in rendered.by_language.items()}
+        skipped_counts = {lang: len(skip) for lang, skip in skip_sets.items() if skip}
+        msg = (
+            f"Cluster render {len(rendered.text)} chars exceeds budget {char_budget}. "
+            f"Per-language sizes: {per_lang_sizes}; skipped nodes: {skipped_counts}."
+        )
+        logger.error("[CFG skip planner] %s", msg)
+        raise ContextBudgetExceededError(msg)
+
+    @staticmethod
+    def _cluster_prompt_budget(prompt_overhead_chars: int) -> int:
+        ctx = get_current_agent_context_window()
+        return ClusterPromptBudget(input_tokens=ctx.input_tokens).available_chars(prompt_overhead_chars)
 
     def _ensure_unique_key_entities(self, analysis: AnalysisInsights):
         """

--- a/agents/constants.py
+++ b/agents/constants.py
@@ -17,6 +17,7 @@ class ModelCapabilities:
     FALLBACK_INPUT = 256_000
     FALLBACK_OUTPUT = 64_000
     CACHE_TTL_SECONDS = 24 * 3600
+    CHARS_PER_TOKEN = 3.5  # community consensus conversion is around 3 or 4 chars/token.
 
     SOURCES = {
         "litellm": "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json",

--- a/agents/details_agent.py
+++ b/agents/details_agent.py
@@ -84,8 +84,18 @@ class DetailsAgent(ClusterMethodsMixin, CodeBoardingAgent):
 
         programming_langs = self.static_analysis.get_languages()
 
-        # Build cluster string using the pre-computed cluster results (same as AbstractionAgent)
-        cluster_str = self._build_cluster_string(programming_langs, subgraph_cluster_results)
+        overhead_chars = len(str(self.system_message.content)) + len(
+            self.prompts["group_clusters"].format(
+                project_name=self.project_name,
+                cfg_clusters="",
+                component=component.llm_str(),
+                meta_context=meta_context_str,
+                project_type=project_type,
+            )
+        )
+        cluster_str = self._build_cluster_string(
+            programming_langs, subgraph_cluster_results, prompt_overhead_chars=overhead_chars
+        )
 
         prompt = self.prompts["group_clusters"].format(
             project_name=self.project_name,

--- a/agents/llm_config.py
+++ b/agents/llm_config.py
@@ -11,7 +11,8 @@ from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain_ollama import ChatOllama
 from langchain_openai import ChatOpenAI
 
-from agents.constants import LLMDefaults
+from agents.constants import LLMDefaults, ModelCapabilities
+from agents.model_capabilities import ContextWindow, get_context_window
 from agents.prompts.prompt_factory import LLMType, initialize_global_factory
 from monitoring.callbacks import MonitoringCallback
 
@@ -311,17 +312,13 @@ def initialize_agent_llm(model_override: str | None = None) -> BaseChatModel:
     return model
 
 
-def get_current_agent_context_window():
-    """Context window for the currently configured agent LLM.
+def get_current_agent_context_window() -> ContextWindow:
+    """Context window for the currently active agent provider/model.
 
-    Resolves the first active provider (same rule as ``_initialize_llm``) and
-    the effective agent model name, then delegates to ``get_context_window``.
-    Returns a ``ContextWindow`` with fallback values when no provider is active
-    (which would only happen if this is called before any LLM is initialized).
+    Resolves the first active provider (same rule as ``_initialize_llm``) on
+    every call. ``get_context_window`` handles its own caching, so this is
+    cheap enough to call without a module-level cache.
     """
-    from agents.constants import ModelCapabilities
-    from agents.model_capabilities import ContextWindow, get_context_window
-
     for name, config in LLM_PROVIDERS.items():
         if not config.is_active():
             continue

--- a/agents/llm_config.py
+++ b/agents/llm_config.py
@@ -259,41 +259,53 @@ def _initialize_llm(
     log_prefix: str,
     init_factory: bool = False,
 ) -> tuple[BaseChatModel, str]:
+    resolved = _resolve_active_provider(model_override, model_attr)
+    if resolved is None:
+        required_vars = []
+        for config in LLM_PROVIDERS.values():
+            required_vars.append(config.api_key_env)
+            required_vars.extend(config.alt_env_vars)
+
+        raise ValueError(
+            f"No valid LLM configuration found. Please set one of: {', '.join(sorted(set(required_vars)))}"
+        )
+
+    name, config, model_name = resolved
+
+    if init_factory:
+        detected_llm_type = LLMType.from_model_name(model_name)
+        initialize_global_factory(detected_llm_type)
+        logger.info(
+            f"Initialized prompt factory for {name} provider with model '{model_name}' "
+            f"-> {detected_llm_type.value} prompt factory"
+        )
+
+    logger.info(f"Using {name.title()} {log_prefix}LLM with model: {model_name}")
+
+    kwargs = {
+        "model": model_name,
+        "temperature": getattr(config, temperature_attr),
+    }
+    kwargs.update(config.get_resolved_extra_args())
+
+    if name not in ["aws", "ollama"]:
+        api_key = config.get_api_key()
+        kwargs["api_key"] = api_key or "no-key-required"
+
+    model = config.chat_class(**kwargs)  # type: ignore[call-arg, arg-type]
+    return model, model_name
+
+
+def _resolve_active_provider(
+    model_override: str | None,
+    model_attr: str,
+) -> tuple[str, LLMConfig, str] | None:
+    """Return the active provider, config, and resolved model name."""
     for name, config in LLM_PROVIDERS.items():
         if not config.is_active():
             continue
-
-        model_name = model_override or getattr(config, model_attr)
-
-        if init_factory:
-            detected_llm_type = LLMType.from_model_name(model_name)
-            initialize_global_factory(detected_llm_type)
-            logger.info(
-                f"Initialized prompt factory for {name} provider with model '{model_name}' "
-                f"-> {detected_llm_type.value} prompt factory"
-            )
-
-        logger.info(f"Using {name.title()} {log_prefix}LLM with model: {model_name}")
-
-        kwargs = {
-            "model": model_name,
-            "temperature": getattr(config, temperature_attr),
-        }
-        kwargs.update(config.get_resolved_extra_args())
-
-        if name not in ["aws", "ollama"]:
-            api_key = config.get_api_key()
-            kwargs["api_key"] = api_key or "no-key-required"
-
-        model = config.chat_class(**kwargs)  # type: ignore[call-arg, arg-type]
-        return model, model_name
-
-    required_vars = []
-    for config in LLM_PROVIDERS.values():
-        required_vars.append(config.api_key_env)
-        required_vars.extend(config.alt_env_vars)
-
-    raise ValueError(f"No valid LLM configuration found. Please set one of: {', '.join(sorted(set(required_vars)))}")
+        return name, config, model_override or getattr(config, model_attr)
+    return None
 
 
 def validate_api_key_provided() -> None:
@@ -319,10 +331,9 @@ def get_current_agent_context_window() -> ContextWindow:
     every call. ``get_context_window`` handles its own caching, so this is
     cheap enough to call without a module-level cache.
     """
-    for name, config in LLM_PROVIDERS.items():
-        if not config.is_active():
-            continue
-        model_name = _agent_model_override or os.getenv("AGENT_MODEL") or config.agent_model
+    resolved = _resolve_active_provider(_agent_model_override or os.getenv("AGENT_MODEL"), "agent_model")
+    if resolved is not None:
+        name, _config, model_name = resolved
         return get_context_window(name, model_name)
     return ContextWindow(ModelCapabilities.FALLBACK_INPUT, ModelCapabilities.FALLBACK_OUTPUT)
 

--- a/agents/llm_config.py
+++ b/agents/llm_config.py
@@ -311,6 +311,25 @@ def initialize_agent_llm(model_override: str | None = None) -> BaseChatModel:
     return model
 
 
+def get_current_agent_context_window():
+    """Context window for the currently configured agent LLM.
+
+    Resolves the first active provider (same rule as ``_initialize_llm``) and
+    the effective agent model name, then delegates to ``get_context_window``.
+    Returns a ``ContextWindow`` with fallback values when no provider is active
+    (which would only happen if this is called before any LLM is initialized).
+    """
+    from agents.constants import ModelCapabilities
+    from agents.model_capabilities import ContextWindow, get_context_window
+
+    for name, config in LLM_PROVIDERS.items():
+        if not config.is_active():
+            continue
+        model_name = _agent_model_override or os.getenv("AGENT_MODEL") or config.agent_model
+        return get_context_window(name, model_name)
+    return ContextWindow(ModelCapabilities.FALLBACK_INPUT, ModelCapabilities.FALLBACK_OUTPUT)
+
+
 def initialize_parsing_llm(model_override: str | None = None) -> BaseChatModel:
     model, _ = _initialize_llm(model_override, "parsing_model", "parsing_temperature", "Extractor ")
     return model

--- a/static_analyzer/cfg_skip_planner.py
+++ b/static_analyzer/cfg_skip_planner.py
@@ -15,18 +15,22 @@ over the allowed peel-order prefix picks the smallest skip set that fits.
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Callable
+from typing import Callable
 
 import networkx as nx
 
-if TYPE_CHECKING:
-    from static_analyzer.graph import CallGraph, ClusterResult
+from static_analyzer.graph import CallGraph, ClusterResult
 
 logger = logging.getLogger(__name__)
 
-# Community consensus middle ground: prose ≈ 4 chars/token, code ≈ 3 chars/token.
-# 3.5 keeps us conservative without leaving too much slack.
-CHARS_PER_TOKEN = 3.5
+
+class ContextBudgetExceededError(RuntimeError):
+    """Cluster-string render cannot fit the agent's context window.
+
+    Raised when the pre-planning overhead already exceeds the input window,
+    or when the most aggressive safe trim (per ``max_peel_frac`` and
+    ``min_keep_per_cluster``) still overflows the remaining budget.
+    """
 
 
 def _compute_peel_order(cfg_nx: nx.DiGraph) -> list[str]:
@@ -39,11 +43,10 @@ def _compute_peel_order(cfg_nx: nx.DiGraph) -> list[str]:
     """
     live = cfg_nx.to_undirected()
     order: list[str] = []
-    while True:
-        leaves = [n for n in live.nodes if live.degree(n) <= 1]
-        if not leaves:
-            break
-        leaves.sort(key=lambda n: live.degree(n))
+    while leaves := sorted(
+        (n for n in live.nodes if live.degree(n) <= 1),
+        key=lambda n: live.degree(n),
+    ):
         for n in leaves:
             order.append(n)
             live.remove_node(n)
@@ -78,18 +81,10 @@ def _binary_search_smallest_fit(
     allowed: list[str],
     render: Callable[[set[str]], int],
     char_budget: int,
-) -> tuple[set[str], bool]:
-    """Binary-search the smallest prefix of ``allowed`` whose render fits budget.
-
-    Returns (skip_set, fits). If even the full prefix doesn't fit, returns the
-    full prefix with fits=False so the caller can decide what to do.
-    """
-    if not allowed:
-        return set(), False
-
-    full_skip = set(allowed)
-    if render(full_skip) > char_budget:
-        return full_skip, False
+) -> set[str] | None:
+    """Smallest prefix of ``allowed`` whose render fits ``char_budget``, or None if none does."""
+    if not allowed or render(set(allowed)) > char_budget:
+        return None
 
     lo, hi = 1, len(allowed)
     result_k = len(allowed)
@@ -100,7 +95,7 @@ def _binary_search_smallest_fit(
             hi = mid - 1
         else:
             lo = mid + 1
-    return set(allowed[:result_k]), True
+    return set(allowed[:result_k])
 
 
 def plan_skip_set(
@@ -114,9 +109,13 @@ def plan_skip_set(
 
     Returns an empty set when the unfiltered rendering already fits. Otherwise
     returns the smallest prefix of the peel order (subject to per-cluster
-    floor + global cap) whose rendering is within budget. If even the maximum
-    allowed skip set does not fit, returns the best-effort set and logs a
-    warning — the caller still uses it but the prompt will be oversized.
+    floor + global cap) whose rendering is within budget.
+
+    Raises:
+        ContextBudgetExceededError: No peel-safe candidates exist, or the
+            maximum allowed trim still exceeds ``char_budget``. Fail-loud is
+            intentional: providers reject oversize input, so silently
+            returning an over-budget render just defers the failure.
     """
     full_str = cfg.to_cluster_string(cluster_result=cluster_result)
     if len(full_str) <= char_budget:
@@ -133,13 +132,12 @@ def plan_skip_set(
     peel_order = [n for n in peel_order if n in node_to_cluster]
 
     if not peel_order:
-        logger.warning(
-            "[CFG skip planner] Full rendering is %d chars (budget %d) but no peel-safe cluster members; "
-            "rendering will exceed budget.",
-            len(full_str),
-            char_budget,
+        msg = (
+            f"No peel-safe cluster members to prune; full render "
+            f"{len(full_str)} chars exceeds budget {char_budget}."
         )
-        return set()
+        logger.error("[CFG skip planner] %s", msg)
+        raise ContextBudgetExceededError(msg)
 
     max_skip_per_cluster = {
         cid: max(0, len(members) - min(min_keep_per_cluster, len(members)))
@@ -152,21 +150,20 @@ def plan_skip_set(
     def render(skip: set[str]) -> int:
         return len(cfg.to_cluster_string(cluster_result=cluster_result, skip_nodes=skip))
 
-    skip, fits = _binary_search_smallest_fit(allowed, render, char_budget)
+    skip = _binary_search_smallest_fit(allowed, render, char_budget)
 
-    if fits:
-        logger.info(
-            "[CFG skip planner] skipping %d/%d nodes (floor=%d per cluster)",
-            len(skip),
-            total_nodes,
-            min_keep_per_cluster,
+    if skip is None:
+        msg = (
+            f"No allowed skip prefix fits budget {char_budget} chars "
+            f"(full render {len(full_str)}, {len(allowed)}/{total_nodes} nodes prunable)."
         )
-    else:
-        logger.warning(
-            "[CFG skip planner] Method-level filtering cannot fit budget (%d chars). "
-            "Returning best-effort skip of %d/%d nodes; prompt will exceed budget.",
-            char_budget,
-            len(skip),
-            total_nodes,
-        )
+        logger.error("[CFG skip planner] %s", msg)
+        raise ContextBudgetExceededError(msg)
+
+    logger.info(
+        "[CFG skip planner] skipping %d/%d nodes (floor=%d per cluster)",
+        len(skip),
+        total_nodes,
+        min_keep_per_cluster,
+    )
     return skip

--- a/static_analyzer/cfg_skip_planner.py
+++ b/static_analyzer/cfg_skip_planner.py
@@ -8,8 +8,8 @@ Node selection follows an iterative leaf-peel order on the undirected graph,
 so every skipped node is safe to remove without disconnecting the rest of
 the graph. Nodes in the 2-core are never candidates. A per-cluster floor
 keeps each cluster recognizable (at least ``min_keep_per_cluster`` members
-remain rendered), and a global cap prevents extreme pruning. Binary search
-over the allowed peel-order prefix picks the smallest skip set that fits.
+remain rendered), and a global cap prevents extreme pruning. The final pass
+selects peel-safe nodes by measured character savings until the render fits.
 """
 
 from __future__ import annotations
@@ -36,7 +36,7 @@ class ContextBudgetExceededError(RuntimeError):
 def _compute_peel_order(cfg_nx: nx.DiGraph) -> list[str]:
     """Return peel-safe nodes in iterative-leaf order.
 
-    Repeatedly removes every node with undirected degree ≤ 1 from the live
+    Repeatedly removes every node with undirected degree <= 1 from the live
     graph, sorted within each round by ascending degree so degree-0 isolates
     go first. Nodes that remain at the end of peeling are in the 2-core and
     are NOT returned — they are unsafe to drop.
@@ -57,45 +57,76 @@ def _build_allowed_skip_list(
     peel_order: list[str],
     node_to_cluster: dict[str, int],
     max_skip_per_cluster: dict[int, int],
-    global_cap: int,
 ) -> list[str]:
-    """Greedy pass over peel_order, keeping each node only if its cluster has room."""
-    skipped_per_cluster: dict[int, int] = {cid: 0 for cid in max_skip_per_cluster}
+    """Return peel-safe candidates from clusters that can still be reduced."""
     allowed: list[str] = []
     for name in peel_order:
-        if len(allowed) >= global_cap:
-            break
         cid = node_to_cluster.get(name)
         if cid is None:
             # Node isn't in any cluster — safe to skip (only affects unclustered edges)
             allowed.append(name)
             continue
-        if skipped_per_cluster[cid] >= max_skip_per_cluster.get(cid, 0):
+        if max_skip_per_cluster.get(cid, 0) <= 0:
             continue
         allowed.append(name)
-        skipped_per_cluster[cid] += 1
     return allowed
 
 
-def _binary_search_smallest_fit(
+def _select_high_savings_fit(
     allowed: list[str],
     render: Callable[[set[str]], int],
     char_budget: int,
+    node_to_cluster: dict[str, int],
+    max_skip_per_cluster: dict[int, int],
+    global_cap: int,
 ) -> set[str] | None:
-    """Smallest prefix of ``allowed`` whose render fits ``char_budget``, or None if none does."""
-    if not allowed or render(set(allowed)) > char_budget:
+    """Greedily select peel-safe nodes by measured character savings."""
+    if not allowed or global_cap <= 0:
         return None
 
-    lo, hi = 1, len(allowed)
-    result_k = len(allowed)
-    while lo <= hi:
-        mid = (lo + hi) // 2
-        if render(set(allowed[:mid])) <= char_budget:
-            result_k = mid
-            hi = mid - 1
-        else:
-            lo = mid + 1
-    return set(allowed[:result_k])
+    full_len = render(set())
+
+    savings: list[tuple[int, str]] = []
+    for name in allowed:
+        saved = full_len - render({name})
+        if saved > 0:
+            savings.append((saved, name))
+
+    selected: set[str] = set()
+    skipped_per_cluster: dict[int, int] = {cid: 0 for cid in max_skip_per_cluster}
+    current_len = full_len
+    for _saved, name in sorted(savings, key=lambda item: (-item[0], item[1])):
+        if len(selected) >= global_cap:
+            break
+        cid = node_to_cluster.get(name)
+        if cid is not None and skipped_per_cluster[cid] >= max_skip_per_cluster.get(cid, 0):
+            continue
+        selected.add(name)
+        new_len = render(selected)
+        if new_len >= current_len:
+            selected.remove(name)
+            continue
+        if cid is not None:
+            skipped_per_cluster[cid] += 1
+        current_len = new_len
+        if current_len <= char_budget:
+            return _minimize_skip_set(selected, render, char_budget)
+
+    return selected if selected and render(selected) <= char_budget else None
+
+
+def _minimize_skip_set(
+    selected: set[str],
+    render: Callable[[set[str]], int],
+    char_budget: int,
+) -> set[str]:
+    """Drop unnecessary selected nodes while preserving the budget fit."""
+    minimized = set(selected)
+    for name in sorted(selected):
+        trial = minimized - {name}
+        if render(trial) <= char_budget:
+            minimized = trial
+    return minimized
 
 
 def plan_skip_set(
@@ -108,7 +139,7 @@ def plan_skip_set(
     """Decide which nodes ``cfg.to_cluster_string`` should omit to fit ``char_budget``.
 
     Returns an empty set when the unfiltered rendering already fits. Otherwise
-    returns the smallest prefix of the peel order (subject to per-cluster
+    returns a high-savings subset of the peel order (subject to per-cluster
     floor + global cap) whose rendering is within budget.
 
     Raises:
@@ -145,16 +176,23 @@ def plan_skip_set(
     }
     total_nodes = len(node_to_cluster)
     global_cap = int(total_nodes * max_peel_frac)
-    allowed = _build_allowed_skip_list(peel_order, node_to_cluster, max_skip_per_cluster, global_cap)
+    allowed = _build_allowed_skip_list(peel_order, node_to_cluster, max_skip_per_cluster)
 
     def render(skip: set[str]) -> int:
         return len(cfg.to_cluster_string(cluster_result=cluster_result, skip_nodes=skip))
 
-    skip = _binary_search_smallest_fit(allowed, render, char_budget)
+    skip = _select_high_savings_fit(
+        allowed,
+        render,
+        char_budget,
+        node_to_cluster,
+        max_skip_per_cluster,
+        global_cap,
+    )
 
     if skip is None:
         msg = (
-            f"No allowed skip prefix fits budget {char_budget} chars "
+            f"No allowed skip set fits budget {char_budget} chars "
             f"(full render {len(full_str)}, {len(allowed)}/{total_nodes} nodes prunable)."
         )
         logger.error("[CFG skip planner] %s", msg)

--- a/static_analyzer/cfg_skip_planner.py
+++ b/static_analyzer/cfg_skip_planner.py
@@ -1,0 +1,216 @@
+"""Plan which nodes to omit when serializing a CallGraph for LLM consumption.
+
+The planner never mutates the graph: it returns a set of qualified names that
+``CallGraph.to_cluster_string`` should drop from its output so the rendered
+text fits a character budget derived from the agent's context window.
+
+Three-stage graceful degradation when the full rendering is over budget:
+
+Stage 1 — per-cluster floor + fraction
+    Keep at least ``max(min_keep_per_cluster, ceil(size * retain_fraction))``
+    methods per cluster. Small clusters stay recognizable; large clusters
+    shed their lowest-degree tails first.
+
+Stage 2 — floor only
+    Drop the fraction, keep just the hard floor of ``min_keep_per_cluster``
+    per cluster. Used when stage 1 can't free enough characters.
+
+Stage 3 — give up
+    Return the best-effort skip set even if it still exceeds budget.
+    Caller logs a warning; the LLM or downstream truncation handles it.
+
+Node selection follows an iterative leaf-peel order on the undirected graph,
+so every skipped node is safe to remove without disconnecting the rest of
+the graph. Nodes in the 2-core are never candidates.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from typing import TYPE_CHECKING, Callable
+
+import networkx as nx
+
+if TYPE_CHECKING:
+    from static_analyzer.graph import CallGraph, ClusterResult
+
+logger = logging.getLogger(__name__)
+
+# Community consensus middle ground: prose ≈ 4 chars/token, code ≈ 3 chars/token.
+# 3.5 keeps us conservative without leaving too much slack.
+CHARS_PER_TOKEN = 3.5
+
+
+def _compute_peel_order(cfg_nx: nx.DiGraph) -> list[str]:
+    """Return peel-safe nodes in iterative-leaf order.
+
+    Repeatedly removes every node with undirected degree ≤ 1 from the live
+    graph, sorted within each round by ascending degree so degree-0 isolates
+    go first. Nodes that remain at the end of peeling are in the 2-core and
+    are NOT returned — they are unsafe to drop.
+    """
+    live = cfg_nx.to_undirected()
+    order: list[str] = []
+    while True:
+        leaves = [n for n in live.nodes if live.degree(n) <= 1]
+        if not leaves:
+            break
+        leaves.sort(key=lambda n: live.degree(n))
+        for n in leaves:
+            order.append(n)
+            live.remove_node(n)
+    return order
+
+
+def _required_keep(size: int, min_keep: int, retain_fraction: float) -> int:
+    """Stage-1 minimum: ``max(min_keep, ceil(size * retain_fraction))``, clamped to size."""
+    return min(size, max(min_keep, math.ceil(size * retain_fraction)))
+
+
+def _stage1_max_skip_per_cluster(
+    clusters: dict[int, set[str]], min_keep: int, retain_fraction: float
+) -> dict[int, int]:
+    return {
+        cid: len(members) - _required_keep(len(members), min_keep, retain_fraction) for cid, members in clusters.items()
+    }
+
+
+def _stage2_max_skip_per_cluster(clusters: dict[int, set[str]], min_keep: int) -> dict[int, int]:
+    return {cid: max(0, len(members) - min(min_keep, len(members))) for cid, members in clusters.items()}
+
+
+def _build_allowed_skip_list(
+    peel_order: list[str],
+    node_to_cluster: dict[str, int],
+    max_skip_per_cluster: dict[int, int],
+    global_cap: int,
+) -> list[str]:
+    """Greedy pass over peel_order, keeping each node only if its cluster has room."""
+    skipped_per_cluster: dict[int, int] = {cid: 0 for cid in max_skip_per_cluster}
+    allowed: list[str] = []
+    for name in peel_order:
+        if len(allowed) >= global_cap:
+            break
+        cid = node_to_cluster.get(name)
+        if cid is None:
+            # Node isn't in any cluster — safe to skip (only affects unclustered edges)
+            allowed.append(name)
+            continue
+        if skipped_per_cluster[cid] >= max_skip_per_cluster.get(cid, 0):
+            continue
+        allowed.append(name)
+        skipped_per_cluster[cid] += 1
+    return allowed
+
+
+def _binary_search_smallest_fit(
+    allowed: list[str],
+    render: Callable[[set[str]], int],
+    char_budget: int,
+) -> tuple[set[str], bool]:
+    """Binary-search the smallest prefix of ``allowed`` whose render fits budget.
+
+    Returns (skip_set, fits). If even the full prefix doesn't fit, returns the
+    full prefix with fits=False so the caller can decide what to do.
+    """
+    if not allowed:
+        return set(), False
+
+    full_skip = set(allowed)
+    if render(full_skip) > char_budget:
+        return full_skip, False
+
+    lo, hi = 1, len(allowed)
+    result_k = len(allowed)
+    while lo <= hi:
+        mid = (lo + hi) // 2
+        if render(set(allowed[:mid])) <= char_budget:
+            result_k = mid
+            hi = mid - 1
+        else:
+            lo = mid + 1
+    return set(allowed[:result_k]), True
+
+
+def plan_skip_set(
+    cfg: CallGraph,
+    cluster_result: ClusterResult,
+    char_budget: int,
+    max_peel_frac: float = 0.5,
+    min_keep_per_cluster: int = 5,
+    retain_fraction: float = 0.5,
+) -> set[str]:
+    """Decide which nodes ``cfg.to_cluster_string`` should omit to fit ``char_budget``.
+
+    Returns an empty set when the unfiltered rendering already fits. Otherwise
+    returns the smallest prefix of the peel order (subject to per-cluster
+    constraints) whose rendering is within budget. If even the maximum allowed
+    skip set does not fit, returns the best-effort set and logs a warning — the
+    caller still uses it but the prompt will be oversized.
+    """
+    full_str = cfg.to_cluster_string(cluster_result=cluster_result)
+    if len(full_str) <= char_budget:
+        return set()
+
+    cfg_nx = cfg.to_networkx()
+    peel_order = _compute_peel_order(cfg_nx)
+
+    # Restrict peel candidates to nodes that are actually rendered (i.e. members
+    # of some cluster). Non-cluster nodes aren't part of the output; skipping
+    # them yields no character savings.
+    node_to_cluster: dict[str, int] = {
+        name: cid for cid, members in cluster_result.clusters.items() for name in members
+    }
+    peel_order = [n for n in peel_order if n in node_to_cluster]
+
+    if not peel_order:
+        logger.warning(
+            "[CFG skip planner] Full rendering is %d chars (budget %d) but no peel-safe cluster members; "
+            "rendering will exceed budget.",
+            len(full_str),
+            char_budget,
+        )
+        return set()
+
+    total_nodes = len(node_to_cluster)
+    global_cap = int(total_nodes * max_peel_frac)
+
+    def render(skip: set[str]) -> int:
+        return len(cfg.to_cluster_string(cluster_result=cluster_result, skip_nodes=skip))
+
+    stage1_caps = _stage1_max_skip_per_cluster(cluster_result.clusters, min_keep_per_cluster, retain_fraction)
+    stage1_allowed = _build_allowed_skip_list(peel_order, node_to_cluster, stage1_caps, global_cap)
+    stage1_skip, stage1_fits = _binary_search_smallest_fit(stage1_allowed, render, char_budget)
+    if stage1_fits:
+        logger.info(
+            "[CFG skip planner] Stage 1 (floor=%d, retain=%.2f): skipping %d/%d nodes",
+            min_keep_per_cluster,
+            retain_fraction,
+            len(stage1_skip),
+            total_nodes,
+        )
+        return stage1_skip
+
+    stage2_caps = _stage2_max_skip_per_cluster(cluster_result.clusters, min_keep_per_cluster)
+    stage2_allowed = _build_allowed_skip_list(peel_order, node_to_cluster, stage2_caps, global_cap)
+    stage2_skip, stage2_fits = _binary_search_smallest_fit(stage2_allowed, render, char_budget)
+    if stage2_fits:
+        logger.info(
+            "[CFG skip planner] Stage 2 (floor=%d only): skipping %d/%d nodes",
+            min_keep_per_cluster,
+            len(stage2_skip),
+            total_nodes,
+        )
+        return stage2_skip
+
+    # Stage 3: exhausted method-level options. Return the largest allowed stage-2 set
+    # (gets us as close as possible) and warn that the render will be over budget.
+    logger.warning(
+        "[CFG skip planner] Method-level filtering cannot fit budget (%d chars). "
+        "Returning best-effort skip of %d/%d nodes; prompt will exceed budget.",
+        char_budget,
+        len(stage2_skip),
+        total_nodes,
+    )
+    return stage2_skip

--- a/static_analyzer/cfg_skip_planner.py
+++ b/static_analyzer/cfg_skip_planner.py
@@ -4,30 +4,17 @@ The planner never mutates the graph: it returns a set of qualified names that
 ``CallGraph.to_cluster_string`` should drop from its output so the rendered
 text fits a character budget derived from the agent's context window.
 
-Three-stage graceful degradation when the full rendering is over budget:
-
-Stage 1 — per-cluster floor + fraction
-    Keep at least ``max(min_keep_per_cluster, ceil(size * retain_fraction))``
-    methods per cluster. Small clusters stay recognizable; large clusters
-    shed their lowest-degree tails first.
-
-Stage 2 — floor only
-    Drop the fraction, keep just the hard floor of ``min_keep_per_cluster``
-    per cluster. Used when stage 1 can't free enough characters.
-
-Stage 3 — give up
-    Return the best-effort skip set even if it still exceeds budget.
-    Caller logs a warning; the LLM or downstream truncation handles it.
-
 Node selection follows an iterative leaf-peel order on the undirected graph,
 so every skipped node is safe to remove without disconnecting the rest of
-the graph. Nodes in the 2-core are never candidates.
+the graph. Nodes in the 2-core are never candidates. A per-cluster floor
+keeps each cluster recognizable (at least ``min_keep_per_cluster`` members
+remain rendered), and a global cap prevents extreme pruning. Binary search
+over the allowed peel-order prefix picks the smallest skip set that fits.
 """
 
 from __future__ import annotations
 
 import logging
-import math
 from typing import TYPE_CHECKING, Callable
 
 import networkx as nx
@@ -61,23 +48,6 @@ def _compute_peel_order(cfg_nx: nx.DiGraph) -> list[str]:
             order.append(n)
             live.remove_node(n)
     return order
-
-
-def _required_keep(size: int, min_keep: int, retain_fraction: float) -> int:
-    """Stage-1 minimum: ``max(min_keep, ceil(size * retain_fraction))``, clamped to size."""
-    return min(size, max(min_keep, math.ceil(size * retain_fraction)))
-
-
-def _stage1_max_skip_per_cluster(
-    clusters: dict[int, set[str]], min_keep: int, retain_fraction: float
-) -> dict[int, int]:
-    return {
-        cid: len(members) - _required_keep(len(members), min_keep, retain_fraction) for cid, members in clusters.items()
-    }
-
-
-def _stage2_max_skip_per_cluster(clusters: dict[int, set[str]], min_keep: int) -> dict[int, int]:
-    return {cid: max(0, len(members) - min(min_keep, len(members))) for cid, members in clusters.items()}
 
 
 def _build_allowed_skip_list(
@@ -139,15 +109,14 @@ def plan_skip_set(
     char_budget: int,
     max_peel_frac: float = 0.5,
     min_keep_per_cluster: int = 5,
-    retain_fraction: float = 0.5,
 ) -> set[str]:
     """Decide which nodes ``cfg.to_cluster_string`` should omit to fit ``char_budget``.
 
     Returns an empty set when the unfiltered rendering already fits. Otherwise
     returns the smallest prefix of the peel order (subject to per-cluster
-    constraints) whose rendering is within budget. If even the maximum allowed
-    skip set does not fit, returns the best-effort set and logs a warning — the
-    caller still uses it but the prompt will be oversized.
+    floor + global cap) whose rendering is within budget. If even the maximum
+    allowed skip set does not fit, returns the best-effort set and logs a
+    warning — the caller still uses it but the prompt will be oversized.
     """
     full_str = cfg.to_cluster_string(cluster_result=cluster_result)
     if len(full_str) <= char_budget:
@@ -156,9 +125,8 @@ def plan_skip_set(
     cfg_nx = cfg.to_networkx()
     peel_order = _compute_peel_order(cfg_nx)
 
-    # Restrict peel candidates to nodes that are actually rendered (i.e. members
-    # of some cluster). Non-cluster nodes aren't part of the output; skipping
-    # them yields no character savings.
+    # Restrict peel candidates to nodes that are actually rendered (cluster
+    # members). Non-cluster nodes yield no character savings.
     node_to_cluster: dict[str, int] = {
         name: cid for cid, members in cluster_result.clusters.items() for name in members
     }
@@ -173,44 +141,32 @@ def plan_skip_set(
         )
         return set()
 
+    max_skip_per_cluster = {
+        cid: max(0, len(members) - min(min_keep_per_cluster, len(members)))
+        for cid, members in cluster_result.clusters.items()
+    }
     total_nodes = len(node_to_cluster)
     global_cap = int(total_nodes * max_peel_frac)
+    allowed = _build_allowed_skip_list(peel_order, node_to_cluster, max_skip_per_cluster, global_cap)
 
     def render(skip: set[str]) -> int:
         return len(cfg.to_cluster_string(cluster_result=cluster_result, skip_nodes=skip))
 
-    stage1_caps = _stage1_max_skip_per_cluster(cluster_result.clusters, min_keep_per_cluster, retain_fraction)
-    stage1_allowed = _build_allowed_skip_list(peel_order, node_to_cluster, stage1_caps, global_cap)
-    stage1_skip, stage1_fits = _binary_search_smallest_fit(stage1_allowed, render, char_budget)
-    if stage1_fits:
+    skip, fits = _binary_search_smallest_fit(allowed, render, char_budget)
+
+    if fits:
         logger.info(
-            "[CFG skip planner] Stage 1 (floor=%d, retain=%.2f): skipping %d/%d nodes",
+            "[CFG skip planner] skipping %d/%d nodes (floor=%d per cluster)",
+            len(skip),
+            total_nodes,
             min_keep_per_cluster,
-            retain_fraction,
-            len(stage1_skip),
+        )
+    else:
+        logger.warning(
+            "[CFG skip planner] Method-level filtering cannot fit budget (%d chars). "
+            "Returning best-effort skip of %d/%d nodes; prompt will exceed budget.",
+            char_budget,
+            len(skip),
             total_nodes,
         )
-        return stage1_skip
-
-    stage2_caps = _stage2_max_skip_per_cluster(cluster_result.clusters, min_keep_per_cluster)
-    stage2_allowed = _build_allowed_skip_list(peel_order, node_to_cluster, stage2_caps, global_cap)
-    stage2_skip, stage2_fits = _binary_search_smallest_fit(stage2_allowed, render, char_budget)
-    if stage2_fits:
-        logger.info(
-            "[CFG skip planner] Stage 2 (floor=%d only): skipping %d/%d nodes",
-            min_keep_per_cluster,
-            len(stage2_skip),
-            total_nodes,
-        )
-        return stage2_skip
-
-    # Stage 3: exhausted method-level options. Return the largest allowed stage-2 set
-    # (gets us as close as possible) and warn that the render will be over budget.
-    logger.warning(
-        "[CFG skip planner] Method-level filtering cannot fit budget (%d chars). "
-        "Returning best-effort skip of %d/%d nodes; prompt will exceed budget.",
-        char_budget,
-        len(stage2_skip),
-        total_nodes,
-    )
-    return stage2_skip
+    return skip

--- a/static_analyzer/graph.py
+++ b/static_analyzer/graph.py
@@ -309,19 +309,19 @@ class CallGraph:
 
         # Filter clusters if specific IDs requested
         if cluster_ids:
-            communities = [
-                cluster_result.clusters[cid] for cid in sorted(cluster_ids) if cid in cluster_result.clusters
-            ]
-            if not communities:
+            selected_ids = [cid for cid in sorted(cluster_ids) if cid in cluster_result.clusters]
+            if not selected_ids:
                 return f"No clusters found for IDs: {cluster_ids}"
         else:
-            # Use all clusters, sorted by ID for consistent output
-            communities = [cluster_result.clusters[cid] for cid in sorted(cluster_result.clusters.keys())]
+            selected_ids = sorted(cluster_result.clusters.keys())
 
-        if skip:
-            communities = [c - skip for c in communities]
+        # Carry original cluster IDs through rendering so skip-induced size shifts
+        # or cluster_ids filtering can't relabel clusters.
+        communities = [(cid, cluster_result.clusters[cid] - skip) for cid in selected_ids]
 
-        top_nodes = set().union(*communities) if communities else set()
+        top_nodes: set[str] = set()
+        for _, members in communities:
+            top_nodes |= members
 
         cluster_str = self.__cluster_str(communities, cfg_graph_x, skip)
         non_cluster_str = self.__non_cluster_str(cfg_graph_x, top_nodes, skip)
@@ -498,12 +498,11 @@ class CallGraph:
         )
 
     @staticmethod
-    def __cluster_str(communities: list[set[str]], cfg_graph_x: nx.DiGraph, skip: set[str] | None = None) -> str:
-        skip = skip or set()
-        valid_communities = [c for c in communities if len(c) >= 2]
-        top_communities = sorted(valid_communities, key=len, reverse=True)
+    def __cluster_str(communities: list[tuple[int, set[str]]], cfg_graph_x: nx.DiGraph, skip: set[str]) -> str:
+        valid_communities = [(cid, members) for cid, members in communities if len(members) >= 2]
+        top_communities = sorted(valid_communities, key=lambda item: len(item[1]), reverse=True)
         communities_str = f"Cluster Definitions ({len(top_communities)} clusters):\n\n"
-        for idx, community in enumerate(top_communities, start=1):
+        for cluster_id, community in top_communities:
             # Group nodes by file, then by class hierarchy within each file
             file_groups: dict[str, dict[str, list[str]]] = defaultdict(lambda: defaultdict(list))
             standalone_nodes: dict[str, list[str]] = defaultdict(list)
@@ -530,7 +529,7 @@ class CallGraph:
                     # Standalone function or unresolvable
                     standalone_nodes[file_path].append(f"{node_name} [{type_label}]")
 
-            communities_str += f"Cluster {idx} ({len(community)} nodes, {len(files_in_cluster)} files):\n"
+            communities_str += f"Cluster {cluster_id} ({len(community)} nodes, {len(files_in_cluster)} files):\n"
 
             for file_path in sorted(files_in_cluster):
                 communities_str += f"  {file_path}:\n"
@@ -546,10 +545,10 @@ class CallGraph:
 
             communities_str += "\n"
 
-        # Build summarized inter-cluster connections
-        node_to_cluster = {node: idx for idx, community in enumerate(top_communities) for node in community}
+        # Build summarized inter-cluster connections keyed by real cluster IDs
+        node_to_cluster = {node: cid for cid, members in top_communities for node in members}
 
-        # Aggregate inter-cluster edges: (src_cluster, dst_cluster) -> count + sample edges
+        # Aggregate inter-cluster edges: (src_cluster_id, dst_cluster_id) -> count + sample edges
         inter_cluster_summary: dict[tuple[int, int], list[str]] = defaultdict(list)
         for src, dst in cfg_graph_x.edges():
             if src in skip or dst in skip:
@@ -563,11 +562,9 @@ class CallGraph:
         if inter_cluster_summary:
             for src_cid, dst_cid in sorted(inter_cluster_summary.keys()):
                 calls = inter_cluster_summary[(src_cid, dst_cid)]
-                src_display = src_cid + 1
-                dst_display = dst_cid + 1
                 # Show count and up to 3 representative edges
                 max_examples = 3
-                inter_cluster_str += f"Cluster {src_display} -> Cluster {dst_display} ({len(calls)} calls):\n"
+                inter_cluster_str += f"Cluster {src_cid} -> Cluster {dst_cid} ({len(calls)} calls):\n"
                 for call in calls[:max_examples]:
                     inter_cluster_str += f"  - {call}\n"
                 if len(calls) > max_examples:
@@ -579,8 +576,7 @@ class CallGraph:
         return communities_str + inter_cluster_str
 
     @staticmethod
-    def __non_cluster_str(graph_x: nx.DiGraph, top_nodes: set[str], skip: set[str] | None = None) -> str:
-        skip = skip or set()
+    def __non_cluster_str(graph_x: nx.DiGraph, top_nodes: set[str], skip: set[str]) -> str:
         # Count unclustered edges rather than listing them all
         non_cluster_edges: list[tuple[str, str]] = []
         for src, dst in graph_x.edges():

--- a/static_analyzer/graph.py
+++ b/static_analyzer/graph.py
@@ -279,6 +279,7 @@ class CallGraph:
         self,
         cluster_ids: set[int] | None = None,
         cluster_result: ClusterResult | None = None,
+        skip_nodes: set[str] | None = None,
     ) -> str:
         """
         Generate a human-readable string representation of clusters.
@@ -289,6 +290,10 @@ class CallGraph:
         Args:
             cluster_ids: Optional set of cluster IDs to include. If None, includes all.
             cluster_result: Optional pre-computed ClusterResult. If None, calls cluster().
+            skip_nodes: Optional set of qualified names to omit from the rendered
+                output (both cluster members and edges). The graph itself is not
+                mutated; this is a serialization-layer filter used by
+                ``cfg_skip_planner`` to keep the LLM prompt under budget.
 
         Returns:
             Formatted string with cluster definitions and inter-cluster connections
@@ -300,6 +305,7 @@ class CallGraph:
             return cluster_result.strategy if cluster_result.strategy in ("empty", "none") else "No clusters found."
 
         cfg_graph_x = self.to_networkx()
+        skip = skip_nodes or set()
 
         # Filter clusters if specific IDs requested
         if cluster_ids:
@@ -312,10 +318,13 @@ class CallGraph:
             # Use all clusters, sorted by ID for consistent output
             communities = [cluster_result.clusters[cid] for cid in sorted(cluster_result.clusters.keys())]
 
+        if skip:
+            communities = [c - skip for c in communities]
+
         top_nodes = set().union(*communities) if communities else set()
 
-        cluster_str = self.__cluster_str(communities, cfg_graph_x)
-        non_cluster_str = self.__non_cluster_str(cfg_graph_x, top_nodes)
+        cluster_str = self.__cluster_str(communities, cfg_graph_x, skip)
+        non_cluster_str = self.__non_cluster_str(cfg_graph_x, top_nodes, skip)
         return cluster_str + non_cluster_str
 
     def _get_abstract_node_name(self, node_name: str, level: str) -> str:
@@ -489,7 +498,8 @@ class CallGraph:
         )
 
     @staticmethod
-    def __cluster_str(communities: list[set[str]], cfg_graph_x: nx.DiGraph) -> str:
+    def __cluster_str(communities: list[set[str]], cfg_graph_x: nx.DiGraph, skip: set[str] | None = None) -> str:
+        skip = skip or set()
         valid_communities = [c for c in communities if len(c) >= 2]
         top_communities = sorted(valid_communities, key=len, reverse=True)
         communities_str = f"Cluster Definitions ({len(top_communities)} clusters):\n\n"
@@ -542,6 +552,8 @@ class CallGraph:
         # Aggregate inter-cluster edges: (src_cluster, dst_cluster) -> count + sample edges
         inter_cluster_summary: dict[tuple[int, int], list[str]] = defaultdict(list)
         for src, dst in cfg_graph_x.edges():
+            if src in skip or dst in skip:
+                continue
             src_cluster = node_to_cluster.get(src)
             dst_cluster = node_to_cluster.get(dst)
             if src_cluster is not None and dst_cluster is not None and src_cluster != dst_cluster:
@@ -567,10 +579,13 @@ class CallGraph:
         return communities_str + inter_cluster_str
 
     @staticmethod
-    def __non_cluster_str(graph_x: nx.DiGraph, top_nodes: set[str]) -> str:
+    def __non_cluster_str(graph_x: nx.DiGraph, top_nodes: set[str], skip: set[str] | None = None) -> str:
+        skip = skip or set()
         # Count unclustered edges rather than listing them all
         non_cluster_edges: list[tuple[str, str]] = []
         for src, dst in graph_x.edges():
+            if src in skip or dst in skip:
+                continue
             if src not in top_nodes or dst not in top_nodes:
                 non_cluster_edges.append((src, dst))
 

--- a/tests/agents/test_cluster_methods_mixin.py
+++ b/tests/agents/test_cluster_methods_mixin.py
@@ -1,11 +1,13 @@
 import unittest
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import networkx as nx
 
+from agents.cluster_budget import ClusterPromptBudget
 from agents.cluster_methods_mixin import ClusterMethodsMixin
 from agents.agent_responses import AnalysisInsights, Component, SourceCodeReference
+from agents.model_capabilities import ContextWindow
 from static_analyzer.graph import CallGraph, ClusterResult
 from static_analyzer.constants import NodeType
 from static_analyzer.node import Node
@@ -207,6 +209,45 @@ class TestBuildFileMethodsFromNodes(unittest.TestCase):
             groups[0].methods[0].qualified_name,
             "diagram_analysis.diagram_generator.DiagramGenerator.generate_analysis_smart",
         )
+
+
+class TestClusterStringBudgeting(unittest.TestCase):
+    def _make_graph(self, language: str, names: list[str]) -> CallGraph:
+        cfg = CallGraph(language=language)
+        for index, name in enumerate(names, start=1):
+            cfg.add_node(Node(name, NodeType.FUNCTION, f"/repo/{language}.py", index, index + 1))
+        for src, dst in zip(names, names[1:]):
+            cfg.add_edge(src, dst)
+        return cfg
+
+    def test_combined_render_that_fits_does_not_use_per_language_skip_planning(self):
+        python_names = ["py." + ("large_name_" * 20) + str(i) for i in range(8)]
+        js_names = ["js.a", "js.b"]
+        py_cfg = self._make_graph("python", python_names)
+        js_cfg = self._make_graph("javascript", js_names)
+        cluster_results = {
+            "python": ClusterResult(clusters={1: set(python_names)}, strategy="test"),
+            "javascript": ClusterResult(clusters={2: set(js_names)}, strategy="test"),
+        }
+        static = MagicMock()
+        static.get_cfg.side_effect = {"python": py_cfg, "javascript": js_cfg}.__getitem__
+        mixin = MockMixin(repo_dir=Path("/repo"), static_analysis=static)
+
+        full = mixin._render_cluster_string(["python", "javascript"], cluster_results, None, {}).text
+        desired_budget = len(full) + 10
+        input_tokens = int(desired_budget / (ClusterPromptBudget(input_tokens=0).chars_per_token * 0.9)) + 8_001
+
+        with (
+            patch(
+                "agents.cluster_methods_mixin.get_current_agent_context_window",
+                return_value=ContextWindow(input_tokens=input_tokens, output_tokens=64_000),
+            ),
+            patch("agents.cluster_methods_mixin.plan_skip_set") as mock_plan_skip,
+        ):
+            result = mixin._build_cluster_string(["python", "javascript"], cluster_results)
+
+        self.assertEqual(result, full)
+        mock_plan_skip.assert_not_called()
 
 
 class TestExpandToMethodLevelClusters(unittest.TestCase):

--- a/tests/static_analyzer/test_cfg_skip_planner.py
+++ b/tests/static_analyzer/test_cfg_skip_planner.py
@@ -1,0 +1,70 @@
+import pytest
+
+from static_analyzer.cfg_skip_planner import ContextBudgetExceededError, plan_skip_set
+from static_analyzer.constants import NodeType
+from static_analyzer.graph import CallGraph, ClusterResult
+from static_analyzer.node import Node
+
+
+def _add_node(cfg: CallGraph, name: str, line: int) -> None:
+    cfg.add_node(Node(name, NodeType.FUNCTION, "/src/mod.py", line, line + 1))
+
+
+def test_plan_skip_set_returns_empty_when_render_fits():
+    cfg = CallGraph(language="python")
+    for line, name in enumerate(("mod.a", "mod.b", "mod.c"), start=1):
+        _add_node(cfg, name, line)
+    cfg.add_edge("mod.a", "mod.b")
+    cfg.add_edge("mod.b", "mod.c")
+    cluster_result = ClusterResult(clusters={1: {"mod.a", "mod.b", "mod.c"}}, strategy="test")
+
+    full = cfg.to_cluster_string(cluster_result=cluster_result)
+
+    assert plan_skip_set(cfg, cluster_result, len(full) + 1) == set()
+
+
+def test_plan_skip_set_raises_when_no_peel_safe_cluster_member_can_fit():
+    cfg = CallGraph(language="python")
+    for line, name in enumerate(("mod.a", "mod.b", "mod.c"), start=1):
+        _add_node(cfg, name, line)
+    cfg.add_edge("mod.a", "mod.b")
+    cfg.add_edge("mod.b", "mod.c")
+    cfg.add_edge("mod.c", "mod.a")
+    cluster_result = ClusterResult(clusters={1: {"mod.a", "mod.b", "mod.c"}}, strategy="test")
+
+    full = cfg.to_cluster_string(cluster_result=cluster_result)
+
+    with pytest.raises(ContextBudgetExceededError):
+        plan_skip_set(cfg, cluster_result, len(full) - 1)
+
+
+def test_plan_skip_set_can_choose_later_high_savings_leaf_under_cap():
+    cfg = CallGraph(language="python")
+    expensive = "mod." + "very_long_function_name_" * 20
+    for line, name in enumerate(("mod.cheap_a", "mod.cheap_b", expensive, "mod.center"), start=1):
+        _add_node(cfg, name, line)
+    cfg.add_edge("mod.center", "mod.cheap_a")
+    cfg.add_edge("mod.center", "mod.cheap_b")
+    cfg.add_edge("mod.center", expensive)
+    cluster_result = ClusterResult(
+        clusters={1: {"mod.cheap_a", "mod.cheap_b", expensive, "mod.center"}},
+        strategy="test",
+    )
+
+    full = cfg.to_cluster_string(cluster_result=cluster_result)
+    expensive_skip_len = len(cfg.to_cluster_string(cluster_result=cluster_result, skip_nodes={expensive}))
+    cheap_skip_len = len(cfg.to_cluster_string(cluster_result=cluster_result, skip_nodes={"mod.cheap_a"}))
+    char_budget = expensive_skip_len + 5
+    assert cheap_skip_len > char_budget
+    assert len(full) > char_budget
+
+    skip = plan_skip_set(
+        cfg,
+        cluster_result,
+        char_budget,
+        max_peel_frac=0.25,
+        min_keep_per_cluster=1,
+    )
+
+    assert skip == {expensive}
+    assert len(cfg.to_cluster_string(cluster_result=cluster_result, skip_nodes=skip)) <= char_budget

--- a/tests/static_analyzer/test_graph.py
+++ b/tests/static_analyzer/test_graph.py
@@ -411,14 +411,14 @@ class TestCallGraph(unittest.TestCase):
 
         nx_graph = graph.to_networkx()
 
-        # Define communities
+        # Define communities as (cluster_id, members) pairs
         communities = [
-            ["module.func0", "module.func1"],
-            ["module.func2", "module.func3"],
+            (1, {"module.func0", "module.func1"}),
+            (2, {"module.func2", "module.func3"}),
         ]
 
         graph_instance = CallGraph()
-        result = graph_instance._CallGraph__cluster_str(communities, nx_graph)  # type: ignore[attr-defined]
+        result = graph_instance._CallGraph__cluster_str(communities, nx_graph, set())  # type: ignore[attr-defined]
 
         self.assertIn("Cluster Definitions", result)
         self.assertIn("Inter-Cluster Connections", result)
@@ -443,7 +443,7 @@ class TestCallGraph(unittest.TestCase):
         top_nodes = {"module.func0", "module.func1"}
 
         graph_instance = CallGraph()
-        result = graph_instance._CallGraph__non_cluster_str(nx_graph, top_nodes)  # type: ignore[attr-defined]
+        result = graph_instance._CallGraph__non_cluster_str(nx_graph, top_nodes, set())  # type: ignore[attr-defined]
 
         # Should show edges involving func2 and func3
         self.assertIn("module.func2", result)


### PR DESCRIPTION
## Summary

- When a repo's call graph is too large to fit in the LLM's input window, the cluster-string prompt is pruned by dropping low-degree (peel-safe) methods — preserving cluster identity and graph structure.
- Single-stage design: keep at least `min_keep_per_cluster=5` members per cluster, respect a global `max_peel_frac=0.5` cap, binary-search the smallest peel-order prefix that fits the budget. Warn and return best-effort if nothing fits.
- Filtering is **serialization-only**: the graph, cluster results, `file_methods`, and inter-component relations are all computed from the unmodified data, so every node still ends up in the final output.
- Budget derived from the `get_context_window` resolver (PR #309): subtracts an 8K-token output headroom and the measured prompt overhead (system message + rendered template), then keeps a 10% safety margin.

## Known limitation — heuristic, not formal safeguard

Peel order is a valid prefix-safe removal sequence, but the final skip set is a *subsequence* of peel order (per-cluster caps and cluster-membership filter can create gaps). A subsequence of a peel-safe order is not itself peel-safe. In pathological cases — e.g. a bridge node `A` with `B — A — C`, where `B` and `C` are in a size-2 cluster (cap = 0) and `A` is in a larger cluster (cap > 0) — the planner can drop `A` while keeping `B` and `C`. The rendered view is still a correct induced subgraph (no false edges), but the LLM loses the signal that `B` and `C` were bridged through `A`.

Why it rarely bites in practice:
- Bridge nodes like `A` are usually in the 2-core and not peel-safe at all.
- `max_peel_frac=0.5` prevents concentration.
- Real clusters are typically well above the size-5 floor, so cap-induced gaps are uncommon.
- DetailsAgent method-level expansion produces cap=0 everywhere → planner no-ops harmlessly.

If we ever observe bad LLM grouping tied to this, the fix is to either (a) restrict skip sets to strict prefixes of the original peel order (drop per-cluster caps), or (b) recompute peel order on the live subgraph after each greedy addition (correct but more expensive).

## Test plan

- [x] `pytest tests/static_analyzer/ tests/agents/ --no-cov` — 910 passed, 24 skipped
- [x] `mypy` clean on all modified files
- [x] `black --check` clean
- [ ] Smoke-test on a large repo that previously tripped the context window

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Smarter context budgeting for multi-language cluster summaries so analyses better fit model windows and avoid unexpected truncation.
  * Better error reporting when prompt overhead leaves insufficient room for content.

* **New Features**
  * Automatic per-language trimming of cluster details to keep outputs within budget; explicit failure when trimming can't satisfy limits.

* **Tests**
  * Expanded tests covering budgeting, trimming behavior, and failure modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->