### PR TITLE
feat(config): support openai_base_url for self-hosted / OpenAI-compatible providers

### DIFF
--- a/agents/llm_config.py
+++ b/agents/llm_config.py
@@ -85,9 +85,25 @@ class LLMConfig:
     parsing_temperature: float = LLMDefaults.DEFAULT_PARSING_TEMPERATURE
     extra_args: dict[str, Any] = field(default_factory=dict)
     alt_env_vars: list[str] = field(default_factory=list)
+    keyless_capable: bool = False
+    """Whether this provider can run without a real API key.
+
+    True for self-hosted / OpenAI-compatible endpoints where ``api_key_env`` (or
+    an ``alt_env_vars`` entry) is really a base-URL existence check rather than a
+    secret. When such a provider is the sole active one and no real key is set,
+    key validation warns instead of failing, and the client uses a placeholder.
+    """
 
     def get_api_key(self) -> str | None:
         return os.getenv(self.api_key_env)
+
+    def has_real_api_key(self) -> bool:
+        """True if the provider's primary API-key env var holds a value.
+
+        Distinct from ``is_active()``: a keyless-capable provider can be active
+        via a base-URL ``alt_env_vars`` entry while having no real key here.
+        """
+        return bool(os.getenv(self.api_key_env))
 
     def is_active(self) -> bool:
         """Check if any of the environment variables (primary or alternate) are set."""
