### PR TITLE
Read .codeboardingignore from repo root, drop initialize helper

### DIFF
--- a/codeboarding_cli/commands/full_analysis.py
+++ b/codeboarding_cli/commands/full_analysis.py
@@ -14,7 +14,6 @@ from diagram_analysis import RunContext
 from monitoring import monitor_execution
 from monitoring.paths import get_monitoring_run_dir
 from repo_utils import get_branch, store_token
-from repo_utils.ignore import initialize_codeboardingignore
 from utils import CODEBOARDING_DIR_NAME, copy_files, monitoring_enabled
 
 logger = logging.getLogger(__name__)
@@ -80,7 +79,6 @@ def _run_local(args: argparse.Namespace) -> None:
 
     should_monitor = args.enable_monitoring or monitoring_enabled()
     run_paths.output_dir.mkdir(parents=True, exist_ok=True)
-    initialize_codeboardingignore(run_paths.output_dir)
 
     def scope(src: SourceContext, run_context: RunContext) -> None:
         run_full(
@@ -156,7 +154,6 @@ def _process_one_remote(
     def scope(src: SourceContext, run_context: RunContext) -> None:
         repo_output_dir = workspace_root / src.project_name / CODEBOARDING_DIR_NAME
         repo_output_dir.mkdir(parents=True, exist_ok=True)
-        initialize_codeboardingignore(repo_output_dir)
 
         monitoring_dir = get_monitoring_run_dir(run_context.log_path, create=should_monitor)
         with monitor_execution(

--- a/codeboarding_cli/commands/partial_analysis.py
+++ b/codeboarding_cli/commands/partial_analysis.py
@@ -7,7 +7,6 @@ from codeboarding_workflows.analysis import run_partial
 from codeboarding_workflows.orchestration import run_analysis_pipeline
 from codeboarding_workflows.sources import SourceContext, local_source
 from diagram_analysis import RunContext
-from repo_utils.ignore import initialize_codeboardingignore
 
 logger = logging.getLogger(__name__)
 
@@ -44,7 +43,6 @@ def run_from_args(args: argparse.Namespace, parser: argparse.ArgumentParser) -> 
     logger.info("Starting CodeBoarding partial component update...")
 
     run_paths.output_dir.mkdir(parents=True, exist_ok=True)
-    initialize_codeboardingignore(run_paths.output_dir)
 
     def scope(src: SourceContext, run_context: RunContext) -> None:
         run_partial(

--- a/diagram_analysis/incremental_pipeline.py
+++ b/diagram_analysis/incremental_pipeline.py
@@ -33,7 +33,6 @@ from diagram_analysis.incremental_updater import IncrementalUpdater
 from diagram_analysis.io_utils import load_full_analysis
 from diagram_analysis.run_metadata import METADATA_FILENAME, write_incremental_run_metadata
 from repo_utils.diff_parser import detect_changes
-from repo_utils.ignore import initialize_codeboardingignore
 from repo_utils import get_git_commit_hash, get_repo_state_hash
 from repo_utils.git_ops import git_object_type, resolve_ref, worktree_has_changes
 from static_analyzer.analysis_result import StaticAnalysisResults
@@ -183,7 +182,6 @@ def run_incremental_pipeline(
     repo_path = generator.repo_location
     output_dir = generator.output_dir
     output_dir.mkdir(parents=True, exist_ok=True)
-    initialize_codeboardingignore(output_dir)
 
     def _abort(msg: str) -> RequiresFullAnalysisPayload:
         logger.info("Incremental aborted (base_ref=%s target_ref=%s): %s", base_ref, target_ref or "WORKTREE", msg)

--- a/repo_utils/ignore.py
+++ b/repo_utils/ignore.py
@@ -6,6 +6,8 @@ import pathspec
 logger = logging.getLogger(__name__)
 
 CODEBOARDINGIGNORE_TEMPLATE = """# CodeBoarding Ignore File
+# Place this file at the root of your repository (next to .gitignore).
+#
 # Add patterns here for files and directories that should be excluded from CodeBoarding analysis.
 # Use the same format as .gitignore (gitignore syntax / gitwildmatch patterns).
 #
@@ -16,8 +18,7 @@ CODEBOARDINGIGNORE_TEMPLATE = """# CodeBoarding Ignore File
 #   - .git/, .codeboarding/, node_modules/, __pycache__/
 #   - Build output: build/, dist/, coverage/
 #
-# This file is automatically loaded by CodeBoarding analysis tools to exclude
-# specified paths from code analysis, architecture generation, and other processing.
+# When this file is missing, CodeBoarding falls back to the patterns below.
 
 # ============================================================================
 # Ignored directories (customizable — remove lines to include them)
@@ -163,10 +164,11 @@ _ALWAYS_IGNORED_DIRS = {
 class RepoIgnoreManager:
     """Centralized manager for handling file and directory exclusions across the repository.
 
-    Combines patterns from .gitignore and .codeboardingignore. Default exclusion
-    patterns are defined in the CODEBOARDINGIGNORE_TEMPLATE and written to
-    ``.codeboarding/.codeboardingignore`` on first run — users can then
-    customize which patterns to keep, remove, or add.
+    Combines patterns from ``.gitignore`` and a repo-root ``.codeboardingignore``
+    (loaded the same way ``.gitignore`` is — from the top of the worktree). When
+    no ``.codeboardingignore`` exists, the patterns in
+    ``CODEBOARDINGIGNORE_TEMPLATE`` are used as a fallback so first-run analysis
+    still has sensible exclusions.
     """
 
     def __init__(self, repo_root: Path):
@@ -201,13 +203,8 @@ class RepoIgnoreManager:
         return []
 
     def _load_codeboardingignore_patterns(self) -> list[str]:
-        """Load and parse .codeboardingignore file from .codeboarding directory.
-
-        If the file does not exist, returns the default template patterns so that
-        first-run analysis still has sensible exclusions even before
-        ``initialize_codeboardingignore`` is called.
-        """
-        codeboardingignore_path = self.repo_root / ".codeboarding" / ".codeboardingignore"
+        """Load .codeboardingignore from the repo root, falling back to the default template."""
+        codeboardingignore_path = self.repo_root / ".codeboardingignore"
 
         if codeboardingignore_path.exists():
             try:
@@ -216,7 +213,6 @@ class RepoIgnoreManager:
             except Exception as e:
                 logger.warning(f"Failed to read .codeboardingignore at {codeboardingignore_path}: {e}")
 
-        # Fall back to the default template so analysis works before the file is created
         return list(CODEBOARDINGIGNORE_TEMPLATE.splitlines(keepends=True))
 
     def should_ignore(self, path: Path) -> bool:
@@ -294,19 +290,3 @@ class RepoIgnoreManager:
         except Exception as e:
             logger.error(f"Error categorizing file {path}: {e}")
             return "other"
-
-
-def initialize_codeboardingignore(output_dir: Path) -> None:
-    """Initialize .codeboardingignore file in the .codeboarding directory if it doesn't exist.
-
-    Args:
-        output_dir: Path to the .codeboarding directory
-    """
-    codeboardingignore_path = output_dir / ".codeboardingignore"
-
-    if not codeboardingignore_path.exists():
-        try:
-            codeboardingignore_path.write_text(CODEBOARDINGIGNORE_TEMPLATE, encoding="utf-8")
-            logger.debug(f"Created .codeboardingignore file at {codeboardingignore_path}")
-        except Exception as e:
-            logger.warning(f"Failed to create .codeboardingignore at {codeboardingignore_path}: {e}")

--- a/tests/integration/test_static_analysis_consistency.py
+++ b/tests/integration/test_static_analysis_consistency.py
@@ -36,7 +36,7 @@ import pytest
 from git import Repo
 
 from repo_utils import clone_repository
-from repo_utils.ignore import initialize_codeboardingignore
+from repo_utils.ignore import CODEBOARDINGIGNORE_TEMPLATE
 from static_analyzer import get_static_analysis
 from static_analyzer.analysis_result import StaticAnalysisResults
 
@@ -221,11 +221,8 @@ class TestStaticAnalysisConsistency:
 
         # Ensure the current .codeboardingignore template is used, not whatever
         # the cloned repo might have from an older version.
-        codeboarding_dir = repo_path / ".codeboarding"
-        codeboarding_dir.mkdir(parents=True, exist_ok=True)
-        ignore_file = codeboarding_dir / ".codeboardingignore"
-        ignore_file.unlink(missing_ok=True)
-        initialize_codeboardingignore(codeboarding_dir)
+        ignore_file = repo_path / ".codeboardingignore"
+        ignore_file.write_text(CODEBOARDINGIGNORE_TEMPLATE, encoding="utf-8")
 
         # Load expected fixture
         expected = load_fixture(config.fixture_file)

--- a/tests/repo_utils/test_ignore.py
+++ b/tests/repo_utils/test_ignore.py
@@ -28,7 +28,6 @@ class TestRepoIgnoreManagerRealWorldScenario(unittest.TestCase):
         (self.repo_path / "spec").mkdir()
         (self.repo_path / "dist").mkdir()
         (self.repo_path / "node_modules").mkdir()
-        (self.repo_path / ".codeboarding").mkdir()
 
         # Create actual files that should be analyzed
         (self.repo_path / "src" / "main.py").write_text("# Main app code")
@@ -64,7 +63,7 @@ dist/
 *.chunk.js
 *.chunk.js.map
 """
-        (self.repo_path / ".codeboarding" / ".codeboardingignore").write_text(codeboardingignore_content)
+        (self.repo_path / ".codeboardingignore").write_text(codeboardingignore_content)
 
         # Create files matching gitignore patterns
         (self.repo_path / "build.log").write_text("Build log content")

--- a/tests/static_analyzer/test_go_adapter.py
+++ b/tests/static_analyzer/test_go_adapter.py
@@ -104,10 +104,7 @@ class TestGoplsConfiguration:
 
     def test_init_options_include_directory_filters_from_ignore_manager(self, tmp_path: Path):
         """Directory filters are derived from .codeboardingignore patterns."""
-        # Create a .codeboardingignore with directory patterns
-        cb_dir = tmp_path / ".codeboarding"
-        cb_dir.mkdir()
-        ignore_file = cb_dir / ".codeboardingignore"
+        ignore_file = tmp_path / ".codeboardingignore"
         ignore_file.write_text("vendor/\n**/tests/**\n**/examples/**\n*.test.js\n")
 
         ignore_manager = RepoIgnoreManager(tmp_path)
@@ -144,9 +141,7 @@ class TestGoplsConfiguration:
 
     def test_directory_filters_deduplicates(self, tmp_path: Path):
         """Same directory from multiple patterns should only appear once."""
-        cb_dir = tmp_path / ".codeboarding"
-        cb_dir.mkdir()
-        ignore_file = cb_dir / ".codeboardingignore"
+        ignore_file = tmp_path / ".codeboardingignore"
         ignore_file.write_text("vendor/\n**/vendor/**\n")
 
         ignore_manager = RepoIgnoreManager(tmp_path)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Consolidated ignore configuration file location to the repository root (`.codeboardingignore`), eliminating the need for a subdirectory structure and simplifying configuration management.
  * Automatic ignore initialization is no longer performed; configuration is now read directly from the repository root when present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->