### PR TITLE
Plumb static_analyzer through run_incremental for warm LSP

### DIFF
--- a/codeboarding_workflows/analysis.py
+++ b/codeboarding_workflows/analysis.py
@@ -25,6 +25,7 @@ def _build_generator(
     log_path: str,
     depth_level: int = 1,
     monitoring_enabled: bool = False,
+    static_analyzer=None,
 ) -> DiagramGenerator:
     return DiagramGenerator(
         repo_location=repo_path,
@@ -35,6 +36,7 @@ def _build_generator(
         run_id=run_id,
         log_path=log_path,
         monitoring_enabled=monitoring_enabled,
+        static_analyzer=static_analyzer,
     )
 
 
@@ -130,6 +132,7 @@ def run_incremental(
     target_ref: str,
     depth_level: int = 1,
     monitoring_enabled: bool = False,
+    static_analyzer=None,
 ) -> IncrementalRunPayload:
     """Incremental scope — diff against *base_ref* and propagate only the semantic deltas."""
     generator = _build_generator(
@@ -140,5 +143,6 @@ def run_incremental(
         log_path=log_path,
         depth_level=depth_level,
         monitoring_enabled=monitoring_enabled,
+        static_analyzer=static_analyzer,
     )
     return run_incremental_pipeline(generator, base_ref=base_ref, target_ref=target_ref)

--- a/diagram_analysis/diagram_generator.py
+++ b/diagram_analysis/diagram_generator.py
@@ -179,7 +179,7 @@ class DiagramGenerator:
 
         def get_static_with_injected_analyzer() -> StaticAnalysisResults:
             cache_dir = None if self.force_full_analysis else get_cache_dir(self.repo_location)
-            return self._get_static_from_injected_analyzer(cache_dir, skip_cache=self.force_full_analysis)
+            return self._get_static_from_injected_analyzer(cache_dir, skip_cache=True)
 
         def get_static_with_new_analyzer() -> StaticAnalysisResults:
             skip_cache = self.force_full_analysis

--- a/tests/codeboarding_workflows/test_analysis.py
+++ b/tests/codeboarding_workflows/test_analysis.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from codeboarding_workflows.analysis import run_incremental
+
+
+def test_run_incremental_forwards_static_analyzer_to_generator(tmp_path: Path) -> None:
+    """Warm-LSP injection: ``static_analyzer`` must reach ``DiagramGenerator.__init__``.
+
+    Why: the wrapper hands a long-lived StaticAnalyzer with warm LSP servers
+    in via this kwarg; if it's silently dropped on the workflow boundary,
+    incremental analysis cold-starts a new analyzer instead.
+    """
+    sentinel_analyzer = MagicMock(name="static_analyzer")
+
+    with (
+        patch("codeboarding_workflows.analysis.DiagramGenerator") as gen_cls,
+        patch("codeboarding_workflows.analysis.run_incremental_pipeline", return_value=MagicMock()),
+    ):
+        run_incremental(
+            repo_path=tmp_path,
+            output_dir=tmp_path / "out",
+            project_name="proj",
+            run_id="rid",
+            log_path="logs/run.log",
+            base_ref="abc",
+            target_ref="",
+            static_analyzer=sentinel_analyzer,
+        )
+
+    gen_cls.assert_called_once()
+    assert gen_cls.call_args.kwargs["static_analyzer"] is sentinel_analyzer

--- a/tests/diagram_analysis/test_analysis_patcher.py
+++ b/tests/diagram_analysis/test_analysis_patcher.py
@@ -1,7 +1,14 @@
 from unittest.mock import MagicMock, patch
 
 from agents.agent_responses import AnalysisInsights, Component, Relation, SourceCodeReference
-from diagram_analysis.analysis_patcher import AnalysisScopePatch, PatchScope, apply_scope_patch, patch_analysis_scope
+from diagram_analysis.analysis_patcher import (
+    AnalysisScopePatch,
+    ComponentPatch,
+    PatchScope,
+    RelationPatch,
+    apply_scope_patch,
+    patch_analysis_scope,
+)
 
 
 def _make_analysis() -> AnalysisInsights:
@@ -45,20 +52,20 @@ def test_apply_scope_patch_updates_only_targeted_components_and_relations():
     scope_patch = AnalysisScopePatch(
         scope_description="Updated scope",
         components=[
-            {
-                "component_id": "1.1",
-                "description": "Updated auth description",
-                "key_entities": [{"qualified_name": "auth.refresh"}],
-            }
+            ComponentPatch(
+                component_id="1.1",
+                description="Updated auth description",
+                key_entities=[SourceCodeReference(qualified_name="auth.refresh")],
+            )
         ],
         relations=[
-            {
-                "src_id": "1.1",
-                "dst_id": "1.2",
-                "relation": "depends_on",
-                "src_name": "Auth",
-                "dst_name": "Store",
-            }
+            RelationPatch(
+                src_id="1.1",
+                dst_id="1.2",
+                relation="depends_on",
+                src_name="Auth",
+                dst_name="Store",
+            )
         ],
     )
 
@@ -89,13 +96,13 @@ def test_apply_scope_patch_ignores_out_of_scope_relation_additions():
         scope_description=None,
         components=[],
         relations=[
-            {
-                "src_id": "1.2",
-                "dst_id": "1.3",
-                "relation": "feeds",
-                "src_name": "Store",
-                "dst_name": "Cache",
-            }
+            RelationPatch(
+                src_id="1.2",
+                dst_id="1.3",
+                relation="feeds",
+                src_name="Store",
+                dst_name="Cache",
+            )
         ],
     )
 

--- a/tests/diagram_analysis/test_analysis_patcher.py
+++ b/tests/diagram_analysis/test_analysis_patcher.py
@@ -1,14 +1,7 @@
 from unittest.mock import MagicMock, patch
 
 from agents.agent_responses import AnalysisInsights, Component, Relation, SourceCodeReference
-from diagram_analysis.analysis_patcher import (
-    AnalysisScopePatch,
-    ComponentPatch,
-    PatchScope,
-    RelationPatch,
-    apply_scope_patch,
-    patch_analysis_scope,
-)
+from diagram_analysis.analysis_patcher import AnalysisScopePatch, PatchScope, apply_scope_patch, patch_analysis_scope
 
 
 def _make_analysis() -> AnalysisInsights:
@@ -52,20 +45,20 @@ def test_apply_scope_patch_updates_only_targeted_components_and_relations():
     scope_patch = AnalysisScopePatch(
         scope_description="Updated scope",
         components=[
-            ComponentPatch(
-                component_id="1.1",
-                description="Updated auth description",
-                key_entities=[SourceCodeReference(qualified_name="auth.refresh")],
-            )
+            {
+                "component_id": "1.1",
+                "description": "Updated auth description",
+                "key_entities": [{"qualified_name": "auth.refresh"}],
+            }
         ],
         relations=[
-            RelationPatch(
-                src_id="1.1",
-                dst_id="1.2",
-                relation="depends_on",
-                src_name="Auth",
-                dst_name="Store",
-            )
+            {
+                "src_id": "1.1",
+                "dst_id": "1.2",
+                "relation": "depends_on",
+                "src_name": "Auth",
+                "dst_name": "Store",
+            }
         ],
     )
 
@@ -96,13 +89,13 @@ def test_apply_scope_patch_ignores_out_of_scope_relation_additions():
         scope_description=None,
         components=[],
         relations=[
-            RelationPatch(
-                src_id="1.2",
-                dst_id="1.3",
-                relation="feeds",
-                src_name="Store",
-                dst_name="Cache",
-            )
+            {
+                "src_id": "1.2",
+                "dst_id": "1.3",
+                "relation": "feeds",
+                "src_name": "Store",
+                "dst_name": "Cache",
+            }
         ],
     )
 

