### PR TITLE
Fix typescript for multiconfigs

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -22,11 +22,10 @@ on:
   push:
     branches: [main]
 
-  # PRs that touch install / bootstrap / LSP code. The Node-bootstrap path
-  # only surfaces on Node-less machines, so the per-OS uninstall steps
+  # PRs that touch install / bootstrap / LSP / scanner code. The Node-bootstrap
+  # path only surfaces on Node-less machines, so the per-OS uninstall steps
   # below simulate that environment and catch regressions before merge.
   pull_request:
-    branches: [main]
     paths:
       - 'install.py'
       - 'tool_registry/**'
@@ -34,6 +33,7 @@ on:
       - 'pyproject.toml'
       - 'uv.lock'
       - 'static_analyzer/**'
+      - 'repo_utils/ignore.py'
       - 'tests/integration/**'
       - 'tests/test_install.py'
       - 'tests/test_tool_registry.py'

--- a/diagram_analysis/diagram_generator.py
+++ b/diagram_analysis/diagram_generator.py
@@ -179,33 +179,21 @@ class DiagramGenerator:
         result.diagnostics = self._static_analyzer.collected_diagnostics  # type: ignore[union-attr]
         return result
 
-    def _persist_pkl_with_cluster_cache(
-        self,
-        cluster_results: dict[str, ClusterResult] | None = None,
-    ) -> None:
-        """Re-save the pkl after clustering has populated ``CallGraph._cluster_cache``.
+    def _seed_incremental_cluster_cache(self, cluster_results: dict[str, ClusterResult]) -> None:
+        """Write post-delta ``cluster_results`` into each language CFG's ``_cluster_cache``.
 
-        ``analyze()`` saves the pkl right after LSP, before anything calls
-        ``cluster()``. We re-save once the abstraction agent has run (full
-        path) or after the cluster delta is materialised (incremental path)
-        so the next process gets a pkl whose CFG already carries the
-        partition. ``cluster_snapshot`` reads exclusively from this cache.
-
-        On the incremental path the post-delta ``cluster_results`` are
-        explicitly written into each language CFG's ``_cluster_cache``
-        before saving; on the full path the abstraction agent already
-        populated those caches via ``cfg.cluster()``.
+        On the incremental path the abstraction agent doesn't run, so the live
+        partition has to be plumbed in explicitly before ``stop_clients`` saves
+        the pkl. ``cluster_snapshot`` reads exclusively from this cache.
         """
-        if self._static_analyzer is None or self.source_sha is None or self.static_analysis is None:
+        if self.static_analysis is None:
             return
-        if cluster_results:
-            for language, cr in cluster_results.items():
-                try:
-                    cfg = self.static_analysis.get_cfg(Language(language))
-                except (ValueError, KeyError):
-                    continue
-                cfg._cluster_cache = cr
-        self._static_analyzer.re_save_with_cluster_cache(source_sha=self.source_sha)
+        for language, cr in cluster_results.items():
+            try:
+                cfg = self.static_analysis.get_cfg(Language(language))
+            except (ValueError, KeyError):
+                continue
+            cfg._cluster_cache = cr
 
     def pre_analysis(self):
         analysis_start_time = time.time()
@@ -418,8 +406,6 @@ class DiagramGenerator:
             assert self.abstraction_agent is not None
 
             analysis, cluster_results = self.abstraction_agent.run()
-            self._persist_pkl_with_cluster_cache()
-
             # Get the initial components to analyze (deterministic, no LLM)
             root_components = get_expandable_components(analysis)
             logger.info(f"Found {len(root_components)} components to analyze at level 1")
@@ -518,21 +504,12 @@ class DiagramGenerator:
                         live_files.add(normalize_repo_path(node.file_path, self.repo_location))
             scrub_deleted_files(root_analysis, sub_analyses, live_files)
 
-            # On a cold-started analyzer (no prior pkl) ``_cluster_cache``
-            # was either left empty or populated by an in-process call to
-            # ``cfg.cluster()`` during ``pre_analysis`` (the cohesion health
-            # check does this). Either way it carries no historical
-            # clustering, so cluster_delta would compare the live partition
-            # against itself and trivially short-circuit.
-            if self._static_analyzer is not None and not self._static_analyzer.warm_started:
-                logger.info("Static analyzer cold-started (no prior pkl); falling back to full analysis.")
-                return self.generate_analysis()
-
             old_snapshot = snapshot_from_static_analysis(self.static_analysis)
             if not old_snapshot.all_cluster_ids():
-                logger.info(
-                    "No cluster cache on the live CFG (legacy pkl or first run); falling back to full analysis."
-                )
+                # No cluster_cache on the live CFG — no prior pkl, legacy pkl,
+                # or first-ever incremental run. Either way, no historical
+                # snapshot to diff against, so fall back to a full run.
+                logger.info("No cluster history available; falling back to full analysis.")
                 return self.generate_analysis()
 
             delta = compute_cluster_delta(
@@ -610,11 +587,12 @@ class DiagramGenerator:
                 file_coverage_summary=self._build_file_coverage_summary(),
                 commit_hash=commit_hash,
             ).resolve()
-            # Persist the new cluster baseline only after analysis.json is on
-            # disk. Order matters: save_analysis first, pickle second — so a
-            # crash between the two writes leaves the next incremental
-            # re-doing this delta (idempotent) rather than silently missing it.
-            self._persist_pkl_with_cluster_cache(delta.cluster_results())
+            # Seed the new cluster baseline only after analysis.json is on
+            # disk. Order matters: save_analysis first, cache seed second — so
+            # a crash between the two leaves the next incremental re-doing
+            # this delta (idempotent) rather than silently missing it. The
+            # actual pkl write happens in ``StaticAnalyzer.stop_clients``.
+            self._seed_incremental_cluster_cache(delta.cluster_results())
             self._write_file_coverage()
             return analysis_path
 

--- a/diagram_analysis/diagram_generator.py
+++ b/diagram_analysis/diagram_generator.py
@@ -518,6 +518,16 @@ class DiagramGenerator:
                         live_files.add(normalize_repo_path(node.file_path, self.repo_location))
             scrub_deleted_files(root_analysis, sub_analyses, live_files)
 
+            # On a cold-started analyzer (no prior pkl) ``_cluster_cache``
+            # was either left empty or populated by an in-process call to
+            # ``cfg.cluster()`` during ``pre_analysis`` (the cohesion health
+            # check does this). Either way it carries no historical
+            # clustering, so cluster_delta would compare the live partition
+            # against itself and trivially short-circuit.
+            if self._static_analyzer is not None and not self._static_analyzer.warm_started:
+                logger.info("Static analyzer cold-started (no prior pkl); falling back to full analysis.")
+                return self.generate_analysis()
+
             old_snapshot = snapshot_from_static_analysis(self.static_analysis)
             if not old_snapshot.all_cluster_ids():
                 logger.info(

--- a/health/checks/cohesion.py
+++ b/health/checks/cohesion.py
@@ -15,6 +15,12 @@ def check_component_cohesion(call_graph: CallGraph, config: HealthCheckConfig) -
     Low cohesion means the cluster's nodes talk more to nodes outside the
     cluster than inside it, suggesting the grouping may not reflect
     actual code organization.
+
+    NOT wired into ``health.runner`` today: the ``cluster()`` call below seeds
+    ``CallGraph._cluster_cache`` with a current-graph partition, which would
+    masquerade as a historical snapshot in the next incremental delta. Before
+    re-enabling, either reset ``_cluster_cache`` after the call or compute the
+    partition without touching the cache.
     """
     warning_entities: list[FindingEntity] = []
 

--- a/health/runner.py
+++ b/health/runner.py
@@ -6,7 +6,6 @@ from pathlib import Path
 
 from core import run_plugin_health_checks
 from health.checks.circular_deps import check_circular_dependencies
-from health.checks.cohesion import check_component_cohesion
 from health.checks.coupling import check_fan_in, check_fan_out
 from health.checks.function_size import check_function_size
 from health.checks.god_class import check_god_classes
