### PR TITLE
Fix remote clone failing with 'Invalid Git repository' on fresh repos

### DIFF
--- a/diagram_analysis/run_context.py
+++ b/diagram_analysis/run_context.py
@@ -41,7 +41,15 @@ class RunContext:
 
 
 def _load_existing_run_id(repo_dir: Path) -> str | None:
-    """Check details caches for the most recent run_id."""
+    """Check details caches for the most recent run_id.
+
+    Why: instantiating the caches creates sqlite files under ``repo_dir/.codeboarding/cache/``.
+    For remote runs that side-effect pre-populates the clone destination and makes the
+    subsequent ``git clone`` fail with ``Invalid Git repository``. Skip when no repo is there yet.
+    """
+    if not (repo_dir / ".git").exists():
+        logger.info("Repo not yet cloned at %s; skipping run_id cache lookup", repo_dir)
+        return None
     final_cache = FinalAnalysisCache(repo_dir)
     cluster_cache = ClusterCache(repo_dir)
     final_latest = final_cache.load_most_recent_run()

--- a/diagram_analysis/run_context.py
+++ b/diagram_analysis/run_context.py
@@ -41,12 +41,7 @@ class RunContext:
 
 
 def _load_existing_run_id(repo_dir: Path) -> str | None:
-    """Check details caches for the most recent run_id.
-
-    Why: instantiating the caches creates sqlite files under ``repo_dir/.codeboarding/cache/``.
-    For remote runs that side-effect pre-populates the clone destination and makes the
-    subsequent ``git clone`` fail with ``Invalid Git repository``. Skip when no repo is there yet.
-    """
+    """Check details caches for the most recent run_id."""
     if not (repo_dir / ".git").exists():
         logger.info("Repo not yet cloned at %s; skipping run_id cache lookup", repo_dir)
         return None

--- a/main.py
+++ b/main.py
@@ -391,11 +391,6 @@ def define_cli_arguments(parser: argparse.ArgumentParser):
         help="Upload onboarding materials to GeneratedOnBoardings repo (remote repos only)",
     )
     parser.add_argument("--enable-monitoring", action="store_true", help="Enable monitoring")
-    parser.add_argument(
-        "--no-cache-check",
-        action="store_true",
-        help="Skip the GeneratedOnBoardings cache check and regenerate docs for remote repos",
-    )
 
     # Incremental update options
     parser.add_argument(
@@ -557,7 +552,6 @@ Examples:
                             output_dir=repo_output_dir,
                             depth_level=args.depth_level,
                             upload=args.upload,
-                            cache_check=not args.no_cache_check,
                             monitoring_enabled=should_monitor,
                         )
                     except Exception as e:

--- a/main.py
+++ b/main.py
@@ -391,6 +391,11 @@ def define_cli_arguments(parser: argparse.ArgumentParser):
         help="Upload onboarding materials to GeneratedOnBoardings repo (remote repos only)",
     )
     parser.add_argument("--enable-monitoring", action="store_true", help="Enable monitoring")
+    parser.add_argument(
+        "--no-cache-check",
+        action="store_true",
+        help="Skip the GeneratedOnBoardings cache check and regenerate docs for remote repos",
+    )
 
     # Incremental update options
     parser.add_argument(
@@ -552,6 +557,7 @@ Examples:
                             output_dir=repo_output_dir,
                             depth_level=args.depth_level,
                             upload=args.upload,
+                            cache_check=not args.no_cache_check,
                             monitoring_enabled=should_monitor,
                         )
                     except Exception as e:

--- a/tests/diagram_analysis/test_run_context.py
+++ b/tests/diagram_analysis/test_run_context.py
@@ -84,6 +84,7 @@ class TestLoadExistingRunId(unittest.TestCase):
         self.temp_dir = tempfile.mkdtemp()
         self.repo_dir = Path(self.temp_dir) / "repo"
         self.repo_dir.mkdir(parents=True, exist_ok=True)
+        (self.repo_dir / ".git").mkdir()
         self.model_settings = ModelSettings(provider="test", chat_class="TestChat", model_name="test-model")
 
     def tearDown(self):


### PR DESCRIPTION
`RunContext.resolve` instantiated `FinalAnalysisCache`/`ClusterCache` before the remote clone ran, creating sqlite files under `repo_dir/.codeboarding/cache/` and causing `git clone` to fail with `Invalid Git repository`. This PR short-circuits `_load_existing_run_id` when the repo hasn't been cloned yet, removing the destructive side effect.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced cache resolution to gracefully handle scenarios where the repository structure is incomplete, preventing potential failures during initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->