### PR TITLE
Fix global state pollution and robustify PHP LSP resolution on Windows

### DIFF
--- a/agents/llm_config.py
+++ b/agents/llm_config.py
@@ -161,8 +161,8 @@ LLM_PROVIDERS = {
     "aws": LLMConfig(
         chat_class=ChatBedrockConverse,
         api_key_env="AWS_BEARER_TOKEN_BEDROCK",  # Used for existence check
-        agent_model="anthropic.claude-sonnet-4-6",
-        parsing_model="claude-haiku-4-5",
+        agent_model="us.anthropic.claude-sonnet-4-6",
+        parsing_model="us.anthropic.claude-haiku-4-5",
         llm_type=LLMType.CLAUDE_SONNET,
         extra_args={
             "max_tokens": 4096,

--- a/tests/test_vscode_constants.py
+++ b/tests/test_vscode_constants.py
@@ -1,3 +1,4 @@
+import copy
 import os
 import platform
 import tempfile
@@ -15,6 +16,15 @@ from vscode_constants import (
 
 
 class TestVSCodeConstants(unittest.TestCase):
+    def setUp(self):
+        # Capture a deep copy of the global config to restore after each test
+        self._original_config = copy.deepcopy(VSCODE_CONFIG)
+
+    def tearDown(self):
+        # Restore the global config
+        VSCODE_CONFIG.clear()
+        VSCODE_CONFIG.update(self._original_config)
+
     @patch("platform.system")
     def test_get_bin_path_windows(self, mock_system):
         # Test bin path for Windows

--- a/tool_registry/manifest.py
+++ b/tool_registry/manifest.py
@@ -227,19 +227,27 @@ def resolve_config(base_dir: Path) -> dict[str, Any]:
         elif dep.kind is ToolKind.NODE:
             binary_path = base_dir / "node_modules" / ".bin" / f"{dep.binary_name}{node_ext}"
             if binary_path.exists():
-                cmd = cast(list[str], config[dep.config_section][dep.key]["command"])
+                section = config[dep.config_section][dep.key]
+                original_cmd = list(section["command"])
                 if dep.js_entry_file:
                     # Prefer [node, <abs/entry.mjs>] so frozen wrapper binaries
                     # can use their embedded Node runtime.
                     js_entry = find_runnable(str(base_dir), dep.js_entry_file, dep.js_entry_parent or dep.binary_name)
                     node_path = preferred_node_path(base_dir)
                     if js_entry and node_path:
-                        cmd[0] = js_entry
-                        cmd.insert(0, node_path)
+                        # Rebuild the command to avoid remnants from half-resolved
+                        # or polluted configs (e.g. ['node', 'old-bin', ...]).
+                        # We keep the flags (everything after the first element).
+                        flags = original_cmd[1:]
+                        if original_cmd[0] == "node" and len(original_cmd) > 1:
+                            # If it was already prefixed with node, flags start at index 2
+                            flags = original_cmd[2:]
+
+                        section["command"] = [node_path, js_entry] + flags
                     else:
-                        cmd[0] = str(binary_path)
+                        section["command"] = [str(binary_path)] + original_cmd[1:]
                 else:
-                    cmd[0] = str(binary_path)
+                    section["command"] = [str(binary_path)] + original_cmd[1:]
 
         elif dep.kind is ToolKind.ARCHIVE and dep.archive_subdir:
             archive_dir = base_dir / "bin" / dep.archive_subdir

--- a/vscode_constants.py
+++ b/vscode_constants.py
@@ -21,26 +21,31 @@ def update_command_paths(bin_dir):
 
     for section in VSCODE_CONFIG.values():
         for key, value in section.items():
-            cmd: list[str] = value["command"]  # type: ignore[assignment]
+            if "command" not in value:
+                continue
+
+            # Create a new list to avoid in-place modification of the original
+            cmd = list(value["command"])
+
             if key == "typescript":
                 # Scan the bin dir to find the cli.mjs path
-                cmd[0] = (
-                    find_runnable(bin_dir, "cli.mjs", "typescript-language-server")
-                    or find_runnable(bin_dir, "typescript-language-server", "node_modules")
-                    or cmd[0]
+                runnable = find_runnable(bin_dir, "cli.mjs", "typescript-language-server") or find_runnable(
+                    bin_dir, "typescript-language-server", "node_modules"
                 )
+                if runnable:
+                    cmd[0] = runnable
             elif key == "python":
-                cmd[0] = (
-                    find_runnable(bin_dir, "langserver.index.js", "pyright")
-                    or find_runnable(bin_dir, "pyright", "node_modules")
-                    or cmd[0]
+                runnable = find_runnable(bin_dir, "langserver.index.js", "pyright") or find_runnable(
+                    bin_dir, "pyright", "node_modules"
                 )
+                if runnable:
+                    cmd[0] = runnable
             elif key == "php":
-                cmd[0] = (
-                    find_runnable(bin_dir, "intelephense.js", "intelephense")
-                    or find_runnable(bin_dir, "intelephense", "node_modules")
-                    or cmd[0]
+                runnable = find_runnable(bin_dir, "intelephense.js", "intelephense") or find_runnable(
+                    bin_dir, "intelephense", "node_modules"
                 )
+                if runnable:
+                    cmd[0] = runnable
             elif key == "java":
                 # Find JDTLS root directory
                 jdtls_dir = os.path.join(bin_dir, "bin", "jdtls")
@@ -50,22 +55,46 @@ def update_command_paths(bin_dir):
                     value["jdtls_root"] = jdtls_dir
                     # Keep command as "java" - it will be constructed by JavaClient
                     cmd[0] = "java"
-            elif "command" in value:
-                if isinstance(cmd, list) and cmd:
-                    cmd[0] = os.path.join(bin_path, cmd[0])
+            elif cmd:
+                cmd[0] = os.path.join(bin_path, cmd[0])
 
             # Apply Windows-specific node prefix for specified languages
             # Use VSCode's bundled Node.js (passed via CODEBOARDING_NODE_PATH) so users
             # don't need a separate Node.js/npm installation on Windows.
             if is_windows and key in node_languages:
-                node_path = os.environ.get("CODEBOARDING_NODE_PATH", "node")
-                cmd.insert(0, node_path)
+                # Avoid double-prepending if the command already starts with node
+                # or if it's already an absolute path to a node binary.
+                first_cmd_lower = cmd[0].lower()
+                is_node = (
+                    first_cmd_lower == "node"
+                    or first_cmd_lower.endswith("\\node.exe")
+                    or first_cmd_lower.endswith("/node.exe")
+                    or first_cmd_lower.endswith("\\node")
+                    or first_cmd_lower.endswith("/node")
+                )
+                if not is_node:
+                    node_path = os.environ.get("CODEBOARDING_NODE_PATH", "node")
+                    cmd.insert(0, node_path)
+
+            # Update the value with the new command list
+            value["command"] = cmd
 
 
 def find_runnable(bin_dir, search_file, part_of_dir):
+    is_windows = platform.system().lower() == "windows"
+    search_file_lower = search_file.lower() if is_windows else None
+    part_of_dir_lower = part_of_dir.lower() if is_windows else None
+
     for root, _, files in os.walk(bin_dir):
-        if search_file in files and part_of_dir in root:
-            return os.path.join(root, search_file)
+        if is_windows:
+            files_lower = [f.lower() for f in files]
+            if search_file_lower in files_lower and part_of_dir_lower in root.lower():
+                # Find the original filename to preserve casing
+                idx = files_lower.index(search_file_lower)
+                return os.path.join(root, files[idx])
+        else:
+            if search_file in files and part_of_dir in root:
+                return os.path.join(root, search_file)
     return None
 
 


### PR DESCRIPTION
TLDR: Was tired of the PHP test failing so tried to fix it. 

Fixed a global state pollution bug where unit tests were permanently poisoning the shared LSP configuration, causing subsequent integration tests on Windows to fail. I refactored the command resolution logic to be idempotent and defensive, preventing broken commands like "node node" from being generated when the resolution runs multiple times. Finally, I made the file discovery utility case-insensitive on Windows to handle inconsistent directory casing that previously led to resolution failures
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/codeboarding/codeboarding/pull/327" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed command resolution for Node.js, TypeScript, Python, and PHP tools to prevent corrupted configurations
  * Prevented duplicate node path prefixes on Windows and improved command path update robustness

* **Tests**
  * Improved test isolation to avoid shared-state leaks between tests

* **Chores**
  * Updated AWS Bedrock model identifiers used by the AWS LLM provider
<!-- end of auto-generated comment: release notes by coderabbit.ai -->