### PR TITLE
Add type hints to fake_download helpers in tool registry tests

### DIFF
--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -1317,7 +1317,7 @@ class TestInstallNativeToolsCompressed(unittest.TestCase):
         binary_payload = b"\x7fELF" + b"fake-elf-bytes" * 200
 
         # The fake "download" writes a gzipped payload to the destination path.
-        def fake_download(url, destination, expected_sha256=None):
+        def fake_download(url: str, destination: Path, expected_sha256: str | None = None) -> bool:
             destination.parent.mkdir(parents=True, exist_ok=True)
             with gzip.open(destination, "wb") as f:
                 f.write(binary_payload)
@@ -1419,7 +1419,7 @@ class TestInstallNativeToolsCompressed(unittest.TestCase):
             ),
         )
 
-        def fake_download(url, destination, expected_sha256=None):
+        def fake_download(url: str, destination: Path, expected_sha256: str | None = None) -> bool:
             destination.parent.mkdir(parents=True, exist_ok=True)
             with gzip.open(destination, "wb") as f:
                 f.write(b"\x7fELFmock")


### PR DESCRIPTION
Summary: align the two fake_download fakes in TestInstallNativeToolsCompressed with the real downloader signature (url: str, destination: Path, expected_sha256: str | None = None) -> bool) so mypy can verify the mocks match the production contract.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced type annotations in test helper functions for improved code clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->