### PR TITLE
ci(docs): switch update-docs workflow to AWS Bedrock auth

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -130,7 +130,7 @@ jobs:
           REPO_ROOT: ${{ github.workspace }}/codeboarding-engine/repos
           STATIC_ANALYSIS_CONFIG: ${{ github.workspace }}/codeboarding-engine/static_analysis_config.yml
           PROJECT_ROOT: ${{ github.workspace }}/codeboarding-engine
-          DIAGRAM_DEPTH_LEVEL: '3'
+          DIAGRAM_DEPTH_LEVEL: '2'
           CACHING_DOCUMENTATION: 'false'
           ENABLE_MONITORING: 'false'
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -124,14 +124,13 @@ jobs:
         working-directory: codeboarding-engine
         timeout-minutes: 30
         env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
-          VERCEL_API_KEY: ${{ secrets.VERCEL_API_KEY }}
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          AGENT_MODEL: ${{ secrets.AGENT_MODEL }}
+          PARSING_MODEL: ${{ secrets.PARSING_MODEL }}
           REPO_ROOT: ${{ github.workspace }}/codeboarding-engine/repos
           STATIC_ANALYSIS_CONFIG: ${{ github.workspace }}/codeboarding-engine/static_analysis_config.yml
           PROJECT_ROOT: ${{ github.workspace }}/codeboarding-engine
-          DIAGRAM_DEPTH_LEVEL: '5'
+          DIAGRAM_DEPTH_LEVEL: '3'
           CACHING_DOCUMENTATION: 'false'
           ENABLE_MONITORING: 'false'
         run: |


### PR DESCRIPTION
Use AWS_BEARER_TOKEN_BEDROCK in place of VERCEL_API_KEY so the docs analysis run authenticates against AWS Bedrock instead of the Vercel AI Gateway (which we emptied credits on)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/codeboarding/codeboarding/pull/328" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated documentation generation workflow configuration with modified API provider settings and adjusted diagram complexity parameters for automated analysis processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->