### PR TITLE
Fix C# LSP: launch crash on .NET-10-only hosts and per-csproj stall o…

### DIFF
--- a/static_analyzer/__init__.py
+++ b/static_analyzer/__init__.py
@@ -251,7 +251,7 @@ class StaticAnalyzer:
                 # via ``wait_for_workspace_ready`` so the language-name
                 # check doesn't keep growing.
                 if adapter.wait_for_workspace_ready:
-                    engine_client.wait_for_server_ready()
+                    engine_client.wait_for_server_ready(timeout=adapter.workspace_ready_timeout)
                     logger.info(f"{adapter.language} workspace ready: {time.monotonic() - t_lsp_started:.1f}s")
 
                 started.append((engine_config, engine_client))

--- a/static_analyzer/csharp_config_scanner.py
+++ b/static_analyzer/csharp_config_scanner.py
@@ -1,7 +1,7 @@
 """Scanner for C# / .NET project configurations.
 
-Detects solution files (.sln), project files (.csproj), and standalone
-C# source trees to support mono-repo analysis with csharp-ls.
+Detects solution files (.sln/.slnx), project files (.csproj), and
+standalone C# source trees to support mono-repo analysis with csharp-ls.
 """
 
 import logging
@@ -10,6 +10,8 @@ from pathlib import Path
 from repo_utils.ignore import RepoIgnoreManager
 
 logger = logging.getLogger(__name__)
+
+SOLUTION_GLOBS: tuple[str, ...] = ("*.sln", "*.slnx")
 
 
 class CSharpProjectConfig:
@@ -31,8 +33,10 @@ class CSharpConfigScanner:
     """Scan a repository for C# / .NET project configurations.
 
     Scanning priority:
-        1. ``.sln`` files — solution-level roots (csharp-ls uses these
-           to discover all referenced projects automatically).
+        1. ``.sln`` / ``.slnx`` files — solution-level roots (csharp-ls
+           uses these to discover all referenced projects automatically).
+           ``.slnx`` is the XML-based replacement Visual Studio adopted in
+           2024; modern .NET repos (e.g. Spectre.Console) ship only it.
         2. Standalone ``.csproj`` files not already covered by a solution.
         3. Fallback to the repository root when ``.cs`` files exist but
            no solution or project files are found.
@@ -64,15 +68,18 @@ class CSharpConfigScanner:
         # 3. Fallback: .cs files exist but no project infrastructure
         if not configs and self._has_cs_files(self.repo_path):
             logger.warning(
-                f"No .sln or .csproj found in {self.repo_path}, but C# files detected. Analysis will be limited."
+                f"No .sln/.slnx or .csproj found in {self.repo_path}, but C# files detected. Analysis will be limited."
             )
             configs.append(CSharpProjectConfig(self.repo_path, "none"))
 
         return configs
 
     def _find_solution_roots(self) -> list[Path]:
-        """Find directories containing .sln files."""
-        return sorted({p.parent for p in self.repo_path.rglob("*.sln") if p.is_file()})
+        """Find directories containing ``.sln`` or ``.slnx`` files."""
+        roots: set[Path] = set()
+        for pattern in SOLUTION_GLOBS:
+            roots.update(p.parent for p in self.repo_path.rglob(pattern) if p.is_file())
+        return sorted(roots)
 
     def _find_project_roots(self) -> list[Path]:
         """Find directories containing .csproj files."""

--- a/static_analyzer/engine/adapters/csharp_adapter.py
+++ b/static_analyzer/engine/adapters/csharp_adapter.py
@@ -120,6 +120,18 @@ class CSharpAdapter(LanguageAdapter):
         return True
 
     @property
+    def workspace_ready_timeout(self) -> int:
+        """csharp-ls 0.20.0 emits a solution-loaded notification only when
+        it finds a ``.sln``/``.slnx`` in the workspace folder. For
+        per-csproj launches (or when the Roslyn MSBuild loader silently
+        skips an unsupported format) it never emits anything. Cap the
+        wait at 60s so analysis proceeds promptly instead of stalling
+        the full default (300s) per discovered project — see
+        ``LSPClient.wait_for_server_ready``.
+        """
+        return 60
+
+    @property
     def probe_before_open(self) -> bool:
         """csharp-ls loads all files from the .sln — didOpen before workspace load kills it."""
         return True
@@ -196,22 +208,30 @@ class CSharpAdapter(LanguageAdapter):
             logger.warning("dotnet restore could not be invoked: %s", exc)
 
     def get_lsp_env(self) -> dict[str, str]:
-        """Set DOTNET_ROOT when not already in the environment.
+        """Set DOTNET_ROOT and DOTNET_ROLL_FORWARD when not already in the environment.
 
         csharp-ls requires the .NET runtime to be discoverable. On systems
         where the SDK is installed via a package manager (e.g. Homebrew on
         macOS), the ``DOTNET_ROOT`` variable may not be set, causing
         csharp-ls to fail at startup.  This resolves the runtime location
         from the ``dotnet`` binary on PATH.
+
+        DOTNET_ROLL_FORWARD=Major: csharp-ls 0.20.0 on NuGet only ships a
+        net9.0 build (no net10.0 tools/), so ``dotnet tool install --framework
+        net10.0`` silently produces a binary whose runtimeconfig pins
+        Microsoft.NETCore.App 9.0.0. Without rollForward, exit code 150 on
+        systems that have only the .NET 10 runtime.
         """