@@ -99,7 +98,13 @@ def _collect_checks_for_language(
         summaries.append(check_circular_dependencies(package_deps, config))
         summaries.append(check_package_instability(package_deps, config))
 
-    summaries.append(check_component_cohesion(call_graph, config))
+    # Component-cohesion check intentionally not run here. It's the only health
+    # check that calls ``CallGraph.cluster()``, which would seed
+    # ``_cluster_cache`` with a current-graph partition and let it masquerade
+    # as a historical snapshot in the next incremental delta. Re-enable via
+    # ``health.checks.cohesion.check_component_cohesion`` only after addressing
+    # that side effect.
+    # use_cache=False
 
     # Run LSP-based unused code detection
     exclude_patterns = config.health_exclude_patterns

--- a/static_analyzer/__init__.py
+++ b/static_analyzer/__init__.py
@@ -142,6 +142,13 @@ class StaticAnalyzer:
         self.collected_diagnostics: dict[Language, FileDiagnosticsMap] = {}
         self._clients_started: bool = False
         self._cached_results: StaticAnalysisResults | None = None
+        # True iff the most recent ``analyze()`` loaded a prior pkl. Read by
+        # ``DiagramGenerator.generate_analysis_incremental`` to decide whether
+        # ``CallGraph._cluster_cache`` is meaningful as an "old snapshot": on
+        # a cold start the cache only holds clusters freshly computed from
+        # the live graph (e.g. by the cohesion health check), so cluster_delta
+        # would compare new-vs-new and trivially short-circuit.
+        self.warm_started: bool = False
 
     def __enter__(self) -> "StaticAnalyzer":
         self.start_clients()
@@ -461,11 +468,13 @@ class StaticAnalyzer:
         if skip_cache:
             logger.info("static_analysis_cache: outcome=bypass (skip_cache=True)")
             results = self._run_full_lsp_pass()
+            self.warm_started = False
         else:
             warm_start = cache.load_with_sha()
             if warm_start is None:
                 logger.info("static_analysis_cache: outcome=miss_absent")
                 results = self._run_full_lsp_pass()
+                self.warm_started = False
             else:
                 cached_results, cached_sha = warm_start
                 logger.info(
@@ -474,6 +483,7 @@ class StaticAnalyzer:
                     source_sha or "<none>",
                 )
                 results = self._update_cached_results(cached_results, cached_sha)
+                self.warm_started = True
 
         self._cached_results = results
         results.diagnostics = self.collected_diagnostics

--- a/static_analyzer/__init__.py
+++ b/static_analyzer/__init__.py
@@ -1,6 +1,6 @@
 import logging
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 from repo_utils.git_ops import get_changed_files_since
@@ -33,14 +33,14 @@ logger = logging.getLogger(__name__)
 class EngineConfig:
     """One adapter + project root the engine should run.
 
-    ``source_files`` is set only when a scanner has authoritatively resolved
-    file membership (currently TypeScript via ``tsc --showConfig``); otherwise
-    the adapter walks ``project_path`` itself in ``_run_full_analysis``.
+    ``source_files`` is non-empty only when a scanner has authoritatively
+    resolved file membership (currently TypeScript via ``tsc --showConfig``);
+    otherwise the adapter walks ``project_path`` itself in ``_run_full_analysis``.
     """
 
     adapter: LanguageAdapter
     project_path: Path
-    source_files: list[Path] | None = None
+    source_files: list[Path] = field(default_factory=list)
 
 
 def _create_engine_configs(
@@ -173,13 +173,10 @@ class StaticAnalyzer:
         self.collected_diagnostics: dict[Language, FileDiagnosticsMap] = {}
         self._clients_started: bool = False
         self._cached_results: StaticAnalysisResults | None = None
-        # True iff the most recent ``analyze()`` loaded a prior pkl. Read by
-        # ``DiagramGenerator.generate_analysis_incremental`` to decide whether
-        # ``CallGraph._cluster_cache`` is meaningful as an "old snapshot": on
-        # a cold start the cache only holds clusters freshly computed from
-        # the live graph (e.g. by the cohesion health check), so cluster_delta
-        # would compare new-vs-new and trivially short-circuit.
-        self.warm_started: bool = False
+        # ``stop_clients`` writes the pkl using ``_pending_source_sha`` as the
+        # tag. ``analyze()`` updates it on every call so the latest run's SHA
+        # always reaches disk — including after warm-start merges.
+        self._pending_source_sha: str | None = None
 
     def __enter__(self) -> "StaticAnalyzer":
         self.start_clients()
@@ -211,8 +208,8 @@ class StaticAnalyzer:
         attempted: list[str] = []
         failed_languages: list[str] = []
 
-        for cfg in self._engine_configs:
-            adapter, project_path = cfg.adapter, cfg.project_path
+        for engine_config in self._engine_configs:
+            adapter, project_path = engine_config.adapter, engine_config.project_path
             attempted.append(adapter.language)
             engine_client: LSPClient | None = None
             try:
@@ -252,7 +249,7 @@ class StaticAnalyzer:
                     engine_client.wait_for_server_ready()
                     logger.info(f"{adapter.language} workspace ready: {time.monotonic() - t_lsp_started:.1f}s")
 
-                started.append((cfg, engine_client))
+                started.append((engine_config, engine_client))
 
             except Exception:
                 logger.exception(
@@ -276,24 +273,44 @@ class StaticAnalyzer:
             logger.warning(
                 f"Proceeding with partial LSP coverage. "
                 f"Failed: {', '.join(failed_languages)}. "
-                f"Started: {', '.join(c.adapter.language for c, _ in started)}"
+                f"Started: {', '.join(s.adapter.language for s, _ in started)}"
             )
 
         self._engine_clients = started
         self._clients_started = True
 
     def stop_clients(self) -> None:
-        """Gracefully shut down all engine LSP server processes. Idempotent."""
+        """Gracefully shut down all engine LSP server processes. Idempotent.
+
+        Persists the latest ``_cached_results`` to the pkl on the way down so
+        downstream mutations (``CallGraph._cluster_cache`` populated by the
+        abstraction agent) reach disk in one save instead of two. Save errors
+        are logged but never block teardown.
+        """
         if not self._clients_started:
             return
-        for cfg, client in self._engine_clients:
+        self._persist_results()
+        for engine_config, client in self._engine_clients:
             try:
                 client.shutdown()
             except Exception as e:
-                logger.error(f"Error shutting down engine LSP client for {cfg.adapter.language}: {e}")
+                logger.error(f"Error shutting down engine LSP client for {engine_config.adapter.language}: {e}")
         self._engine_clients = []
         self._clients_started = False
         self._cached_results = None
+
+    def _persist_results(self) -> None:
+        """Write ``_cached_results`` to the SHA-tagged pkl (no-op if absent)."""
+        if self._cached_results is None:
+            return
+        artifact_dir = get_artifact_dir(self.repository_path)
+        try:
+            StaticAnalysisCache(artifact_dir, self.repository_path).save(
+                self._cached_results, source_sha=self._pending_source_sha
+            )
+            logger.info(f"Saved static analysis run artifact to {artifact_dir}")
+        except Exception:
+            logger.exception("Failed to persist static analysis pkl during stop_clients; continuing teardown")
 
     def collect_fresh_diagnostics(self) -> dict[Language, FileDiagnosticsMap]:
         """Read current diagnostics from all running LSP clients without re-analyzing.
@@ -303,10 +320,10 @@ class StaticAnalyzer:
         diagnostics without triggering any new analysis work.
         """
         result: dict[Language, FileDiagnosticsMap] = {}
-        for cfg, client in self._engine_clients:
+        for engine_config, client in self._engine_clients:
             diags = client.get_collected_diagnostics()
             if diags:
-                result[cfg.adapter.language_enum] = diags
+                result[engine_config.adapter.language_enum] = diags
         return result
 
     def get_diagnostics_generation(self) -> int:
@@ -345,22 +362,6 @@ class StaticAnalyzer:
             self.collected_diagnostics = cached_results.diagnostics
         return cached_results
 
-    def re_save_with_cluster_cache(self, source_sha: str | None = None) -> None:
-        """Re-persist the on-disk pkl after clustering has populated ``CallGraph._cluster_cache``.
-
-        ``analyze()`` saves the pkl right after LSP, *before* anything calls
-        ``CallGraph.cluster()``. Once a downstream caller (``DiagramGenerator``)
-        runs ``build_all_cluster_results`` and the per-language CFGs warm up
-        their ``_cluster_cache``, this method re-saves so the next process
-        gets a pkl whose CFG already carries the partition — no re-cluster
-        on warm-start.
-        """
-        if self._cached_results is None:
-            logger.warning("re_save_with_cluster_cache: no cached results to save; skipping")
-            return
-        artifact_dir = get_artifact_dir(self.repository_path)
-        StaticAnalysisCache(artifact_dir, self.repository_path).save(self._cached_results, source_sha=source_sha)
-
     def notify_file_changed(self, file_path: Path, content: str) -> None:
         """Notify the LSP server that the editor has saved new content for a file.
 
@@ -372,8 +373,8 @@ class StaticAnalyzer:
             content:   Full current text content of the file.
         """
         suffix = file_path.suffix
-        for cfg, client in self._engine_clients:
-            adapter = cfg.adapter
+        for engine_config, client in self._engine_clients:
+            adapter = engine_config.adapter
             if suffix in adapter.file_extensions:
                 # Open + change to ensure the server has the latest content
                 client.did_open(file_path, adapter.language_id)
@@ -394,8 +395,8 @@ class StaticAnalyzer:
             Returns an empty list if no matching client is found.
         """
         suffix = file_path.suffix
-        for cfg, client in self._engine_clients:
-            if suffix in cfg.adapter.file_extensions:
+        for engine_config, client in self._engine_clients:
+            if suffix in engine_config.adapter.file_extensions:
                 try:
                     symbols = client.document_symbol(file_path)
                     logger.debug(f"Got {len(symbols)} symbols for {file_path}")
@@ -408,9 +409,9 @@ class StaticAnalyzer:
     def get_adapter_for_file(self, file_path: Path) -> tuple[LanguageAdapter, Path] | None:
         """Return the (adapter, project_root) pair that handles a given file extension."""
         suffix = file_path.suffix
-        for cfg, _ in self._engine_clients:
-            if suffix in cfg.adapter.file_extensions:
-                return cfg.adapter, cfg.project_path
+        for engine_config, _ in self._engine_clients:
+            if suffix in engine_config.adapter.file_extensions:
+                return engine_config.adapter, engine_config.project_path
         return None
 
     def discover_file_dependencies(self, file_path: Path) -> list[str]:
@@ -430,7 +431,9 @@ class StaticAnalyzer:
             Returns an empty list if no matching client is found or on failure.
         """
         suffix = file_path.suffix
-        client = next((c for cfg, c in self._engine_clients if suffix in cfg.adapter.file_extensions), None)
+        client = next(
+            (c for engine_config, c in self._engine_clients if suffix in engine_config.adapter.file_extensions), None
+        )
         if client is None:
             return []
 
@@ -472,13 +475,14 @@ class StaticAnalyzer:
         Flow:
 
         1. In-memory cache hit -> return.
-        2. ``skip_cache=True`` -> full LSP analysis, save pkl tagged with
-           *source_sha*.
+        2. ``skip_cache=True`` -> full LSP analysis.
         3. Pkl present -> load it, ask git for files changed since the pkl's
-           tag SHA, re-LSP just those files, merge in memory, re-save the
-           pkl tagged with *source_sha*. The pkl is the only persistent
-           cache; per-language JSON caches are gone.
-        4. No pkl -> full LSP, save pkl tagged with *source_sha*.
+           tag SHA, re-LSP just those files, merge in memory.
+        4. No pkl -> full LSP.
+
+        Persistence is deferred to ``stop_clients`` so downstream mutations
+        (cluster cache populated by the abstraction agent) reach disk in one
+        save instead of two. ``source_sha`` is stashed for that save.
 
         Clients must be running before calling this method. Use ``start_clients()``
         or the context manager (``with StaticAnalyzer(...) as sa:``).
@@ -501,13 +505,11 @@ class StaticAnalyzer:
         if skip_cache:
             logger.info("static_analysis_cache: outcome=bypass (skip_cache=True)")
             results = self._run_full_lsp_pass()
-            self.warm_started = False
         else:
             warm_start = cache.load_with_sha()
             if warm_start is None:
                 logger.info("static_analysis_cache: outcome=miss_absent")
                 results = self._run_full_lsp_pass()
-                self.warm_started = False
             else:
                 cached_results, cached_sha = warm_start
                 logger.info(
@@ -516,12 +518,10 @@ class StaticAnalyzer:
                     source_sha or "<none>",
                 )
                 results = self._update_cached_results(cached_results, cached_sha)
-                self.warm_started = True
 
         self._cached_results = results
+        self._pending_source_sha = source_sha
         results.diagnostics = self.collected_diagnostics
-        logger.info(f"Saving static analysis run artifact to {artifact_dir}")
-        cache.save(results, source_sha=source_sha)
         return results
 
     def _run_full_lsp_pass(self) -> StaticAnalysisResults:
@@ -532,13 +532,13 @@ class StaticAnalyzer:
         explicitly requested ``skip_cache=True``.
         """
         results = StaticAnalysisResults()
-        for cfg, engine_client in self._engine_clients:
-            adapter, project_path = cfg.adapter, cfg.project_path
+        for engine_config, engine_client in self._engine_clients:
+            adapter, project_path = engine_config.adapter, engine_config.project_path
             language = adapter.language_enum
             try:
                 t_lang_start = time.monotonic()
                 logger.info(f"Starting engine analysis for {adapter.language} in {project_path}")
-                analysis = self._run_full_analysis(cfg, engine_client)
+                analysis = self._run_full_analysis(engine_config, engine_client)
                 self._absorb_into_results(results, language, analysis)
                 logger.info(
                     f"Engine analysis for {adapter.language} completed in {time.monotonic() - t_lang_start:.1f}s"
@@ -563,8 +563,8 @@ class StaticAnalyzer:
         valid output.
         """
         results = StaticAnalysisResults()
-        for cfg, engine_client in self._engine_clients:
-            adapter, project_path = cfg.adapter, cfg.project_path
+        for engine_config, engine_client in self._engine_clients:
+            adapter, project_path = engine_config.adapter, engine_config.project_path
             language = adapter.language_enum
             cached_lang_dict = self._extract_language_dict(cached_results, language)
             try:
@@ -577,7 +577,7 @@ class StaticAnalyzer:
                 changed_files = None
 
             if changed_files is None:
-                analysis = self._run_full_analysis(cfg, engine_client)
+                analysis = self._run_full_analysis(engine_config, engine_client)
             else:
                 logger.info(f"warmstart {adapter.language}: re-LSPing {len(changed_files)} changed file(s)")
                 analysis = update_cfg_for_changed_files(
@@ -646,21 +646,19 @@ class StaticAnalyzer:
             )
         self.collected_diagnostics[adapter.language_enum] = merged_diags
 
-    def _run_full_analysis(self, cfg: EngineConfig, engine_client: LSPClient) -> dict:
+    def _run_full_analysis(self, engine_config: EngineConfig, engine_client: LSPClient) -> dict:
         """Run a full analysis using the engine pipeline.
 
         Returns the dict shape expected by analyze():
             call_graph, class_hierarchies, package_relations, references, source_files, diagnostics
 
-        Uses ``cfg.source_files`` when the scanner authoritatively resolved file
-        membership (currently TypeScript via ``tsc --showConfig``); otherwise the
-        adapter walks ``cfg.project_path`` and applies the ignore manager.
+        Uses ``engine_config.source_files`` when the scanner authoritatively
+        resolved file membership (currently TypeScript via ``tsc --showConfig``);
+        otherwise the adapter walks ``engine_config.project_path`` and applies
+        the ignore manager.
         """
-        adapter, project_path = cfg.adapter, cfg.project_path
-        if cfg.source_files is not None:
-            source_files = cfg.source_files
-        else:
-            source_files = adapter.discover_source_files(project_path, self.ignore_manager)
+        adapter, project_path = engine_config.adapter, engine_config.project_path
+        source_files = engine_config.source_files or adapter.discover_source_files(project_path, self.ignore_manager)
 
         if not source_files:
             logger.warning(f"No source files found for {adapter.language} in {project_path}")

--- a/static_analyzer/__init__.py
+++ b/static_analyzer/__init__.py
@@ -1,5 +1,6 @@
 import logging
 import time
+from dataclasses import dataclass
 from pathlib import Path
 
 from repo_utils.git_ops import get_changed_files_since
@@ -28,26 +29,31 @@ from utils import get_artifact_dir
 logger = logging.getLogger(__name__)
 
 
+@dataclass
+class EngineConfig:
+    """One adapter + project root the engine should run.
+
+    ``source_files`` is set only when a scanner has authoritatively resolved
+    file membership (currently TypeScript via ``tsc --showConfig``); otherwise
+    the adapter walks ``project_path`` itself in ``_run_full_analysis``.
+    """
+
+    adapter: LanguageAdapter
+    project_path: Path
+    source_files: list[Path] | None = None
+
+
 def _create_engine_configs(
     programming_languages: list[ProgrammingLanguage],
     repository_path: Path,
     ignore_manager: RepoIgnoreManager,
-) -> tuple[list[tuple[LanguageAdapter, Path]], dict[Path, list[Path]]]:
-    """Create (adapter, project_path) pairs from detected languages.
+) -> list[EngineConfig]:
+    """Create one ``EngineConfig`` per sub-project from the detected languages.
 
-    Returns ``(configs, explicit_source_files)``:
-      - ``configs``: ``(adapter, project_path)`` tuples, one per sub-project.
-      - ``explicit_source_files``: project_path -> file list, populated only
-        when a scanner has authoritatively resolved file membership for that
-        project (currently TypeScript via ``tsc --showConfig``). Other
-        languages aren't listed; their adapters fall back to a filesystem
-        walk in ``_run_full_analysis``.
-
-    Handles mono-repo support: for TypeScript/Java/C#, scans for multiple
-    project configurations and creates one pair per sub-project.
+    Handles monorepo support: for TypeScript/Java/C#, scans for multiple
+    project configurations and emits one entry per sub-project.
     """
-    configs: list[tuple[LanguageAdapter, Path]] = []
-    explicit_source_files: dict[Path, list[Path]] = {}
+    configs: list[EngineConfig] = []
 
     for pl in programming_languages:
         if not pl.is_supported_lang():
@@ -95,11 +101,10 @@ def _create_engine_configs(
                         f"({len(union)} files across {len(typescript_projects)} tsconfig project(s): "
                         f"{project_dirs})"
                     )
-                    configs.append((adapter, repository_path))
-                    explicit_source_files[repository_path] = union
+                    configs.append(EngineConfig(adapter, repository_path, source_files=union))
                 else:
                     logger.info(f"No TypeScript config files found, using repository root for {adapter_name}")
-                    configs.append((adapter, repository_path))
+                    configs.append(EngineConfig(adapter, repository_path))
 
             elif lang_lower == Language.JAVA:
                 java_config_scanner = JavaConfigScanner(repository_path, ignore_manager=ignore_manager)
@@ -111,7 +116,7 @@ def _create_engine_configs(
                             f"Creating engine config for Java ({project_config.build_system}) at: "
                             f"{project_config.root.relative_to(repository_path)}"
                         )
-                        configs.append((adapter, project_config.root))
+                        configs.append(EngineConfig(adapter, project_config.root))
                 else:
                     logger.info("No Java projects detected")
 
@@ -125,17 +130,17 @@ def _create_engine_configs(
                             f"Creating engine config for CSharp ({csharp_config.project_type}) at: "
                             f"{csharp_config.root.relative_to(repository_path)}"
                         )
-                        configs.append((adapter, csharp_config.root))
+                        configs.append(EngineConfig(adapter, csharp_config.root))
                 else:
                     logger.info("No C# projects detected")
 
             else:
-                configs.append((adapter, repository_path))
+                configs.append(EngineConfig(adapter, repository_path))
 
         except RuntimeError as e:
             logger.error(f"Failed to create engine config for {pl.language}: {e}")
 
-    return configs, explicit_source_files
+    return configs
 
 
 def _lang_to_adapter_name(language: str) -> str | None:
@@ -163,10 +168,8 @@ class StaticAnalyzer:
         self.repository_path = repository_path.resolve()
         self.ignore_manager = RepoIgnoreManager(self.repository_path)
         programming_langs = ProjectScanner(self.repository_path).scan()
-        self._engine_configs, self._explicit_source_files = _create_engine_configs(
-            programming_langs, self.repository_path, self.ignore_manager
-        )
-        self._engine_clients: list[tuple[LanguageAdapter, Path, LSPClient]] = []
+        self._engine_configs = _create_engine_configs(programming_langs, self.repository_path, self.ignore_manager)
+        self._engine_clients: list[tuple[EngineConfig, LSPClient]] = []
         self.collected_diagnostics: dict[Language, FileDiagnosticsMap] = {}
         self._clients_started: bool = False
         self._cached_results: StaticAnalysisResults | None = None
@@ -204,11 +207,12 @@ class StaticAnalyzer:
             self._clients_started = True
             return
 
-        started: list[tuple[LanguageAdapter, Path, LSPClient]] = []
+        started: list[tuple[EngineConfig, LSPClient]] = []
         attempted: list[str] = []
         failed_languages: list[str] = []
 
-        for adapter, project_path in self._engine_configs:
+        for cfg in self._engine_configs:
+            adapter, project_path = cfg.adapter, cfg.project_path
             attempted.append(adapter.language)
             engine_client: LSPClient | None = None
             try:
@@ -248,7 +252,7 @@ class StaticAnalyzer:
                     engine_client.wait_for_server_ready()
                     logger.info(f"{adapter.language} workspace ready: {time.monotonic() - t_lsp_started:.1f}s")
 
-                started.append((adapter, project_path, engine_client))
+                started.append((cfg, engine_client))
 
             except Exception:
                 logger.exception(
@@ -272,7 +276,7 @@ class StaticAnalyzer:
             logger.warning(
                 f"Proceeding with partial LSP coverage. "
                 f"Failed: {', '.join(failed_languages)}. "
-                f"Started: {', '.join(a.language for a, _, _ in started)}"
+                f"Started: {', '.join(c.adapter.language for c, _ in started)}"
             )
 
         self._engine_clients = started
@@ -282,11 +286,11 @@ class StaticAnalyzer:
         """Gracefully shut down all engine LSP server processes. Idempotent."""
         if not self._clients_started:
             return
-        for adapter, _, client in self._engine_clients:
+        for cfg, client in self._engine_clients:
             try:
                 client.shutdown()
             except Exception as e:
-                logger.error(f"Error shutting down engine LSP client for {adapter.language}: {e}")
+                logger.error(f"Error shutting down engine LSP client for {cfg.adapter.language}: {e}")
         self._engine_clients = []
         self._clients_started = False
         self._cached_results = None
@@ -299,15 +303,15 @@ class StaticAnalyzer:
         diagnostics without triggering any new analysis work.
         """
         result: dict[Language, FileDiagnosticsMap] = {}
-        for adapter, _, client in self._engine_clients:
+        for cfg, client in self._engine_clients:
             diags = client.get_collected_diagnostics()
             if diags:
-                result[adapter.language_enum] = diags
+                result[cfg.adapter.language_enum] = diags
         return result
 
     def get_diagnostics_generation(self) -> int:
         """Return the sum of diagnostics generation counters across all LSP clients."""
-        return sum(client.get_diagnostics_generation() for _, _, client in self._engine_clients)
+        return sum(client.get_diagnostics_generation() for _, client in self._engine_clients)
 
     def load_from_disk_cache(
         self,
@@ -368,7 +372,8 @@ class StaticAnalyzer:
             content:   Full current text content of the file.
         """
         suffix = file_path.suffix
-        for adapter, _, client in self._engine_clients:
+        for cfg, client in self._engine_clients:
+            adapter = cfg.adapter
             if suffix in adapter.file_extensions:
                 # Open + change to ensure the server has the latest content
                 client.did_open(file_path, adapter.language_id)
@@ -389,8 +394,8 @@ class StaticAnalyzer:
             Returns an empty list if no matching client is found.
         """
         suffix = file_path.suffix
-        for adapter, project_path, client in self._engine_clients:
-            if suffix in adapter.file_extensions:
+        for cfg, client in self._engine_clients:
+            if suffix in cfg.adapter.file_extensions:
                 try:
                     symbols = client.document_symbol(file_path)
                     logger.debug(f"Got {len(symbols)} symbols for {file_path}")
@@ -403,9 +408,9 @@ class StaticAnalyzer:
     def get_adapter_for_file(self, file_path: Path) -> tuple[LanguageAdapter, Path] | None:
         """Return the (adapter, project_root) pair that handles a given file extension."""
         suffix = file_path.suffix
-        for adapter, project_path, _ in self._engine_clients:
-            if suffix in adapter.file_extensions:
-                return adapter, project_path
+        for cfg, _ in self._engine_clients:
+            if suffix in cfg.adapter.file_extensions:
+                return cfg.adapter, cfg.project_path
         return None
 
     def discover_file_dependencies(self, file_path: Path) -> list[str]:
@@ -425,7 +430,7 @@ class StaticAnalyzer:
             Returns an empty list if no matching client is found or on failure.
         """
         suffix = file_path.suffix
-        client = next((c for adapter, _, c in self._engine_clients if suffix in adapter.file_extensions), None)
+        client = next((c for cfg, c in self._engine_clients if suffix in cfg.adapter.file_extensions), None)
         if client is None:
             return []
 
@@ -527,12 +532,13 @@ class StaticAnalyzer:
         explicitly requested ``skip_cache=True``.
         """
         results = StaticAnalysisResults()
-        for adapter, project_path, engine_client in self._engine_clients:
+        for cfg, engine_client in self._engine_clients:
+            adapter, project_path = cfg.adapter, cfg.project_path
             language = adapter.language_enum
             try:
                 t_lang_start = time.monotonic()
                 logger.info(f"Starting engine analysis for {adapter.language} in {project_path}")
-                analysis = self._run_full_analysis(adapter, project_path, engine_client)
+                analysis = self._run_full_analysis(cfg, engine_client)
                 self._absorb_into_results(results, language, analysis)
                 logger.info(
                     f"Engine analysis for {adapter.language} completed in {time.monotonic() - t_lang_start:.1f}s"
@@ -557,7 +563,8 @@ class StaticAnalyzer:
         valid output.
         """
         results = StaticAnalysisResults()
-        for adapter, project_path, engine_client in self._engine_clients:
+        for cfg, engine_client in self._engine_clients:
+            adapter, project_path = cfg.adapter, cfg.project_path
             language = adapter.language_enum
             cached_lang_dict = self._extract_language_dict(cached_results, language)
             try:
@@ -570,7 +577,7 @@ class StaticAnalyzer:
                 changed_files = None
 
             if changed_files is None:
-                analysis = self._run_full_analysis(adapter, project_path, engine_client)
+                analysis = self._run_full_analysis(cfg, engine_client)
             else:
                 logger.info(f"warmstart {adapter.language}: re-LSPing {len(changed_files)} changed file(s)")
                 analysis = update_cfg_for_changed_files(
@@ -639,25 +646,19 @@ class StaticAnalyzer:
             )
         self.collected_diagnostics[adapter.language_enum] = merged_diags
 
-    def _run_full_analysis(
-        self,
-        adapter: LanguageAdapter,
-        project_path: Path,
-        engine_client: LSPClient,
-    ) -> dict:
+    def _run_full_analysis(self, cfg: EngineConfig, engine_client: LSPClient) -> dict:
         """Run a full analysis using the engine pipeline.
 
         Returns the dict shape expected by analyze():
             call_graph, class_hierarchies, package_relations, references, source_files, diagnostics
 
-        If the project's file list was authoritatively resolved during config
-        creation (TypeScript via ``tsc --showConfig``), use it directly so
-        sibling sub-projects don't double-claim files. Otherwise the adapter
-        walks its project root and applies the ignore manager.
+        Uses ``cfg.source_files`` when the scanner authoritatively resolved file
+        membership (currently TypeScript via ``tsc --showConfig``); otherwise the
+        adapter walks ``cfg.project_path`` and applies the ignore manager.
         """
-        explicit = self._explicit_source_files.get(project_path)
-        if explicit is not None:
-            source_files = explicit
+        adapter, project_path = cfg.adapter, cfg.project_path
+        if cfg.source_files is not None:
+            source_files = cfg.source_files
         else:
             source_files = adapter.discover_source_files(project_path, self.ignore_manager)
 

--- a/static_analyzer/__init__.py
+++ b/static_analyzer/__init__.py
@@ -37,7 +37,7 @@ def _create_engine_configs(
 
     Returns ``(configs, explicit_source_files)``:
       - ``configs``: ``(adapter, project_path)`` tuples, one per sub-project.
-      - ``explicit_source_files``: project_path → file list, populated only
+      - ``explicit_source_files``: project_path -> file list, populated only
         when a scanner has authoritatively resolved file membership for that
         project (currently TypeScript via ``tsc --showConfig``). Other
         languages aren't listed; their adapters fall back to a filesystem

--- a/static_analyzer/__init__.py
+++ b/static_analyzer/__init__.py
@@ -32,13 +32,22 @@ def _create_engine_configs(
     programming_languages: list[ProgrammingLanguage],
     repository_path: Path,
     ignore_manager: RepoIgnoreManager,
-) -> list[tuple[LanguageAdapter, Path]]:
+) -> tuple[list[tuple[LanguageAdapter, Path]], dict[Path, list[Path]]]:
     """Create (adapter, project_path) pairs from detected languages.
 
-    Handles mono-repo support: for TypeScript/Java, scans for multiple
+    Returns ``(configs, explicit_source_files)``:
+      - ``configs``: ``(adapter, project_path)`` tuples, one per sub-project.
+      - ``explicit_source_files``: project_path → file list, populated only
+        when a scanner has authoritatively resolved file membership for that
+        project (currently TypeScript via ``tsc --showConfig``). Other
+        languages aren't listed; their adapters fall back to a filesystem
+        walk in ``_run_full_analysis``.
+
+    Handles mono-repo support: for TypeScript/Java/C#, scans for multiple
     project configurations and creates one pair per sub-project.
     """
     configs: list[tuple[LanguageAdapter, Path]] = []
+    explicit_source_files: dict[Path, list[Path]] = {}
 
     for pl in programming_languages:
         if not pl.is_supported_lang():
@@ -65,12 +74,29 @@ def _create_engine_configs(
                 typescript_projects = ts_config_scanner.find_typescript_projects()
 
                 if typescript_projects:
-                    for project_path in typescript_projects:
-                        logger.info(
-                            f"Creating engine config for {adapter_name} at: "
-                            f"{project_path.relative_to(repository_path)}"
-                        )
-                        configs.append((adapter, project_path))
+                    # One LSP rooted at the repo, fed the union of all
+                    # leaf-tsconfig files. Why: tsserver attaches each
+                    # ``didOpen`` file to its nearest enclosing tsconfig
+                    # (Configured Project), so cross-project navigation
+                    # via ``references`` keeps working — but only when a
+                    # single language-service instance sees both ends of
+                    # the edge. Spawning one LSP per tsconfig partitions
+                    # the workspace and drops cross-project edges.
+                    union: list[Path] = []
+                    seen: set[Path] = set()
+                    for project in typescript_projects:
+                        for f in project.files:
+                            if f not in seen:
+                                seen.add(f)
+                                union.append(f)
+                    project_dirs = ", ".join(str(p.root.relative_to(repository_path)) for p in typescript_projects)
+                    logger.info(
+                        f"Creating engine config for {adapter_name} at repo root "
+                        f"({len(union)} files across {len(typescript_projects)} tsconfig project(s): "
+                        f"{project_dirs})"
+                    )
+                    configs.append((adapter, repository_path))
+                    explicit_source_files[repository_path] = union
                 else:
                     logger.info(f"No TypeScript config files found, using repository root for {adapter_name}")
                     configs.append((adapter, repository_path))
@@ -109,7 +135,7 @@ def _create_engine_configs(
         except RuntimeError as e:
             logger.error(f"Failed to create engine config for {pl.language}: {e}")
 
-    return configs
+    return configs, explicit_source_files
 
 
 def _lang_to_adapter_name(language: str) -> str | None:
@@ -137,7 +163,9 @@ class StaticAnalyzer:
         self.repository_path = repository_path.resolve()
         self.ignore_manager = RepoIgnoreManager(self.repository_path)
         programming_langs = ProjectScanner(self.repository_path).scan()
-        self._engine_configs = _create_engine_configs(programming_langs, self.repository_path, self.ignore_manager)
+        self._engine_configs, self._explicit_source_files = _create_engine_configs(
+            programming_langs, self.repository_path, self.ignore_manager
+        )
         self._engine_clients: list[tuple[LanguageAdapter, Path, LSPClient]] = []
         self.collected_diagnostics: dict[Language, FileDiagnosticsMap] = {}
         self._clients_started: bool = False
@@ -621,8 +649,17 @@ class StaticAnalyzer:
 
         Returns the dict shape expected by analyze():
             call_graph, class_hierarchies, package_relations, references, source_files, diagnostics
+
+        If the project's file list was authoritatively resolved during config
+        creation (TypeScript via ``tsc --showConfig``), use it directly so
+        sibling sub-projects don't double-claim files. Otherwise the adapter
+        walks its project root and applies the ignore manager.
         """
-        source_files = adapter.discover_source_files(project_path, self.ignore_manager)
+        explicit = self._explicit_source_files.get(project_path)
+        if explicit is not None:
+            source_files = explicit
+        else:
+            source_files = adapter.discover_source_files(project_path, self.ignore_manager)
 
         if not source_files:
             logger.warning(f"No source files found for {adapter.language} in {project_path}")

--- a/static_analyzer/typescript_config_scanner.py
+++ b/static_analyzer/typescript_config_scanner.py
@@ -1,54 +1,314 @@
+"""TypeScript / JavaScript project discovery.
+
+Resolves each project's owned file list authoritatively via ``tsc --showConfig``
+so that nested ``tsconfig.json`` files in a monorepo don't double-claim files.
+Why: a "solution" tsconfig at the repo root (``files: []`` + ``references: [...]``)
+must contribute zero files itself — otherwise its filesystem walk overlaps with
+the leaf projects it points at, and every overlapping file ends up analyzed
+twice under two different qualified-name roots, inflating reference and
+package counts.
+"""
+
+import json
 import logging
+import shutil
+import subprocess
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import List
 
 from repo_utils.ignore import RepoIgnoreManager
+from tool_registry.paths import get_servers_dir, preferred_node_path
 
 logger = logging.getLogger(__name__)
 
 
+@dataclass
+class TypeScriptProject:
+    """One TS/JS project the engine should analyze.
+
+    ``files`` holds absolute paths resolved by ``tsc --showConfig`` (or by a
+    filesystem fallback if tsc is unavailable). The engine should send exactly
+    these to the LSP client rooted at ``root`` — anything broader would re-claim
+    files that belong to a sibling project.
+    """
+
+    root: Path
+    files: list[Path] = field(default_factory=list)
+
+
+_TS_EXTENSIONS = (".ts", ".tsx", ".mts", ".cts")
+_JS_EXTENSIONS = (".js", ".jsx", ".mjs", ".cjs")
+_ALL_EXTENSIONS = _TS_EXTENSIONS + _JS_EXTENSIONS
+
+
 class TypeScriptConfigScanner:
-    """
-    Scanner for finding TypeScript/JavaScript configuration files in a repository.
-    Supports multi-project setups (mono-repos) by finding all tsconfig.json and jsconfig.json files.
-    """
+    """Discovers TS/JS project roots and their owned files for monorepo support."""
 
     CONFIG_FILES = ["tsconfig.json", "jsconfig.json"]
 
     def __init__(self, repo_location: Path, ignore_manager: RepoIgnoreManager | None = None):
-        self.repo_location = repo_location
-        self.ignore_manager = ignore_manager if ignore_manager else RepoIgnoreManager(repo_location)
+        self.repo_location = repo_location.resolve()
+        self.ignore_manager = ignore_manager or RepoIgnoreManager(repo_location)
 
-    def find_typescript_projects(self) -> List[Path]:
+    def find_typescript_projects(self) -> list[TypeScriptProject]:
+        """Return one project per leaf tsconfig with its authoritative file list.
+
+        Strategy (two-tier resolution + trim):
+        1. ``rglob`` the repo for ``tsconfig.json`` / ``jsconfig.json`` (skipping
+           ignored paths). This is the candidate set.
+        2. **Option A**: ask ``tsc --showConfig`` what files each candidate owns.
+           Authoritative because tsc honours ``files``/``include``/``exclude``
+           semantics. The result is then filtered through ``ignore_manager``
+           so ``.codeboardingignore`` patterns (e.g. ``*.test.*``) apply
+           consistently with Option B.
+        3. **Option B (fallback)**: if tsc is unavailable or fails for a
+           candidate, fall back to a filesystem walk that explicitly excludes
+           any subtree owned by another candidate and applies the ignore
+           manager. Less precise than tsc (no ``include``/``exclude``
+           honour) but each file is still claimed at most once.
+        4. ``_trim_overlap`` then assigns each file to exactly one project —
+           the deepest candidate that claims it. Files that only the root
+           tsconfig sees (e.g. ``excalidraw-app/`` in a monorepo) survive
+           on the root project; files claimed by both root and a leaf go
+           to the leaf. A project whose entire claim is covered by deeper
+           projects (a pure "solution" tsconfig) is dropped.
         """
-        Scan the repository for TypeScript/JavaScript configuration files, skipping ignored paths.
-
-        Returns:
-            List[Path]: List of directories containing TypeScript/JavaScript projects (config file locations).
-                        Each path is the directory containing a tsconfig.json or jsconfig.json.
-        """
-        project_roots = []
-        seen_dirs = set()
-
-        for config_file in self.CONFIG_FILES:
-            # Find all config files recursively
-            for config_path in self.repo_location.rglob(config_file):
-                if config_path.is_file():
-                    # Skip if path should be ignored
-                    if self.ignore_manager.should_ignore(config_path):
-                        logger.debug(f"Skipping ignored config file: {config_path}")
-                        continue
-
-                    project_dir = config_path.parent
-
-                    # Avoid duplicates (e.g., if both tsconfig.json and jsconfig.json exist)
-                    if project_dir not in seen_dirs:
-                        seen_dirs.add(project_dir)
-                        project_roots.append(project_dir)
-
-        if not project_roots:
+        candidate_dirs = self._discover_candidates()
+        if not candidate_dirs:
             logger.warning(f"No TypeScript configuration files found in {self.repo_location}")
-        else:
-            logger.info(f"Found {len(project_roots)} TypeScript project(s) in repository")
+            return []
 
-        return project_roots
+        node_path = preferred_node_path(get_servers_dir())
+        tsc_js = _resolve_tsc_js()
+        tsc_cmd_prefix = _build_tsc_command_prefix(node_path, tsc_js)
+        if tsc_cmd_prefix is None:
+            logger.warning(
+                "tsc not available (neither bundled tsc.js under servers/ nor system tsc on PATH); "
+                "falling back to disjoint filesystem walks. File-membership precision will be "
+                "lower than tsc --showConfig but each file is still claimed by exactly one project."
+            )
+
+        projects: list[TypeScriptProject] = []
+        for project_dir in candidate_dirs:
+            files = self._resolve_project_files(project_dir, tsc_cmd_prefix, candidate_dirs)
+            if not files:
+                # No owned files even before trim — already a solution
+                # tsconfig (or every file ignored). Either way, no work
+                # for this project.
+                logger.debug(f"Skipping tsconfig at {project_dir} (no owned files)")
+                continue
+            projects.append(TypeScriptProject(root=project_dir, files=files))
+
+        projects = self._trim_overlap(projects)
+
+        if projects:
+            total_files = sum(len(p.files) for p in projects)
+            logger.info(
+                f"Found {len(projects)} TypeScript project(s) in repository "
+                f"({total_files} total files across all projects)"
+            )
+        return projects
+
+    # ------------------------------------------------------------------ #
+    # Candidate discovery
+    # ------------------------------------------------------------------ #
+
+    def _discover_candidates(self) -> list[Path]:
+        seen: set[Path] = set()
+        candidates: list[Path] = []
+        for config_file in self.CONFIG_FILES:
+            for config_path in self.repo_location.rglob(config_file):
+                if not config_path.is_file():
+                    continue
+                if self.ignore_manager.should_ignore(config_path):
+                    logger.debug(f"Skipping ignored config file: {config_path}")
+                    continue
+                project_dir = config_path.parent.resolve()
+                if project_dir in seen:
+                    continue
+                seen.add(project_dir)
+                candidates.append(project_dir)
+        return candidates
+
+    # ------------------------------------------------------------------ #
+    # File resolution per project (tsc --showConfig with FS fallback)
+    # ------------------------------------------------------------------ #
+
+    def _resolve_project_files(
+        self,
+        project_dir: Path,
+        tsc_cmd_prefix: list[str] | None,
+        all_candidates: list[Path],
+    ) -> list[Path]:
+        if tsc_cmd_prefix is not None:
+            config = self._showconfig(project_dir, tsc_cmd_prefix)
+            if config is not None:
+                files = [_normalize(project_dir, raw) for raw in config.get("files", []) if isinstance(raw, str)]
+                # Apply ignore_manager too: tsc honours each tsconfig's own
+                # include/exclude, but a permissive root tsconfig can claim
+                # files (e.g. ``*.test.ts`` in packages/) that the user has
+                # asked CodeBoarding to skip via .codeboardingignore. Without
+                # this filter, Option A would re-introduce noise that Option B
+                # already drops via ``_fallback_walk``.
+                return [f for f in files if f.suffix in _ALL_EXTENSIONS and not self.ignore_manager.should_ignore(f)]
+            # tsc was available but failed for THIS project — fall through
+            # to a filesystem walk for this one project specifically.
+        return self._fallback_walk(project_dir, all_candidates)
+
+    def _showconfig(self, project_dir: Path, tsc_cmd_prefix: list[str]) -> dict | None:
+        """Invoke ``tsc --showConfig -p <dir>`` and return parsed JSON."""
+        cmd = [*tsc_cmd_prefix, "-p", str(project_dir)]
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=30,
+                check=False,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired) as e:
+            logger.debug(f"tsc --showConfig invocation failed for {project_dir}: {e}")
+            return None
+
+        if result.returncode != 0:
+            logger.debug(
+                f"tsc --showConfig exited {result.returncode} for {project_dir}: " f"{result.stderr.strip()[:200]}"
+            )
+            return None
+        try:
+            return json.loads(result.stdout)
+        except json.JSONDecodeError as e:
+            logger.debug(f"tsc --showConfig JSON parse failed for {project_dir}: {e}")
+            return None
+
+    def _fallback_walk(self, project_dir: Path, all_candidates: list[Path]) -> list[Path]:
+        """Disjoint filesystem walk used when ``tsc --showConfig`` is unavailable.
+
+        Walks ``project_dir`` and skips any subtree owned by another candidate
+        project. Each TS/JS file ends up in exactly one project (the deepest
+        candidate containing it).
+
+        Why disjoint: a naive walk from a parent (e.g. the repo root) would
+        re-claim every file already owned by a child (e.g. ``packages/foo/``).
+        Both projects would then add overlapping ``source_files`` lists,
+        re-introducing the duplicate-counting bug this module exists to fix.
+        Less precise than tsc's resolution (no ``include`` / ``exclude``
+        semantics) but each file is claimed by exactly one project.
+        """
+        nested = [c for c in all_candidates if c != project_dir and _is_ancestor(project_dir, c)]
+        files: list[Path] = []
+        for path in project_dir.rglob("*"):
+            if not path.is_file():
+                continue
+            if path.suffix not in _ALL_EXTENSIONS:
+                continue
+            if self.ignore_manager.should_ignore(path):
+                continue
+            if any(_is_ancestor(n, path) for n in nested):
+                continue
+            files.append(path.resolve())
+        files.sort()
+        return files
+
+    # ------------------------------------------------------------------ #
+    # Per-file ownership trim
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def _trim_overlap(projects: list[TypeScriptProject]) -> list[TypeScriptProject]:
+        """Each file is owned by exactly one project — the deepest that claims it.
+
+        Why deepest-first: leaf tsconfigs typically have stricter ``exclude``
+        patterns (e.g. ``packages/foo/tsconfig.json`` excludes ``**/*.test.*``)
+        and represent the package author's view of "production code." A root
+        tsconfig that ``include``s the whole repo overlaps with every leaf;
+        attributing shared files to the leaf preserves the leaf's intent.
+
+        A parent that has files NOT claimed by any leaf (e.g. an Excalidraw-
+        style root that ``include``s ``packages`` *and* ``excalidraw-app``,
+        where no leaf covers ``excalidraw-app/``) keeps its leftover. A parent
+        whose entire file set is covered by leaves (a pure solution tsconfig)
+        is dropped.
+
+        Determinism: on equal depth, alphabetical order of the absolute path
+        breaks ties — so two same-depth siblings claiming the same file (rare,
+        weird ``include`` globs) get consistent first-wins behavior across
+        runs.
+        """
+        # Track original index so survivors come out in caller's order.
+        indexed = list(enumerate(projects))
+        # Deepest first; alphabetical secondary for stable tiebreak.
+        indexed.sort(key=lambda ip: (-len(ip[1].root.parts), str(ip[1].root)))
+
+        claimed: set[Path] = set()
+        survivors: list[tuple[int, TypeScriptProject]] = []
+        for orig_idx, project in indexed:
+            unique = [f for f in project.files if f not in claimed]
+            if not unique:
+                logger.debug(f"Dropping project {project.root} — all files claimed by deeper projects")
+                continue
+            if len(unique) < len(project.files):
+                logger.debug(f"Trimmed project {project.root} from {len(project.files)} to {len(unique)} files")
+            claimed.update(unique)
+            survivors.append((orig_idx, TypeScriptProject(root=project.root, files=unique)))
+
+        survivors.sort(key=lambda ip: ip[0])
+        return [p for _, p in survivors]
+
+
+# ---------------------------------------------------------------------- #
+# Module-level helpers
+# ---------------------------------------------------------------------- #
+
+
+def _normalize(project_dir: Path, raw: str) -> Path:
+    """Resolve a tsc-emitted file path (often relative) to an absolute path."""
+    p = Path(raw)
+    if not p.is_absolute():
+        p = project_dir / p
+    return p.resolve()
+
+
+def _is_ancestor(maybe_ancestor: Path, descendant: Path) -> bool:
+    try:
+        descendant.relative_to(maybe_ancestor)
+    except ValueError:
+        return False
+    return descendant != maybe_ancestor
+
+
+def _resolve_tsc_js() -> Path | None:
+    """Return the bundled ``tsc.js`` shipped with typescript-language-server."""
+    candidate = get_servers_dir() / "node_modules" / "typescript" / "lib" / "tsc.js"
+    return candidate if candidate.exists() else None
+
+
+def _build_tsc_command_prefix(node_path: str | None, tsc_js: Path | None) -> list[str] | None:
+    """Pick the most reliable way to invoke ``tsc --showConfig`` on this host.
+
+    Preference order:
+    1. Embedded ``node`` + bundled ``tsc.js`` (vendored alongside
+       typescript-language-server, no PATH assumptions).
+    2. System ``tsc`` if it's on PATH.
+    Returns ``None`` if neither is available.
+
+    The returned list is the prefix to which the caller appends ``-p <dir>``.
+    """
+    if node_path and tsc_js and tsc_js.exists():
+        return [node_path, str(tsc_js), "--showConfig"]
+    system_tsc = _resolve_system_tsc()
+    if system_tsc is not None:
+        return [system_tsc, "--showConfig"]
+    return None
+
+
+def _resolve_system_tsc() -> str | None:
+    """Find a usable ``tsc`` binary on the system PATH.
+
+    Why ``shutil.which`` rather than hand-rolling the loop: on Windows the
+    binary may be ``tsc.cmd`` (npm-global), ``tsc.exe`` (some chocolatey/scoop
+    shims), or ``tsc.bat``. ``shutil.which`` honors ``PATHEXT`` and resolves
+    whichever extension is registered first — matching what a user typing
+    ``tsc`` in their shell would get.
+    """
+    return shutil.which("tsc")

--- a/static_analyzer/typescript_config_scanner.py
+++ b/static_analyzer/typescript_config_scanner.py
@@ -1,12 +1,10 @@
 """TypeScript / JavaScript project discovery.
 
-Resolves each project's owned file list authoritatively via ``tsc --showConfig``
-so that nested ``tsconfig.json`` files in a monorepo don't double-claim files.
-Why: a "solution" tsconfig at the repo root (``files: []`` + ``references: [...]``)
-must contribute zero files itself — otherwise its filesystem walk overlaps with
-the leaf projects it points at, and every overlapping file ends up analyzed
-twice under two different qualified-name roots, inflating reference and
-package counts.
+Resolves each project's owned file list via ``tsc --showConfig`` so that nested
+``tsconfig.json`` files in a monorepo don't double-claim files. Why: a "solution"
+tsconfig at the repo root (``files: []`` + ``references: [...]``) must contribute
+zero files itself, or every overlapping file gets analyzed twice and inflates
+reference / package counts.
 """
 
 import json
@@ -17,6 +15,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from repo_utils.ignore import RepoIgnoreManager
+from static_analyzer.constants import LANGUAGE_EXTENSIONS, Language
 from tool_registry.paths import get_servers_dir, preferred_node_path
 
 logger = logging.getLogger(__name__)
@@ -26,19 +25,15 @@ logger = logging.getLogger(__name__)
 class TypeScriptProject:
     """One TS/JS project the engine should analyze.
 
-    ``files`` holds absolute paths resolved by ``tsc --showConfig`` (or by a
-    filesystem fallback if tsc is unavailable). The engine should send exactly
-    these to the LSP client rooted at ``root`` — anything broader would re-claim
-    files that belong to a sibling project.
+    ``files`` are absolute paths the engine should send to the LSP — anything
+    broader would re-claim files belonging to a sibling project.
     """
 
     root: Path
     files: list[Path] = field(default_factory=list)
 
 
-_TS_EXTENSIONS = (".ts", ".tsx", ".mts", ".cts")
-_JS_EXTENSIONS = (".js", ".jsx", ".mjs", ".cjs")
-_ALL_EXTENSIONS = _TS_EXTENSIONS + _JS_EXTENSIONS
+_ALL_EXTENSIONS = LANGUAGE_EXTENSIONS[Language.TYPESCRIPT] + LANGUAGE_EXTENSIONS[Language.JAVASCRIPT]
 
 
 class TypeScriptConfigScanner:
@@ -53,34 +48,18 @@ class TypeScriptConfigScanner:
     def find_typescript_projects(self) -> list[TypeScriptProject]:
         """Return one project per leaf tsconfig with its authoritative file list.
 
-        Strategy (two-tier resolution + trim):
-        1. ``rglob`` the repo for ``tsconfig.json`` / ``jsconfig.json`` (skipping
-           ignored paths). This is the candidate set.
-        2. **Option A**: ask ``tsc --showConfig`` what files each candidate owns.
-           Authoritative because tsc honours ``files``/``include``/``exclude``
-           semantics. The result is then filtered through ``ignore_manager``
-           so ``.codeboardingignore`` patterns (e.g. ``*.test.*``) apply
-           consistently with Option B.
-        3. **Option B (fallback)**: if tsc is unavailable or fails for a
-           candidate, fall back to a filesystem walk that explicitly excludes
-           any subtree owned by another candidate and applies the ignore
-           manager. Less precise than tsc (no ``include``/``exclude``
-           honour) but each file is still claimed at most once.
-        4. ``_trim_overlap`` then assigns each file to exactly one project —
-           the deepest candidate that claims it. Files that only the root
-           tsconfig sees (e.g. ``excalidraw-app/`` in a monorepo) survive
-           on the root project; files claimed by both root and a leaf go
-           to the leaf. A project whose entire claim is covered by deeper
-           projects (a pure "solution" tsconfig) is dropped.
+        Strategy: discover candidate tsconfigs, resolve each one's file set via
+        ``tsc --showConfig`` (or a disjoint FS walk if tsc is unavailable), then
+        ``_trim_overlap`` so each file ends up in exactly one project — the
+        deepest that claims it. A project whose entire claim is covered by
+        deeper ones (a pure "solution" tsconfig) is dropped.
         """
         candidate_dirs = self._discover_candidates()
         if not candidate_dirs:
             logger.warning(f"No TypeScript configuration files found in {self.repo_location}")
             return []
 
-        node_path = preferred_node_path(get_servers_dir())
-        tsc_js = _resolve_tsc_js()
-        tsc_cmd_prefix = _build_tsc_command_prefix(node_path, tsc_js)
+        tsc_cmd_prefix = _resolve_tsc_command()
         if tsc_cmd_prefix is None:
             logger.warning(
                 "tsc not available (neither bundled tsc.js under servers/ nor system tsc on PATH); "
@@ -92,9 +71,6 @@ class TypeScriptConfigScanner:
         for project_dir in candidate_dirs:
             files = self._resolve_project_files(project_dir, tsc_cmd_prefix, candidate_dirs)
             if not files:
-                # No owned files even before trim — already a solution
-                # tsconfig (or every file ignored). Either way, no work
-                # for this project.
                 logger.debug(f"Skipping tsconfig at {project_dir} (no owned files)")
                 continue
             projects.append(TypeScriptProject(root=project_dir, files=files))
@@ -108,10 +84,6 @@ class TypeScriptConfigScanner:
                 f"({total_files} total files across all projects)"
             )
         return projects
-
-    # ------------------------------------------------------------------ #
-    # Candidate discovery
-    # ------------------------------------------------------------------ #
 
     def _discover_candidates(self) -> list[Path]:
         seen: set[Path] = set()
@@ -130,10 +102,6 @@ class TypeScriptConfigScanner:
                 candidates.append(project_dir)
         return candidates
 
-    # ------------------------------------------------------------------ #
-    # File resolution per project (tsc --showConfig with FS fallback)
-    # ------------------------------------------------------------------ #
-
     def _resolve_project_files(
         self,
         project_dir: Path,
@@ -143,16 +111,19 @@ class TypeScriptConfigScanner:
         if tsc_cmd_prefix is not None:
             config = self._showconfig(project_dir, tsc_cmd_prefix)
             if config is not None:
-                files = [_normalize(project_dir, raw) for raw in config.get("files", []) if isinstance(raw, str)]
-                # Apply ignore_manager too: tsc honours each tsconfig's own
-                # include/exclude, but a permissive root tsconfig can claim
-                # files (e.g. ``*.test.ts`` in packages/) that the user has
-                # asked CodeBoarding to skip via .codeboardingignore. Without
-                # this filter, Option A would re-introduce noise that Option B
-                # already drops via ``_fallback_walk``.
+                files = []
+                for raw in config.get("files", []):
+                    if not isinstance(raw, str):
+                        continue
+                    p = Path(raw)
+                    if not p.is_absolute():
+                        p = project_dir / p
+                    files.append(p.resolve())
+                # Apply ignore_manager: a permissive root tsconfig can claim
+                # files (e.g. ``*.test.ts``) the user has skipped via
+                # .codeboardingignore — keep that consistent with the FS fallback.
                 return [f for f in files if f.suffix in _ALL_EXTENSIONS and not self.ignore_manager.should_ignore(f)]
-            # tsc was available but failed for THIS project — fall through
-            # to a filesystem walk for this one project specifically.
+            # tsc available but failed for this project — try the FS walk.
         return self._fallback_walk(project_dir, all_candidates)
 
     def _showconfig(self, project_dir: Path, tsc_cmd_prefix: list[str]) -> dict | None:
@@ -184,16 +155,9 @@ class TypeScriptConfigScanner:
     def _fallback_walk(self, project_dir: Path, all_candidates: list[Path]) -> list[Path]:
         """Disjoint filesystem walk used when ``tsc --showConfig`` is unavailable.
 
-        Walks ``project_dir`` and skips any subtree owned by another candidate
-        project. Each TS/JS file ends up in exactly one project (the deepest
-        candidate containing it).
-
-        Why disjoint: a naive walk from a parent (e.g. the repo root) would
-        re-claim every file already owned by a child (e.g. ``packages/foo/``).
-        Both projects would then add overlapping ``source_files`` lists,
-        re-introducing the duplicate-counting bug this module exists to fix.
-        Less precise than tsc's resolution (no ``include`` / ``exclude``
-        semantics) but each file is claimed by exactly one project.
+        Walks ``project_dir`` skipping any subtree owned by another candidate so
+        each TS/JS file is claimed exactly once. Less precise than tsc (no
+        ``include``/``exclude`` honour) but avoids the double-counting bug.
         """
         nested = [c for c in all_candidates if c != project_dir and _is_ancestor(project_dir, c)]
         files: list[Path] = []
@@ -210,34 +174,18 @@ class TypeScriptConfigScanner:
         files.sort()
         return files
 
-    # ------------------------------------------------------------------ #
-    # Per-file ownership trim
-    # ------------------------------------------------------------------ #
-
     @staticmethod
     def _trim_overlap(projects: list[TypeScriptProject]) -> list[TypeScriptProject]:
-        """Each file is owned by exactly one project — the deepest that claims it.
+        """Assign each file to the deepest project that claims it.
 
         Why deepest-first: leaf tsconfigs typically have stricter ``exclude``
-        patterns (e.g. ``packages/foo/tsconfig.json`` excludes ``**/*.test.*``)
-        and represent the package author's view of "production code." A root
-        tsconfig that ``include``s the whole repo overlaps with every leaf;
-        attributing shared files to the leaf preserves the leaf's intent.
-
-        A parent that has files NOT claimed by any leaf (e.g. an Excalidraw-
-        style root that ``include``s ``packages`` *and* ``excalidraw-app``,
-        where no leaf covers ``excalidraw-app/``) keeps its leftover. A parent
-        whose entire file set is covered by leaves (a pure solution tsconfig)
-        is dropped.
-
-        Determinism: on equal depth, alphabetical order of the absolute path
-        breaks ties — so two same-depth siblings claiming the same file (rare,
-        weird ``include`` globs) get consistent first-wins behavior across
-        runs.
+        patterns and represent the package author's view of "production code,"
+        so attributing shared files to the leaf preserves that intent. A parent
+        with files no leaf covers keeps its leftover; a parent whose entire set
+        is covered by leaves (pure solution tsconfig) is dropped. Alphabetical
+        path tiebreak on equal depth keeps siblings deterministic across runs.
         """
-        # Track original index so survivors come out in caller's order.
         indexed = list(enumerate(projects))
-        # Deepest first; alphabetical secondary for stable tiebreak.
         indexed.sort(key=lambda ip: (-len(ip[1].root.parts), str(ip[1].root)))
 
         claimed: set[Path] = set()
@@ -256,19 +204,6 @@ class TypeScriptConfigScanner:
         return [p for _, p in survivors]
 
 
-# ---------------------------------------------------------------------- #
-# Module-level helpers
-# ---------------------------------------------------------------------- #
-
-
-def _normalize(project_dir: Path, raw: str) -> Path:
-    """Resolve a tsc-emitted file path (often relative) to an absolute path."""
-    p = Path(raw)
-    if not p.is_absolute():
-        p = project_dir / p
-    return p.resolve()
-
-
 def _is_ancestor(maybe_ancestor: Path, descendant: Path) -> bool:
     try:
         descendant.relative_to(maybe_ancestor)
@@ -277,38 +212,24 @@ def _is_ancestor(maybe_ancestor: Path, descendant: Path) -> bool:
     return descendant != maybe_ancestor
 
 
-def _resolve_tsc_js() -> Path | None:
-    """Return the bundled ``tsc.js`` shipped with typescript-language-server."""
-    candidate = get_servers_dir() / "node_modules" / "typescript" / "lib" / "tsc.js"
-    return candidate if candidate.exists() else None
+def _resolve_system_tsc() -> str | None:
+    """Find ``tsc`` on PATH via ``shutil.which`` so Windows ``PATHEXT`` is honoured
+    (``tsc.cmd``/``tsc.exe``/``tsc.bat`` from various installers all resolve)."""
+    return shutil.which("tsc")
 
 
-def _build_tsc_command_prefix(node_path: str | None, tsc_js: Path | None) -> list[str] | None:
-    """Pick the most reliable way to invoke ``tsc --showConfig`` on this host.
+def _resolve_tsc_command() -> list[str] | None:
+    """Return the prefix for invoking ``tsc --showConfig`` on this host.
 
-    Preference order:
-    1. Embedded ``node`` + bundled ``tsc.js`` (vendored alongside
-       typescript-language-server, no PATH assumptions).
-    2. System ``tsc`` if it's on PATH.
-    Returns ``None`` if neither is available.
-
-    The returned list is the prefix to which the caller appends ``-p <dir>``.
+    Prefers the embedded ``node`` + bundled ``tsc.js`` (vendored alongside
+    typescript-language-server, no PATH assumptions); falls back to ``tsc`` on
+    PATH; returns ``None`` if neither is available. The caller appends ``-p <dir>``.
     """
-    if node_path and tsc_js and tsc_js.exists():
-        return [node_path, str(tsc_js), "--showConfig"]
+    node_path = preferred_node_path(get_servers_dir())
+    bundled_tsc = get_servers_dir() / "node_modules" / "typescript" / "lib" / "tsc.js"
+    if node_path and bundled_tsc.exists():
+        return [node_path, str(bundled_tsc), "--showConfig"]
     system_tsc = _resolve_system_tsc()
     if system_tsc is not None:
         return [system_tsc, "--showConfig"]
     return None
-
-
-def _resolve_system_tsc() -> str | None:
-    """Find a usable ``tsc`` binary on the system PATH.
-
-    Why ``shutil.which`` rather than hand-rolling the loop: on Windows the
-    binary may be ``tsc.cmd`` (npm-global), ``tsc.exe`` (some chocolatey/scoop
-    shims), or ``tsc.bat``. ``shutil.which`` honors ``PATHEXT`` and resolves
-    whichever extension is registered first — matching what a user typing
-    ``tsc`` in their shell would get.
-    """
-    return shutil.which("tsc")

--- a/tests/integration/fixtures/real_projects/excalidraw_typescript.json
+++ b/tests/integration/fixtures/real_projects/excalidraw_typescript.json
@@ -3,47 +3,36 @@
     "repo_url": "https://github.com/excalidraw/excalidraw",
     "pinned_commit": "v0.18.0",
     "language": "TypeScript",
-    "generated_at": "2026-03-09T18:03:10.411661+00:00",
+    "generated_at": "2026-05-04T22:58:13.749429+00:00",
     "codeboarding_version": "0.2.0"
   },
   "metrics": {
     "references_count_by_os": {
-      "Linux": 12994,
-      "Darwin": 12994,
-      "Windows": 12994
+      "Linux": 13061,
+      "Darwin": 13061,
+      "Windows": 13061
     },
-    "packages_count": 56,
-    "call_graph_nodes": 4891,
-    "call_graph_edges": 12309,
-    "source_files_count": 2035,
+    "packages_count": 58,
+    "call_graph_nodes": 4902,
+    "call_graph_edges": 12407,
+    "source_files_count": 414,
     "execution_time_seconds_by_os": {
-      "Linux": 147,
-      "Darwin": 192,
-      "Windows": 294
+      "Linux": 70,
+      "Darwin": 87,
+      "Windows": 140
     }
   },
   "sample_references": [
-    "dev-docs.src.components.Homepage.index.Feature",
-    "dev-docs.src.components.Homepage.index.Feature.clsx",
-    "dev-docs.src.components.Homepage.index.FeatureItem",
-    "dev-docs.src.components.Homepage.index.FeatureList",
-    "dev-docs.src.components.Homepage.index.FeatureList.<unknown>",
-    "dev-docs.src.components.Homepage.index.FeatureList.Svg",
-    "dev-docs.src.components.Homepage.index.FeatureList.and",
-    "dev-docs.src.components.Homepage.index.FeatureList.be",
-    "dev-docs.src.components.Homepage.index.FeatureList.description",
-    "dev-docs.src.components.Homepage.index.FeatureList.designed"
+    "dev-docs.sidebars.sidebars",
+    "dev-docs.sidebars.sidebars.docs",
+    "dev-docs.sidebars.sidebars.docs.collapsed",
+    "dev-docs.sidebars.sidebars.docs.items",
+    "dev-docs.sidebars.sidebars.docs.items.items",
+    "dev-docs.sidebars.sidebars.docs.items.items.items",
+    "dev-docs.sidebars.sidebars.docs.items.items.label",
+    "dev-docs.sidebars.sidebars.docs.items.items.link",
+    "dev-docs.sidebars.sidebars.docs.items.items.link.id",
+    "dev-docs.sidebars.sidebars.docs.items.items.link.type"
   ],
-  "sample_classes": [
-    "dev-docs.src.components.Homepage.index.FeatureList",
-    "examples.with-nextjs.src.app.page.ExcalidrawWithClientOnly",
-    "examples.with-nextjs.src.pages.excalidraw-in-pages.Excalidraw",
-    "examples.with-script-in-browser.components.ExampleApp.AppProps",
-    "examples.with-script-in-browser.components.ExampleApp.ExampleApp.renderExcalidraw.Excalidraw",
-    "examples.with-script-in-browser.components.ExampleApp.ExampleApp.renderExcalidraw.newElement",
-    "examples.with-script-in-browser.components.ExampleApp.ExampleApp.useEffect() callback.fetchData",
-    "examples.with-script-in-browser.components.ExampleApp.onLinkOpen",
-    "examples.with-script-in-browser.components.ExampleApp.onPointerMoveFromPointerDownHandler",
-    "examples.with-script-in-browser.components.ExampleApp.onPointerUpFromPointerDownHandler"
-  ]
+  "sample_classes": []
 }

--- a/tests/static_analyzer/test_discover_file_dependencies.py
+++ b/tests/static_analyzer/test_discover_file_dependencies.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from static_analyzer import StaticAnalyzer
+from static_analyzer import EngineConfig
 
 
 class TestDiscoverFileDependencies(unittest.TestCase):
@@ -13,7 +14,8 @@ class TestDiscoverFileDependencies(unittest.TestCase):
         adapter = MagicMock()
         adapter.file_extensions = {file_ext}
         client = MagicMock()
-        analyzer._engine_clients = [(adapter, Path("/fake"), client)]
+        cfg = EngineConfig(adapter=adapter, project_path=Path("/fake"))
+        analyzer._engine_clients = [(cfg, client)]
         return analyzer, client
 
     @patch.object(StaticAnalyzer, "__init__", lambda self, *a, **kw: None)

--- a/tests/static_analyzer/test_static_analyzer_start_clients.py
+++ b/tests/static_analyzer/test_static_analyzer_start_clients.py
@@ -12,7 +12,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from static_analyzer import StaticAnalyzer
+from static_analyzer import EngineConfig, StaticAnalyzer
 from static_analyzer.engine.language_adapter import LanguageAdapter
 
 
@@ -44,9 +44,9 @@ class TestStartClientsGracefulDegradation:
         cs_adapter = _make_adapter("CSharp")
         ts_adapter = _make_adapter("TypeScript")
         analyzer._engine_configs = [
-            (py_adapter, tmp_path),
-            (cs_adapter, tmp_path),
-            (ts_adapter, tmp_path),
+            EngineConfig(py_adapter, tmp_path),
+            EngineConfig(cs_adapter, tmp_path),
+            EngineConfig(ts_adapter, tmp_path),
         ]
 
         good_client_py = MagicMock(name="PythonClient")
@@ -61,7 +61,7 @@ class TestStartClientsGracefulDegradation:
             analyzer.start_clients()
 
         assert analyzer._clients_started is True
-        assert [a.language for a, _, _ in analyzer._engine_clients] == ["Python", "TypeScript"]
+        assert [c.adapter.language for c, _ in analyzer._engine_clients] == ["Python", "TypeScript"]
         # Healthy clients must NOT be shut down because a sibling failed.
         good_client_py.shutdown.assert_not_called()
         good_client_ts.shutdown.assert_not_called()
@@ -73,7 +73,7 @@ class TestStartClientsGracefulDegradation:
     ) -> None:
         py_adapter = _make_adapter("Python")
         cs_adapter = _make_adapter("CSharp")
-        analyzer._engine_configs = [(py_adapter, tmp_path), (cs_adapter, tmp_path)]
+        analyzer._engine_configs = [EngineConfig(py_adapter, tmp_path), EngineConfig(cs_adapter, tmp_path)]
 
         bad_py = MagicMock()
         bad_py.start.side_effect = RuntimeError("pyright missing")
@@ -90,7 +90,7 @@ class TestStartClientsGracefulDegradation:
     def test_all_success_records_no_failures(self, analyzer: StaticAnalyzer, tmp_path: Path) -> None:
         py_adapter = _make_adapter("Python")
         ts_adapter = _make_adapter("TypeScript")
-        analyzer._engine_configs = [(py_adapter, tmp_path), (ts_adapter, tmp_path)]
+        analyzer._engine_configs = [EngineConfig(py_adapter, tmp_path), EngineConfig(ts_adapter, tmp_path)]
 
         with patch("static_analyzer.LSPClient", side_effect=[MagicMock(), MagicMock()]):
             analyzer.start_clients()
@@ -106,7 +106,7 @@ class TestStartClientsWorkspaceReadyDispatch:
 
     def test_adapter_opting_in_triggers_wait(self, analyzer: StaticAnalyzer, tmp_path: Path) -> None:
         rust_adapter = _make_adapter("Rust", wait_for_workspace_ready=True)
-        analyzer._engine_configs = [(rust_adapter, tmp_path)]
+        analyzer._engine_configs = [EngineConfig(rust_adapter, tmp_path)]
 
         client = MagicMock(name="RustClient")
         with patch("static_analyzer.LSPClient", return_value=client):
@@ -116,7 +116,7 @@ class TestStartClientsWorkspaceReadyDispatch:
 
     def test_adapter_not_opting_in_skips_wait(self, analyzer: StaticAnalyzer, tmp_path: Path) -> None:
         py_adapter = _make_adapter("Python", wait_for_workspace_ready=False)
-        analyzer._engine_configs = [(py_adapter, tmp_path)]
+        analyzer._engine_configs = [EngineConfig(py_adapter, tmp_path)]
 
         client = MagicMock(name="PythonClient")
         with patch("static_analyzer.LSPClient", return_value=client):
@@ -127,7 +127,7 @@ class TestStartClientsWorkspaceReadyDispatch:
     def test_mixed_adapters_only_waits_on_opting_in_clients(self, analyzer: StaticAnalyzer, tmp_path: Path) -> None:
         rust_adapter = _make_adapter("Rust", wait_for_workspace_ready=True)
         py_adapter = _make_adapter("Python", wait_for_workspace_ready=False)
-        analyzer._engine_configs = [(py_adapter, tmp_path), (rust_adapter, tmp_path)]
+        analyzer._engine_configs = [EngineConfig(py_adapter, tmp_path), EngineConfig(rust_adapter, tmp_path)]
 
         py_client = MagicMock(name="PythonClient")
         rust_client = MagicMock(name="RustClient")

--- a/tests/static_analyzer/test_typescript_config_scanner.py
+++ b/tests/static_analyzer/test_typescript_config_scanner.py
@@ -1,0 +1,329 @@
+"""Tests for TypeScript / JavaScript project configuration scanner."""
+
+import json
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+from static_analyzer.typescript_config_scanner import (
+    TypeScriptConfigScanner,
+    TypeScriptProject,
+    _resolve_system_tsc,
+)
+
+
+def _force_fallback_walk(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make the scanner skip ``tsc --showConfig`` and use the FS-walk fallback.
+
+    Why: unit tests shouldn't depend on a real ``tsc`` install. The fallback
+    walk is the path actually exercised in test/CI environments without
+    ``servers/`` provisioned.
+    """
+    monkeypatch.setattr(
+        "static_analyzer.typescript_config_scanner._build_tsc_command_prefix",
+        lambda *_a, **_k: None,
+    )
+
+
+class TestNoConfigFiles:
+    def test_empty_repo_returns_empty(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        _force_fallback_walk(monkeypatch)
+        scanner = TypeScriptConfigScanner(tmp_path)
+        assert scanner.find_typescript_projects() == []
+
+
+class TestSinglePackage:
+    def test_one_tsconfig_one_project(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        _force_fallback_walk(monkeypatch)
+        (tmp_path / "tsconfig.json").write_text(json.dumps({"compilerOptions": {}}))
+        (tmp_path / "src").mkdir()
+        (tmp_path / "src" / "index.ts").write_text("export {};")
+
+        scanner = TypeScriptConfigScanner(tmp_path)
+        projects = scanner.find_typescript_projects()
+        assert len(projects) == 1
+        assert projects[0].root == tmp_path.resolve()
+        assert (tmp_path / "src" / "index.ts").resolve() in projects[0].files
+
+
+class TestSolutionTsconfigDropped:
+    """A repo-root tsconfig with empty ``files`` and ``references`` pointing at
+    leaf packages must NOT be returned as a project of its own. Otherwise its
+    walk overlaps with the leaves, double-claiming files."""
+
+    def test_solution_root_dropped_when_tsc_says_files_empty(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        # Layout: solution at root, two leaf packages.
+        (tmp_path / "tsconfig.json").write_text(
+            json.dumps({"files": [], "references": [{"path": "./packages/a"}, {"path": "./packages/b"}]})
+        )
+        (tmp_path / "packages" / "a").mkdir(parents=True)
+        (tmp_path / "packages" / "a" / "tsconfig.json").write_text(json.dumps({}))
+        (tmp_path / "packages" / "a" / "x.ts").write_text("export {};")
+        (tmp_path / "packages" / "b").mkdir(parents=True)
+        (tmp_path / "packages" / "b" / "tsconfig.json").write_text(json.dumps({}))
+        (tmp_path / "packages" / "b" / "y.ts").write_text("export {};")
+
+        # Stub tsc to produce empty files for the solution and real files for leaves.
+        def fake_run(cmd, **kwargs):
+            project_dir = Path(cmd[cmd.index("-p") + 1]).resolve()
+            payload: dict
+            if project_dir == tmp_path.resolve():
+                payload = {"files": []}
+            elif project_dir.name == "a":
+                payload = {"files": [str(project_dir / "x.ts")]}
+            else:
+                payload = {"files": [str(project_dir / "y.ts")]}
+
+            class _R:
+                returncode = 0
+                stdout = json.dumps(payload)
+                stderr = ""
+
+            return _R()
+
+        monkeypatch.setattr(
+            "static_analyzer.typescript_config_scanner._build_tsc_command_prefix",
+            lambda *_a, **_k: ["fake-tsc", "--showConfig"],
+        )
+        monkeypatch.setattr("static_analyzer.typescript_config_scanner.subprocess.run", fake_run)
+
+        scanner = TypeScriptConfigScanner(tmp_path)
+        projects = scanner.find_typescript_projects()
+        roots = {p.root for p in projects}
+        assert tmp_path.resolve() not in roots, "Solution tsconfig must be dropped"
+        assert (tmp_path / "packages" / "a").resolve() in roots
+        assert (tmp_path / "packages" / "b").resolve() in roots
+        assert len(projects) == 2
+
+
+def _stub_tsc(monkeypatch: pytest.MonkeyPatch, payload_for: Callable[[Path], dict]) -> None:
+    """Make tsc invocations return ``payload_for(project_dir)`` as JSON."""
+
+    def fake_run(cmd, **_kwargs):
+        project_dir = Path(cmd[cmd.index("-p") + 1]).resolve()
+        payload = payload_for(project_dir)
+
+        class _R:
+            returncode = 0
+            stdout = json.dumps(payload)
+            stderr = ""
+
+        return _R()
+
+    monkeypatch.setattr(
+        "static_analyzer.typescript_config_scanner._build_tsc_command_prefix",
+        lambda *_a, **_k: ["fake-tsc", "--showConfig"],
+    )
+    monkeypatch.setattr("static_analyzer.typescript_config_scanner.subprocess.run", fake_run)
+
+
+class TestTrimOverlap:
+    """The trim step assigns each file to the deepest project that claims it."""
+
+    def test_partial_overlap_trims_parent_keeps_unique_files(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        """Parent claims ``root.ts`` AND ``child/c.ts``. Child claims ``c.ts``.
+        After trim: parent keeps only ``root.ts``, child keeps ``c.ts``. Both
+        survive — this is the Excalidraw ``excalidraw-app/`` scenario where
+        the root tsconfig contributes files no leaf covers.
+        """
+        (tmp_path / "tsconfig.json").write_text(json.dumps({}))
+        (tmp_path / "child").mkdir()
+        (tmp_path / "child" / "tsconfig.json").write_text(json.dumps({}))
+        (tmp_path / "child" / "c.ts").write_text("export {};")
+        (tmp_path / "root.ts").write_text("export {};")
+
+        def payload_for(project_dir: Path) -> dict:
+            if project_dir == tmp_path.resolve():
+                return {"files": [str(tmp_path / "root.ts"), str(tmp_path / "child" / "c.ts")]}
+            return {"files": [str(project_dir / "c.ts")]}
+
+        _stub_tsc(monkeypatch, payload_for)
+
+        scanner = TypeScriptConfigScanner(tmp_path)
+        projects = scanner.find_typescript_projects()
+        roots_to_files = {p.root: {f.name for f in p.files} for p in projects}
+        assert roots_to_files == {
+            tmp_path.resolve(): {"root.ts"},
+            (tmp_path / "child").resolve(): {"c.ts"},
+        }
+
+    def test_full_overlap_drops_parent(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        """When the parent's *entire* file set is also claimed by a child, the
+        parent has nothing unique left after trim and is dropped — same effect
+        as the previous "drop on overlap" rule, but achieved by emptiness.
+        """
+        (tmp_path / "tsconfig.json").write_text(json.dumps({}))
+        (tmp_path / "child").mkdir()
+        (tmp_path / "child" / "tsconfig.json").write_text(json.dumps({}))
+        (tmp_path / "child" / "c.ts").write_text("export {};")
+
+        def payload_for(project_dir: Path) -> dict:
+            if project_dir == tmp_path.resolve():
+                return {"files": [str(tmp_path / "child" / "c.ts")]}
+            return {"files": [str(project_dir / "c.ts")]}
+
+        _stub_tsc(monkeypatch, payload_for)
+
+        scanner = TypeScriptConfigScanner(tmp_path)
+        projects = scanner.find_typescript_projects()
+        assert len(projects) == 1
+        assert projects[0].root == (tmp_path / "child").resolve()
+
+    def test_same_depth_alphabetical_tiebreak(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        """Two same-depth sibling projects claiming the same file: alphabetical
+        order of the absolute path decides who keeps it.
+        """
+        # ``apple`` and ``banana`` are siblings; both claim ``shared.ts``.
+        (tmp_path / "apple").mkdir()
+        (tmp_path / "apple" / "tsconfig.json").write_text(json.dumps({}))
+        (tmp_path / "banana").mkdir()
+        (tmp_path / "banana" / "tsconfig.json").write_text(json.dumps({}))
+        shared = tmp_path / "shared.ts"
+        shared.write_text("export {};")
+        (tmp_path / "apple" / "a.ts").write_text("export {};")
+        (tmp_path / "banana" / "b.ts").write_text("export {};")
+
+        def payload_for(project_dir: Path) -> dict:
+            if project_dir.name == "apple":
+                return {"files": [str(project_dir / "a.ts"), str(shared)]}
+            return {"files": [str(project_dir / "b.ts"), str(shared)]}
+
+        _stub_tsc(monkeypatch, payload_for)
+
+        scanner = TypeScriptConfigScanner(tmp_path)
+        projects = scanner.find_typescript_projects()
+        roots_to_files = {p.root: {f.name for f in p.files} for p in projects}
+        # Alphabetical-first wins; ``apple`` < ``banana``.
+        assert "shared.ts" in roots_to_files[(tmp_path / "apple").resolve()]
+        assert "shared.ts" not in roots_to_files[(tmp_path / "banana").resolve()]
+        # Both projects survive — each still has its unique file.
+        assert "a.ts" in roots_to_files[(tmp_path / "apple").resolve()]
+        assert "b.ts" in roots_to_files[(tmp_path / "banana").resolve()]
+
+
+class TestTscResultsFiltered:
+    def test_tsc_results_filtered_through_codeboardingignore(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        """Files tsc returns must still be filtered through ``.codeboardingignore``.
+        Otherwise a permissive root tsconfig (no test exclusion) would re-introduce
+        ``*.test.ts`` files into the analyzer that the user has explicitly asked
+        CodeBoarding to skip — Option B already drops them; Option A must too.
+        """
+        (tmp_path / ".codeboarding").mkdir()
+        (tmp_path / ".codeboarding" / ".codeboardingignore").write_text("*.test.ts\n")
+        (tmp_path / "tsconfig.json").write_text(json.dumps({}))
+        (tmp_path / "a.ts").write_text("export {};")
+        (tmp_path / "a.test.ts").write_text("export {};")
+
+        def payload_for(_project_dir: Path) -> dict:
+            return {"files": [str(tmp_path / "a.ts"), str(tmp_path / "a.test.ts")]}
+
+        _stub_tsc(monkeypatch, payload_for)
+
+        scanner = TypeScriptConfigScanner(tmp_path)
+        projects = scanner.find_typescript_projects()
+        assert len(projects) == 1
+        names = {f.name for f in projects[0].files}
+        assert names == {"a.ts"}, "tsc-returned *.test.ts must be filtered by .codeboardingignore"
+
+
+class TestFallbackWhenTscMissing:
+    def test_fallback_walks_filesystem_for_each_tsconfig(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        _force_fallback_walk(monkeypatch)
+
+        (tmp_path / "tsconfig.json").write_text(json.dumps({}))
+        (tmp_path / "a.ts").write_text("export {};")
+        (tmp_path / "b.tsx").write_text("export {};")
+
+        scanner = TypeScriptConfigScanner(tmp_path)
+        projects = scanner.find_typescript_projects()
+        assert len(projects) == 1
+        names = {f.name for f in projects[0].files}
+        assert names == {"a.ts", "b.tsx"}
+
+    def test_fallback_skips_ignored_files(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        _force_fallback_walk(monkeypatch)
+        (tmp_path / ".codeboarding").mkdir()
+        (tmp_path / ".codeboarding" / ".codeboardingignore").write_text("*.spec.ts\n")
+        (tmp_path / "tsconfig.json").write_text(json.dumps({}))
+        (tmp_path / "a.ts").write_text("export {};")
+        (tmp_path / "a.spec.ts").write_text("export {};")
+
+        scanner = TypeScriptConfigScanner(tmp_path)
+        projects = scanner.find_typescript_projects()
+        names = {f.name for f in projects[0].files}
+        assert "a.ts" in names
+        assert "a.spec.ts" not in names
+
+    def test_fallback_walks_are_disjoint_across_nested_projects(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+        """When tsc is unavailable, each candidate's walk must exclude
+        subtrees owned by other candidates. Otherwise the parent's walk
+        re-claims files already owned by a child, re-introducing the
+        duplicate-counting bug the module exists to fix.
+        """
+        _force_fallback_walk(monkeypatch)
+        # Layout: root tsconfig + nested child tsconfig under packages/foo/.
+        # Files: a "lone" file at the root that's only the parent's,
+        # and a nested file that the child owns.
+        (tmp_path / "tsconfig.json").write_text(json.dumps({}))
+        (tmp_path / "lone.ts").write_text("export {};")
+        nested = tmp_path / "packages" / "foo"
+        nested.mkdir(parents=True)
+        (nested / "tsconfig.json").write_text(json.dumps({}))
+        (nested / "child.ts").write_text("export {};")
+
+        scanner = TypeScriptConfigScanner(tmp_path)
+        projects = scanner.find_typescript_projects()
+        # After the disjoint walk + drop_overlapping_parents safety net:
+        # the parent owns ``lone.ts`` (not ``child.ts``), the child owns
+        # ``child.ts``. _drop_overlapping_parents would *not* drop the
+        # parent because child.ts is no longer in its set, so both survive.
+        roots_to_files = {p.root: {f.name for f in p.files} for p in projects}
+        assert nested.resolve() in roots_to_files
+        assert roots_to_files[nested.resolve()] == {"child.ts"}
+        # Parent project survives if it owns at least one disjoint file.
+        # If the test layout had only ``child.ts``, the parent would be
+        # dropped (no owned files). Here ``lone.ts`` keeps it alive.
+        assert tmp_path.resolve() in roots_to_files
+        assert roots_to_files[tmp_path.resolve()] == {"lone.ts"}
+        # Sanity: every file appears in exactly one project's list.
+        all_files = [f for files in roots_to_files.values() for f in files]
+        assert sorted(all_files) == sorted(set(all_files))
+
+
+class TestTypeScriptProjectDataclass:
+    def test_default_files_empty_list(self):
+        p = TypeScriptProject(root=Path("/x"))
+        assert p.files == []
+
+
+class TestResolveSystemTsc:
+    """Pins the contract that we delegate to ``shutil.which("tsc")``.
+
+    Why: Windows can install tsc as ``tsc.cmd`` (npm), ``tsc.exe``, or
+    ``tsc.bat`` depending on the installer. ``shutil.which`` honors
+    ``PATHEXT`` and finds whichever is registered first; a hand-rolled
+    PATH loop with a fixed extension (which we used to have) would miss
+    the alternatives. Regressing back to a hardcoded extension would
+    silently break Windows users without a typescript-language-server
+    install under ``servers/``.
+    """
+
+    def test_delegates_to_shutil_which_with_tsc(self, monkeypatch: pytest.MonkeyPatch):
+        calls: list[str] = []
+
+        def fake_which(name: str) -> str | None:
+            calls.append(name)
+            return "/some/path/to/tsc"
+
+        monkeypatch.setattr("static_analyzer.typescript_config_scanner.shutil.which", fake_which)
+        result = _resolve_system_tsc()
+        assert result == "/some/path/to/tsc"
+        assert calls == ["tsc"]
+
+    def test_returns_none_when_tsc_absent(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(
+            "static_analyzer.typescript_config_scanner.shutil.which",
+            lambda _name: None,
+        )
+        assert _resolve_system_tsc() is None

--- a/tests/static_analyzer/test_typescript_config_scanner.py
+++ b/tests/static_analyzer/test_typescript_config_scanner.py
@@ -21,7 +21,7 @@ def _force_fallback_walk(monkeypatch: pytest.MonkeyPatch) -> None:
     ``servers/`` provisioned.
     """
     monkeypatch.setattr(
-        "static_analyzer.typescript_config_scanner._build_tsc_command_prefix",
+        "static_analyzer.typescript_config_scanner._resolve_tsc_command",
         lambda *_a, **_k: None,
     )
 
@@ -83,7 +83,7 @@ class TestSolutionTsconfigDropped:
             return _R()
 
         monkeypatch.setattr(
-            "static_analyzer.typescript_config_scanner._build_tsc_command_prefix",
+            "static_analyzer.typescript_config_scanner._resolve_tsc_command",
             lambda *_a, **_k: ["fake-tsc", "--showConfig"],
         )
         monkeypatch.setattr("static_analyzer.typescript_config_scanner.subprocess.run", fake_run)
@@ -112,7 +112,7 @@ def _stub_tsc(monkeypatch: pytest.MonkeyPatch, payload_for: Callable[[Path], dic
         return _R()
 
     monkeypatch.setattr(
-        "static_analyzer.typescript_config_scanner._build_tsc_command_prefix",
+        "static_analyzer.typescript_config_scanner._resolve_tsc_command",
         lambda *_a, **_k: ["fake-tsc", "--showConfig"],
     )
     monkeypatch.setattr("static_analyzer.typescript_config_scanner.subprocess.run", fake_run)


### PR DESCRIPTION
On a cold-started analyzer (no prior pkl), is either empty or populated by an in-process call to cfg.cluster() during pre_analysis (the cohesion health check). Either way it has no historical meaning, so cluster_delta compares the live partition against itself and trivially short-circuits the user's edits get silently absorbed without any re-detailing.