### PR TITLE
Add codeboarding-agents-md CLI and architecture-digest generator

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,3 +34,7 @@
 - **Logging is centralized**: Review `logging_config.py` for logging configuration. Structured logging is used throughout the project; integrate logs into this system rather than using ad-hoc print statements.
 - **Multiple output formats supported**: The project generates Markdown, HTML, MDX, and Sphinx documentation. When adding features, consider all output generators if they are affected.
 - **Monitor execution stats**: The `monitoring/` directory provides `StreamingStatsWriter` for tracking LLM usage and performance metrics. Use this for tracking long-running operations.
+
+<!-- codeboarding:begin -->
+@CODEBOARDING.md
+<!-- codeboarding:end -->

--- a/CODEBOARDING.md
+++ b/CODEBOARDING.md
@@ -1,0 +1,3 @@
+# CodeBoarding — Architecture Overview
+
+_This file is managed by CodeBoarding. It will be populated on your next `codeboarding --local .` run._

--- a/agents_md_setup.py
+++ b/agents_md_setup.py
@@ -1,0 +1,40 @@
+"""Entry point for ``codeboarding-agents-md``: install the CODEBOARDING marker into cwd."""
+
+import argparse
+from pathlib import Path
+
+from output_generators.agents_md_install import setup_agents_md, setup_agents_md_all
+
+
+def main() -> None:
+    """Entry point for the ``codeboarding-agents-md`` CLI command."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Install the CODEBOARDING marker into the current repo's agent-instruction files. "
+            "Non-destructive: existing content outside the marker block is preserved."
+        )
+    )
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help=(
+            "Install into AGENTS.md, CLAUDE.md, .github/copilot-instructions.md, and .windsurfrules "
+            "(default: AGENTS.md only)."
+        ),
+    )
+    args = parser.parse_args()
+
+    repo_path = Path.cwd()
+    if args.all:
+        touched = setup_agents_md_all(repo_path)
+        print(f"Installed CODEBOARDING.md placeholder and marker in {len(touched)} agent-instruction files:")
+        for p in touched:
+            print(f"  - {p.relative_to(repo_path)}")
+    else:
+        setup_agents_md(repo_path)
+        print(f"Installed CODEBOARDING.md placeholder and AGENTS.md marker in {repo_path}")
+    print("Run `codeboarding --local .` to populate the digest.")
+
+
+if __name__ == "__main__":
+    main()

--- a/main.py
+++ b/main.py
@@ -19,6 +19,7 @@ from monitoring import monitor_execution
 from monitoring.paths import get_monitoring_run_dir
 from install import ensure_tools
 from tool_registry import needs_install
+from output_generators.agents_md_install import has_install_marker, install_codeboarding_md
 from output_generators.markdown import generate_markdown_file
 from repo_utils import (
     clone_repository,
@@ -252,6 +253,9 @@ def process_remote_repository(
             demo_mode=True,
         )
 
+        if has_install_marker(repo_path):
+            install_codeboarding_md(analysis_path, repo_path, temp_folder, repo_name)
+
         # Copy files to output directory if specified
         if output_dir:
             copy_files(temp_folder, output_dir)
@@ -309,7 +313,7 @@ def process_local_repository(
         return
 
     # Full analysis (local repo - no markdown generation)
-    generate_analysis(
+    analysis_path = generate_analysis(
         repo_name=project_name,
         repo_path=repo_path,
         output_dir=output_dir,
@@ -319,6 +323,9 @@ def process_local_repository(
         monitoring_enabled=monitoring_enabled,
         force_full=force_full,
     )
+
+    if has_install_marker(repo_path):
+        install_codeboarding_md(analysis_path, repo_path, output_dir, project_name)
 
 
 def copy_files(temp_folder: Path, output_dir: Path):

--- a/output_generators/agents_md.py
+++ b/output_generators/agents_md.py
@@ -1,0 +1,193 @@
+"""Generate a single LLM-oriented AGENTS.md-style digest of a CodeBoarding analysis.
+
+Layout: YAML frontmatter, nested TOC with anchors, depth-tiered component blocks
+(inline relations + hybrid id/name edge refs), and a trailing flat edge index.
+No Mermaid — redundant with the indented text for LLM consumption.
+"""
+
+import re
+from pathlib import Path
+
+from agents.agent_responses import AnalysisInsights, Component, Relation, SourceCodeReference
+
+
+def _slug(text: str) -> str:
+    """Render GFM-compatible heading anchor."""
+    s = re.sub(r"[^\w\s-]", "", text.lower())
+    return re.sub(r"\s+", "-", s).strip("-")
+
+
+def _anchor(comp: Component) -> str:
+    return _slug(f"{comp.component_id} {comp.name}")
+
+
+def _one_line(text: str, limit: int = 100) -> str:
+    first = text.strip().splitlines()[0] if text.strip() else ""
+    return first if len(first) <= limit else first[: limit - 1].rstrip() + "…"
+
+
+def _ref_str(ref: SourceCodeReference, include_lines: bool = True) -> str:
+    if not ref.reference_file:
+        return f"`{ref.qualified_name}`"
+    loc = ref.reference_file
+    if include_lines and ref.reference_start_line and ref.reference_end_line:
+        if ref.reference_start_line < ref.reference_end_line:
+            loc += f":L{ref.reference_start_line}-L{ref.reference_end_line}"
+    return f"`{ref.qualified_name}` — {loc}"
+
+
+def _edge_bullet(rel: Relation) -> str:
+    dst = f"`{rel.dst_id} {rel.dst_name}`" if rel.dst_id else f"`{rel.dst_name}`"
+    return f"- {rel.relation} → {dst}"
+
+
+def _component_block(
+    comp: Component,
+    outgoing: list[Relation],
+    depth: int,
+) -> list[str]:
+    """Render a component. Depth tiers: 1=full, 2=terse, 3+=minimal.
+
+    Why: GraphRAG-style tiering keeps the whole graph in one file without
+    blowing the context budget. Leaf components only need names + edges; mid
+    levels drop the exhaustive file_methods listing; the root tier carries
+    full source detail.
+    """
+    heading_hashes = "#" * min(depth + 1, 6)
+    lines = [f"{heading_hashes} {comp.component_id} {comp.name}", ""]
+
+    desc = _one_line(comp.description, limit=140) if depth >= 3 else comp.description.strip()
+    if desc:
+        lines += [desc, ""]
+
+    if outgoing:
+        lines.append("**Relations:**")
+        lines += [_edge_bullet(r) for r in outgoing]
+        lines.append("")
+
+    if comp.key_entities:
+        lines.append("**Key entities:**")
+        lines += [f"- {_ref_str(e, include_lines=depth < 3)}" for e in comp.key_entities]
+        lines.append("")
+
+    if depth == 1 and comp.file_methods:
+        lines.append("**Source files:**")
+        for fg in comp.file_methods:
+            lines.append(f"- `{fg.file_path}`")
+            for m in fg.methods:
+                lines.append(f"  - `{m.qualified_name}` (L{m.start_line}-L{m.end_line}) — {m.node_type}")
+        lines.append("")
+
+    return lines
+
+
+def _toc(root: AnalysisInsights, sub_analyses: dict[str, AnalysisInsights]) -> list[str]:
+    lines = ["## Components (TOC)", ""]
+
+    def _walk(comp: Component, indent: int) -> None:
+        pad = "  " * indent
+        summary = _one_line(comp.description, limit=80)
+        lines.append(f"{pad}- [{comp.component_id} {comp.name}](#{_anchor(comp)}) — {summary}")
+        sub = sub_analyses.get(comp.component_id)
+        if sub:
+            for child in sub.components:
+                _walk(child, indent + 1)
+
+    for c in root.components:
+        _walk(c, 0)
+    lines.append("")
+    return lines
+
+
+def _render_tree(
+    comp: Component,
+    outgoing_by_name: dict[str, list[Relation]],
+    sub_analyses: dict[str, AnalysisInsights],
+    depth: int,
+) -> list[str]:
+    lines = _component_block(comp, outgoing_by_name.get(comp.name, []), depth)
+    sub = sub_analyses.get(comp.component_id)
+    if sub:
+        child_outgoing = _group_by_src_name(sub.components_relations)
+        for child in sub.components:
+            lines += _render_tree(child, child_outgoing, sub_analyses, depth + 1)
+    return lines
+
+
+def _group_by_src_name(relations: list[Relation]) -> dict[str, list[Relation]]:
+    """Key on src_name: always populated, while src_id may be blank on older analyses."""
+    by_src: dict[str, list[Relation]] = {}
+    for r in relations:
+        by_src.setdefault(r.src_name, []).append(r)
+    return by_src
+
+
+def _edge_index(root: AnalysisInsights, sub_analyses: dict[str, AnalysisInsights]) -> list[str]:
+    """Flat edge listing. Cheap global-reasoning win (KG-LLM-Bench)."""
+    lines = ["## Edge Index", ""]
+    seen: set[tuple[str, str, str]] = set()
+
+    def _emit(rel: Relation) -> None:
+        key = (rel.src_id or rel.src_name, rel.relation, rel.dst_id or rel.dst_name)
+        if key in seen:
+            return
+        seen.add(key)
+        src = f"{rel.src_id} {rel.src_name}" if rel.src_id else rel.src_name
+        dst = f"{rel.dst_id} {rel.dst_name}" if rel.dst_id else rel.dst_name
+        lines.append(f"- `{src}` — {rel.relation} → `{dst}`")
+
+    for rel in root.components_relations:
+        _emit(rel)
+    for sub in sub_analyses.values():
+        for rel in sub.components_relations:
+            _emit(rel)
+    lines.append("")
+    return lines
+
+
+def generate_agents_md(
+    root: AnalysisInsights,
+    sub_analyses: dict[str, AnalysisInsights] | None = None,
+    project: str = "",
+) -> str:
+    """Render a flat AGENTS.md-style digest of root + sub-analyses."""
+    sub_analyses = sub_analyses or {}
+
+    lines: list[str] = [
+        "---",
+        f"project: {project}" if project else "project: unnamed",
+        "kind: codeboarding-analysis",
+        "---",
+        "",
+        f"# {project or 'Project'} — Architecture",
+        "",
+        root.description.strip(),
+        "",
+    ]
+    lines += _toc(root, sub_analyses)
+
+    outgoing = _group_by_src_name(root.components_relations)
+    for comp in root.components:
+        lines += _render_tree(comp, outgoing, sub_analyses, depth=1)
+
+    lines += _edge_index(root, sub_analyses)
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def generate_agents_md_file(
+    root: AnalysisInsights,
+    sub_analyses: dict[str, AnalysisInsights],
+    project: str,
+    output_dir: Path,
+    file_name: str = "CODEBOARDING",
+) -> Path:
+    """Write the digest to ``<output_dir>/<file_name>.md`` and return the path.
+
+    Why CODEBOARDING.md (not AGENTS.md): AGENTS.md is user-owned and overwriting
+    it would be a data-loss incident. The CodeBoarding-generated digest gets a
+    distinct filename; discoverability from AGENTS.md is handled separately via
+    ``install_into_repo`` (non-destructive ``@`` import).
+    """
+    path = output_dir / f"{file_name}.md"
+    path.write_text(generate_agents_md(root, sub_analyses, project=project), encoding="utf-8")
+    return path

--- a/output_generators/agents_md_install.py
+++ b/output_generators/agents_md_install.py
@@ -1,0 +1,114 @@
+"""Install the generated CODEBOARDING.md into a target repo and register it in agent-instruction files.
+
+Non-destructive: content outside the ``codeboarding:begin/end`` marker block is never touched.
+Idempotent: re-running replaces only the block between the markers.
+"""
+
+import json
+import logging
+import re
+import shutil
+from pathlib import Path
+
+from diagram_analysis.analysis_json import parse_unified_analysis
+from output_generators.agents_md import generate_agents_md_file
+
+logger = logging.getLogger(__name__)
+
+BEGIN_MARKER = "<!-- codeboarding:begin -->"
+END_MARKER = "<!-- codeboarding:end -->"
+IMPORT_LINE = "@CODEBOARDING.md"
+MD_LINK_LINE = "See [CODEBOARDING.md](./CODEBOARDING.md) for the generated architecture digest."
+BLOCK = f"{BEGIN_MARKER}\n{IMPORT_LINE}\n{END_MARKER}"
+_BLOCK_RE = re.compile(rf"{re.escape(BEGIN_MARKER)}.*?{re.escape(END_MARKER)}", re.DOTALL)
+
+PLACEHOLDER_CONTENT = (
+    "# CodeBoarding — Architecture Overview\n"
+    "\n"
+    "_This file is managed by CodeBoarding. It will be populated on your next"
+    " `codeboarding --local .` run._\n"
+)
+
+# (relative path, inner-block content). ``@`` import for Claude-Code-aware files
+# (it treats the line as a recursive @-import); plain markdown reference everywhere else.
+ALL_TARGETS: list[tuple[str, str]] = [
+    ("AGENTS.md", IMPORT_LINE),
+    ("CLAUDE.md", IMPORT_LINE),
+    (".github/copilot-instructions.md", MD_LINK_LINE),
+    (".windsurfrules", MD_LINK_LINE),
+]
+
+
+def setup_agents_md(repo_path: Path) -> None:
+    """Register the AGENTS.md import marker and drop a placeholder CODEBOARDING.md."""
+    _write_placeholder(repo_path)
+    _ensure_marker_block(repo_path / "AGENTS.md", IMPORT_LINE)
+
+
+def setup_agents_md_all(repo_path: Path) -> list[Path]:
+    """Install marker blocks across every known agent-instruction file. Returns paths touched."""
+    _write_placeholder(repo_path)
+    touched: list[Path] = []
+    for rel_path, inner in ALL_TARGETS:
+        target = repo_path / rel_path
+        _ensure_marker_block(target, inner)
+        touched.append(target)
+    return touched
+
+
+def has_install_marker(repo_path: Path) -> bool:
+    """Return True if ``<repo_path>/AGENTS.md`` already contains the CodeBoarding marker block.
+
+    Why: AGENTS.md is the canonical consent receipt even when ``--all`` wrote markers
+    to sibling files; keeping detection here means one source of truth for "is install on?"
+    """
+    agents_md = repo_path / "AGENTS.md"
+    if not agents_md.exists():
+        return False
+    return BEGIN_MARKER in agents_md.read_text(encoding="utf-8")
+
+
+def install_codeboarding_md(analysis_path: Path, repo_path: Path, output_dir: Path, repo_name: str) -> None:
+    """Render the AGENTS-style digest and install it into ``repo_path``.
+
+    Why: single entry point for the auto-refresh path in ``main.py`` so callers do one
+    call per mode rather than re-threading the analysis-json parsing + generation steps.
+    """
+    if not analysis_path.exists():
+        logger.warning("install_codeboarding_md: no analysis.json at %s; skipping", analysis_path)
+        return
+    data = json.loads(analysis_path.read_text(encoding="utf-8"))
+    root, sub_analyses = parse_unified_analysis(data)
+    digest = generate_agents_md_file(root, sub_analyses, repo_name, output_dir)
+    install_into_repo(repo_path, digest)
+    logger.info("Installed CODEBOARDING.md into %s", repo_path)
+
+
+def install_into_repo(repo_path: Path, generated_md: Path) -> None:
+    """Copy the digest to ``<repo_path>/CODEBOARDING.md`` and ensure AGENTS.md imports it."""
+    shutil.copyfile(generated_md, repo_path / "CODEBOARDING.md")
+    _ensure_marker_block(repo_path / "AGENTS.md", IMPORT_LINE)
+
+
+def _write_placeholder(repo_path: Path) -> None:
+    placeholder = repo_path / "CODEBOARDING.md"
+    if not placeholder.exists():
+        placeholder.write_text(PLACEHOLDER_CONTENT, encoding="utf-8")
+
+
+def _ensure_marker_block(target: Path, inner: str) -> None:
+    block = f"{BEGIN_MARKER}\n{inner}\n{END_MARKER}"
+    if not target.exists():
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(block + "\n", encoding="utf-8")
+        return
+
+    original = target.read_text(encoding="utf-8")
+    if _BLOCK_RE.search(original):
+        updated = _BLOCK_RE.sub(block, original)
+    else:
+        sep = "" if original.startswith("\n") else "\n"
+        updated = f"{block}\n{sep}{original}"
+
+    if updated != original:
+        target.write_text(updated, encoding="utf-8")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,12 +64,13 @@ all = [
 
 [tool.setuptools]
 packages = ["agents", "agents.prompts", "agents.tools", "core", "diagram_analysis", "health", "health.checks", "monitoring", "output_generators", "repo_utils", "static_analyzer", "static_analyzer.engine", "static_analyzer.engine.adapters", "static_analyzer.lsp_client", "caching", "tool_registry"]
-py-modules = ["constants", "utils", "vscode_constants", "logging_config", "duckdb_crud", "github_action", "user_config", "main", "install"]
+py-modules = ["constants", "utils", "vscode_constants", "logging_config", "duckdb_crud", "github_action", "user_config", "main", "install", "agents_md_setup"]
 include-package-data = true
 
 [project.scripts]
 codeboarding = "main:main"
 codeboarding-setup = "install:main"
+codeboarding-agents-md = "agents_md_setup:main"
 
 [project.urls]
 Repository = "https://github.com/CodeBoarding/CodeBoarding"

--- a/tests/output_generators/test_agents_md_install.py
+++ b/tests/output_generators/test_agents_md_install.py
@@ -1,0 +1,179 @@
+from pathlib import Path
+
+import pytest
+
+from output_generators.agents_md_install import (
+    ALL_TARGETS,
+    BEGIN_MARKER,
+    BLOCK,
+    END_MARKER,
+    IMPORT_LINE,
+    MD_LINK_LINE,
+    PLACEHOLDER_CONTENT,
+    has_install_marker,
+    install_into_repo,
+    setup_agents_md,
+    setup_agents_md_all,
+)
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    return tmp_path
+
+
+@pytest.fixture
+def digest(tmp_path: Path) -> Path:
+    src = tmp_path / "src" / "CODEBOARDING.md"
+    src.parent.mkdir()
+    src.write_text("# digest\n", encoding="utf-8")
+    return src
+
+
+def test_creates_agents_md_when_missing(repo: Path, digest: Path) -> None:
+    install_into_repo(repo, digest)
+    assert (repo / "CODEBOARDING.md").read_text() == "# digest\n"
+    assert (repo / "AGENTS.md").read_text() == BLOCK + "\n"
+
+
+def test_prepends_block_when_agents_md_has_no_markers(repo: Path, digest: Path) -> None:
+    original = "# Project\n\nExisting guidance.\n"
+    (repo / "AGENTS.md").write_text(original, encoding="utf-8")
+
+    install_into_repo(repo, digest)
+
+    result = (repo / "AGENTS.md").read_text()
+    assert result.startswith(BLOCK)
+    assert result.endswith(original)
+
+
+def test_refreshes_block_between_existing_markers(repo: Path, digest: Path) -> None:
+    stale_block = f"{BEGIN_MARKER}\n@OLD.md\nextra garbage\n{END_MARKER}"
+    original = f"# Project\n\nExisting.\n\n{stale_block}\n\nTrailing content.\n"
+    (repo / "AGENTS.md").write_text(original, encoding="utf-8")
+
+    install_into_repo(repo, digest)
+
+    result = (repo / "AGENTS.md").read_text()
+    assert "@OLD.md" not in result
+    assert "extra garbage" not in result
+    assert IMPORT_LINE in result
+    assert "Trailing content." in result
+    assert result.count(BEGIN_MARKER) == 1
+
+
+def test_noop_when_block_already_current(repo: Path, digest: Path) -> None:
+    current = f"# Project\n\n{BLOCK}\n"
+    agents_md = repo / "AGENTS.md"
+    agents_md.write_text(current, encoding="utf-8")
+    mtime_before = agents_md.stat().st_mtime_ns
+
+    install_into_repo(repo, digest)
+
+    assert agents_md.read_text() == current
+    assert agents_md.stat().st_mtime_ns == mtime_before
+
+
+def test_copies_digest_to_repo_root(repo: Path, digest: Path) -> None:
+    digest.write_text("# v2\n", encoding="utf-8")
+    install_into_repo(repo, digest)
+    assert (repo / "CODEBOARDING.md").read_text() == "# v2\n"
+
+
+def test_handles_agents_md_without_trailing_newline(repo: Path, digest: Path) -> None:
+    (repo / "AGENTS.md").write_text("# Project", encoding="utf-8")
+    install_into_repo(repo, digest)
+    result = (repo / "AGENTS.md").read_text()
+    assert result.startswith(BLOCK)
+    assert result.endswith("# Project")
+
+
+def test_has_install_marker_false_when_agents_md_missing(repo: Path) -> None:
+    assert has_install_marker(repo) is False
+
+
+def test_has_install_marker_false_when_no_marker(repo: Path) -> None:
+    (repo / "AGENTS.md").write_text("# Plain guidance, no markers here.\n", encoding="utf-8")
+    assert has_install_marker(repo) is False
+
+
+def test_has_install_marker_true_after_install(repo: Path, digest: Path) -> None:
+    install_into_repo(repo, digest)
+    assert has_install_marker(repo) is True
+
+
+def test_has_install_marker_false_after_marker_removed(repo: Path, digest: Path) -> None:
+    install_into_repo(repo, digest)
+    agents_md = repo / "AGENTS.md"
+    agents_md.write_text("# Project\n", encoding="utf-8")
+    assert has_install_marker(repo) is False
+
+
+def test_setup_writes_placeholder_and_marker(repo: Path) -> None:
+    setup_agents_md(repo)
+    assert (repo / "CODEBOARDING.md").read_text() == PLACEHOLDER_CONTENT
+    assert has_install_marker(repo) is True
+
+
+def test_setup_does_not_overwrite_existing_codeboarding_md(repo: Path) -> None:
+    (repo / "CODEBOARDING.md").write_text("# user content\n", encoding="utf-8")
+    setup_agents_md(repo)
+    assert (repo / "CODEBOARDING.md").read_text() == "# user content\n"
+    assert has_install_marker(repo) is True
+
+
+def test_setup_is_idempotent(repo: Path) -> None:
+    setup_agents_md(repo)
+    setup_agents_md(repo)
+    assert (repo / "AGENTS.md").read_text().count(BEGIN_MARKER) == 1
+
+
+def test_setup_all_writes_to_all_four_targets(repo: Path) -> None:
+    touched = setup_agents_md_all(repo)
+    assert {p.relative_to(repo).as_posix() for p in touched} == {p for p, _ in ALL_TARGETS}
+    for rel, _ in ALL_TARGETS:
+        assert (repo / rel).exists(), rel
+
+
+def test_setup_all_uses_import_line_for_claude_agents(repo: Path) -> None:
+    setup_agents_md_all(repo)
+    for rel in ("AGENTS.md", "CLAUDE.md"):
+        content = (repo / rel).read_text()
+        assert IMPORT_LINE in content, rel
+        assert MD_LINK_LINE not in content, rel
+
+
+def test_setup_all_uses_markdown_link_for_copilot_windsurf(repo: Path) -> None:
+    setup_agents_md_all(repo)
+    for rel in (".github/copilot-instructions.md", ".windsurfrules"):
+        content = (repo / rel).read_text()
+        assert MD_LINK_LINE in content, rel
+        assert IMPORT_LINE not in content, rel
+
+
+def test_setup_all_creates_github_subdirectory(repo: Path) -> None:
+    assert not (repo / ".github").exists()
+    setup_agents_md_all(repo)
+    assert (repo / ".github" / "copilot-instructions.md").exists()
+
+
+def test_setup_all_preserves_existing_content_in_all_targets(repo: Path) -> None:
+    (repo / "AGENTS.md").write_text("# project rules\n", encoding="utf-8")
+    (repo / "CLAUDE.md").write_text("# claude-specific\n", encoding="utf-8")
+    (repo / ".github").mkdir()
+    (repo / ".github" / "copilot-instructions.md").write_text("# copilot rules\n", encoding="utf-8")
+    (repo / ".windsurfrules").write_text("# windsurf rules\n", encoding="utf-8")
+
+    setup_agents_md_all(repo)
+
+    assert "# project rules" in (repo / "AGENTS.md").read_text()
+    assert "# claude-specific" in (repo / "CLAUDE.md").read_text()
+    assert "# copilot rules" in (repo / ".github" / "copilot-instructions.md").read_text()
+    assert "# windsurf rules" in (repo / ".windsurfrules").read_text()
+
+
+def test_setup_all_idempotent(repo: Path) -> None:
+    setup_agents_md_all(repo)
+    setup_agents_md_all(repo)
+    for rel, _ in ALL_TARGETS:
+        assert (repo / rel).read_text().count(BEGIN_MARKER) == 1, rel


### PR DESCRIPTION
This sets up an .md in a precommit hook fashion. It adds a CODEBOARDING.md when you run `codeboarding-agents-md` , and it will add @CODEBOARDING.md to your agent.md . If you add `--all` it will add it to all whatever agent md convention you're using e.g. claude.md 

* **New Features**
  * Added CodeBoarding integration with automatic marker installation for agent instruction files.
  * Introduced new CLI command to set up CodeBoarding across supported instruction file formats.
  * Added automatic architecture digest generation and management.

* **Tests**
  * Added comprehensive test coverage for CodeBoarding installation and marker handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->