-        if os.environ.get("DOTNET_ROOT"):
-            return {}
-        dotnet = shutil.which("dotnet")
-        if dotnet:
-            dotnet_root = Path(dotnet).resolve().parent.parent / "libexec"
-            if dotnet_root.is_dir():
-                return {"DOTNET_ROOT": str(dotnet_root)}
-        return {}
+        env: dict[str, str] = {}
+        if not os.environ.get("DOTNET_ROOT"):
+            dotnet = shutil.which("dotnet")
+            if dotnet:
+                dotnet_root = Path(dotnet).resolve().parent.parent / "libexec"
+                if dotnet_root.is_dir():
+                    env["DOTNET_ROOT"] = str(dotnet_root)
+        if not os.environ.get("DOTNET_ROLL_FORWARD"):
+            env["DOTNET_ROLL_FORWARD"] = "Major"
+        return env
 
     def is_reference_worthy(self, symbol_kind: int) -> bool:
         """Include namespaces in reference tracking (similar to PHP modules)."""

--- a/static_analyzer/engine/language_adapter.py
+++ b/static_analyzer/engine/language_adapter.py
@@ -169,6 +169,19 @@ class LanguageAdapter(ABC):
         return False
 
     @property
+    def workspace_ready_timeout(self) -> int:
+        """Seconds to wait for the workspace-ready signal before proceeding anyway.
+
+        Only consulted when ``wait_for_workspace_ready`` is True. The
+        default (300s = 5 min) matches the ``LSPClient.wait_for_server_ready``
+        default and is sized for slow Roslyn/JDT workspace loads on large
+        repos. Adapters whose readiness signal is unreliable (or whose
+        per-project workspaces are small) should override with a shorter
+        value so analysis proceeds promptly without it.
+        """
+        return 300
+
+    @property
     def probe_before_open(self) -> bool:
         """If True, send the sync probe BEFORE bulk didOpen notifications.
 

--- a/tests/static_analyzer/test_csharp_adapter.py
+++ b/tests/static_analyzer/test_csharp_adapter.py
@@ -235,17 +235,28 @@ class TestLspConfiguration:
         adapter = CSharpAdapter()
         assert adapter.get_probe_timeout_minimum() > 300
 
+    def test_workspace_ready_timeout_shorter_than_default(self):
+        # Why: csharp-ls's solution-loaded notification only fires when a
+        # .sln/.slnx is found in the workspace folder. The default 300s
+        # wait stalls analysis when the notification never arrives.
+        adapter = CSharpAdapter()
+        assert adapter.workspace_ready_timeout < 300
+
 
 class TestLspEnv:
-    """Tests for DOTNET_ROOT resolution."""
+    """Tests for DOTNET_ROOT and DOTNET_ROLL_FORWARD resolution."""
 
-    def test_returns_empty_when_dotnet_root_set(self, monkeypatch):
+    def test_skips_dotnet_root_when_already_set(self, monkeypatch):
         monkeypatch.setenv("DOTNET_ROOT", "/usr/share/dotnet")
+        monkeypatch.delenv("DOTNET_ROLL_FORWARD", raising=False)
         adapter = CSharpAdapter()
-        assert adapter.get_lsp_env() == {}
+        env = adapter.get_lsp_env()
+        assert "DOTNET_ROOT" not in env
+        assert env.get("DOTNET_ROLL_FORWARD") == "Major"
 
     def test_resolves_dotnet_root_from_path(self, monkeypatch, tmp_path):
         monkeypatch.delenv("DOTNET_ROOT", raising=False)
+        monkeypatch.delenv("DOTNET_ROLL_FORWARD", raising=False)
         # Simulate Homebrew layout: bin/dotnet -> Cellar/.../libexec/dotnet
         libexec = tmp_path / "opt" / "dotnet" / "libexec"
         libexec.mkdir(parents=True)
@@ -259,11 +270,28 @@ class TestLspEnv:
         env = adapter.get_lsp_env()
         assert env.get("DOTNET_ROOT") == str(libexec)
 
-    def test_returns_empty_when_dotnet_not_found(self, monkeypatch):
+    def test_skips_dotnet_root_when_dotnet_not_found(self, monkeypatch):
         monkeypatch.delenv("DOTNET_ROOT", raising=False)
+        monkeypatch.delenv("DOTNET_ROLL_FORWARD", raising=False)
         monkeypatch.setattr("shutil.which", lambda _: None)
         adapter = CSharpAdapter()
-        assert adapter.get_lsp_env() == {}
+        env = adapter.get_lsp_env()
+        assert "DOTNET_ROOT" not in env
+
+    def test_sets_roll_forward_when_unset(self, monkeypatch):
+        # Why: csharp-ls 0.20.0 nupkg ships only tools/net9.0/, so the
+        # installed binary pins Microsoft.NETCore.App 9.0.0. Without
+        # DOTNET_ROLL_FORWARD=Major it exits 150 on .NET-10-only hosts.
+        monkeypatch.delenv("DOTNET_ROLL_FORWARD", raising=False)
+        monkeypatch.setenv("DOTNET_ROOT", "/usr/share/dotnet")
+        adapter = CSharpAdapter()
+        assert adapter.get_lsp_env()["DOTNET_ROLL_FORWARD"] == "Major"
+
+    def test_preserves_user_roll_forward(self, monkeypatch):
+        monkeypatch.setenv("DOTNET_ROLL_FORWARD", "LatestMajor")
+        monkeypatch.setenv("DOTNET_ROOT", "/usr/share/dotnet")
+        adapter = CSharpAdapter()
+        assert "DOTNET_ROLL_FORWARD" not in adapter.get_lsp_env()
 
 
 class TestReferenceTracking:

--- a/tests/static_analyzer/test_csharp_config_scanner.py
+++ b/tests/static_analyzer/test_csharp_config_scanner.py
@@ -37,6 +37,24 @@ class TestCSharpConfigScanner:
         assert projects[0].root == tmp_path
         assert projects[0].project_type == "solution"
 
+    def test_scan_slnx_solution_file(self, tmp_path: Path):
+        """``.slnx`` is the XML-based replacement for ``.sln`` adopted by
+        Visual Studio in 2024. Modern .NET repos (e.g. Spectre.Console)
+        ship only the .slnx; missing it caused per-csproj LSP launches
+        that stall on csharp-ls's solution-loaded notification.
+        """
+        (tmp_path / "MyApp.slnx").write_text("<Solution/>")
+        sub = tmp_path / "src" / "Api"
+        sub.mkdir(parents=True)
+        (sub / "Api.csproj").write_text("<Project/>")
+
+        scanner = CSharpConfigScanner(tmp_path)
+        projects = scanner.scan()
+
+        assert len(projects) == 1
+        assert projects[0].root == tmp_path
+        assert projects[0].project_type == "solution"
+
     def test_scan_csproj_file(self, tmp_path: Path):
         (tmp_path / "MyApp.csproj").write_text('<Project Sdk="Microsoft.NET.Sdk"/>')
         scanner = CSharpConfigScanner(tmp_path)

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -1642,13 +1642,19 @@ class TestInstallPackageManagerTools(unittest.TestCase):
         assert isinstance(csharp.source, PackageManagerToolSource)
         self.assertIn(csharp.source.tag, tools_fingerprint())
 
-    def test_csharp_registry_targets_net10_framework(self):
-        """C# package-manager install must target .NET 10 during full migration."""
+    def test_csharp_registry_targets_net9_framework(self):
+        """C# install must request net9.0 because csharp-ls 0.20.0 ships
+        only ``tools/net9.0/``. Asking for net10.0 is silently downgraded
+        and obscures what was actually installed. The runtime-side
+        ``DOTNET_ROLL_FORWARD=Major`` env var (set by ``CSharpAdapter``)
+        is what lets the resulting net9.0 binary run on a host with only
+        the .NET 10 runtime.
+        """
         csharp = next(d for d in TOOL_REGISTRY if d.key == "csharp")
         assert isinstance(csharp.source, PackageManagerToolSource)
         self.assertIn("--framework", csharp.source.install_args)
         framework_idx = csharp.source.install_args.index("--framework") + 1