--- a/tests/diagram_analysis/test_scope_planner.py
+++ b/tests/diagram_analysis/test_scope_planner.py
@@ -13,6 +13,7 @@ from agents.agent_responses import (
 from agents.change_status import ChangeStatus
 from diagram_analysis.incremental_models import TraceResult, TraceStopReason
 from diagram_analysis.incremental_updater import FileDelta, IncrementalDelta, MethodChange, apply_method_delta
+from diagram_analysis.analysis_patcher import PatchScope
 from diagram_analysis.scope_planner import apply_patch_scopes, build_ownership_index, derive_patch_scopes
 
 
@@ -61,7 +62,7 @@ def test_derive_patch_scopes_maps_new_methods_after_delta_application():
     )
 
     updated_root = root.model_copy(deep=True)
-    updated_subs = {}
+    updated_subs: dict[str, AnalysisInsights] = {}
     apply_method_delta(updated_root, updated_subs, delta)
     ownership_index = build_ownership_index(updated_root, updated_subs)
     trace_result = TraceResult(
@@ -121,13 +122,11 @@ def test_apply_patch_scopes_raises_when_patch_generation_fails():
         components_relations=[],
     )
     patch_scopes = [
-        MagicMock(
+        PatchScope(
             scope_id=None,
             target_component_ids=["1.1"],
             visited_methods=["auth.login"],
             impacted_methods=["auth.login"],
-            synthetic_files=[],
-            semantic_impact_summary="",
         )
     ]
 

--- a/tests/diagram_analysis/test_scope_planner.py
+++ b/tests/diagram_analysis/test_scope_planner.py
@@ -13,7 +13,6 @@ from agents.agent_responses import (
 from agents.change_status import ChangeStatus
 from diagram_analysis.incremental_models import TraceResult, TraceStopReason
 from diagram_analysis.incremental_updater import FileDelta, IncrementalDelta, MethodChange, apply_method_delta
-from diagram_analysis.analysis_patcher import PatchScope
 from diagram_analysis.scope_planner import apply_patch_scopes, build_ownership_index, derive_patch_scopes
 
 
@@ -62,7 +61,7 @@ def test_derive_patch_scopes_maps_new_methods_after_delta_application():
     )
 
     updated_root = root.model_copy(deep=True)
-    updated_subs: dict[str, AnalysisInsights] = {}
+    updated_subs = {}
     apply_method_delta(updated_root, updated_subs, delta)
     ownership_index = build_ownership_index(updated_root, updated_subs)
     trace_result = TraceResult(
@@ -122,11 +121,13 @@ def test_apply_patch_scopes_raises_when_patch_generation_fails():
         components_relations=[],
     )
     patch_scopes = [
-        PatchScope(
+        MagicMock(
             scope_id=None,
             target_component_ids=["1.1"],
             visited_methods=["auth.login"],
             impacted_methods=["auth.login"],
+            synthetic_files=[],
+            semantic_impact_summary="",
         )
     ]
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -63,6 +63,7 @@ class TestGenerateAnalysis(unittest.TestCase):
                 run_id="test-run-id",
                 log_path="test_repo/test-run-log",
                 monitoring_enabled=False,
+                static_analyzer=None,
             )
             mock_generator.generate_analysis.assert_called_once()
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Incremental workflow now accepts an optional static analyzer so runs can be configured with a custom analyzer.

* **Improvements**
  * Injected static analyzers now bypass caching to ensure consistent pre-analysis behavior.

* **Tests**
  * Added a unit test verifying analyzer propagation through the workflow.
  * Updated tests to use concrete typed patch and scope objects and clearer typing in setups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->