### PR TITLE
feat(llm): make agent and parsing timeouts configurable via config.toml

### DIFF
--- a/agents/agent.py
+++ b/agents/agent.py
@@ -21,7 +21,7 @@ from agents.validation import ValidationResult, score_validation_results, VALIDA
 from monitoring.mixin import MonitoringMixin
 from repo_utils.ignore import RepoIgnoreManager
 from agents.agent_responses import LLMBaseModel
-from agents.llm_config import MONITORING_CALLBACK
+from agents.llm_config import MONITORING_CALLBACK, get_agent_timeout
 from static_analyzer.analysis_result import StaticAnalysisResults
 from static_analyzer.reference_resolve_mixin import ReferenceResolverMixin
 
@@ -112,7 +112,7 @@ class CodeBoardingAgent(ReferenceResolverMixin, MonitoringMixin):
         def call_once() -> str:
             attempt = attempt_counter[0]
             attempt_counter[0] += 1
-            timeout_seconds = 300 if attempt == 0 else 600
+            timeout_seconds = get_agent_timeout(attempt)
             callback_list = (callbacks or []) + [MONITORING_CALLBACK, self.agent_monitoring_callback]
             logger.info(
                 f"Starting agent.invoke() [attempt {attempt + 1}/{max_attempts}] with prompt length: {len(prompt)}, timeout: {timeout_seconds}s"

--- a/agents/llm_config.py
+++ b/agents/llm_config.py
@@ -30,12 +30,22 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 _agent_model_override: str | None = None
 _parsing_model_override: str | None = None
+_agent_timeout_override: int | None = None
+_parsing_timeout_override: int | None = None
+
+# Default thread-join timeouts for the agent invoke loop (seconds).
+# First attempt is shorter; retries get the longer budget. Overridden as a
+# single flat value when agent_timeout_s is configured (see get_agent_timeout).
+_DEFAULT_AGENT_TIMEOUT_FIRST = 300
+_DEFAULT_AGENT_TIMEOUT_RETRY = 600
 
 
 def configure_models(
     agent_model: str | None = None,
     parsing_model: str | None = None,
     api_keys: dict[str, str] | None = None,
+    agent_timeout_s: int | None = None,
+    parsing_timeout_s: int | None = None,
 ) -> None:
     """Set process-wide model and provider overrides.  Call this once at startup.
 
@@ -46,6 +56,12 @@ def configure_models(
     Keys already present in the shell environment are never overwritten, so
     CI/CD pipelines that export keys directly retain full control.
 
+    ``agent_timeout_s`` overrides the agent invoke thread-join timeout (a single
+    flat value for every attempt). ``parsing_timeout_s`` overrides the parsing
+    model's HTTP client timeout. Both are optional; when unset the built-in
+    defaults apply. Useful for slow self-hosted / local backends whose
+    long-context completions exceed the default budgets.
+
     Priority (highest to lowest):
       1. Shell environment variables (set before the process starts)
       2. ``api_keys`` passed here  /  values from ~/.codeboarding/config.toml
@@ -53,12 +69,31 @@ def configure_models(
       4. Provider defaults defined in LLM_PROVIDERS
     """
     global _agent_model_override, _parsing_model_override
+    global _agent_timeout_override, _parsing_timeout_override
     _agent_model_override = agent_model
     _parsing_model_override = parsing_model
+    _agent_timeout_override = agent_timeout_s
+    _parsing_timeout_override = parsing_timeout_s
     if api_keys:
         for env_var, value in api_keys.items():
             if value and not os.environ.get(env_var):
                 os.environ[env_var] = value
+
+
+def get_agent_timeout(attempt: int) -> int:
+    """Thread-join timeout (seconds) for an agent invoke attempt.
+
+    When ``agent_timeout_s`` was configured, return it flat for every attempt
+    (B1a). Otherwise fall back to the default first/retry split.
+    """
+    if _agent_timeout_override is not None:
+        return _agent_timeout_override
+    return _DEFAULT_AGENT_TIMEOUT_FIRST if attempt == 0 else _DEFAULT_AGENT_TIMEOUT_RETRY
+
+
+def get_parsing_timeout() -> int | None:
+    """HTTP client timeout (seconds) for the parsing model, or None for no limit."""
+    return _parsing_timeout_override
 
 
 @dataclass
@@ -258,6 +293,7 @@ def _initialize_llm(
     temperature_attr: str,
     log_prefix: str,
     init_factory: bool = False,
+    apply_parsing_timeout: bool = False,
 ) -> tuple[BaseChatModel, str]:
     resolved = _resolve_active_provider(model_override, model_attr)
     if resolved is None:
@@ -287,6 +323,14 @@ def _initialize_llm(
         "temperature": getattr(config, temperature_attr),
     }
     kwargs.update(config.get_resolved_extra_args())
+
+    # Why: parsing calls have no thread-join wrapper (unlike the agent loop), so
+    # without an HTTP client timeout a slow backend can hang the parse step
+    # indefinitely. parsing_timeout_s, when set, bounds it.
+    if apply_parsing_timeout:
+        parsing_timeout = get_parsing_timeout()
+        if parsing_timeout is not None:
+            kwargs["timeout"] = parsing_timeout
 
     if name not in ["aws", "ollama"]:
         api_key = config.get_api_key()
@@ -343,7 +387,9 @@ def get_current_agent_context_window() -> ContextWindow:
 
 
 def initialize_parsing_llm(model_override: str | None = None) -> BaseChatModel:
-    model, _ = _initialize_llm(model_override, "parsing_model", "parsing_temperature", "Extractor ")
+    model, _ = _initialize_llm(
+        model_override, "parsing_model", "parsing_temperature", "Extractor ", apply_parsing_timeout=True
+    )
     return model
 
 

--- a/codeboarding_cli/bootstrap.py
+++ b/codeboarding_cli/bootstrap.py
@@ -40,7 +40,12 @@ def bootstrap_environment(output_dir: Path, binary_location: Path | None) -> Non
     ensure_config_template()
     user_cfg = load_user_config()
     user_cfg.apply_to_env()
-    configure_models(agent_model=user_cfg.llm.agent_model, parsing_model=user_cfg.llm.parsing_model)
+    configure_models(
+        agent_model=user_cfg.llm.agent_model,
+        parsing_model=user_cfg.llm.parsing_model,
+        agent_timeout_s=user_cfg.llm.agent_timeout_s,
+        parsing_timeout_s=user_cfg.llm.parsing_timeout_s,
+    )
     validate_api_key_provided()
     load_plugins(get_registries())
     if binary_location is not None:

--- a/tests/agents/test_llm_config_timeouts.py
+++ b/tests/agents/test_llm_config_timeouts.py
@@ -1,0 +1,73 @@
+import pytest
+
+from agents import llm_config
+from agents.llm_config import configure_models, get_agent_timeout, get_parsing_timeout
+
+
+@pytest.fixture(autouse=True)
+def reset_overrides():
+    """Restore module-level timeout overrides after each test."""
+    yield
+    configure_models()
+
+
+class TestAgentTimeout:
+    def test_defaults_to_300_first_600_retry_when_unset(self):
+        configure_models()
+
+        assert get_agent_timeout(0) == 300
+        assert get_agent_timeout(1) == 600
+        assert get_agent_timeout(2) == 600
+
+    def test_flat_override_applies_to_every_attempt(self):
+        configure_models(agent_timeout_s=1200)
+
+        assert get_agent_timeout(0) == 1200
+        assert get_agent_timeout(1) == 1200
+        assert get_agent_timeout(2) == 1200
+
+
+class TestParsingTimeout:
+    def test_none_when_unset(self):
+        configure_models()
+
+        assert get_parsing_timeout() is None
+
+    def test_returns_configured_value(self):
+        configure_models(parsing_timeout_s=900)
+
+        assert get_parsing_timeout() == 900
+
+    def test_injected_into_parsing_client_kwargs(self, monkeypatch):
+        """parsing_timeout_s must reach the chat client as timeout kwarg."""
+        captured = {}
+
+        class FakeChat:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+        cfg = llm_config.LLM_PROVIDERS["openai"]
+        monkeypatch.setattr(cfg, "chat_class", FakeChat)
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+        configure_models(parsing_timeout_s=900)
+
+        llm_config.initialize_parsing_llm("some-model")
+
+        assert captured.get("timeout") == 900
+
+    def test_no_timeout_kwarg_override_when_unset(self, monkeypatch):
+        captured = {}
+
+        class FakeChat:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+        cfg = llm_config.LLM_PROVIDERS["openai"]
+        monkeypatch.setattr(cfg, "chat_class", FakeChat)
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+        configure_models()
+
+        llm_config.initialize_parsing_llm("some-model")
+
+        # extra_args carries timeout=None for openai; unset override must not change it.
+        assert captured.get("timeout") is None

--- a/tests/test_user_config.py
+++ b/tests/test_user_config.py
@@ -1,6 +1,6 @@
 import os
 
-from user_config import ProviderUserConfig, UserConfig, ensure_config_template
+from user_config import ProviderUserConfig, UserConfig, ensure_config_template, load_user_config
 
 
 class TestUserConfigApplyToEnv:
@@ -96,3 +96,30 @@ class TestEnsureConfigTemplate:
         text = path.read_text()
         assert "[llm]" in text
         assert "context_window" in text
+
+
+class TestLoadUserConfig:
+    def test_loads_timeouts(self, tmp_path):
+        path = tmp_path / "config.toml"
+        path.write_text(
+            "[provider]\n"
+            'openai_api_key = "local"\n'
+            "\n[llm]\n"
+            'agent_model = "qwen"\n'
+            "agent_timeout_s = 1200\n"
+            "parsing_timeout_s = 900\n"
+        )
+
+        cfg = load_user_config(path)
+
+        assert cfg.llm.agent_timeout_s == 1200
+        assert cfg.llm.parsing_timeout_s == 900
+
+    def test_timeouts_default_none_when_absent(self, tmp_path):
+        path = tmp_path / "config.toml"
+        path.write_text('[llm]\nagent_model = "qwen"\n')
+
+        cfg = load_user_config(path)
+
+        assert cfg.llm.agent_timeout_s is None
+        assert cfg.llm.parsing_timeout_s is None

--- a/user_config.py
+++ b/user_config.py
@@ -14,7 +14,6 @@ import tomllib
 from dataclasses import dataclass, field
 from pathlib import Path
 
-
 CONFIG_PATH = Path.home() / ".codeboarding" / "config.toml"
 
 # Mapping from config.toml key names to the env var each provider reads.
@@ -61,6 +60,8 @@ CONFIG_TEMPLATE = """\
 # agent_model    = "google/gemini-3-flash-preview"
 # parsing_model  = "google/gemini-3.1-flash-lite-preview"
 # context_window = 272000   # override if needed
+# agent_timeout_s   = 1200   # thread-join timeout per agent invoke attempt (slow/local backends)
+# parsing_timeout_s = 1200   # HTTP client timeout for the parsing model
 """
 
 
@@ -86,6 +87,8 @@ class LLMUserConfig:
     agent_model: str | None = None
     parsing_model: str | None = None
     context_window: int | None = None
+    agent_timeout_s: int | None = None
+    parsing_timeout_s: int | None = None
 
 
 @dataclass
@@ -130,6 +133,8 @@ def load_user_config(path: Path = CONFIG_PATH) -> UserConfig:
             agent_model=llm_data.get("agent_model") or None,
             parsing_model=llm_data.get("parsing_model") or None,
             context_window=llm_data.get("context_window"),
+            agent_timeout_s=llm_data.get("agent_timeout_s"),
+            parsing_timeout_s=llm_data.get("parsing_timeout_s"),
         ),
     )
 


