### PR TITLE
fix(installer): SHA-verify existing native binaries against the registry pin

### DIFF
--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -1828,6 +1828,40 @@ class TestInstallNativeToolsPinDrift(unittest.TestCase):
             mock_dl.assert_called_once()
             self.assertEqual(stale.read_bytes(), new_payload)
 
+    def test_missing_platform_pin_aborts_batch_before_later_deps(self):
+        missing_pin_dep = ToolDependency(
+            key="tokei",
+            binary_name="tokei",
+            kind=ToolKind.NATIVE,
+            config_section=ConfigSection.TOOLS,
+            source=GitHubToolSource(
+                tag="tools-2026.04.05",
+                repo="CodeBoarding/tools",
+                asset_template="tokei-{platform_suffix}",
+                sha256={"macos": "0" * 64},
+            ),
+        )
+        later_dep = ToolDependency(
+            key="go",
+            binary_name="gopls",
+            kind=ToolKind.NATIVE,
+            config_section=ConfigSection.LSP_SERVERS,
+            source=GitHubToolSource(
+                tag="tools-2026.04.05",
+                repo="CodeBoarding/tools",
+                asset_template="gopls-{platform_suffix}",
+                sha256={"linux": "1" * 64},
+            ),
+        )
+
+        with tempfile.TemporaryDirectory() as tmp, self._patched_linux():
+            with (
+                self.assertRaisesRegex(ValueError, "missing SHA256 pin"),
+                patch("tool_registry.installers.download_asset") as mock_dl,
+            ):
+                install_native_tools(Path(tmp), [missing_pin_dep, later_dep])
+            mock_dl.assert_not_called()
+
     def test_no_pin_skips_with_caveat(self):
         """When the registry has no SHA for this platform we cannot verify,
         so the existing binary is trusted (legacy behavior preserved)."""

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -48,6 +48,7 @@ from tool_registry import PackageManagerToolSource
 from tool_registry.installers import (
     _existing_binary_is_usable,
     _extract_compressed_binary,
+    _resolve_native_download_hash,
     install_package_manager_tools,
     package_manager_tool_dir,
     resolve_native_asset_name,
@@ -1654,32 +1655,7 @@ class TestInstallPackageManagerTools(unittest.TestCase):
 
 
 class TestExistingBinaryIsUsable(unittest.TestCase):
-    """Focused tests for the drift-check helper used by install_native_tools.
-
-    These exercise the predicate (and its side-effect of deleting the file
-    on mismatch) in isolation — no platform mocking, no download mocking.
-    ``TestInstallNativeToolsPinDrift`` below covers the same logic
-    end-to-end through ``install_native_tools``.
-    """
-
-    def test_compressed_skips_without_reading_file(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            path = Path(tmp) / "rust-analyzer"
-            path.write_bytes(b"would mismatch any hash")
-            usable = _existing_binary_is_usable(
-                path, expected_hash="0" * 64, compressed=True, binary_name="rust-analyzer"
-            )
-        self.assertTrue(usable)
-        # File is preserved — we did not even try to verify.
-        # (Asserting via the bytes we just wrote would be racy after the
-        # tempdir teardown, so we trust the True return as the contract.)
-
-    def test_no_pin_skips_without_reading_file(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            path = Path(tmp) / "tokei"
-            path.write_bytes(b"unpinned")
-            self.assertTrue(_existing_binary_is_usable(path, expected_hash=None, compressed=False, binary_name="tokei"))
-            self.assertTrue(path.exists())
+    """Focused tests for the drift-check helper used by install_native_tools."""
 
     def test_matching_sha_returns_true_and_preserves_file(self):
         payload = b"binary bytes" * 100
@@ -1687,29 +1663,38 @@ class TestExistingBinaryIsUsable(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / "tokei"
             path.write_bytes(payload)
-            self.assertTrue(_existing_binary_is_usable(path, expected_hash=sha, compressed=False, binary_name="tokei"))
+            self.assertTrue(_existing_binary_is_usable(path, expected_hash=sha, binary_name="tokei"))
             self.assertEqual(path.read_bytes(), payload)
 
-    def test_drifted_sha_returns_false_and_deletes_file(self):
+    def test_drifted_sha_returns_false_and_preserves_file(self):
         payload = b"stale binary"
         wrong_sha = hashlib.sha256(b"different bytes").hexdigest()
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / "tokei"
             path.write_bytes(payload)
-            self.assertFalse(
-                _existing_binary_is_usable(path, expected_hash=wrong_sha, compressed=False, binary_name="tokei")
-            )
-            self.assertFalse(path.exists())
+            self.assertFalse(_existing_binary_is_usable(path, expected_hash=wrong_sha, binary_name="tokei"))
+            self.assertEqual(path.read_bytes(), payload)
 
-    def test_unreadable_file_returns_false_and_deletes_file(self):
+    def test_unreadable_file_returns_false_and_preserves_file(self):
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / "tokei"
             path.write_bytes(b"x")
             with patch.object(Path, "read_bytes", side_effect=OSError("simulated")):
-                self.assertFalse(
-                    _existing_binary_is_usable(path, expected_hash="0" * 64, compressed=False, binary_name="tokei")
-                )
-            self.assertFalse(path.exists())
+                self.assertFalse(_existing_binary_is_usable(path, expected_hash="0" * 64, binary_name="tokei"))
+            self.assertTrue(path.exists())
+
+
+class TestResolveNativeDownloadHash(unittest.TestCase):
+    def test_missing_platform_pin_raises_for_preextracted_asset(self):
+        source = GitHubToolSource(
+            tag="tools-2026.04.05",
+            repo="CodeBoarding/tools",
+            asset_template="tokei-{platform_suffix}",
+            sha256={"macos": "0" * 64},
+        )
+
+        with self.assertRaisesRegex(ValueError, "missing SHA256 pin"):
+            _resolve_native_download_hash(source, "tokei-linux", compressed=False, platform_suffix="linux")
 
 
 class TestInstallNativeToolsPinDrift(unittest.TestCase):
@@ -1751,7 +1736,7 @@ class TestInstallNativeToolsPinDrift(unittest.TestCase):
             yield
 
     def test_matching_sha_skips_download(self):
-        """The happy path: on-disk hash equals the pin → no network call."""
+        """The happy path: on-disk hash equals the pin, so no network call."""
         payload = b"fresh tokei bytes" * 100
         dep = self._make_dep(sha=hashlib.sha256(payload).hexdigest())
 

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -45,6 +45,7 @@ from tool_registry import (
 )
 from tool_registry import PackageManagerToolSource
 from tool_registry.installers import (
+    _existing_binary_is_usable,
     _extract_compressed_binary,
     install_package_manager_tools,
     package_manager_tool_dir,
@@ -1649,6 +1650,65 @@ class TestInstallPackageManagerTools(unittest.TestCase):
         self.assertIn("--framework", csharp.source.install_args)
         framework_idx = csharp.source.install_args.index("--framework") + 1
         self.assertEqual(csharp.source.install_args[framework_idx], "net10.0")
+
+
+class TestExistingBinaryIsUsable(unittest.TestCase):
+    """Focused tests for the drift-check helper used by install_native_tools.
+
+    These exercise the predicate (and its side-effect of deleting the file
+    on mismatch) in isolation — no platform mocking, no download mocking.
+    ``TestInstallNativeToolsPinDrift`` below covers the same logic
+    end-to-end through ``install_native_tools``.
+    """
+
+    def test_compressed_skips_without_reading_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "rust-analyzer"
+            path.write_bytes(b"would mismatch any hash")
+            usable = _existing_binary_is_usable(
+                path, expected_hash="0" * 64, compressed=True, binary_name="rust-analyzer"
+            )
+        self.assertTrue(usable)
+        # File is preserved — we did not even try to verify.
+        # (Asserting via the bytes we just wrote would be racy after the
+        # tempdir teardown, so we trust the True return as the contract.)
+
+    def test_no_pin_skips_without_reading_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "tokei"
+            path.write_bytes(b"unpinned")
+            self.assertTrue(_existing_binary_is_usable(path, expected_hash=None, compressed=False, binary_name="tokei"))
+            self.assertTrue(path.exists())
+
+    def test_matching_sha_returns_true_and_preserves_file(self):
+        payload = b"binary bytes" * 100
+        sha = hashlib.sha256(payload).hexdigest()
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "tokei"
+            path.write_bytes(payload)
+            self.assertTrue(_existing_binary_is_usable(path, expected_hash=sha, compressed=False, binary_name="tokei"))
+            self.assertEqual(path.read_bytes(), payload)
+
+    def test_drifted_sha_returns_false_and_deletes_file(self):
+        payload = b"stale binary"
+        wrong_sha = hashlib.sha256(b"different bytes").hexdigest()
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "tokei"
+            path.write_bytes(payload)
+            self.assertFalse(
+                _existing_binary_is_usable(path, expected_hash=wrong_sha, compressed=False, binary_name="tokei")
+            )
+            self.assertFalse(path.exists())
+
+    def test_unreadable_file_returns_false_and_deletes_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "tokei"
+            path.write_bytes(b"x")
+            with patch.object(Path, "read_bytes", side_effect=OSError("simulated")):
+                self.assertFalse(
+                    _existing_binary_is_usable(path, expected_hash="0" * 64, compressed=False, binary_name="tokei")
+                )
+            self.assertFalse(path.exists())
 
 
 class TestInstallNativeToolsPinDrift(unittest.TestCase):

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -1,3 +1,4 @@
+import contextlib
 import gzip
 import hashlib
 import io
@@ -1734,69 +1735,55 @@ class TestInstallNativeToolsPinDrift(unittest.TestCase):
             ),
         )
 
-    def _platform_patches(self):
-        """Return a list of patches that pin the test host to Linux/x86_64.
+    @contextlib.contextmanager
+    def _patched_linux(self):
+        """Pin all three platform call sites the installer touches to Linux/x86_64.
 
-        Used as a unit, never split across separate ``with`` statements —
-        all three must enter together so the in-installer ``platform_bin_dir``
-        call resolves to ``target_dir/bin/linux`` consistently with the
-        pre-created on-disk binary.
+        Entered around the entire test body so ``platform_bin_dir`` resolves
+        consistently to ``<target_dir>/bin/linux`` for both the pre-created
+        on-disk binary and the in-installer lookup.
         """
-        return [
+        with (
             patch("tool_registry.installers.platform.system", return_value="Linux"),
             patch("tool_registry.installers.platform.machine", return_value="x86_64"),
             patch("tool_registry.paths.platform.system", return_value="Linux"),
-        ]
-
-    def _bin_dir_under(self, target_dir: Path) -> Path:
-        """Resolve the Linux ``bin_dir`` the installer will see under our patches.
-
-        Done as a callable so the test body computes it ONLY after the patches
-        are active — otherwise ``platform_bin_dir`` resolves against the host
-        platform and writes the pre-existing binary in the wrong subdir.
-        """
-        with patch("tool_registry.paths.platform.system", return_value="Linux"):
-            return platform_bin_dir(target_dir)
+        ):
+            yield
 
     def test_matching_sha_skips_download(self):
         """The happy path: on-disk hash equals the pin → no network call."""
         payload = b"fresh tokei bytes" * 100
-        sha = hashlib.sha256(payload).hexdigest()
-        dep = self._make_dep(sha=sha)
+        dep = self._make_dep(sha=hashlib.sha256(payload).hexdigest())
 
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory() as tmp, self._patched_linux():
             target_dir = Path(tmp)
-            bin_dir = self._bin_dir_under(target_dir)
+            bin_dir = platform_bin_dir(target_dir)
             bin_dir.mkdir(parents=True, exist_ok=True)
             (bin_dir / "tokei").write_bytes(payload)
 
-            p1, p2, p3 = self._platform_patches()
-            with p1, p2, p3, patch("tool_registry.installers.download_asset") as mock_dl:
+            with patch("tool_registry.installers.download_asset") as mock_dl:
                 install_native_tools(target_dir, [dep])
             mock_dl.assert_not_called()
             self.assertEqual((bin_dir / "tokei").read_bytes(), payload)
 
     def test_drifted_sha_triggers_reinstall(self):
         """The motivating case: pin moved upstream, on-disk binary is stale."""
-        stale_payload = b"stale tokei v12.1.2" * 50
         new_payload = b"fresh tokei v14.0.0" * 50
-        new_sha = hashlib.sha256(new_payload).hexdigest()
-        dep = self._make_dep(sha=new_sha)
+        dep = self._make_dep(sha=hashlib.sha256(new_payload).hexdigest())
 
         def fake_download(url, destination, expected_sha256=None):
             destination.parent.mkdir(parents=True, exist_ok=True)
             destination.write_bytes(new_payload)
             return True
 
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory() as tmp, self._patched_linux():
             target_dir = Path(tmp)
-            bin_dir = self._bin_dir_under(target_dir)
+            bin_dir = platform_bin_dir(target_dir)
             bin_dir.mkdir(parents=True, exist_ok=True)
             stale = bin_dir / "tokei"
-            stale.write_bytes(stale_payload)
+            stale.write_bytes(b"stale tokei v12.1.2" * 50)
 
-            p1, p2, p3 = self._platform_patches()
-            with p1, p2, p3, patch("tool_registry.installers.download_asset", side_effect=fake_download) as mock_dl:
+            with patch("tool_registry.installers.download_asset", side_effect=fake_download) as mock_dl:
                 install_native_tools(target_dir, [dep])
             mock_dl.assert_called_once()
             self.assertEqual(stale.read_bytes(), new_payload)
@@ -1805,16 +1792,14 @@ class TestInstallNativeToolsPinDrift(unittest.TestCase):
         """When the registry has no SHA for this platform we cannot verify,
         so the existing binary is trusted (legacy behavior preserved)."""
         dep = self._make_dep(sha=None)
-        payload = b"unpinned binary"
 
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory() as tmp, self._patched_linux():
             target_dir = Path(tmp)
-            bin_dir = self._bin_dir_under(target_dir)
+            bin_dir = platform_bin_dir(target_dir)
             bin_dir.mkdir(parents=True, exist_ok=True)
-            (bin_dir / "tokei").write_bytes(payload)
+            (bin_dir / "tokei").write_bytes(b"unpinned binary")
 
-            p1, p2, p3 = self._platform_patches()
-            with p1, p2, p3, patch("tool_registry.installers.download_asset") as mock_dl:
+            with patch("tool_registry.installers.download_asset") as mock_dl:
                 install_native_tools(target_dir, [dep])
             mock_dl.assert_not_called()
 
@@ -1823,17 +1808,16 @@ class TestInstallNativeToolsPinDrift(unittest.TestCase):
         not skip — reinstall defensively rather than report a broken file
         as healthy."""
         new_payload = b"reinstalled binary"
-        new_sha = hashlib.sha256(new_payload).hexdigest()
-        dep = self._make_dep(sha=new_sha)
+        dep = self._make_dep(sha=hashlib.sha256(new_payload).hexdigest())
 
         def fake_download(url, destination, expected_sha256=None):
             destination.parent.mkdir(parents=True, exist_ok=True)
             destination.write_bytes(new_payload)
             return True
 
-        with tempfile.TemporaryDirectory() as tmp:
+        with tempfile.TemporaryDirectory() as tmp, self._patched_linux():
             target_dir = Path(tmp)
-            bin_dir = self._bin_dir_under(target_dir)
+            bin_dir = platform_bin_dir(target_dir)
             bin_dir.mkdir(parents=True, exist_ok=True)
             existing = bin_dir / "tokei"
             existing.write_bytes(b"x")
@@ -1845,11 +1829,7 @@ class TestInstallNativeToolsPinDrift(unittest.TestCase):
                     raise OSError("permission denied (simulated)")
                 return real_read_bytes(self)
 
-            p1, p2, p3 = self._platform_patches()
             with (
-                p1,
-                p2,
-                p3,
                 patch("tool_registry.installers.download_asset", side_effect=fake_download) as mock_dl,
                 patch.object(Path, "read_bytes", selective_read_bytes),
             ):

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -1651,5 +1651,152 @@ class TestInstallPackageManagerTools(unittest.TestCase):
         self.assertEqual(csharp.source.install_args[framework_idx], "net10.0")
 
 
+class TestInstallNativeToolsPinDrift(unittest.TestCase):
+    """Existing on-disk binaries are SHA-verified against the registry pin.
+
+    Why: the original ``if binary_path.exists(): skip`` shortcut meant a user
+    who installed CodeBoarding before a tools-repo re-cut kept their stale
+    binary forever — pin bumps in ``registry.py`` were silently ignored. The
+    fix re-fetches on hash mismatch so users converge on the pinned artifact.
+    """
+
+    def _make_dep(self, sha: str | None = None) -> ToolDependency:
+        return ToolDependency(
+            key="tokei",
+            binary_name="tokei",
+            kind=ToolKind.NATIVE,
+            config_section=ConfigSection.TOOLS,
+            source=GitHubToolSource(
+                tag="tools-2026.04.05",
+                repo="CodeBoarding/tools",
+                asset_template="tokei-{platform_suffix}",
+                sha256={"linux": sha} if sha else {},
+            ),
+        )
+
+    def _platform_patches(self):
+        """Return a list of patches that pin the test host to Linux/x86_64.
+
+        Used as a unit, never split across separate ``with`` statements —
+        all three must enter together so the in-installer ``platform_bin_dir``
+        call resolves to ``target_dir/bin/linux`` consistently with the
+        pre-created on-disk binary.
+        """
+        return [
+            patch("tool_registry.installers.platform.system", return_value="Linux"),
+            patch("tool_registry.installers.platform.machine", return_value="x86_64"),
+            patch("tool_registry.paths.platform.system", return_value="Linux"),
+        ]
+
+    def _bin_dir_under(self, target_dir: Path) -> Path:
+        """Resolve the Linux ``bin_dir`` the installer will see under our patches.
+
+        Done as a callable so the test body computes it ONLY after the patches
+        are active — otherwise ``platform_bin_dir`` resolves against the host
+        platform and writes the pre-existing binary in the wrong subdir.
+        """
+        with patch("tool_registry.paths.platform.system", return_value="Linux"):
+            return platform_bin_dir(target_dir)
+
+    def test_matching_sha_skips_download(self):
+        """The happy path: on-disk hash equals the pin → no network call."""
+        payload = b"fresh tokei bytes" * 100
+        sha = hashlib.sha256(payload).hexdigest()
+        dep = self._make_dep(sha=sha)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            target_dir = Path(tmp)
+            bin_dir = self._bin_dir_under(target_dir)
+            bin_dir.mkdir(parents=True, exist_ok=True)
+            (bin_dir / "tokei").write_bytes(payload)
+
+            p1, p2, p3 = self._platform_patches()
+            with p1, p2, p3, patch("tool_registry.installers.download_asset") as mock_dl:
+                install_native_tools(target_dir, [dep])
+            mock_dl.assert_not_called()
+            self.assertEqual((bin_dir / "tokei").read_bytes(), payload)
+
+    def test_drifted_sha_triggers_reinstall(self):
+        """The motivating case: pin moved upstream, on-disk binary is stale."""
+        stale_payload = b"stale tokei v12.1.2" * 50
+        new_payload = b"fresh tokei v14.0.0" * 50
+        new_sha = hashlib.sha256(new_payload).hexdigest()
+        dep = self._make_dep(sha=new_sha)
+
+        def fake_download(url, destination, expected_sha256=None):
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            destination.write_bytes(new_payload)
+            return True
+
+        with tempfile.TemporaryDirectory() as tmp:
+            target_dir = Path(tmp)
+            bin_dir = self._bin_dir_under(target_dir)
+            bin_dir.mkdir(parents=True, exist_ok=True)
+            stale = bin_dir / "tokei"
+            stale.write_bytes(stale_payload)
+
+            p1, p2, p3 = self._platform_patches()
+            with p1, p2, p3, patch("tool_registry.installers.download_asset", side_effect=fake_download) as mock_dl:
+                install_native_tools(target_dir, [dep])
+            mock_dl.assert_called_once()
+            self.assertEqual(stale.read_bytes(), new_payload)
+
+    def test_no_pin_skips_with_caveat(self):
+        """When the registry has no SHA for this platform we cannot verify,
+        so the existing binary is trusted (legacy behavior preserved)."""
+        dep = self._make_dep(sha=None)
+        payload = b"unpinned binary"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            target_dir = Path(tmp)
+            bin_dir = self._bin_dir_under(target_dir)
+            bin_dir.mkdir(parents=True, exist_ok=True)
+            (bin_dir / "tokei").write_bytes(payload)
+
+            p1, p2, p3 = self._platform_patches()
+            with p1, p2, p3, patch("tool_registry.installers.download_asset") as mock_dl:
+                install_native_tools(target_dir, [dep])
+            mock_dl.assert_not_called()
+
+    def test_unreadable_existing_binary_triggers_reinstall(self):
+        """If we cannot read the on-disk binary (permissions, FS error), do
+        not skip — reinstall defensively rather than report a broken file
+        as healthy."""
+        new_payload = b"reinstalled binary"
+        new_sha = hashlib.sha256(new_payload).hexdigest()
+        dep = self._make_dep(sha=new_sha)
+
+        def fake_download(url, destination, expected_sha256=None):
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            destination.write_bytes(new_payload)
+            return True
+
+        with tempfile.TemporaryDirectory() as tmp:
+            target_dir = Path(tmp)
+            bin_dir = self._bin_dir_under(target_dir)
+            bin_dir.mkdir(parents=True, exist_ok=True)
+            existing = bin_dir / "tokei"
+            existing.write_bytes(b"x")
+
+            real_read_bytes = Path.read_bytes
+
+            def selective_read_bytes(self):
+                if self == existing:
+                    raise OSError("permission denied (simulated)")
+                return real_read_bytes(self)
+
+            p1, p2, p3 = self._platform_patches()
+            with (
+                p1,
+                p2,
+                p3,
+                patch("tool_registry.installers.download_asset", side_effect=fake_download) as mock_dl,
+                patch.object(Path, "read_bytes", selective_read_bytes),
+            ):
+                install_native_tools(target_dir, [dep])
+            mock_dl.assert_called_once()
+            self.assertEqual(existing.read_bytes(), new_payload)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -1350,6 +1350,61 @@ class TestInstallNativeToolsCompressed(unittest.TestCase):
                 mode = installed.stat().st_mode & 0o777
                 self.assertEqual(mode & 0o111, 0o111)
 
+    def test_existing_compressed_asset_is_refetched(self):
+        dep = self._make_compressed_dep("rust-analyzer-x86_64-unknown-linux-gnu.gz")
+        old_payload = b"\x7fELFold-rust-analyzer"
+        new_payload = b"\x7fELFnew-rust-analyzer"
+
+        def fake_download(url: str, destination: Path, expected_sha256: str | None = None) -> bool:
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            with gzip.open(destination, "wb") as f:
+                f.write(new_payload)
+            return True
+
+        with tempfile.TemporaryDirectory() as tmp:
+            target_dir = Path(tmp)
+            with (
+                patch("tool_registry.installers.platform.system", return_value="Linux"),
+                patch("tool_registry.installers.platform.machine", return_value="x86_64"),
+                patch("tool_registry.paths.platform.system", return_value="Linux"),
+            ):
+                bin_dir = platform_bin_dir(target_dir)
+                bin_dir.mkdir(parents=True, exist_ok=True)
+                installed = bin_dir / "rust-analyzer"
+                installed.write_bytes(old_payload)
+
+                with (
+                    self.assertLogs("tool_registry.installers", level="INFO") as logs,
+                    patch("tool_registry.installers.download_asset", side_effect=fake_download) as mock_dl,
+                ):
+                    install_native_tools(target_dir, [dep])
+
+            mock_dl.assert_called_once()
+            self.assertEqual(installed.read_bytes(), new_payload)
+            self.assertIn("compressed asset; reinstalling", "\n".join(logs.output))
+
+    def test_failed_existing_compressed_refetch_preserves_binary(self):
+        dep = self._make_compressed_dep("rust-analyzer-x86_64-unknown-linux-gnu.gz")
+        old_payload = b"\x7fELFold-rust-analyzer"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            target_dir = Path(tmp)
+            with (
+                patch("tool_registry.installers.platform.system", return_value="Linux"),
+                patch("tool_registry.installers.platform.machine", return_value="x86_64"),
+                patch("tool_registry.paths.platform.system", return_value="Linux"),
+            ):
+                bin_dir = platform_bin_dir(target_dir)
+                bin_dir.mkdir(parents=True, exist_ok=True)
+                installed = bin_dir / "rust-analyzer"
+                installed.write_bytes(old_payload)
+
+                with patch("tool_registry.installers.download_asset", side_effect=RuntimeError("network")) as mock_dl:
+                    install_native_tools(target_dir, [dep])
+
+            mock_dl.assert_called_once()
+            self.assertEqual(installed.read_bytes(), old_payload)
+
     def test_compressed_asset_honors_per_asset_sha256(self):
         """``sha256[asset_name]`` lets a registry author pin compressed assets."""
         binary_payload = b"#!/bin/sh\necho rust-analyzer\n" * 10
@@ -1784,9 +1839,13 @@ class TestInstallNativeToolsPinDrift(unittest.TestCase):
             bin_dir.mkdir(parents=True, exist_ok=True)
             (bin_dir / "tokei").write_bytes(b"unpinned binary")
 
-            with patch("tool_registry.installers.download_asset") as mock_dl:
+            with (
+                self.assertLogs("tool_registry.installers", level="INFO") as logs,
+                patch("tool_registry.installers.download_asset") as mock_dl,
+            ):
                 install_native_tools(target_dir, [dep])
             mock_dl.assert_not_called()
+            self.assertIn("unpinned binary; skipping verification", "\n".join(logs.output))
 
     def test_unreadable_existing_binary_triggers_reinstall(self):
         """If we cannot read the on-disk binary (permissions, FS error), do

--- a/tool_registry/installers.py
+++ b/tool_registry/installers.py
@@ -163,70 +163,45 @@ def download_asset(url: str, destination: Path, expected_sha256: str | None = No
 # -- Native binary installer --------------------------------------------------
 
 
-def _resolve_native_expected_hash(
+def _resolve_native_download_hash(
     source: GitHubToolSource,
     asset_name: str,
     compressed: bool,
     platform_suffix: str,
 ) -> str | None:
-    """SHA256 to expect for a NATIVE asset, or None when no pin applies.
-
-    Precedence:
-      1. ``sha256[asset_name]`` — exact-asset pin (works for any asset
-         including compressed; one entry per arch override).
-      2. ``sha256[platform_suffix]`` — per-platform pin used by tools we
-         republish ourselves (tokei, gopls); only consulted for
-         pre-extracted assets so a stale platform-keyed hash doesn't get
-         applied to a freshly compressed binary.
-      3. ``None`` — no pin, callers must skip verification.
-    """
+    """Resolve the SHA256 pin for the downloaded release asset."""
     if asset_name in source.sha256:
         return source.sha256[asset_name]
     if not compressed:
-        return source.sha256.get(platform_suffix or "")
+        if not source.sha256:
+            return None
+        platform_hash = source.sha256.get(platform_suffix or "")
+        if platform_hash is None:
+            raise ValueError(f"{asset_name}: missing SHA256 pin for platform {platform_suffix!r}")
+        return platform_hash
     return None
 
 
 def _existing_binary_is_usable(
     binary_path: Path,
-    expected_hash: str | None,
-    compressed: bool,
+    expected_hash: str,
     binary_name: str,
 ) -> bool:
-    """Return True when the on-disk binary can be trusted (skip reinstall).
-
-    Side effect: deletes ``binary_path`` on hash mismatch or read failure,
-    leaving the slot empty for the caller's subsequent download.
-
-    Trusts the existing file (returns True) when:
-
-    - The asset is compressed — the pin is over the archive, not the
-      extracted binary, so on-disk verification is structurally impossible.
-    - No SHA is pinned for this platform.
-    - The on-disk SHA matches the pin.
-
-    Returns False (and deletes the file) when the on-disk hash differs
-    from the pin, or the file exists but cannot be read.
-    """
-    if compressed or expected_hash is None:
-        logger.info("  %s: already installed (no on-disk pin to verify)", binary_name)
-        return True
+    """Return whether the on-disk binary can be reused."""
     try:
         actual = hashlib.sha256(binary_path.read_bytes()).hexdigest()
     except OSError as exc:
-        logger.warning("  %s: existing binary unreadable (%s); reinstalling", binary_name, exc)
-        binary_path.unlink(missing_ok=True)
+        logger.warning("  %s: existing binary unreadable (%s)", binary_name, exc)
         return False
     if actual == expected_hash:
         logger.info("  %s: already installed (sha256 verified)", binary_name)
         return True
     logger.info(
-        "  %s: pin drift (have %s..., want %s...); reinstalling",
+        "  %s: pin drift (have %s..., want %s...)",
         binary_name,
         actual[:12],
         expected_hash[:12],
     )
-    binary_path.unlink(missing_ok=True)
     return False
 
 
@@ -241,10 +216,7 @@ def install_native_tools(
     ``gopls``) and compressed-binary assets (``rust-analyzer``); the
     archive format is inferred from the asset filename suffix.
 
-    On-disk binaries are SHA256-verified against the pin before the
-    skip-if-installed shortcut. A drifted binary (pin moved upstream
-    after the user's first install) is removed and re-fetched so users
-    pick up corrected/updated artifacts automatically.
+    Pre-extracted on-disk binaries are SHA256-verified before reuse.
     """
     system = platform.system()
     suffix = PLATFORM_SUFFIX.get(system)
@@ -286,15 +258,23 @@ def install_native_tools(
             continue
         url = asset_url(source, asset_name)
         compressed = _is_compressed_asset(asset_name)
-        expected_hash = _resolve_native_expected_hash(source, asset_name, compressed, suffix or "")
+        download_hash = _resolve_native_download_hash(source, asset_name, compressed, suffix or "")
+        # Compressed pins apply to the archive, not the extracted binary.
+        existing_binary_hash = None if compressed else download_hash
 
-        if binary_path.exists() and _existing_binary_is_usable(binary_path, expected_hash, compressed, dep.binary_name):
-            continue
+        if binary_path.exists():
+            if existing_binary_hash is None:
+                logger.info("  %s: already installed (no on-disk pin to verify)", dep.binary_name)
+                continue
+            if _existing_binary_is_usable(binary_path, existing_binary_hash, dep.binary_name):
+                continue
+            logger.info("  %s: existing binary unusable; reinstalling", dep.binary_name)
+            binary_path.unlink(missing_ok=True)
 
         try:
             if compressed:
                 archive_path = bin_dir / asset_name
-                if not download_asset(url, archive_path, expected_sha256=expected_hash):
+                if not download_asset(url, archive_path, expected_sha256=download_hash):
                     logger.warning("  %s: download failed (empty file)", dep.binary_name)
                     archive_path.unlink(missing_ok=True)
                     continue
@@ -303,7 +283,7 @@ def install_native_tools(
                 finally:
                     archive_path.unlink(missing_ok=True)
             else:
-                if not download_asset(url, binary_path, expected_sha256=expected_hash):
+                if not download_asset(url, binary_path, expected_sha256=download_hash):
                     logger.warning("  %s: download failed (empty file)", dep.binary_name)
                     binary_path.unlink(missing_ok=True)
                     continue

--- a/tool_registry/installers.py
+++ b/tool_registry/installers.py
@@ -163,6 +163,30 @@ def download_asset(url: str, destination: Path, expected_sha256: str | None = No
 # -- Native binary installer --------------------------------------------------
 
 
+def _resolve_native_expected_hash(
+    source: GitHubToolSource,
+    asset_name: str,
+    compressed: bool,
+    platform_suffix: str,
+) -> str | None:
+    """SHA256 to expect for a NATIVE asset, or None when no pin applies.
+
+    Precedence:
+      1. ``sha256[asset_name]`` — exact-asset pin (works for any asset
+         including compressed; one entry per arch override).
+      2. ``sha256[platform_suffix]`` — per-platform pin used by tools we
+         republish ourselves (tokei, gopls); only consulted for
+         pre-extracted assets so a stale platform-keyed hash doesn't get
+         applied to a freshly compressed binary.
+      3. ``None`` — no pin, callers must skip verification.
+    """
+    if asset_name in source.sha256:
+        return source.sha256[asset_name]
+    if not compressed:
+        return source.sha256.get(platform_suffix or "")
+    return None
+
+
 def install_native_tools(
     target_dir: Path,
     deps: list[ToolDependency],
@@ -173,6 +197,11 @@ def install_native_tools(
     Supports both pre-extracted binaries (default, e.g. ``tokei``,
     ``gopls``) and compressed-binary assets (``rust-analyzer``); the
     archive format is inferred from the asset filename suffix.
+
+    On-disk binaries are SHA256-verified against the pin before the
+    skip-if-installed shortcut. A drifted binary (pin moved upstream
+    after the user's first install) is removed and re-fetched so users
+    pick up corrected/updated artifacts automatically.
     """
     system = platform.system()
     suffix = PLATFORM_SUFFIX.get(system)
@@ -205,9 +234,6 @@ def install_native_tools(
             )
             continue
         binary_path = bin_dir / f"{dep.binary_name}{exe_suffix()}"
-        if binary_path.exists():
-            logger.info("  %s: already installed, skipping", dep.binary_name)
-            continue
         source = dep.source
         assert isinstance(source, GitHubToolSource)
         asset_name = resolve_native_asset_name(source, suffix or "")
@@ -217,20 +243,32 @@ def install_native_tools(
             continue
         url = asset_url(source, asset_name)
         compressed = _is_compressed_asset(asset_name)
-        # Hash lookup precedence:
-        #   1. ``sha256[asset_name]`` — exact-asset pin (works for any asset
-        #      including compressed; one entry per arch override).
-        #   2. ``sha256[suffix]`` — per-platform pin used by tools we
-        #      republish ourselves (tokei, gopls); only consulted for
-        #      pre-extracted assets so a stale platform-keyed hash doesn't
-        #      get applied to a freshly compressed binary.
-        #   3. ``None`` — no pin, ``download_asset`` skips verification.
-        if asset_name in source.sha256:
-            expected_hash: str | None = source.sha256[asset_name]
-        elif not compressed:
-            expected_hash = source.sha256.get(suffix or "")
-        else:
-            expected_hash = None
+        expected_hash = _resolve_native_expected_hash(source, asset_name, compressed, suffix or "")
+
+        if binary_path.exists():
+            # Compressed assets carry a SHA for the archive, not the extracted
+            # binary, so on-disk verification is structurally impossible —
+            # trust the existing install rather than reinstall on every run.
+            if compressed or expected_hash is None:
+                logger.info("  %s: already installed (no on-disk pin to verify)", dep.binary_name)
+                continue
+            try:
+                actual = hashlib.sha256(binary_path.read_bytes()).hexdigest()
+            except OSError as exc:
+                logger.warning("  %s: existing binary unreadable (%s); reinstalling", dep.binary_name, exc)
+                binary_path.unlink(missing_ok=True)
+            else:
+                if actual == expected_hash:
+                    logger.info("  %s: already installed (sha256 verified)", dep.binary_name)
+                    continue
+                logger.info(
+                    "  %s: pin drift (have %s..., want %s...); reinstalling",
+                    dep.binary_name,
+                    actual[:12],
+                    expected_hash[:12],
+                )
+                binary_path.unlink(missing_ok=True)
+
         try:
             if compressed:
                 archive_path = bin_dir / asset_name

--- a/tool_registry/installers.py
+++ b/tool_registry/installers.py
@@ -187,6 +187,49 @@ def _resolve_native_expected_hash(
     return None
 
 
+def _existing_binary_is_usable(
+    binary_path: Path,
+    expected_hash: str | None,
+    compressed: bool,
+    binary_name: str,
+) -> bool:
+    """Return True when the on-disk binary can be trusted (skip reinstall).
+
+    Side effect: deletes ``binary_path`` on hash mismatch or read failure,
+    leaving the slot empty for the caller's subsequent download.
+
+    Trusts the existing file (returns True) when:
+
+    - The asset is compressed — the pin is over the archive, not the
+      extracted binary, so on-disk verification is structurally impossible.
+    - No SHA is pinned for this platform.
+    - The on-disk SHA matches the pin.
+
+    Returns False (and deletes the file) when the on-disk hash differs
+    from the pin, or the file exists but cannot be read.
+    """
+    if compressed or expected_hash is None:
+        logger.info("  %s: already installed (no on-disk pin to verify)", binary_name)
+        return True
+    try:
+        actual = hashlib.sha256(binary_path.read_bytes()).hexdigest()
+    except OSError as exc:
+        logger.warning("  %s: existing binary unreadable (%s); reinstalling", binary_name, exc)
+        binary_path.unlink(missing_ok=True)
+        return False
+    if actual == expected_hash:
+        logger.info("  %s: already installed (sha256 verified)", binary_name)
+        return True
+    logger.info(
+        "  %s: pin drift (have %s..., want %s...); reinstalling",
+        binary_name,
+        actual[:12],
+        expected_hash[:12],
+    )
+    binary_path.unlink(missing_ok=True)
+    return False
+
+
 def install_native_tools(
     target_dir: Path,
     deps: list[ToolDependency],
@@ -245,29 +288,8 @@ def install_native_tools(
         compressed = _is_compressed_asset(asset_name)
         expected_hash = _resolve_native_expected_hash(source, asset_name, compressed, suffix or "")
 
-        if binary_path.exists():
-            # Compressed assets carry a SHA for the archive, not the extracted
-            # binary, so on-disk verification is structurally impossible —
-            # trust the existing install rather than reinstall on every run.
-            if compressed or expected_hash is None:
-                logger.info("  %s: already installed (no on-disk pin to verify)", dep.binary_name)
-                continue
-            try:
-                actual = hashlib.sha256(binary_path.read_bytes()).hexdigest()
-            except OSError as exc:
-                logger.warning("  %s: existing binary unreadable (%s); reinstalling", dep.binary_name, exc)
-                binary_path.unlink(missing_ok=True)
-            else:
-                if actual == expected_hash:
-                    logger.info("  %s: already installed (sha256 verified)", dep.binary_name)
-                    continue
-                logger.info(
-                    "  %s: pin drift (have %s..., want %s...); reinstalling",
-                    dep.binary_name,
-                    actual[:12],
-                    expected_hash[:12],
-                )
-                binary_path.unlink(missing_ok=True)
+        if binary_path.exists() and _existing_binary_is_usable(binary_path, expected_hash, compressed, dep.binary_name):
+            continue
 
         try:
             if compressed:

--- a/tool_registry/installers.py
+++ b/tool_registry/installers.py
@@ -259,17 +259,23 @@ def install_native_tools(
         url = asset_url(source, asset_name)
         compressed = _is_compressed_asset(asset_name)
         download_hash = _resolve_native_download_hash(source, asset_name, compressed, suffix or "")
-        # Compressed pins apply to the archive, not the extracted binary.
-        existing_binary_hash = None if compressed else download_hash
+        had_existing_binary = binary_path.exists()
 
-        if binary_path.exists():
-            if existing_binary_hash is None:
-                logger.info("  %s: already installed (no on-disk pin to verify)", dep.binary_name)
+        if had_existing_binary:
+            if compressed:
+                logger.info(
+                    "  %s: already installed (compressed asset; reinstalling because extracted binary "
+                    "cannot be verified against archive pin)",
+                    dep.binary_name,
+                )
+            elif download_hash is None:
+                logger.info("  %s: already installed (unpinned binary; skipping verification)", dep.binary_name)
                 continue
-            if _existing_binary_is_usable(binary_path, existing_binary_hash, dep.binary_name):
+            elif _existing_binary_is_usable(binary_path, download_hash, dep.binary_name):
                 continue
-            logger.info("  %s: existing binary unusable; reinstalling", dep.binary_name)
-            binary_path.unlink(missing_ok=True)
+            else:
+                logger.info("  %s: existing binary unusable; reinstalling", dep.binary_name)
+                binary_path.unlink(missing_ok=True)
 
         try:
             if compressed:
@@ -292,7 +298,8 @@ def install_native_tools(
             logger.info("  %s: downloaded successfully", dep.binary_name)
         except Exception:
             logger.exception("  %s: download failed", dep.binary_name)
-            binary_path.unlink(missing_ok=True)
+            if not (compressed and had_existing_binary):
+                binary_path.unlink(missing_ok=True)
 
 
 # -- Package-manager installer (dotnet tool, cargo install, ...) --------------

--- a/tool_registry/installers.py
+++ b/tool_registry/installers.py
@@ -169,7 +169,11 @@ def _resolve_native_download_hash(
     compressed: bool,
     platform_suffix: str,
 ) -> str | None:
-    """Resolve the SHA256 pin for the downloaded release asset."""
+    """Resolve the SHA256 pin for the downloaded release asset.
+
+    Exact asset-name pins apply to any asset; platform-suffix pins only apply
+    to pre-extracted binaries, not compressed archives with different bytes.
+    """
     if asset_name in source.sha256:
         return source.sha256[asset_name]
     if not compressed:


### PR DESCRIPTION
## Summary

`install_native_tools` had a `if binary_path.exists(): skip` shortcut that treated any existing file at `binary_path` as healthy, so a user who installed CodeBoarding before a tools-repo re-cut kept their stale binary indefinitely — pin bumps in `tool_registry/registry.py` were silently ignored.

I noticed this empirically: my own \`~/.codeboarding/servers/bin/macos/tokei\` is sha256 \`1a43d9a3…\` and 3.1 MB, but the currently-pinned binary at the same release URL is sha256 \`90ae8a2e…\` and 4.1 MB. Both are tokei 12.1.2, but they're different builds — the `tools-2026.04.05` release got re-cut after my install, and the installer never noticed.

## What changes

- Extract the hash-lookup precedence (asset-name → platform-suffix → None) into `_resolve_native_expected_hash` so it can be called twice: once before the skip, once inside the download path.
- Before the skip-if-installed shortcut, compute the on-disk SHA256 and compare to the pin. On mismatch, delete and re-fetch.
- On read failure (permissions, FS error), reinstall defensively rather than report a broken file as healthy.
- Compressed assets (rust-analyzer) keep the legacy skip — their pin is over the archive, not the decompressed binary.

## What this doesn't touch

The same drift bug exists in `install_archive_tool` (JDTLS, clangd) and `install_package_manager_tools` (csharp-ls), but they need different verification strategies (marker-file or `--version` checks). Deferred to follow-up issues so this PR stays focused.

## Test plan

- [x] New `TestInstallNativeToolsPinDrift` class — 4 tests:
  - matching SHA skips download
  - drifted SHA triggers reinstall with new bytes on disk
  - no-pin case preserves legacy skip behavior
  - unreadable existing binary triggers defensive reinstall
- [x] Full `tests/test_tool_registry.py` + `tests/test_registry_coverage.py` sweep — 120/120 passing, no regressions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Installer now verifies native tool binaries using SHA256 pins (preferring per-asset, then per-platform), auto-replacing binaries when pins drift or files are unreadable.
  * Compressed-asset handling: archives are reinstalled when appropriate; existing compressed files are preserved if a refetch fails; unpinned binaries retain legacy behavior.

* **Tests**
  * Added tests for matching pins, pin drift replacements, unreadable binaries, legacy unpinned behavior, and compressed-asset reinstall/preserve scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->