-        self.assertEqual(csharp.source.install_args[framework_idx], "net10.0")
+        self.assertEqual(csharp.source.install_args[framework_idx], "net9.0")
 
 
 if __name__ == "__main__":

--- a/tool_registry/registry.py
+++ b/tool_registry/registry.py
@@ -214,9 +214,14 @@ TOOL_REGISTRY: list[ToolDependency] = [
     ),
     # csharp-ls ships only as a NuGet dotnet-tool; installed via ``dotnet tool install``.
     # Pinned 0.20.0: 0.21.0+ has a malformed NuGet upstream.
-    # During .NET 10 migration we request ``--framework net10.0``; ``--tool-path``
-    # avoids a misleading "DotnetToolSettings.xml not found" error when no local
-    # manifest is present.
+    # ``--framework net9.0`` matches what the 0.20.0 nupkg actually ships
+    # (only ``tools/net9.0/`` is present); ``--framework net10.0`` is
+    # silently ignored and produces the same net9.0 binary. The launched
+    # binary's runtimeconfig pins ``Microsoft.NETCore.App 9.0.0``; the
+    # CSharpAdapter sets ``DOTNET_ROLL_FORWARD=Major`` at launch so hosts
+    # with only the .NET 10 runtime can still run it. ``--tool-path``
+    # avoids a misleading "DotnetToolSettings.xml not found" error when no
+    # local manifest is present.
     ToolDependency(
         key="csharp",
         binary_name="csharp-ls",
@@ -232,7 +237,7 @@ TOOL_REGISTRY: list[ToolDependency] = [
                 "--version",
                 "{tag}",
                 "--framework",
-                "net10.0",
+                "net9.0",
                 "--tool-path",
                 "{tool_path}",
             ),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for modern Visual Studio solution format (`.slnx`) alongside traditional `.sln` files in C# project detection.
  * Implemented explicit workspace readiness timeout for C# language server (60 seconds) with fallback default (300 seconds) to improve startup reliability.

* **Chores**
  * Updated C# language server tool target to .NET 9 framework.
  * Enhanced .NET runtime environment configuration with automatic `DOTNET_ROLL_FORWARD` setting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CodeBoarding/CodeBoarding/pull/349?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->