@@ -113,6 +129,7 @@ LLM_PROVIDERS = {
         parsing_model="gpt-4o-mini",
         llm_type=LLMType.GPT4,
         alt_env_vars=["OPENAI_BASE_URL"],
+        keyless_capable=True,
         extra_args={
             "base_url": lambda: os.getenv("OPENAI_BASE_URL"),
             "max_tokens": None,
@@ -313,13 +330,32 @@ class LLMConfigError(ValueError):
 
 
 def validate_api_key_provided() -> None:
-    """Raise LLMConfigError if zero or more than one LLM provider key is configured."""
+    """Raise LLMConfigError if zero or more than one LLM provider is configured.
+
+    A provider is "active" when its API-key env var *or* a base-URL alternate
+    (``alt_env_vars``) is set. Keyless-capable providers (self-hosted /
+    OpenAI-compatible endpoints, e.g. an ``OPENAI_BASE_URL`` with no key) are
+    therefore valid: they are activated by their base URL, and the client falls
+    back to a placeholder key downstream. In that case we log a warning rather
+    than fail. Ambiguity detection (more than one active provider) is preserved
+    so a stray second key is still surfaced.
+    """
     active = [name for name, config in LLM_PROVIDERS.items() if config.is_active()]
     if not active:
         required = sorted({config.api_key_env for config in LLM_PROVIDERS.values()})
         raise LLMConfigError(f"No LLM provider API key found. Set one of: {', '.join(required)}")
     if len(active) > 1:
         raise LLMConfigError(f"Multiple LLM provider keys detected ({', '.join(active)}); please set only one.")
+
+    (name,) = active
+    config = LLM_PROVIDERS[name]
+    if config.keyless_capable and not config.has_real_api_key():
+        logger.warning(
+            "Provider '%s' is active via a base URL with no %s set; "
+            "treating as a keyless local endpoint (a placeholder key is used).",
+            name,
+            config.api_key_env,
+        )
 
 
 def initialize_agent_llm(model_override: str | None = None) -> BaseChatModel:

--- a/tests/agents/test_llm_config.py
+++ b/tests/agents/test_llm_config.py
@@ -24,6 +24,51 @@ class TestValidateApiKeyProvided:
             with pytest.raises(ValueError, match="Multiple LLM provider keys detected"):
                 validate_api_key_provided()
 
+    def test_base_url_without_key_passes_with_warning(self, caplog):
+        # Self-hosted / OpenAI-compatible endpoint: active via OPENAI_BASE_URL,
+        # no OPENAI_API_KEY. Should not raise; should warn.
+        import logging
+
+        with patch.dict(os.environ, {"OPENAI_BASE_URL": "http://127.0.0.1:8000/v1"}, clear=True):
+            with caplog.at_level(logging.WARNING, logger="agents.llm_config"):
+                validate_api_key_provided()  # should not raise
+        assert any("keyless local endpoint" in r.message for r in caplog.records)
+
+    def test_base_url_with_key_passes_without_warning(self, caplog):
+        # base_url + a real key: valid and no keyless warning.
+        import logging
+
+        env = {"OPENAI_BASE_URL": "http://127.0.0.1:8000/v1", "OPENAI_API_KEY": "sk-test"}
+        with patch.dict(os.environ, env, clear=True):
+            with caplog.at_level(logging.WARNING, logger="agents.llm_config"):
+                validate_api_key_provided()  # should not raise
+        assert not any("keyless local endpoint" in r.message for r in caplog.records)
+
+    def test_base_url_plus_other_provider_still_ambiguous(self):
+        # Multi-key detection is preserved even when a base URL is set.
+        env = {"OPENAI_BASE_URL": "http://127.0.0.1:8000/v1", "ANTHROPIC_API_KEY": "sk-ant-test"}
+        with patch.dict(os.environ, env, clear=True):
+            with pytest.raises(ValueError, match="Multiple LLM provider keys detected"):
+                validate_api_key_provided()
+
+
+class TestLLMConfigKeyless:
+    def test_openai_is_keyless_capable(self):
+        from agents.llm_config import LLM_PROVIDERS
+
+        assert LLM_PROVIDERS["openai"].keyless_capable is True
+
+    def test_has_real_api_key_distinguishes_from_is_active(self):
+        from agents.llm_config import LLM_PROVIDERS
+
+        openai = LLM_PROVIDERS["openai"]
+        with patch.dict(os.environ, {"OPENAI_BASE_URL": "http://127.0.0.1:8000/v1"}, clear=True):
+            assert openai.is_active() is True
+            assert openai.has_real_api_key() is False
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test"}, clear=True):
+            assert openai.is_active() is True
+            assert openai.has_real_api_key() is True
+
 
 class TestDetectLLMTypeFromModel:
     """Test the LLMType.from_model_name function with various model names."""

--- a/tests/test_user_config.py
+++ b/tests/test_user_config.py
@@ -1,6 +1,6 @@
 import os
 
-from user_config import ProviderUserConfig, UserConfig, ensure_config_template
+from user_config import ProviderUserConfig, UserConfig, ensure_config_template, load_user_config
 
 
 class TestUserConfigApplyToEnv:
@@ -63,6 +63,52 @@ class TestUserConfigApplyToEnv:
         finally:
             os.environ.clear()
             os.environ.update(original)
+
+    def test_injects_openai_base_url_for_self_hosted_proxy(self):
+        cfg = UserConfig(provider=ProviderUserConfig(openai_base_url="http://127.0.0.1:8000/v1"))
+
+        original = os.environ.copy()
+        try:
+            os.environ.pop("OPENAI_BASE_URL", None)
+
+            cfg.apply_to_env()
+
+            assert os.environ["OPENAI_BASE_URL"] == "http://127.0.0.1:8000/v1"
+        finally:
+            os.environ.clear()
+            os.environ.update(original)
+
+    def test_shell_openai_base_url_takes_precedence(self):
+        cfg = UserConfig(provider=ProviderUserConfig(openai_base_url="http://config-value/v1"))
+
+        original = os.environ.copy()
+        try:
+            os.environ["OPENAI_BASE_URL"] = "http://shell-value/v1"
+
+            cfg.apply_to_env()
+
+            assert os.environ["OPENAI_BASE_URL"] == "http://shell-value/v1"
+        finally:
+            os.environ.clear()
+            os.environ.update(original)
+
+
+class TestLoadUserConfig:
+    def test_loads_openai_base_url(self, tmp_path):
+        path = tmp_path / "config.toml"
+        path.write_text("[provider]\n" 'openai_api_key = "local"\n' 'openai_base_url = "http://127.0.0.1:8000/v1"\n')
+
+        cfg = load_user_config(path)
+
+        assert cfg.provider.openai_base_url == "http://127.0.0.1:8000/v1"
+
+    def test_openai_base_url_defaults_none_when_absent(self, tmp_path):
+        path = tmp_path / "config.toml"
+        path.write_text('[provider]\nopenai_api_key = "local"\n')
+
+        cfg = load_user_config(path)
+
+        assert cfg.provider.openai_base_url is None
 
 
 class TestEnsureConfigTemplate:

--- a/user_config.py
+++ b/user_config.py
@@ -14,13 +14,13 @@ import tomllib
 from dataclasses import dataclass, field
 from pathlib import Path
 
-
 CONFIG_PATH = Path.home() / ".codeboarding" / "config.toml"
 
 # Mapping from config.toml key names to the env var each provider reads.
 # These are the canonical env var names used in agents/llm_config.py.
 _PROVIDER_KEY_TO_ENV: dict[str, str] = {
     "openai_api_key": "OPENAI_API_KEY",
+    "openai_base_url": "OPENAI_BASE_URL",
     "anthropic_api_key": "ANTHROPIC_API_KEY",
     "google_api_key": "GOOGLE_API_KEY",
     "vercel_api_key": "VERCEL_API_KEY",
@@ -44,6 +44,7 @@ CONFIG_TEMPLATE = """\
 
 [provider]
 # openai_api_key            = "sk-..."
+# openai_base_url           = "http://localhost:8000/v1"   # self-hosted / OpenAI-compatible proxy
 # anthropic_api_key         = "sk-ant-..."
 # google_api_key            = "AIza..."
 # vercel_api_key            = "vck_..."
@@ -69,6 +70,7 @@ class ProviderUserConfig:
     """Raw API key / URL values read from [provider] in config.toml."""
 
     openai_api_key: str | None = None
+    openai_base_url: str | None = None
     anthropic_api_key: str | None = None
     google_api_key: str | None = None
     vercel_api_key: str | None = None
@@ -115,6 +117,7 @@ def load_user_config(path: Path = CONFIG_PATH) -> UserConfig:
     return UserConfig(
         provider=ProviderUserConfig(
             openai_api_key=provider_data.get("openai_api_key") or None,
+            openai_base_url=provider_data.get("openai_base_url") or None,
             anthropic_api_key=provider_data.get("anthropic_api_key") or None,
             google_api_key=provider_data.get("google_api_key") or None,
             vercel_api_key=provider_data.get("vercel_api_key") or None,


### PR DESCRIPTION
Adds an `openai_base_url` field to the `[provider]` section of `config.toml`, so users who point the OpenAI client at a self-hosted or OpenAI-compatible endpoint (local inference server, gateway, or proxy) can configure it in one place instead of relying on an exported `OPENAI_BASE_URL` shell variable.

## Why

Today the OpenAI base URL can only be set through the environment. Projects that standardize on `config.toml` for provider/model settings have to special-case this one value via shell wrappers or exported env vars, which is easy to get wrong and inconsistent with how other provider settings are handled.

## What

- `user_config.py`: new `openai_base_url` field on `ProviderUserConfig`, loader wiring, and an entry in `_PROVIDER_KEY_TO_ENV` mapping it to the canonical `OPENAI_BASE_URL` env var.
- Commented template line in the generated `config.toml`.
- This mirrors the existing `ollama_base_url` handling exactly.

## Precedence

`apply_to_env()` does not overwrite an already-set environment variable, so an explicit `OPENAI_BASE_URL` in the shell still wins over the config value. Behavior is unchanged when the field is unset.

## Tests

- `apply_to_env` injects the configured base URL when no env var is set.
- An existing shell `OPENAI_BASE_URL` takes precedence.
- Loading from `config.toml` populates the field; absent -> `None`.

## Verification

Manually verified end-to-end against a local OpenAI-compatible server: with no `OPENAI_BASE_URL` set in the environment, requests routed to the base URL configured in `config.toml`.

---
This PR is independent of and can be merged before or after the companion timeouts PR; the only overlap is one adjacent commented template line in `config.toml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can set a custom OpenAI base URL in settings; environment variables (including shell) take precedence.
  * If a base URL is used without an API key, the app treats it as a keyless local endpoint and emits a warning (multiple-provider key conflicts still raise an error).

* **Tests**
  * Added comprehensive tests covering base-URL handling, precedence rules, and keyless-endpoint warning behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CodeBoarding/CodeBoarding/pull/345?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->