### PR TITLE
Factor shared dotted prefix per file in cluster string

### DIFF
--- a/static_analyzer/graph.py
+++ b/static_analyzer/graph.py
@@ -489,6 +489,22 @@ class CallGraph:
         )
 
     @staticmethod
+    def _common_dot_prefix(names: list[str]) -> str:
+        """Longest dotted-segment prefix shared by all names, leaving at least one trailing segment per name."""
+        if len(names) < 2:
+            return ""
+        parts_list = [n.split(".") for n in names]
+        min_len = min(len(p) for p in parts_list)
+        common: list[str] = []
+        for i in range(min_len - 1):
+            seg = parts_list[0][i]
+            if all(p[i] == seg for p in parts_list):
+                common.append(seg)
+            else:
+                break
+        return ".".join(common)
+
+    @staticmethod
     def __cluster_str(communities: list[set[str]], cfg_graph_x: nx.DiGraph) -> str:
         valid_communities = [c for c in communities if len(c) >= 2]
         top_communities = sorted(valid_communities, key=len, reverse=True)
@@ -523,15 +539,29 @@ class CallGraph:
             communities_str += f"Cluster {idx} ({len(community)} nodes, {len(files_in_cluster)} files):\n"
 
             for file_path in sorted(files_in_cluster):
-                communities_str += f"  {file_path}:\n"
-                # Render class groups
-                for class_name in sorted(file_groups.get(file_path, {})):
+                classes_in_file = sorted(file_groups.get(file_path, {}))
+                funcs_in_file = sorted(standalone_nodes.get(file_path, []))
+                func_fqns = [f.rsplit(" [", 1)[0] for f in funcs_in_file]
+                prefix = CallGraph._common_dot_prefix(classes_in_file + func_fqns)
+
+                if prefix and prefix.count(".") >= 1 and len(classes_in_file) + len(funcs_in_file) >= 2:
+                    communities_str += f'  {file_path} (identifiers below prefixed with "{prefix}."):\n'
+                    strip = f"{prefix}."
+                else:
+                    communities_str += f"  {file_path}:\n"
+                    strip = ""
+
+                for class_name in classes_in_file:
                     methods = file_groups[file_path][class_name]
-                    communities_str += f"    {class_name} [Class]\n"
+                    display_class = class_name[len(strip) :] if strip and class_name.startswith(strip) else class_name
+                    communities_str += f"    {display_class} [Class]\n"
                     for method in sorted(methods):
                         communities_str += f"      {method}\n"
-                # Render standalone functions
-                for func in sorted(standalone_nodes.get(file_path, [])):
+                for func in funcs_in_file:
+                    if strip:
+                        fqn_part, sep, label_part = func.partition(" [")
+                        if fqn_part.startswith(strip):
+                            func = fqn_part[len(strip) :] + sep + label_part
                     communities_str += f"    {func}\n"
 
             communities_str += "\n"

--- a/static_analyzer/graph.py
+++ b/static_analyzer/graph.py
@@ -489,11 +489,11 @@ class CallGraph:
         )
 
     @staticmethod
-    def _common_dot_prefix(names: list[str]) -> str:
-        """Longest dotted-segment prefix shared by all names, leaving at least one trailing segment per name."""
-        if len(names) < 2:
+    def _common_dot_prefix(qualified_names: list[str]) -> str:
+        """Longest dotted-segment prefix shared by all qualified names, leaving at least one trailing segment each."""
+        if len(qualified_names) < 2:
             return ""
-        parts_list = [n.split(".") for n in names]
+        parts_list = [n.split(".") for n in qualified_names]
         min_len = min(len(p) for p in parts_list)
         common: list[str] = []
         for i in range(min_len - 1):

--- a/tests/static_analyzer/test_graph.py
+++ b/tests/static_analyzer/test_graph.py
@@ -425,6 +425,39 @@ class TestCallGraph(unittest.TestCase):
         self.assertIn("Cluster 1", result)
         self.assertIn("Cluster 2", result)
 
