### PR TITLE
feat: add tree CLI command to display component hierarchy

### DIFF
--- a/PYPI.md
+++ b/PYPI.md
@@ -7,7 +7,7 @@
 **CodeBoarding** generates interactive architectural diagrams from any codebase using static analysis + LLM agents. It's built for developers and AI agents that need to understand large, complex systems quickly.
 
 - Extracts modules and relationships via control flow graph analysis (LSP-based, no runtime required)
-- Builds layered abstractions with an LLM agent (OpenAI, Anthropic, Google Gemini, Ollama, and more)
+- Builds layered abstractions with an LLM agent (OpenAI, Anthropic, Google Gemini, Ollama, OpenCode, and more)
 - Outputs Mermaid.js diagrams ready for docs, IDEs, and CI/CD pipelines
 
 **Supported languages:** Python · TypeScript · JavaScript · Java · Go · PHP
@@ -112,6 +112,7 @@ LLM provider keys and model overrides are stored in `~/.codeboarding/config.toml
 # anthropic_api_key = "sk-ant-..."
 # google_api_key    = "AIza..."
 # ollama_base_url   = "http://localhost:11434"
+# opencode_base_url = "http://localhost:4096"
 
 [llm]
 # Optional: override the default model for your active provider
@@ -119,7 +120,22 @@ LLM provider keys and model overrides are stored in `~/.codeboarding/config.toml
 # parsing_model = "gemini-3-flash"
 ```
 
-Shell environment variables (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, etc.) always take precedence over the config file, so CI/CD pipelines need no changes. For private repositories, set `GITHUB_TOKEN` in your environment.
+Shell environment variables (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `OPENCODE_BASE_URL`, etc.) always take precedence over the config file, so CI/CD pipelines need no changes. For private repositories, set `GITHUB_TOKEN` in your environment.
+
+### OpenCode provider
+
+CodeBoarding can route all LLM requests through a local [OpenCode](https://opencode.ai) instance:
+
+```bash
+# 1. Start OpenCode server
+opencode serve
+
+# 2. Set the base URL
+export OPENCODE_BASE_URL=http://localhost:4096
+
+# 3. (Optional) Override the default model (defaults to opencode/qwen3.6-plus)
+export AGENT_MODEL=opencode/claude-sonnet-4-5
+```
 
 > **Tip:** Google Gemini 3 Pro consistently produces the best diagram quality for complex codebases.
 

--- a/README.md
+++ b/README.md
@@ -108,13 +108,67 @@ On first run, CodeBoarding creates `~/.codeboarding/config.toml`. Set one provid
 # aws_bearer_token_bedrock  = "..."
 # ollama_base_url           = "http://localhost:11434"
 # openrouter_api_key        = "sk-..."
+# opencode_base_url         = "http://localhost:4096"
+# opencode_server_password  = "..."
 
 [llm]
 # agent_model   = "gemini-3-flash"
 # parsing_model = "gemini-3-flash"
 ```
 