### PR DESCRIPTION
Adds two optional `[llm]` settings so users running slower or self-hosted backends can raise the timeouts without editing source.

## Why

The agent invoke timeout and the parsing model client timeout are currently hard-coded. On slower or local inference backends, large prompts (e.g. the cluster-grouping step) can exceed the built-in limit and fail, with no supported way to extend it short of patching the installed package.

While wiring this up I also noticed the parsing client was being constructed with **no timeout at all**, so a hung upstream could block indefinitely. This PR makes that an explicit, configurable value.

## What

- `agent_timeout_s` (optional): thread-join timeout applied to each `agent.invoke()` attempt.
- `parsing_timeout_s` (optional): HTTP client timeout for the parsing model.

Both thread through `configure_models()` into module-level settings read by `get_agent_timeout()` / `get_parsing_timeout()`. `agents/agent.py` and the CLI bootstrap use the accessors.

## Backward compatibility

Leaving both unset preserves prior behavior: the agent keeps its existing default, and the parsing client keeps its previous (no-timeout) construction — the timeout is applied only when explicitly configured.

## Files

- `user_config.py`: new fields + loader wiring + template comments.
- `agents/llm_config.py`: module globals, `configure_models` params, accessors, parsing-client timeout injection.
- `agents/agent.py`: use `get_agent_timeout(attempt)`.
- `codeboarding_cli/bootstrap.py`: pass configured timeouts through.
- tests: load/default coverage, accessor behavior, and parsing-client injection.

## Verification

Manually verified end-to-end against a slow local backend: `agent.invoke()` logs the configured timeout and the parsing client is constructed with it. Existing behavior confirmed unchanged when the settings are absent.

---
Independent of the companion `openai_base_url` PR; the only overlap is one adjacent commented template line in `config.toml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration file now supports timeout settings for agent and parsing operations, allowing users to customize how long these operations can run before timing out.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CodeBoarding/CodeBoarding/pull/346?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->