+    def test_cluster_str_prefix_factoring(self):
+        graph = CallGraph()
+
+        nodes = [
+            Node("pkg.sub.module.ClassA", NodeType.CLASS, "/pkg/sub/module.py", 1, 5),
+            Node("pkg.sub.module.ClassA.method_one", NodeType.METHOD, "/pkg/sub/module.py", 6, 10),
+            Node("pkg.sub.module.ClassA.method_two", NodeType.METHOD, "/pkg/sub/module.py", 11, 15),
+            Node("pkg.sub.module.helper_func", NodeType.FUNCTION, "/pkg/sub/module.py", 16, 20),
+            Node("other.Outside", NodeType.CLASS, "/other.py", 1, 5),
+        ]
+        for n in nodes:
+            graph.add_node(n)
+        graph.add_edge("pkg.sub.module.ClassA.method_one", "pkg.sub.module.helper_func")
+
+        nx_graph = graph.to_networkx()
+        communities = [{n.fully_qualified_name for n in nodes[:4]}, {"other.Outside"}]
+
+        result = graph._CallGraph__cluster_str(communities, nx_graph)  # type: ignore[attr-defined]
+
+        self.assertIn('(identifiers below prefixed with "pkg.sub.module.")', result)
+        self.assertIn("ClassA [Class]", result)
+        self.assertIn("helper_func [Function]", result)
+        # Full FQN must not appear inside the factored file block
+        self.assertNotIn("    pkg.sub.module.ClassA [Class]", result)
+
+    def test_common_dot_prefix(self):
+        self.assertEqual(CallGraph._common_dot_prefix([]), "")
+        self.assertEqual(CallGraph._common_dot_prefix(["a.b.c"]), "")
+        self.assertEqual(CallGraph._common_dot_prefix(["a.b.c", "a.b.d"]), "a.b")
+        self.assertEqual(CallGraph._common_dot_prefix(["a.b.c", "x.y.z"]), "")
+        # Prevents collapsing identical names to empty short form
+        self.assertEqual(CallGraph._common_dot_prefix(["a.b", "a.b"]), "a")
+
     def test_non_cluster_str_static_method(self):
         # Test __non_cluster_str static method
         graph = CallGraph()


### PR DESCRIPTION
## Summary

When `CallGraph.to_cluster_string()` lists nodes in a cluster, every class and standalone function is printed with its full dotted qualified name (e.g. `agents.llm_config.LLMConfig`). Within a single file block, that prefix is shared by every identifier, so on large polyglot repos this becomes the largest source of redundancy in the grouping-prompt payload fed to the LLM.

This change hoists the shared prefix once per file block:

**Before**
```
  agents/llm_config.py:
    agents.llm_config.LLMConfig [Class]
      .get_api_key [Method]
    agents.llm_config._initialize_llm [Function]
    agents.llm_config.initialize_llms [Function]
```

**After**
```
  agents/llm_config.py (identifiers below prefixed with "agents.llm_config."):
    LLMConfig [Class]
      .get_api_key [Method]
    _initialize_llm [Function]
    initialize_llms [Function]
```

Only triggers when the prefix has at least 2 dotted segments **and** the file block has at least 2 identifiers — so short names are never ambiguous and the header overhead is always net-positive. Method lines were already short-form so they are unchanged.

Measured on the CodeBoarding self-analysis (1,293 nodes / 87 clusters): this lever alone accounts for roughly the dominant share of per-file FQN bytes in the cluster string; the header format is adjacent to the TOON-style header-then-rows pattern that benchmarks show LLMs parse reliably.

## Test plan

- [x] New unit tests cover both the factoring path and the `_common_dot_prefix` helper (single-name and all-names-identical edge cases).
- [x] `pytest tests/static_analyzer/test_graph.py` → 46 passed.
- [x] `pytest --ignore=tests/integration` → only 2 failures, both pre-existing on `main` and unrelated (non-cp1252 char in an untracked script; unrelated registry coverage test).
- [x] `black --check` and `mypy static_analyzer/graph.py` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Call graph output now factors shared dotted-name prefixes across identifiers (including standalone functions and classes), showing shortened names with a "prefixed with…" header when applicable and preserving original label suffixes.

* **Tests**
  * Added unit tests covering prefix factoring behavior and dot-notation prefix computation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->