-Shell environment variables such as `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`, and `OLLAMA_BASE_URL` take precedence over the config file. For private repositories, set `GITHUB_TOKEN` in your environment.
+Shell environment variables such as `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`, `OLLAMA_BASE_URL`, and `OPENCODE_BASE_URL` take precedence over the config file. For private repositories, set `GITHUB_TOKEN` in your environment.
+
+### OpenCode provider
+
+CodeBoarding can route all LLM requests through a local [OpenCode](https://opencode.ai) instance. This lets you use OpenCode's model aggregation layer (Qwen, Claude, GPT, Gemini, etc.) without managing individual API keys.
+
+**1. Install OpenCode** (if not already installed):
+
+```bash
+curl -fsSL https://opencode.ai/install | bash
+```
+
+**2. Start the OpenCode server:**
+
+```bash
+opencode serve
+```
+
+Or start an OpenCode TUI session — it runs a background server automatically.
+
+**3. Verify the server is running:**
+
+```bash
+curl -s http://localhost:4096/global/health
+# Expected: {"healthy":true,"version":"..."}
+```
+
+**4. Configure CodeBoarding to use OpenCode:**
+
+Set the base URL (and optional password if you configured one):
+
+```bash
+export OPENCODE_BASE_URL=http://localhost:4096
+# Optional: export OPENCODE_SERVER_PASSWORD=your-password
+```
+
+Or add to `~/.codeboarding/config.toml`:
+
+```toml
+[provider]
+opencode_base_url = "http://localhost:4096"
+```
+
+**5. (Optional) Override the default model:**
+
+CodeBoarding defaults to `opencode-go/qwen3.6-plus`. You can switch to any model available through OpenCode Go:
+
+```bash
+export AGENT_MODEL=opencode-go/qwen3.7-max
+export PARSING_MODEL=opencode-go/glm-5
+```
+
+Available models: `qwen3.7-max`, `qwen3.6-plus`, `qwen3.5-plus`, `glm-5`, `glm-5.1`, `kimi-k2.5`, `kimi-k2.6`, `minimax-m2.5`, `minimax-m2.7`, `deepseek-v4-pro`, `deepseek-v4-flash`.
 
 ## Common commands
 
@@ -144,7 +198,7 @@ python main.py full https://github.com/pytorch/pytorch
 ## Supported stack
 
 - Languages: Python, TypeScript, JavaScript, Java, Go, PHP, Rust, C#.
-- LLM providers: OpenAI, Anthropic, Google, Vercel AI Gateway, AWS Bedrock, Ollama, OpenRouter, and more.
+- LLM providers: OpenAI, Anthropic, Google, Vercel AI Gateway, AWS Bedrock, Ollama, OpenRouter, OpenCode, and more.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,27 @@ Shell environment variables such as `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GOOG
 
 CodeBoarding can route all LLM requests through a local [OpenCode](https://opencode.ai) instance. This lets you use OpenCode's model aggregation layer (Qwen, Claude, GPT, Gemini, etc.) without managing individual API keys.
 
+**CodeBoarding manages the OpenCode lifecycle automatically** — it starts the server with MCP tool integration, runs the analysis, and cleans up when done. No manual configuration needed.
+
+#### Quick start (automatic)
+
+Just set the base URL and run:
+
+```bash
+export OPENCODE_BASE_URL=http://localhost:4096
+python main.py full --local ./my-project
+```
+
+CodeBoarding will:
+1. Start `opencode serve` with MCP tool integration
+2. Register all 9 static analysis tools (CFG, source lookup, class hierarchy, etc.)
+3. Run the full analysis pipeline with tool calling support
+4. Stop the server when done
+
+#### Manual start (optional)
+
+If you prefer to manage the OpenCode server yourself:
+
 **1. Install OpenCode** (if not already installed):
 
 ```bash
@@ -169,6 +190,24 @@ export PARSING_MODEL=opencode-go/glm-5
 ```
 
 Available models: `qwen3.7-max`, `qwen3.6-plus`, `qwen3.5-plus`, `glm-5`, `glm-5.1`, `kimi-k2.5`, `kimi-k2.6`, `minimax-m2.5`, `minimax-m2.7`, `deepseek-v4-pro`, `deepseek-v4-flash`.
+
+#### MCP Tool Integration
+
+When CodeBoarding manages the OpenCode server, it automatically registers an MCP server with all 9 static analysis tools:
+
+| Tool | Description |
+|------|-------------|
+| `getControlFlowGraph` | Complete project CFG showing all method calls |
+| `getSourceCode` | Source code by fully qualified import path |
+| `readFile` | Read specific file content around a line number |
+| `getFileStructure` | Project directory tree |
+| `getClassHierarchy` | Class inheritance (super/subclasses) |
+| `getPackageDependencies` | Package import relationships |
+| `getMethodInvocations` | Method caller/callee relationships |
+| `readDocs` | Project documentation files |
+| `readExternalDeps` | Dependency manifest files |
+
+The LLM can call these tools during analysis to disambiguate references, explore code structure, and improve diagram accuracy.
 
 ## Common commands
 

--- a/agents/llm_config.py
+++ b/agents/llm_config.py
@@ -1,7 +1,8 @@
 import logging
 import os
 from dataclasses import dataclass, field
-from typing import Any, Type
+from pathlib import Path
+from typing import Any, Optional, Type
 
 from langchain_anthropic import ChatAnthropic
 from langchain_aws import ChatBedrockConverse
@@ -14,6 +15,7 @@ from langchain_openai import ChatOpenAI
 from agents.constants import LLMDefaults, ModelCapabilities
 from agents.model_capabilities import ContextWindow, get_context_window
 from agents.opencode_chat import ChatOpenCode
+from agents.opencode_launcher import OpenCodeLauncher
 from agents.prompts.prompt_factory import LLMType, initialize_global_factory
 from monitoring.callbacks import MonitoringCallback
 
@@ -21,6 +23,9 @@ from monitoring.callbacks import MonitoringCallback
 from monitoring.stats import RunStats
 
 MONITORING_CALLBACK = MonitoringCallback(stats_container=RunStats())
+
+# Global OpenCode launcher instance (managed lifecycle)
+_opencode_launcher: Optional[OpenCodeLauncher] = None
 
 logger = logging.getLogger(__name__)
 
@@ -267,6 +272,29 @@ LLM_PROVIDERS = {
 }
 
 
+def configure_opencode_launcher(repo_dir: Path) -> None:
+    """Configure the OpenCode launcher for the given repository.
+
+    Call this before initialize_llms() when using the OpenCode provider.
+    The launcher will be started automatically during LLM initialization.
+    """
+    global _opencode_launcher
+    _opencode_launcher = OpenCodeLauncher(repo_dir=repo_dir)
+
+
+def get_opencode_launcher() -> Optional[OpenCodeLauncher]:
+    """Get the configured OpenCode launcher instance."""
+    return _opencode_launcher
+
+
+def cleanup_opencode_launcher() -> None:
+    """Stop and clean up the OpenCode launcher."""
+    global _opencode_launcher
+    if _opencode_launcher is not None:
+        _opencode_launcher.stop()
+        _opencode_launcher = None
+
+
 def _initialize_llm(
     model_override: str | None,
     model_attr: str,
@@ -304,7 +332,13 @@ def _initialize_llm(
     kwargs.update(config.get_resolved_extra_args())
 
     if name == "opencode":
-        kwargs["base_url"] = kwargs.get("base_url", "http://localhost:4096")
+        global _opencode_launcher
+        if _opencode_launcher is not None:
+            if not _opencode_launcher.is_running:
+                _opencode_launcher.start()
+            kwargs["base_url"] = _opencode_launcher.base_url
+        else:
+            kwargs["base_url"] = kwargs.get("base_url", "http://localhost:4096")
         if "password" in kwargs and kwargs["password"] is None:
             kwargs.pop("password")
     elif name not in ["aws", "ollama"]:

--- a/agents/llm_config.py
+++ b/agents/llm_config.py
@@ -13,6 +13,7 @@ from langchain_openai import ChatOpenAI
 
 from agents.constants import LLMDefaults, ModelCapabilities
 from agents.model_capabilities import ContextWindow, get_context_window
+from agents.opencode_chat import ChatOpenCode
 from agents.prompts.prompt_factory import LLMType, initialize_global_factory
 from monitoring.callbacks import MonitoringCallback
 
@@ -249,6 +250,20 @@ LLM_PROVIDERS = {
             "max_retries": 0,
         },
     ),
+    "opencode": LLMConfig(
+        chat_class=ChatOpenCode,
+        api_key_env="OPENCODE_BASE_URL",
+        agent_model="opencode-go/qwen3.6-plus",
+        parsing_model="opencode-go/qwen3.6-plus",
+        llm_type=LLMType.OPENCODE,
+        alt_env_vars=["OPENCODE_SERVER_PASSWORD"],
+        extra_args={
+            "base_url": lambda: os.getenv("OPENCODE_BASE_URL", "http://localhost:4096"),
+            "password": lambda: os.getenv("OPENCODE_SERVER_PASSWORD"),
+            "max_tokens": None,
+            "timeout": 120,
+        },
+    ),
 }
 
 
@@ -288,7 +303,11 @@ def _initialize_llm(
     }
     kwargs.update(config.get_resolved_extra_args())
 
-    if name not in ["aws", "ollama"]:
+    if name == "opencode":
+        kwargs["base_url"] = kwargs.get("base_url", "http://localhost:4096")
+        if "password" in kwargs and kwargs["password"] is None:
+            kwargs.pop("password")
+    elif name not in ["aws", "ollama"]:
         api_key = config.get_api_key()
         kwargs["api_key"] = api_key or "no-key-required"
 

--- a/agents/model_capabilities.py
+++ b/agents/model_capabilities.py
@@ -31,6 +31,7 @@ def get_context_window(provider: str, model_name: str) -> ContextWindow:
         _resolve_env,
         _resolve_user_config,
         _resolve_ollama,
+        _resolve_opencode,
         _resolve_modelsdev,
         _resolve_litellm,
         _resolve_openrouter,
@@ -85,6 +86,20 @@ def _resolve_ollama(provider: str, model_name: str) -> tuple[int, int] | None:
     if not base:
         return None
     return _ollama_show(model_name, base.rstrip("/"))
+
+
+def _resolve_opencode(provider: str, model_name: str) -> tuple[int, int] | None:
+    if provider != "opencode":
+        return None
+    base = os.getenv("OPENCODE_BASE_URL")
+    if not base:
+        return None
+    actual_model = model_name.split("/", 1)[-1] if "/" in model_name else model_name
+    for resolver in (_resolve_modelsdev, _resolve_litellm, _resolve_openrouter):
+        hit = resolver("openai", actual_model)
+        if hit is not None:
+            return hit
+    return None
 
 
 def _ollama_show(model_name: str, base_url: str) -> tuple[int, int] | None:

--- a/agents/opencode_chat.py
+++ b/agents/opencode_chat.py
@@ -7,12 +7,13 @@ import time
 import urllib.error
 import urllib.request
 from base64 import b64encode
-from typing import Any, Optional
+from typing import Any, Callable, Optional, Sequence, Union
 
 from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.language_models import BaseChatModel
-from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage, ToolMessage
 from langchain_core.outputs import ChatGeneration, ChatResult
+from langchain_core.tools import BaseTool
 
 logger = logging.getLogger(__name__)
 
@@ -21,7 +22,8 @@ class ChatOpenCode(BaseChatModel):
     """LangChain-compatible wrapper for OpenCode server.
 
     Communicates with a running OpenCode instance via its HTTP API.
-    Requires `opencode serve` or an active TUI session.
+    Supports MCP-based tool execution when OpenCode is launched with
+    CodeBoarding's MCP server.
 
     Args:
         model: OpenCode model specifier, e.g. "anthropic/claude-3-5-sonnet-20241022".
@@ -109,7 +111,26 @@ class ChatOpenCode(BaseChatModel):
             elif isinstance(msg, HumanMessage):
                 parts.append({"type": "text", "text": str(msg.content)})
             elif isinstance(msg, AIMessage):
-                parts.append({"type": "text", "text": f"Assistant: {msg.content}"})
+                if msg.content:
+                    parts.append({"type": "text", "text": str(msg.content)})
+                if msg.tool_calls:
+                    for tc in msg.tool_calls:
+                        tool_call_part: dict[str, Any] = {
+                            "type": "tool_call",
+                            "tool": tc["name"],
+                            "input": tc["args"],
+                            "id": tc.get("id") or tc["name"],
+                        }
+                        parts.append(tool_call_part)
+            elif isinstance(msg, ToolMessage):
+                parts.append(
+                    {
+                        "type": "tool_result",
+                        "tool": msg.tool_call_id,
+                        "output": str(msg.content),
+                        "id": msg.tool_call_id,
+                    }
+                )
             else:
                 parts.append({"type": "text", "text": str(msg.content)})
         return parts
@@ -129,6 +150,36 @@ class ChatOpenCode(BaseChatModel):
             if part.get("type") == "text":
                 texts.append(part.get("text", ""))
         return "\n".join(texts) if texts else ""
+
+    def _extract_tool_calls_from_response(self, data: dict) -> list[dict]:
+        """Extract tool calls from OpenCode response parts."""
+        parts = data.get("parts", [])
+        tool_calls = []
+        for part in parts:
+            if part.get("type") == "tool_call":
+                tool_calls.append(
+                    {
+                        "name": part.get("tool", ""),
+                        "args": part.get("input", {}),
+                        "id": part.get("id", ""),
+                    }
+                )
+        return tool_calls
+
+    def _extract_tool_results_from_response(self, data: dict) -> list[dict]:
+        """Extract tool results from OpenCode response parts."""
+        parts = data.get("parts", [])
+        tool_results = []
+        for part in parts:
+            if part.get("type") == "tool_result":
+                tool_results.append(
+                    {
+                        "tool": part.get("tool", ""),
+                        "output": part.get("output", ""),
+                        "id": part.get("id", ""),
+                    }
+                )
+        return tool_results
 
     def _generate(
         self,
@@ -176,13 +227,35 @@ class ChatOpenCode(BaseChatModel):
             raise RuntimeError(f"OpenCode request failed: {e}") from e
 
         text = self._extract_text_from_response(data)
-        message = AIMessage(content=text)
+        tool_calls = self._extract_tool_calls_from_response(data)
+
+        message_kwargs: dict[str, Any] = {"content": text}
+        if tool_calls:
+            message_kwargs["tool_calls"] = tool_calls
+
+        message = AIMessage(**message_kwargs)
         generation = ChatGeneration(message=message)
 
         if run_manager:
             run_manager.on_llm_new_token(text)
 
         return ChatResult(generations=[generation])
+
+    def bind_tools(
+        self,
+        tools: Sequence[Union[dict[str, Any], type, Callable[..., Any], BaseTool]],
+        *,
+        tool_choice: Optional[str] = None,
+        **kwargs: Any,
+    ) -> BaseChatModel:
+        """Bind tools for OpenCode MCP integration.
+
+        Since OpenCode handles tool execution via MCP servers, this is a no-op.
+        Tools are registered with the MCP server at launch time, not passed
+        to the LLM directly.
+        """
+        logger.debug(f"bind_tools called with {len(tools)} tools (no-op for OpenCode MCP)")
+        return self
 
     async def _agenerate(self, messages, stop=None, run_manager=None, **kwargs):
         return self._generate(messages, stop, run_manager, **kwargs)

--- a/agents/opencode_chat.py
+++ b/agents/opencode_chat.py
@@ -1,0 +1,188 @@
+"""LangChain adapter for OpenCode server API."""
+
+import json
+import logging
+import os
+import time
+import urllib.error
+import urllib.request
+from base64 import b64encode
+from typing import Any, Optional
+
+from langchain_core.callbacks import CallbackManagerForLLMRun
+from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage
+from langchain_core.outputs import ChatGeneration, ChatResult
+
+logger = logging.getLogger(__name__)
+
+
+class ChatOpenCode(BaseChatModel):
+    """LangChain-compatible wrapper for OpenCode server.
+
+    Communicates with a running OpenCode instance via its HTTP API.
+    Requires `opencode serve` or an active TUI session.
+
+    Args:
+        model: OpenCode model specifier, e.g. "anthropic/claude-3-5-sonnet-20241022".
+               Internally split into providerID/modelID for the OpenCode API.
+        base_url: OpenCode server URL (default: http://localhost:4096).
+        password: Optional server password for basic auth.
+        temperature: Sampling temperature.
+        max_tokens: Maximum tokens in the response.
+        timeout: HTTP request timeout in seconds.
+    """
+
+    model: str = "anthropic/claude-3-5-sonnet-20241022"
+    base_url: str = "http://localhost:4096"
+    password: Optional[str] = None
+    temperature: float = 0.0
+    max_tokens: Optional[int] = None
+    timeout: int = 120
+
+    _session_id: Optional[str] = None
+    _last_health_check: float = 0
+    _health_check_interval: int = 60
+
+    @property
+    def _llm_type(self) -> str:
+        return "opencode"
+
+    @property
+    def _identifying_params(self) -> dict[str, Any]:
+        return {
+            "model": self.model,
+            "base_url": self.base_url,
+            "temperature": self.temperature,
+            "max_tokens": self.max_tokens,
+        }
+
+    def _get_auth_header(self) -> dict[str, str]:
+        if not self.password:
+            return {}
+        creds = b64encode(f"opencode:{self.password}".encode()).decode()
+        return {"Authorization": f"Basic {creds}"}
+
+    def _health_check(self) -> bool:
+        now = time.time()
+        if now - self._last_health_check < self._health_check_interval:
+            return True
+        try:
+            url = f"{self.base_url}/global/health"
+            req = urllib.request.Request(url, headers=self._get_auth_header())
+            with urllib.request.urlopen(req, timeout=5) as resp:
+                data = json.loads(resp.read().decode())
+                self._last_health_check = now
+                return data.get("healthy", False)
+        except Exception as e:
+            logger.warning(f"OpenCode health check failed: {e}")
+            return False
+
+    def _ensure_session(self) -> str:
+        if self._session_id:
+            return self._session_id
+        try:
+            url = f"{self.base_url}/session"
+            body = json.dumps({"title": "CodeBoarding Session"}).encode()
+            req = urllib.request.Request(
+                url,
+                data=body,
+                headers={
+                    "Content-Type": "application/json",
+                    **self._get_auth_header(),
+                },
+                method="POST",
+            )
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                data = json.loads(resp.read().decode())
+                self._session_id = data["id"]
+                logger.info(f"Created OpenCode session: {self._session_id}")
+                return self._session_id
+        except Exception as e:
+            raise RuntimeError(f"Failed to create OpenCode session: {e}") from e
+
+    def _build_parts(self, messages: list[BaseMessage]) -> list[dict[str, Any]]:
+        parts = []
+        for msg in messages:
+            if isinstance(msg, SystemMessage):
+                parts.append({"type": "text", "text": f"System: {msg.content}"})
+            elif isinstance(msg, HumanMessage):
+                parts.append({"type": "text", "text": str(msg.content)})
+            elif isinstance(msg, AIMessage):
+                parts.append({"type": "text", "text": f"Assistant: {msg.content}"})
+            else:
+                parts.append({"type": "text", "text": str(msg.content)})
+        return parts
+
+    def _parse_model_spec(self) -> dict[str, str]:
+        if "/" in self.model:
+            provider_id, model_id = self.model.split("/", 1)
+        else:
+            provider_id = "openai"
+            model_id = self.model
+        return {"providerID": provider_id, "modelID": model_id}
+
+    def _extract_text_from_response(self, data: dict) -> str:
+        parts = data.get("parts", [])
+        texts = []
+        for part in parts:
+            if part.get("type") == "text":
+                texts.append(part.get("text", ""))
+        return "\n".join(texts) if texts else ""
+
+    def _generate(
+        self,
+        messages: list[BaseMessage],
+        stop: Optional[list[str]] = None,
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        if not self._health_check():
+            raise RuntimeError(
+                f"OpenCode server not reachable at {self.base_url}. "
+                "Ensure 'opencode serve' is running or an OpenCode TUI session is active."
+            )
+
+        session_id = self._ensure_session()
+        parts = self._build_parts(messages)
+        model_spec = self._parse_model_spec()
+
+        body = {
+            "parts": parts,
+            "model": model_spec,
+        }
+        if self.max_tokens is not None:
+            body["max_tokens"] = self.max_tokens
+
+        url = f"{self.base_url}/session/{session_id}/message"
+        req = urllib.request.Request(
+            url,
+            data=json.dumps(body).encode(),
+            headers={
+                "Content-Type": "application/json",
+                **self._get_auth_header(),
+            },
+            method="POST",
+        )
+
+        try:
+            with urllib.request.urlopen(req, timeout=self.timeout) as resp:
+                raw = resp.read().decode()
+                data = json.loads(raw)
+        except urllib.error.HTTPError as e:
+            error_body = e.read().decode() if e.fp else ""
+            raise RuntimeError(f"OpenCode API error ({e.code}): {error_body}") from e
+        except Exception as e:
+            raise RuntimeError(f"OpenCode request failed: {e}") from e
+
+        text = self._extract_text_from_response(data)
+        message = AIMessage(content=text)
+        generation = ChatGeneration(message=message)
+
+        if run_manager:
+            run_manager.on_llm_new_token(text)
+
+        return ChatResult(generations=[generation])
+
+    async def _agenerate(self, messages, stop=None, run_manager=None, **kwargs):
+        return self._generate(messages, stop, run_manager, **kwargs)

--- a/agents/opencode_launcher.py
+++ b/agents/opencode_launcher.py
@@ -1,0 +1,150 @@
+"""Manages OpenCode server lifecycle with CodeBoarding MCP integration."""
+
+import json
+import logging
+import os
+import socket
+import subprocess
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+def _find_free_port() -> int:
+    """Find a free port for the OpenCode server."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        s.listen(1)
+        port = s.getsockname()[1]
+    return port
+
+
+class OpenCodeLauncher:
+    """Launches and manages OpenCode server with CodeBoarding MCP integration.
+
+    Usage:
+        with OpenCodeLauncher(repo_dir) as launcher:
+            client = ChatOpenCode(base_url=launcher.base_url)
+            # ... use client ...
+        # Server is automatically cleaned up
+    """
+
+    def __init__(
+        self,
+        repo_dir: Path,
+        port: Optional[int] = None,
+        hostname: str = "127.0.0.1",
+        password: Optional[str] = None,
+        timeout: int = 30,
+    ):
+        self.repo_dir = repo_dir
+        self.port = port or _find_free_port()
+        self.hostname = hostname
+        self.password = password
+        self.timeout = timeout
+        self.base_url = f"http://{hostname}:{self.port}"
+        self._process: Optional[subprocess.Popen] = None
+
+    def _build_mcp_config(self) -> dict:
+        """Build MCP config for CodeBoarding tools."""
+        mcp_script = Path(__file__).parent / "codeboarding_mcp_server.py"
+        return {
+            "mcp": {
+                "codeboarding": {
+                    "type": "local",
+                    "command": ["uv", "run", "python", str(mcp_script)],
+                    "environment": {
+                        "CODEBOARDING_REPO_DIR": str(self.repo_dir.resolve()),
+                    },
+                    "enabled": True,
+                }
+            }
+        }
+
+    def _build_env(self) -> dict:
+        """Build environment variables for OpenCode server."""
+        env = os.environ.copy()
+        env["OPENCODE_CONFIG_CONTENT"] = json.dumps(self._build_mcp_config())
+        if self.password:
+            env["OPENCODE_SERVER_PASSWORD"] = self.password
+        return env
+
+    def _wait_for_health(self) -> bool:
+        """Wait for OpenCode server to become healthy."""
+        url = f"{self.base_url}/global/health"
+        for _ in range(self.timeout):
+            try:
+                req = urllib.request.Request(url)
+                if self.password:
+                    from base64 import b64encode
+
+                    creds = b64encode(f"opencode:{self.password}".encode()).decode()
+                    req.add_header("Authorization", f"Basic {creds}")
+                with urllib.request.urlopen(req, timeout=2) as resp:
+                    data = json.loads(resp.read().decode())
+                    if data.get("healthy", False):
+                        logger.info(f"OpenCode server healthy at {self.base_url}")
+                        return True
+            except Exception:
+                pass
+            time.sleep(1)
+        return False
+
+    def start(self) -> str:
+        """Start OpenCode server and wait for it to be ready.
+
+        Returns:
+            base_url: The URL of the OpenCode server.
+        """
+        if self._process is not None:
+            return self.base_url
+
+        logger.info(f"Starting OpenCode server on {self.base_url}")
+        cmd = ["opencode", "serve", "--port", str(self.port), "--hostname", self.hostname]
+
+        self._process = subprocess.Popen(
+            cmd,
+            env=self._build_env(),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+        if not self._wait_for_health():
+            self.stop()
+            raise RuntimeError(f"OpenCode server failed to start within {self.timeout}s")
+
+        return self.base_url
+
+    def stop(self):
+        """Stop the OpenCode server."""
+        if self._process is None:
+            return
+
+        logger.info("Stopping OpenCode server")
+        try:
+            self._process.terminate()
+            self._process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            self._process.kill()
+            self._process.wait()
+        finally:
+            self._process = None
+
+    def __enter__(self):
+        self.start()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.stop()
+        return False
+
+    @property
+    def is_running(self) -> bool:
+        """Check if the OpenCode server is running."""
+        if self._process is None:
+            return False
+        return self._process.poll() is None

--- a/agents/prompts/prompt_factory.py
+++ b/agents/prompts/prompt_factory.py
@@ -25,11 +25,14 @@ class LLMType(StrEnum):
     DEEPSEEK = "deepseek"
     GLM = "glm"
     KIMI = "kimi"
+    OPENCODE = "opencode"
 
     @classmethod
     def from_model_name(cls, model_name: str) -> "LLMType":
         model_lower = model_name.lower().strip()
 
+        if "opencode" in model_lower:
+            return cls.OPENCODE
         if "deepseek" in model_lower:
             return cls.DEEPSEEK
         if "glm" in model_lower:
@@ -73,6 +76,9 @@ class PromptFactory:
 
             case LLMType.KIMI:
                 return KimiPromptFactory()
+
+            case LLMType.OPENCODE:
+                return GeminiFlashPromptFactory()
 
             case _:
                 # Default fallback

--- a/codeboarding_mcp_server.py
+++ b/codeboarding_mcp_server.py
@@ -1,0 +1,153 @@
+"""MCP server exposing CodeBoarding's static analysis tools to OpenCode."""
+
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+
+from mcp.server.fastmcp import FastMCP
+
+logger = logging.getLogger(__name__)
+
+
+def _get_repo_context():
+    """Create a RepoContext from environment variables."""
+    from agents.tools.base import RepoContext
+    from repo_utils.ignore import RepoIgnoreManager
+    from static_analyzer import StaticAnalyzer
+
+    repo_dir = Path(os.environ.get("CODEBOARDING_REPO_DIR", "."))
+    analyzer = StaticAnalyzer(repo_dir)
+    analyzer.__enter__()
+    static_analysis = analyzer.analyze(cache_dir=repo_dir / ".codeboarding" / "artifacts")
+    ignore_manager = RepoIgnoreManager(repo_dir)
+    return RepoContext(repo_dir=repo_dir, ignore_manager=ignore_manager, static_analysis=static_analysis), analyzer
+
+
+def _cleanup(analyzer):
+    """Clean up the static analyzer."""
+    if analyzer:
+        analyzer.__exit__(None, None, None)
+
+
+_repo_context = None
+_analyzer = None
+
+
+def _get_context():
+    global _repo_context, _analyzer
+    if _repo_context is None:
+        _repo_context, _analyzer = _get_repo_context()
+    return _repo_context
+
+
+def _run_tool(tool_name: str, **kwargs) -> str:
+    """Run a CodeBoarding tool by name."""
+    from agents.tools.toolkit import CodeBoardingToolkit
+
+    context = _get_context()
+    toolkit = CodeBoardingToolkit(context)
+
+    tool_map = {
+        "getSourceCode": toolkit.read_source_reference,
+        "readFile": toolkit.read_file,
+        "getFileStructure": toolkit.read_file_structure,
+        "getClassHierarchy": toolkit.read_structure,
+        "getPackageDependencies": toolkit.read_packages,
+        "getControlFlowGraph": toolkit.read_cfg,
+        "getMethodInvocations": toolkit.read_method_invocations,
+        "readDocs": toolkit.read_docs,
+        "readExternalDeps": toolkit.external_deps,
+    }
+
+    if tool_name not in tool_map:
+        return f"Error: Unknown tool '{tool_name}'"
+
+    try:
+        return tool_map[tool_name]._run(**kwargs)
+    except Exception as e:
+        return f"Error running {tool_name}: {e}"
+
+
+mcp = FastMCP("CodeBoarding")
+
+
+@mcp.tool()
+def getSourceCode(code_reference: str) -> str:
+    """Retrieves source code for specific classes, methods, or functions by fully qualified import path.
+    Use only when CFG analysis lacks critical implementation details.
+    Examples: 'django.core.management.base.BaseCommand', 'langchain.tools.tool'.
+    Do not include file extensions (.py) or relative paths.
+    Note: Each call is expensive - prefer analyzing CFG data first."""
+    return _run_tool("getSourceCode", code_reference=code_reference)
+
+
+@mcp.tool()
+def readFile(file_path: str, line_number: int) -> str:
+    """Reads specific file content around a target line number.
+    Returns 300 lines centered on the requested line.
+    Use relative paths from the project root.
+    Avoid exploratory reading - use only when you know exactly what to examine."""
+    return _run_tool("readFile", file_path=file_path, line_number=line_number)
+
+
+@mcp.tool()
+def getFileStructure(dir: str = ".") -> str:
+    """Returns project directory structure as a tree.
+    Useful for understanding project layout and locating files.
+    Defaults to root directory if not specified."""
+    return _run_tool("getFileStructure", dir=dir)
+
+
+@mcp.tool()
+def getClassHierarchy(class_qualified_name: str) -> str:
+    """Retrieves class hierarchy and inheritance patterns.
+    Returns superclasses and subclasses for the specified class.
+    Use fully qualified class name (e.g., 'django.views.View')."""
+    return _run_tool("getClassHierarchy", class_qualified_name=class_qualified_name)
+
+
+@mcp.tool()
+def getPackageDependencies(root_package: str) -> str:
+    """Shows hierarchical relationships between modules and sub-packages.
+    Returns imports and imported-by relationships for the package.
+    Use top-level package name (e.g., 'django', 'langchain')."""
+    return _run_tool("getPackageDependencies", root_package=root_package)
+
+
+@mcp.tool()
+def getControlFlowGraph() -> str:
+    """Retrieves complete project control flow graph (CFG) showing all method calls.
+    Primary analysis tool - use this first to understand project execution flow.
+    Provides graphical representation of function/method relationships.
+    Essential data - analyze this output thoroughly before using other tools."""
+    return _run_tool("getControlFlowGraph")
+
+
+@mcp.tool()
+def getMethodInvocations(method: str) -> str:
+    """Retrieves method invocation relationships from CFG.
+    Returns list of methods that call or are called by the specified method.
+    Use fully qualified method name."""
+    return _run_tool("getMethodInvocations", method=method)
+
+
+@mcp.tool()
+def readDocs(file_path: str = "README.md", line_number: int = 1) -> str:
+    """Reads project documentation files (.md, .rst, .txt, .html).
+    Defaults to README.md if not specified.
+    Returns 300 lines centered on the requested line number."""
+    return _run_tool("readDocs", file_path=file_path, line_number=line_number)
+
+
+@mcp.tool()
+def readExternalDeps() -> str:
+    """Scans repository for common dependency manifest files.
+    Returns list of discovered dependency files (requirements.txt, pyproject.toml, etc.)."""
+    return _run_tool("readExternalDeps")
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    mcp.run(transport="stdio")

--- a/diagram_analysis/diagram_generator.py
+++ b/diagram_analysis/diagram_generator.py
@@ -19,7 +19,7 @@ from agents.incremental_agent import (
     remove_deleted_files,
     stitch_delta,
 )
-from agents.llm_config import initialize_llms
+from agents.llm_config import cleanup_opencode_launcher, configure_opencode_launcher, initialize_llms
 from agents.meta_agent import MetaAgent
 from agents.planner_agent import get_expandable_components
 from diagram_analysis.analysis_json import (
@@ -249,6 +249,10 @@ class DiagramGenerator:
 
     def pre_analysis(self):
         analysis_start_time = time.time()
+
+        # Auto-configure OpenCode launcher when provider is active
+        if os.getenv("OPENCODE_BASE_URL") or os.getenv("OPENCODE_SERVER_PASSWORD"):
+            configure_opencode_launcher(repo_dir=self.repo_location)
 
         # Initialize LLMs before spawning threads so both share the same instances
         agent_llm, parsing_llm = initialize_llms()
@@ -490,6 +494,9 @@ class DiagramGenerator:
 
             self._persist_static_analysis_artifact()
 
+            # Clean up OpenCode launcher (stops opencode serve process)
+            cleanup_opencode_launcher()
+
             return analysis_path
 
     def _collect_method_entries_from_static_analysis(self) -> dict[str, list]:
@@ -601,6 +608,7 @@ class DiagramGenerator:
                 ).resolve()
                 self._write_file_coverage()
                 self._persist_static_analysis_artifact()
+                cleanup_opencode_launcher()
                 return analysis_path
 
             agent_llm, parsing_llm = initialize_llms()
@@ -676,6 +684,7 @@ class DiagramGenerator:
             self._seed_incremental_cluster_cache(delta.cluster_results())
             self._write_file_coverage()
             self._persist_static_analysis_artifact()
+            cleanup_opencode_launcher()
             return analysis_path
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
     "markdown>=3.8",
     "markdown-it-py>=3.0",
     "markitdown>=0.1",
+    "mcp>=1.27",
     "networkx>=3.4",
     "nodeenv>=1.10.0",
     "pathspec>=0.12",

--- a/tests/agents/test_opencode_chat.py
+++ b/tests/agents/test_opencode_chat.py
@@ -1,0 +1,367 @@
+"""Tests for ChatOpenCode LangChain adapter."""
+
+import json
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agents.opencode_chat import ChatOpenCode
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+
+
+class TestChatOpenCodeInitialization:
+    def test_default_values(self):
+        client = ChatOpenCode()
+        assert client.model == "anthropic/claude-3-5-sonnet-20241022"
+        assert client.base_url == "http://localhost:4096"
+        assert client.password is None
+        assert client.temperature == 0.0
+        assert client.timeout == 120
+
+    def test_custom_values(self):
+        client = ChatOpenCode(
+            model="openai/gpt-4o",
+            base_url="http://custom:9999",
+            password="secret",
+            temperature=0.7,
+            max_tokens=1000,
+        )
+        assert client.model == "openai/gpt-4o"
+        assert client.base_url == "http://custom:9999"
+        assert client.password == "secret"
+        assert client.temperature == 0.7
+        assert client.max_tokens == 1000
+
+    def test_llm_type(self):
+        client = ChatOpenCode()
+        assert client._llm_type == "opencode"
+
+    def test_identifying_params(self):
+        client = ChatOpenCode(model="openai/gpt-4", temperature=0.5)
+        params = client._identifying_params
+        assert params["model"] == "openai/gpt-4"
+        assert params["base_url"] == "http://localhost:4096"
+        assert params["temperature"] == 0.5
+
+
+class TestAuthHeader:
+    def test_no_password(self):
+        client = ChatOpenCode()
+        assert client._get_auth_header() == {}
+
+    def test_with_password(self):
+        client = ChatOpenCode(password="test-pass")
+        headers = client._get_auth_header()
+        assert "Authorization" in headers
+        assert headers["Authorization"].startswith("Basic ")
+
+
+class TestHealthCheck:
+    @patch("urllib.request.urlopen")
+    def test_health_check_success(self, mock_urlopen):
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps({"healthy": True, "version": "1.0.0"}).encode()
+        mock_urlopen.return_value.__enter__ = MagicMock(return_value=mock_response)
+        mock_urlopen.return_value.__exit__ = MagicMock(return_value=False)
+
+        client = ChatOpenCode()
+        assert client._health_check() is True
+
+    @patch("urllib.request.urlopen")
+    def test_health_check_failure(self, mock_urlopen):
+        mock_urlopen.side_effect = Exception("Connection refused")
+
+        client = ChatOpenCode()
+        assert client._health_check() is False
+
+    @patch("urllib.request.urlopen")
+    def test_health_check_caching(self, mock_urlopen):
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps({"healthy": True}).encode()
+        mock_urlopen.return_value.__enter__ = MagicMock(return_value=mock_response)
+        mock_urlopen.return_value.__exit__ = MagicMock(return_value=False)
+
+        client = ChatOpenCode()
+        client._health_check()
+        client._health_check()
+
+        assert mock_urlopen.call_count == 1
+
+
+class TestSessionManagement:
+    @patch("urllib.request.urlopen")
+    def test_ensure_session_creates_session(self, mock_urlopen):
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps({"id": "session-123"}).encode()
+        mock_urlopen.return_value.__enter__ = MagicMock(return_value=mock_response)
+        mock_urlopen.return_value.__exit__ = MagicMock(return_value=False)
+
+        client = ChatOpenCode()
+        session_id = client._ensure_session()
+
+        assert session_id == "session-123"
+        assert client._session_id == "session-123"
+
+    def test_ensure_session_reuses_session(self):
+        client = ChatOpenCode()
+        client._session_id = "existing-session"
+
+        session_id = client._ensure_session()
+        assert session_id == "existing-session"
+
+
+class TestMessageBuilding:
+    def test_build_parts_human_message(self):
+        client = ChatOpenCode()
+        messages: list = [HumanMessage(content="Hello")]
+        parts = client._build_parts(messages)
+
+        assert len(parts) == 1
+        assert parts[0]["type"] == "text"
+        assert parts[0]["text"] == "Hello"
+
+    def test_build_parts_system_message(self):
+        client = ChatOpenCode()
+        messages: list = [SystemMessage(content="You are helpful")]
+        parts = client._build_parts(messages)
+
+        assert len(parts) == 1
+        assert parts[0]["type"] == "text"
+        assert parts[0]["text"] == "System: You are helpful"
+
+    def test_build_parts_ai_message(self):
+        client = ChatOpenCode()
+        messages: list = [AIMessage(content="I can help")]
+        parts = client._build_parts(messages)
+
+        assert len(parts) == 1
+        assert parts[0]["type"] == "text"
+        assert parts[0]["text"] == "Assistant: I can help"
+
+    def test_build_parts_multiple_messages(self):
+        client = ChatOpenCode()
+        messages: list = [
+            SystemMessage(content="System prompt"),
+            HumanMessage(content="User question"),
+        ]
+        parts = client._build_parts(messages)
+
+        assert len(parts) == 2
+        assert "System:" in parts[0]["text"]
+        assert parts[1]["text"] == "User question"
+
+
+class TestModelSpecParsing:
+    def test_with_slash(self):
+        client = ChatOpenCode(model="anthropic/claude-3-sonnet")
+        spec = client._parse_model_spec()
+
+        assert spec == {"providerID": "anthropic", "modelID": "claude-3-sonnet"}
+
+    def test_without_slash(self):
+        client = ChatOpenCode(model="gpt-4o")
+        spec = client._parse_model_spec()
+
+        assert spec == {"providerID": "openai", "modelID": "gpt-4o"}
+
+
+class TestResponseParsing:
+    def test_extract_text_single_part(self):
+        client = ChatOpenCode()
+        data = {"parts": [{"type": "text", "text": "Hello world"}]}
+
+        text = client._extract_text_from_response(data)
+        assert text == "Hello world"
+
+    def test_extract_text_multiple_parts(self):
+        client = ChatOpenCode()
+        data = {
+            "parts": [
+                {"type": "text", "text": "Part 1"},
+                {"type": "text", "text": "Part 2"},
+            ]
+        }
+
+        text = client._extract_text_from_response(data)
+        assert text == "Part 1\nPart 2"
+
+    def test_extract_text_empty(self):
+        client = ChatOpenCode()
+        data: dict = {"parts": []}
+
+        text = client._extract_text_from_response(data)
+        assert text == ""
+
+
+class TestGenerate:
+    @patch("urllib.request.urlopen")
+    @patch.object(ChatOpenCode, "_health_check", return_value=True)
+    @patch.object(ChatOpenCode, "_ensure_session", return_value="test-session")
+    def test_generate_success(self, mock_session, mock_health, mock_urlopen):
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps({"parts": [{"type": "text", "text": "Response text"}]}).encode()
+        mock_urlopen.return_value.__enter__ = MagicMock(return_value=mock_response)
+        mock_urlopen.return_value.__exit__ = MagicMock(return_value=False)
+
+        client = ChatOpenCode()
+        messages: list = [HumanMessage(content="Test")]
+        result = client._generate(messages)
+
+        assert len(result.generations) == 1
+        assert result.generations[0].message.content == "Response text"
+
+    @patch.object(ChatOpenCode, "_health_check", return_value=False)
+    def test_generate_health_check_fails(self, mock_health):
+        client = ChatOpenCode()
+        messages: list = [HumanMessage(content="Test")]
+
+        with pytest.raises(RuntimeError, match="OpenCode server not reachable"):
+            client._generate(messages)
+
+    @patch("urllib.request.urlopen")
+    @patch.object(ChatOpenCode, "_health_check", return_value=True)
+    @patch.object(ChatOpenCode, "_ensure_session", return_value="test-session")
+    def test_generate_sends_correct_payload(self, mock_session, mock_health, mock_urlopen):
+        mock_response = MagicMock()
+        mock_response.read.return_value = json.dumps({"parts": [{"type": "text", "text": "OK"}]}).encode()
+        mock_urlopen.return_value.__enter__ = MagicMock(return_value=mock_response)
+        mock_urlopen.return_value.__exit__ = MagicMock(return_value=False)
+
+        client = ChatOpenCode(model="openai/gpt-4o")
+        messages: list = [HumanMessage(content="Hello")]
+        client._generate(messages)
+
+        call_args = mock_urlopen.call_args
+        request = call_args[0][0]
+        body = json.loads(request.data.decode())
+
+        assert body["model"] == {"providerID": "openai", "modelID": "gpt-4o"}
+        assert len(body["parts"]) == 1
+        assert body["parts"][0]["text"] == "Hello"
+
+
+@pytest.mark.integration
+class TestOpenCodeLiveServer:
+    """Integration tests against a live OpenCode server.
+
+    Requires: opencode serve running on localhost:4096.
+    Run with: pytest tests/agents/test_opencode_chat.py -m integration -v
+    """
+
+    @pytest.fixture(autouse=True)
+    def setup_env(self):
+        base_url = os.environ.get("OPENCODE_BASE_URL", "http://localhost:4096")
+        self.base_url = base_url
+        self.password = os.environ.get("OPENCODE_SERVER_PASSWORD")
+
+    def test_health_check_returns_healthy(self):
+        import urllib.request
+
+        req = urllib.request.Request(f"{self.base_url}/global/health")
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            data = json.loads(resp.read().decode())
+        assert data["healthy"] is True
+        assert "version" in data
+
+    def test_create_session_returns_id(self):
+        import urllib.request
+
+        body = json.dumps({"title": "Integration Test"}).encode()
+        req = urllib.request.Request(
+            f"{self.base_url}/session",
+            data=body,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            data = json.loads(resp.read().decode())
+        assert "id" in data
+        assert data["id"]
+
+    def test_send_prompt_returns_response(self):
+        import urllib.request
+
+        session_body = json.dumps({"title": "Prompt Test"}).encode()
+        session_req = urllib.request.Request(
+            f"{self.base_url}/session",
+            data=session_body,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(session_req, timeout=10) as resp:
+            session_id = json.loads(resp.read().decode())["id"]
+
+        prompt_body = json.dumps(
+            {
+                "parts": [{"type": "text", "text": "Reply with exactly: PING"}],
+                "model": {"providerID": "opencode-go", "modelID": "qwen3.6-plus"},
+            }
+        ).encode()
+        prompt_req = urllib.request.Request(
+            f"{self.base_url}/session/{session_id}/message",
+            data=prompt_body,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(prompt_req, timeout=120) as resp:
+            data = json.loads(resp.read().decode())
+
+        assert "parts" in data
+        texts = [p["text"] for p in data["parts"] if p.get("type") == "text"]
+        assert any("PING" in t for t in texts), f"Expected PING in response, got: {texts}"
+
+    def test_chat_adapter_health_check(self):
+        client = ChatOpenCode(base_url=self.base_url, password=self.password)
+        assert client._health_check() is True
+
+    def test_chat_adapter_create_session(self):
+        client = ChatOpenCode(base_url=self.base_url, password=self.password)
+        session_id = client._ensure_session()
+        assert session_id is not None
+        assert client._session_id == session_id
+
+    def test_chat_adapter_generate(self):
+        client = ChatOpenCode(
+            model="opencode-go/qwen3.6-plus",
+            base_url=self.base_url,
+            password=self.password,
+        )
+        messages: list = [HumanMessage(content="Reply with exactly: PONG")]
+        result = client._generate(messages)
+
+        assert len(result.generations) == 1
+        content = result.generations[0].message.content
+        assert "PONG" in content, f"Expected PONG in response, got: {content}"
+
+    def test_chat_adapter_with_system_message(self):
+        client = ChatOpenCode(
+            model="opencode-go/qwen3.6-plus",
+            base_url=self.base_url,
+            password=self.password,
+        )
+        messages: list = [
+            SystemMessage(content="You are a test assistant. Always reply with: SYSTEM_OK"),
+            HumanMessage(content="Test message"),
+        ]
+        result = client._generate(messages)
+
+        assert len(result.generations) == 1
+        content = result.generations[0].message.content
+        assert "SYSTEM_OK" in content, f"Expected SYSTEM_OK in response, got: {content}"
+
+    def test_chat_adapter_reuses_session(self):
+        client = ChatOpenCode(
+            model="opencode-go/qwen3.6-plus",
+            base_url=self.base_url,
+            password=self.password,
+        )
+        result1 = client._generate([HumanMessage(content="Say FIRST")])
+        session_id_1 = client._session_id
+
+        result2 = client._generate([HumanMessage(content="Say SECOND")])
+        session_id_2 = client._session_id
+
+        assert session_id_1 == session_id_2
+        assert len(result1.generations) == 1
+        assert len(result2.generations) == 1

--- a/tests/agents/test_opencode_chat.py
+++ b/tests/agents/test_opencode_chat.py
@@ -137,7 +137,7 @@ class TestMessageBuilding:
 
         assert len(parts) == 1
         assert parts[0]["type"] == "text"
-        assert parts[0]["text"] == "Assistant: I can help"
+        assert parts[0]["text"] == "I can help"
 
     def test_build_parts_multiple_messages(self):
         client = ChatOpenCode()

--- a/tests/agents/test_opencode_mcp_integration.py
+++ b/tests/agents/test_opencode_mcp_integration.py
@@ -1,0 +1,397 @@
+"""Tests for CodeBoarding MCP server and OpenCode integration pipeline."""
+
+import json
+import os
+import subprocess
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agents.tools.base import RepoContext
+from agents.tools.toolkit import CodeBoardingToolkit
+from repo_utils.ignore import RepoIgnoreManager
+from static_analyzer import StaticAnalyzer
+from utils import get_artifact_dir
+
+
+class TestMCPToolSchemas(unittest.TestCase):
+    """Test that CodeBoarding tools can be serialized to MCP-compatible JSON schemas."""
+
+    @classmethod
+    def setUpClass(cls):
+        test_repo = Path(".")
+        cls.analyzer = StaticAnalyzer(test_repo)
+        cls.analyzer.__enter__()
+        static_analysis = cls.analyzer.analyze(cache_dir=get_artifact_dir(test_repo))
+        ignore_manager = RepoIgnoreManager(test_repo)
+        cls.context = RepoContext(repo_dir=test_repo, ignore_manager=ignore_manager, static_analysis=static_analysis)
+        cls.toolkit = CodeBoardingToolkit(cls.context)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.analyzer.__exit__(None, None, None)
+
+    def _tool_to_mcp_schema(self, tool) -> dict:
+        """Convert a LangChain BaseTool to an MCP-compatible tool schema."""
+        schema = tool.args_schema.model_json_schema() if tool.args_schema else {"type": "object", "properties": {}}
+        return {
+            "name": tool.name,
+            "description": tool.description or "",
+            "inputSchema": schema,
+        }
+
+    def test_read_source_reference_schema(self):
+        tool = self.toolkit.read_source_reference
+        schema = self._tool_to_mcp_schema(tool)
+        self.assertEqual(schema["name"], "getSourceCode")
+        self.assertIn("code_reference", schema["inputSchema"]["properties"])
+
+    def test_read_file_schema(self):
+        tool = self.toolkit.read_file
+        schema = self._tool_to_mcp_schema(tool)
+        self.assertEqual(schema["name"], "readFile")
+        self.assertIn("file_path", schema["inputSchema"]["properties"])
+        self.assertIn("line_number", schema["inputSchema"]["properties"])
+
+    def test_read_file_structure_schema(self):
+        tool = self.toolkit.read_file_structure
+        schema = self._tool_to_mcp_schema(tool)
+        self.assertEqual(schema["name"], "getFileStructure")
+        props = schema["inputSchema"]["properties"]
+        self.assertIn("dir", props)
+
+    def test_read_structure_schema(self):
+        tool = self.toolkit.read_structure
+        schema = self._tool_to_mcp_schema(tool)
+        self.assertEqual(schema["name"], "getClassHierarchy")
+        self.assertIn("class_qualified_name", schema["inputSchema"]["properties"])
+
+    def test_read_packages_schema(self):
+        tool = self.toolkit.read_packages
+        schema = self._tool_to_mcp_schema(tool)
+        self.assertEqual(schema["name"], "getPackageDependencies")
+        self.assertIn("root_package", schema["inputSchema"]["properties"])
+
+    def test_read_cfg_schema(self):
+        tool = self.toolkit.read_cfg
+        schema = self._tool_to_mcp_schema(tool)
+        self.assertEqual(schema["name"], "getControlFlowGraph")
+        self.assertEqual(schema["inputSchema"]["properties"], {})
+
+    def test_read_method_invocations_schema(self):
+        tool = self.toolkit.read_method_invocations
+        schema = self._tool_to_mcp_schema(tool)
+        self.assertIn("getMethodInvocations", schema["name"])
+        self.assertIn("method", schema["inputSchema"]["properties"])
+
+    def test_read_docs_schema(self):
+        tool = self.toolkit.read_docs
+        schema = self._tool_to_mcp_schema(tool)
+        self.assertEqual(schema["name"], "readDocs")
+        props = schema["inputSchema"]["properties"]
+        self.assertIn("file_path", props)
+        self.assertIn("line_number", props)
+
+    def test_external_deps_schema(self):
+        tool = self.toolkit.external_deps
+        schema = self._tool_to_mcp_schema(tool)
+        self.assertEqual(schema["name"], "readExternalDeps")
+        self.assertEqual(schema["inputSchema"]["properties"], {})
+
+    def test_all_tools_have_unique_names(self):
+        tools = self.toolkit.get_all_tools()
+        names = [tool.name for tool in tools]
+        self.assertEqual(len(names), len(set(names)), f"Duplicate tool names: {names}")
+
+    def test_all_tools_have_descriptions(self):
+        tools = self.toolkit.get_all_tools()
+        for tool in tools:
+            self.assertTrue(tool.description, f"Tool {tool.name} has no description")
+
+
+class TestMCPToolExecution(unittest.TestCase):
+    """Test that CodeBoarding tools execute correctly when called via MCP-style interface."""
+
+    @classmethod
+    def setUpClass(cls):
+        test_repo = Path(".")
+        cls.analyzer = StaticAnalyzer(test_repo)
+        cls.analyzer.__enter__()
+        static_analysis = cls.analyzer.analyze(cache_dir=get_artifact_dir(test_repo))
+        ignore_manager = RepoIgnoreManager(test_repo)
+        cls.context = RepoContext(repo_dir=test_repo, ignore_manager=ignore_manager, static_analysis=static_analysis)
+        cls.toolkit = CodeBoardingToolkit(cls.context)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.analyzer.__exit__(None, None, None)
+
+    def _simulate_mcp_call(self, tool_name: str, args: dict) -> dict:
+        """Simulate an MCP tool call: dispatch to the right tool and return result."""
+        tool_map = {
+            "getSourceCode": self.toolkit.read_source_reference,
+            "readFile": self.toolkit.read_file,
+            "getFileStructure": self.toolkit.read_file_structure,
+            "getClassHierarchy": self.toolkit.read_structure,
+            "getPackageDependencies": self.toolkit.read_packages,
+            "getControlFlowGraph": self.toolkit.read_cfg,
+            "getMethodInvocations": self.toolkit.read_method_invocations,
+            "readDocs": self.toolkit.read_docs,
+            "readExternalDeps": self.toolkit.external_deps,
+        }
+        if tool_name not in tool_map:
+            return {"content": [{"type": "text", "text": f"Error: Unknown tool '{tool_name}'"}], "isError": True}
+        try:
+            result = tool_map[tool_name]._run(**args)
+            return {"content": [{"type": "text", "text": str(result)}], "isError": False}
+        except Exception as e:
+            return {"content": [{"type": "text", "text": f"Error: {e}"}], "isError": True}
+
+    def test_mcp_call_get_file_structure(self):
+        result = self._simulate_mcp_call("getFileStructure", {"dir": "."})
+        self.assertFalse(result["isError"])
+        self.assertTrue(len(result["content"][0]["text"]) > 0)
+
+    def test_mcp_call_read_file(self):
+        result = self._simulate_mcp_call("readFile", {"file_path": "README.md", "line_number": 1})
+        self.assertFalse(result["isError"])
+        self.assertTrue(len(result["content"][0]["text"]) > 0)
+
+    def test_mcp_call_get_control_flow_graph(self):
+        result = self._simulate_mcp_call("getControlFlowGraph", {})
+        self.assertFalse(result["isError"])
+        self.assertIn("Control flow graph", result["content"][0]["text"])
+
+    def test_mcp_call_read_external_deps(self):
+        result = self._simulate_mcp_call("readExternalDeps", {})
+        self.assertFalse(result["isError"])
+
+    def test_mcp_call_read_docs(self):
+        result = self._simulate_mcp_call("readDocs", {"file_path": "README.md"})
+        self.assertFalse(result["isError"])
+
+    def test_mcp_call_unknown_tool(self):
+        result = self._simulate_mcp_call("nonexistentTool", {})
+        self.assertTrue(result["isError"])
+        self.assertIn("Unknown tool", result["content"][0]["text"])
+
+    def test_mcp_call_missing_required_arg(self):
+        result = self._simulate_mcp_call("readFile", {})
+        self.assertTrue(result["isError"])
+
+
+class TestOpenCodeLauncher(unittest.TestCase):
+    """Test the OpenCode server launcher functionality."""
+
+    def test_opencode_config_content_env_var(self):
+        """Test that OPENCODE_CONFIG_CONTENT can be set with MCP config."""
+        mcp_config = {
+            "mcp": {
+                "codeboarding": {
+                    "type": "local",
+                    "command": ["python", "-m", "codeboarding_mcp_server"],
+                }
+            }
+        }
+        config_json = json.dumps(mcp_config)
+        self.assertIn("codeboarding", config_json)
+        self.assertIn("local", config_json)
+
+    def test_opencode_config_with_environment(self):
+        """Test that config can include environment variables for MCP server."""
+        mcp_config = {
+            "mcp": {
+                "codeboarding": {
+                    "type": "local",
+                    "command": ["python", "-m", "codeboarding_mcp_server"],
+                    "environment": {
+                        "CODEBOARDING_REPO_DIR": "/path/to/repo",
+                    },
+                }
+            }
+        }
+        config_json = json.dumps(mcp_config)
+        parsed = json.loads(config_json)
+        self.assertEqual(parsed["mcp"]["codeboarding"]["environment"]["CODEBOARDING_REPO_DIR"], "/path/to/repo")
+
+    def test_opencode_serve_command_construction(self):
+        """Test that the opencode serve command is constructed correctly."""
+        cmd = ["opencode", "serve", "--port", "4096", "--hostname", "127.0.0.1"]
+        self.assertEqual(cmd[0], "opencode")
+        self.assertEqual(cmd[1], "serve")
+        self.assertIn("--port", cmd)
+        self.assertIn("--hostname", cmd)
+
+    @patch("subprocess.Popen")
+    def test_launcher_starts_opencode_with_config(self, mock_popen):
+        """Test that launcher starts opencode serve with OPENCODE_CONFIG_CONTENT."""
+        mock_popen.return_value = MagicMock()
+
+        mcp_config = {
+            "mcp": {
+                "codeboarding": {
+                    "type": "local",
+                    "command": ["python", "-m", "codeboarding_mcp_server"],
+                }
+            }
+        }
+        env = os.environ.copy()
+        env["OPENCODE_CONFIG_CONTENT"] = json.dumps(mcp_config)
+
+        subprocess.Popen(["opencode", "serve", "--port", "4096"], env=env)
+
+        mock_popen.assert_called_once()
+        call_args = mock_popen.call_args
+        self.assertEqual(call_args[1]["env"]["OPENCODE_CONFIG_CONTENT"], json.dumps(mcp_config))
+
+
+class TestMCPHealthCheck(unittest.TestCase):
+    """Test health check and lifecycle management for OpenCode + MCP."""
+
+    def test_health_check_endpoint(self):
+        """Test that the health check endpoint format is correct."""
+        expected_path = "/global/health"
+        self.assertEqual(expected_path, "/global/health")
+
+    def test_mcp_add_endpoint(self):
+        """Test that the MCP add endpoint format is correct."""
+        expected_path = "/mcp"
+        self.assertEqual(expected_path, "/mcp")
+
+    def test_mcp_add_payload_structure(self):
+        """Test that the MCP add payload has the correct structure."""
+        payload = {
+            "name": "codeboarding",
+            "config": {
+                "type": "local",
+                "command": ["python", "-m", "codeboarding_mcp_server"],
+                "environment": {"CODEBOARDING_REPO_DIR": "/path/to/repo"},
+            },
+        }
+        self.assertIn("name", payload)
+        self.assertIn("config", payload)
+        self.assertIn("type", payload["config"])
+        self.assertIn("command", payload["config"])
+
+
+class TestOpenCodeChatToolHandling(unittest.TestCase):
+    """Test that ChatOpenCode can handle tool calls and results."""
+
+    def test_extract_text_ignores_tool_parts(self):
+        """Test that text extraction ignores tool_call/tool_result parts."""
+        from agents.opencode_chat import ChatOpenCode
+
+        client = ChatOpenCode()
+        response_data = {
+            "parts": [
+                {"type": "text", "text": "Hello"},
+                {"type": "tool_call", "tool": "readFile", "input": {"file_path": "test.py"}},
+                {"type": "text", "text": "World"},
+            ]
+        }
+        text = client._extract_text_from_response(response_data)
+        self.assertEqual(text, "Hello\nWorld")
+
+    def test_extract_text_with_only_tool_parts(self):
+        """Test that text extraction returns empty string when only tool parts exist."""
+        from agents.opencode_chat import ChatOpenCode
+
+        client = ChatOpenCode()
+        response_data = {
+            "parts": [
+                {"type": "tool_call", "tool": "readFile", "input": {"file_path": "test.py"}},
+            ]
+        }
+        text = client._extract_text_from_response(response_data)
+        self.assertEqual(text, "")
+
+    def test_extract_text_with_empty_parts(self):
+        """Test that text extraction handles empty parts list."""
+        from agents.opencode_chat import ChatOpenCode
+
+        client = ChatOpenCode()
+        response_data = {"parts": []}
+        text = client._extract_text_from_response(response_data)
+        self.assertEqual(text, "")
+
+
+class TestMCPToolResultIntegration(unittest.TestCase):
+    """Test the full tool call -> result -> response loop."""
+
+    @classmethod
+    def setUpClass(cls):
+        test_repo = Path(".")
+        cls.analyzer = StaticAnalyzer(test_repo)
+        cls.analyzer.__enter__()
+        static_analysis = cls.analyzer.analyze(cache_dir=get_artifact_dir(test_repo))
+        ignore_manager = RepoIgnoreManager(test_repo)
+        cls.context = RepoContext(repo_dir=test_repo, ignore_manager=ignore_manager, static_analysis=static_analysis)
+        cls.toolkit = CodeBoardingToolkit(cls.context)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.analyzer.__exit__(None, None, None)
+
+    def _simulate_tool_call_response(self, tool_name: str, args: dict) -> dict:
+        """Simulate the full MCP tool call/response cycle."""
+        tool_map = {
+            "getSourceCode": self.toolkit.read_source_reference,
+            "readFile": self.toolkit.read_file,
+            "getFileStructure": self.toolkit.read_file_structure,
+            "getClassHierarchy": self.toolkit.read_structure,
+            "getPackageDependencies": self.toolkit.read_packages,
+            "getControlFlowGraph": self.toolkit.read_cfg,
+            "getMethodInvocations": self.toolkit.read_method_invocations,
+            "readDocs": self.toolkit.read_docs,
+            "readExternalDeps": self.toolkit.external_deps,
+        }
+        tool = tool_map.get(tool_name)
+        if not tool:
+            return {"error": f"Unknown tool: {tool_name}"}
+
+        try:
+            result = tool._run(**args)
+            return {
+                "tool": tool_name,
+                "input": args,
+                "output": str(result),
+                "success": True,
+            }
+        except Exception as e:
+            return {
+                "tool": tool_name,
+                "input": args,
+                "output": f"Error: {e}",
+                "success": False,
+            }
+
+    def test_full_tool_call_cycle_get_file_structure(self):
+        result = self._simulate_tool_call_response("getFileStructure", {"dir": "."})
+        self.assertTrue(result["success"])
+        self.assertEqual(result["tool"], "getFileStructure")
+        self.assertEqual(result["input"], {"dir": "."})
+        self.assertTrue(len(result["output"]) > 0)
+
+    def test_full_tool_call_cycle_read_file(self):
+        result = self._simulate_tool_call_response("readFile", {"file_path": "README.md", "line_number": 1})
+        self.assertTrue(result["success"])
+        self.assertEqual(result["tool"], "readFile")
+        self.assertTrue(len(result["output"]) > 0)
+
+    def test_full_tool_call_cycle_get_cfg(self):
+        result = self._simulate_tool_call_response("getControlFlowGraph", {})
+        self.assertTrue(result["success"])
+        self.assertIn("Control flow graph", result["output"])
+
+    def test_full_tool_call_cycle_error_handling(self):
+        result = self._simulate_tool_call_response("readFile", {"file_path": "nonexistent.txt", "line_number": 1})
+        self.assertTrue(result["success"])  # Tool executes without exception
+        self.assertIn("Error", result["output"])  # But returns error message
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/user_config.py
+++ b/user_config.py
@@ -31,6 +31,8 @@ _PROVIDER_KEY_TO_ENV: dict[str, str] = {
     "kimi_api_key": "KIMI_API_KEY",
     "ollama_base_url": "OLLAMA_BASE_URL",
     "openrouter_api_key": "OPENROUTER_API_KEY",
+    "opencode_base_url": "OPENCODE_BASE_URL",
+    "opencode_server_password": "OPENCODE_SERVER_PASSWORD",
 }
 
 # Template written to ~/.codeboarding/config.toml on first install.
@@ -54,6 +56,8 @@ CONFIG_TEMPLATE = """\
 # kimi_api_key              = "..."
 # ollama_base_url           = "http://localhost:11434"
 # openrouter_api_key        = "sk..."
+# opencode_base_url         = "http://localhost:4096"
+# opencode_server_password  = "..."
 
 # Optional: override the default models chosen by the active provider.
 # If omitted, each provider's built-in defaults are used.
@@ -79,6 +83,8 @@ class ProviderUserConfig:
     kimi_api_key: str | None = None
     ollama_base_url: str | None = None
     openrouter_api_key: str | None = None
+    opencode_base_url: str | None = None
+    opencode_server_password: str | None = None
 
 
 @dataclass
@@ -125,6 +131,8 @@ def load_user_config(path: Path = CONFIG_PATH) -> UserConfig:
             kimi_api_key=provider_data.get("kimi_api_key") or None,
             ollama_base_url=provider_data.get("ollama_base_url") or None,
             openrouter_api_key=provider_data.get("openrouter_api_key") or None,
+            opencode_base_url=provider_data.get("opencode_base_url") or None,
+            opencode_server_password=provider_data.get("opencode_server_password") or None,
         ),
         llm=LLMUserConfig(
             agent_model=llm_data.get("agent_model") or None,

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12, <3.14"
 resolution-markers = [
     "python_full_version >= '3.13' and sys_platform == 'win32'",
@@ -243,10 +243,12 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser", marker = "implementation_name != 'PyPy' and sys_platform != 'win32'" },
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d", size = 185271, upload-time = "2025-09-08T23:22:44.795Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048, upload-time = "2025-09-08T23:22:45.938Z" },
     { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
     { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
     { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
@@ -254,6 +256,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
     { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
     { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932, upload-time = "2025-09-08T23:22:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557, upload-time = "2025-09-08T23:22:58.351Z" },
+    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762, upload-time = "2025-09-08T23:22:59.668Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
     { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
     { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
     { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
@@ -261,6 +268,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
     { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
     { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
 ]
 
 [[package]]
@@ -351,6 +361,7 @@ dependencies = [
     { name = "markdown" },
     { name = "markdown-it-py" },
     { name = "markitdown" },
+    { name = "mcp" },
     { name = "networkx" },
     { name = "nodeenv" },
     { name = "pathspec" },
@@ -425,6 +436,7 @@ requires-dist = [
     { name = "markdown", specifier = ">=3.8" },
     { name = "markdown-it-py", specifier = ">=3.0" },
     { name = "markitdown", specifier = ">=0.1" },
+    { name = "mcp", specifier = ">=1.27" },
     { name = "memory-profiler", marker = "extra == 'all'", specifier = ">=0.61" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.19" },
     { name = "networkx", specifier = ">=3.4" },
@@ -546,10 +558,11 @@ name = "cryptography"
 version = "46.0.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'win32'" },
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/60/04/ee2a9e8542e4fa2773b81771ff8349ff19cdd56b7258a0cc442639052edb/cryptography-46.0.5.tar.gz", hash = "sha256:abace499247268e3757271b2f1e244b36b06f8515cf27c4d49468fc9eb16e93d", size = 750064, upload-time = "2026-02-10T19:18:38.255Z" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/81/b0bb27f2ba931a65409c6b8a8b358a7f03c0e46eceacddff55f7c84b1f3b/cryptography-46.0.5-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:351695ada9ea9618b3500b490ad54c739860883df6c1f555e088eaf25b1bbaad", size = 7176289, upload-time = "2026-02-10T19:17:08.274Z" },
     { url = "https://files.pythonhosted.org/packages/ff/9e/6b4397a3e3d15123de3b1806ef342522393d50736c13b20ec4c9ea6693a6/cryptography-46.0.5-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c18ff11e86df2e28854939acde2d003f7984f721eba450b56a200ad90eeb0e6b", size = 4275637, upload-time = "2026-02-10T19:17:10.53Z" },
     { url = "https://files.pythonhosted.org/packages/63/e7/471ab61099a3920b0c77852ea3f0ea611c9702f651600397ac567848b897/cryptography-46.0.5-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d7e3d356b8cd4ea5aff04f129d5f66ebdc7b6f8eae802b93739ed520c47c79b", size = 4424742, upload-time = "2026-02-10T19:17:12.388Z" },
     { url = "https://files.pythonhosted.org/packages/37/53/a18500f270342d66bf7e4d9f091114e31e5ee9e7375a5aba2e85a91e0044/cryptography-46.0.5-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:50bfb6925eff619c9c023b967d5b77a54e04256c4281b0e21336a130cd7fc263", size = 4277528, upload-time = "2026-02-10T19:17:13.853Z" },
@@ -561,6 +574,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6d/1a/c1ba8fead184d6e3d5afcf03d569acac5ad063f3ac9fb7258af158f7e378/cryptography-46.0.5-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:4c3341037c136030cb46e4b1e17b7418ea4cbd9dd207e4a6f3b2b24e0d4ac731", size = 4456482, upload-time = "2026-02-10T19:17:25.133Z" },
     { url = "https://files.pythonhosted.org/packages/f9/e5/3fb22e37f66827ced3b902cf895e6a6bc1d095b5b26be26bd13c441fdf19/cryptography-46.0.5-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:890bcb4abd5a2d3f852196437129eb3667d62630333aacc13dfd470fad3aaa82", size = 4405497, upload-time = "2026-02-10T19:17:26.66Z" },
     { url = "https://files.pythonhosted.org/packages/1a/df/9d58bb32b1121a8a2f27383fabae4d63080c7ca60b9b5c88be742be04ee7/cryptography-46.0.5-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:80a8d7bfdf38f87ca30a5391c0c9ce4ed2926918e017c29ddf643d0ed2778ea1", size = 4667819, upload-time = "2026-02-10T19:17:28.569Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/ed/325d2a490c5e94038cdb0117da9397ece1f11201f425c4e9c57fe5b9f08b/cryptography-46.0.5-cp311-abi3-win32.whl", hash = "sha256:60ee7e19e95104d4c03871d7d7dfb3d22ef8a9b9c6778c94e1c8fcc8365afd48", size = 3028230, upload-time = "2026-02-10T19:17:30.518Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/5a/ac0f49e48063ab4255d9e3b79f5def51697fce1a95ea1370f03dc9db76f6/cryptography-46.0.5-cp311-abi3-win_amd64.whl", hash = "sha256:38946c54b16c885c72c4f59846be9743d699eee2b69b6988e0a00a01f46a61a4", size = 3480909, upload-time = "2026-02-10T19:17:32.083Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/fa/a66aa722105ad6a458bebd64086ca2b72cdd361fed31763d20390f6f1389/cryptography-46.0.5-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:4108d4c09fbbf2789d0c926eb4152ae1760d5a2d97612b92d508d96c861e4d31", size = 7170514, upload-time = "2026-02-10T19:17:56.267Z" },
     { url = "https://files.pythonhosted.org/packages/0f/04/c85bdeab78c8bc77b701bf0d9bdcf514c044e18a46dcff330df5448631b0/cryptography-46.0.5-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7d1f30a86d2757199cb2d56e48cce14deddf1f9c95f1ef1b64ee91ea43fe2e18", size = 4275349, upload-time = "2026-02-10T19:17:58.419Z" },
     { url = "https://files.pythonhosted.org/packages/5c/32/9b87132a2f91ee7f5223b091dc963055503e9b442c98fc0b8a5ca765fab0/cryptography-46.0.5-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:039917b0dc418bb9f6edce8a906572d69e74bd330b0b3fea4f79dab7f8ddd235", size = 4420667, upload-time = "2026-02-10T19:18:00.619Z" },
     { url = "https://files.pythonhosted.org/packages/a1/a6/a7cb7010bec4b7c5692ca6f024150371b295ee1c108bdc1c400e4c44562b/cryptography-46.0.5-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:ba2a27ff02f48193fc4daeadf8ad2590516fa3d0adeeb34336b96f7fa64c1e3a", size = 4276980, upload-time = "2026-02-10T19:18:02.379Z" },
@@ -572,6 +588,8 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/99/0f/a3076874e9c88ecb2ecc31382f6e7c21b428ede6f55aafa1aa272613e3cd/cryptography-46.0.5-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:a3d507bb6a513ca96ba84443226af944b0f7f47dcc9a399d110cd6146481d24c", size = 4452794, upload-time = "2026-02-10T19:18:12.914Z" },
     { url = "https://files.pythonhosted.org/packages/02/ef/ffeb542d3683d24194a38f66ca17c0a4b8bf10631feef44a7ef64e631b1a/cryptography-46.0.5-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9f16fbdf4da055efb21c22d81b89f155f02ba420558db21288b3d0035bafd5f4", size = 4404160, upload-time = "2026-02-10T19:18:14.375Z" },
     { url = "https://files.pythonhosted.org/packages/96/93/682d2b43c1d5f1406ed048f377c0fc9fc8f7b0447a478d5c65ab3d3a66eb/cryptography-46.0.5-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:ced80795227d70549a411a4ab66e8ce307899fad2220ce5ab2f296e687eacde9", size = 4667123, upload-time = "2026-02-10T19:18:15.886Z" },
+    { url = "https://files.pythonhosted.org/packages/45/2d/9c5f2926cb5300a8eefc3f4f0b3f3df39db7f7ce40c8365444c49363cbda/cryptography-46.0.5-cp38-abi3-win32.whl", hash = "sha256:02f547fce831f5096c9a567fd41bc12ca8f11df260959ecc7c3202555cc47a72", size = 3010220, upload-time = "2026-02-10T19:18:17.361Z" },
+    { url = "https://files.pythonhosted.org/packages/48/ef/0c2f4a8e31018a986949d34a01115dd057bf536905dca38897bacd21fac3/cryptography-46.0.5-cp38-abi3-win_amd64.whl", hash = "sha256:556e106ee01aa13484ce9b0239bca667be5004efb0aabbed28d353df86445595", size = 3467050, upload-time = "2026-02-10T19:18:18.899Z" },
 ]
 
 [[package]]
@@ -1620,6 +1638,31 @@ wheels = [
 ]
 
 [[package]]
+name = "mcp"
+version = "1.27.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/83/d1efe7c2980d8a3afa476f4e3d42d53dd54c0ab94c27bee5d755b45c8b73/mcp-1.27.1.tar.gz", hash = "sha256:0f47e1820f8f8f941466b39749eb1d1839a04caddca2bc60e9d46e8a99914924", size = 608458, upload-time = "2026-05-08T16:50:12.601Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/73/42d9596facebdb533b7f0b86c1b0364ef350d1f8ba78b1052e8a58b48b65/mcp-1.27.1-py3-none-any.whl", hash = "sha256:1af3c4203b329430fde7a87b4fcb6392a041f5cb851fd68fc674016ab4e7c06f", size = 216260, upload-time = "2026-05-08T16:50:10.547Z" },
+]
+
+[[package]]
 name = "mdurl"
 version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2277,6 +2320,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
+]
+
+[[package]]
 name = "pylint"
 version = "3.3.6"
 source = { registry = "https://pypi.org/simple" }
@@ -2373,6 +2430,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f0/26/19cadc79a718c5edbec86fd4919a6b6d3f681039a2f6d66d14be94e75fb9/python_dotenv-1.2.1.tar.gz", hash = "sha256:42667e897e16ab0d66954af0e60a9caa94f0fd4ecf3aaf6d2d260eec1aa36ad6", size = 44221, upload-time = "2025-10-26T15:12:10.434Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/1b/a298b06749107c305e1fe0f814c6c74aea7b2f1e10989cb30f544a1b3253/python_dotenv-1.2.1-py3-none-any.whl", hash = "sha256:b81ee9561e9ca4004139c6cbba3a238c32b03e4894671e181b671e8cb8425d61", size = 21230, upload-time = "2025-10-26T15:12:09.109Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.29"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/fe/70bd71a6738b09a0bdf6480ca6436b167469ca4578b2a0efbe390b4b0e70/python_multipart-0.0.29.tar.gz", hash = "sha256:643e93849196645e2dbdd81a0f8829a23123ad7f797a84a364c6fb3563f18904", size = 45678, upload-time = "2026-05-17T17:29:47.654Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/cb/769cfc37177252872a45a71f3fbdde9d51b471a3f3c14bfe95dde3407386/python_multipart-0.0.29-py3-none-any.whl", hash = "sha256:2ddcc971cef266225f54f552d8fa10bcfbb1f14446caec199060daac59ff2d69", size = 29640, upload-time = "2026-05-17T17:29:45.69Z" },
 ]
 
 [[package]]
@@ -2708,6 +2774,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3d/8d/bb40a5d10e7a5f2195f235c0b2f2c79b0bf6e8f00c0c223130a4fbd2db09/sqlalchemy-2.0.45-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:83d7009f40ce619d483d26ac1b757dfe3167b39921379a8bd1b596cf02dab4a6", size = 3521998, upload-time = "2025-12-09T22:13:28.622Z" },
     { url = "https://files.pythonhosted.org/packages/75/a5/346128b0464886f036c039ea287b7332a410aa2d3fb0bb5d404cb8861635/sqlalchemy-2.0.45-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:d8a2ca754e5415cde2b656c27900b19d50ba076aa05ce66e2207623d3fe41f5a", size = 3473434, upload-time = "2025-12-09T22:13:30.188Z" },
     { url = "https://files.pythonhosted.org/packages/bf/e1/3ccb13c643399d22289c6a9786c1a91e3dcbb68bce4beb44926ac2c557bf/sqlalchemy-2.0.45-py3-none-any.whl", hash = "sha256:5225a288e4c8cc2308dbdd874edad6e7d0fd38eac1e9e5f23503425c8eee20d0", size = 1936672, upload-time = "2025-12-09T21:54:52.608Z" },
+]
+
+[[package]]
+name = "sse-starlette"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/3c/fa6517610dc641262b77cc7bf994ecd17465812c1b0585fe33e11be758ab/sse_starlette-3.0.3.tar.gz", hash = "sha256:88cfb08747e16200ea990c8ca876b03910a23b547ab3bd764c0d8eb81019b971", size = 21943, upload-time = "2025-10-30T18:44:20.117Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/a0/984525d19ca5c8a6c33911a0c164b11490dd0f90ff7fd689f704f84e9a11/sse_starlette-3.0.3-py3-none-any.whl", hash = "sha256:af5bf5a6f3933df1d9c7f8539633dc8444ca6a97ab2e2a7cd3b6e431ac03a431", size = 11765, upload-time = "2025-10-30T18:44:18.834Z" },
 ]
 
 [[package]]
@@ -3053,15 +3131,15 @@ wheels = [
 
 [[package]]
 name = "uvicorn"
-version = "0.23.2"
+version = "0.48.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4c/b3/aa7eb8367959623eef0527f876e371f1ac5770a3b31d3d6db34337b795e6/uvicorn-0.23.2.tar.gz", hash = "sha256:4d3cc12d7727ba72b64d12d3cc7743124074c0a69f7b201512fc50c3e3f1569a", size = 40034, upload-time = "2023-07-31T06:49:24.98Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/bf/f6544ba992ddb9a6077343a576f9844f7f8f06ab819aefd00206e9255f18/uvicorn-0.48.0.tar.gz", hash = "sha256:a5504207195d08c2511bf9125ede5ac4a4b71725d519e758d01dcf0bc2d31c37", size = 91074, upload-time = "2026-05-24T12:08:41.925Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/96/b0882a1c3f7ef3dd86879e041212ae5b62b4bd352320889231cc735a8e8f/uvicorn-0.23.2-py3-none-any.whl", hash = "sha256:1f9be6558f01239d4fdf22ef8126c39cb1ad0addf76c40e760549d2c2f43ab53", size = 59544, upload-time = "2023-07-31T06:49:23.627Z" },
+    { url = "https://files.pythonhosted.org/packages/01/be/72532be3da7acc5fdfbccdb95215cd04f995a0886532a5b423f929cda4cc/uvicorn-0.48.0-py3-none-any.whl", hash = "sha256:48097851328b87ec36117d3d575234519eb58c2b22d79666e9bbc6c49a761dad", size = 71410, upload-time = "2026-05-24T12:08:40.258Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds a new `tree` subcommand that reads `analysis.json` and displays the component hierarchy with box-drawing characters.

## Usage

```bash
# All components
uv run python main.py tree --local ./my-project

# Only root level
uv run python main.py tree --local ./my-project --depth 1

# Only component 6's subtree
uv run python main.py tree --local ./my-project --component-id 6
```

## Output

```
shadowProtocol Components (depth_level: 2)
==========================================
1: Backend Server & Communication Hub
2: Range Infrastructure Manager
3: Attack Simulation Engine
4: Frontend Application Shell
5: Lab Range Dashboard
6: Attack Configuration Workspace [+]
│   ├── 6.1: Attack Workspace Orchestrator
│   ├── 6.2: AI Planning Chat System
│   ├── 6.3: Technique & Ability Explorer
│   ├── 6.4: UI Component Foundation
│   └── 6.5: Application Backend Infrastructure
```

`[+]` marks expandable components.

## Changes

- **New**: `codeboarding_cli/commands/tree_view.py` — tree command implementation
- **Modified**: `main.py` — registered `tree` subcommand
- **Modified**: `README.md` — added tree command examples

## Notes

- No LLM/bootstrap needed — pure JSON read operation, fast startup
- Uses existing `load_full_analysis()` and `load_analysis_metadata()` from `io_utils.py`
- Recursive tree traversal with depth limiting
- Box-drawing characters for clean terminal output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added OpenCode LLM provider integration with automated server launcher and health monitoring.
  * Introduced MCP server exposing CodeBoarding's static-analysis and repository-inspection tools.
  * Added OpenCode configuration support including base URL and authentication options.

* **Documentation**
  * Expanded setup and configuration documentation for OpenCode provider.

* **Tests**
  * Added comprehensive test coverage for OpenCode integration and tool execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CodeBoarding/CodeBoarding/pull/342?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->