### PR TITLE
chore: bump tokei to v14.0.0 (recognizes Mojo + other new languages)

### DIFF
--- a/.github/workflows/build-tools.yml
+++ b/.github/workflows/build-tools.yml
@@ -6,7 +6,7 @@ on:
 env:
   TOKEI_VERSION: "v14.0.0"
   GOPLS_VERSION: "v0.21.1"
-  TOOLS_TAG: "tools-2026.04.05"
+  TOOLS_TAG: "tools-2026.05.31"
 
 permissions:
   contents: read

--- a/tool_registry/registry.py
+++ b/tool_registry/registry.py
@@ -24,7 +24,7 @@ from enum import StrEnum
 ProgressCallback = Callable[[str, int, int], None]
 
 TOOLS_REPO = "CodeBoarding/tools"
-TOOLS_TAG = "tools-2026.04.05"
+TOOLS_TAG = "tools-2026.05.31"
 
 JDTLS_VERSION = "1.44.0"
 JDTLS_BUILD = "202501221502"
@@ -163,9 +163,9 @@ TOOL_REGISTRY: list[ToolDependency] = [
             repo=TOOLS_REPO,
             asset_template="tokei-{platform_suffix}",
             sha256={
-                "linux": "e366026993bce6a40d6df19dcac9c1c58e88820268c68304c056cd3878e545e2",
-                "macos": "90ae8a2e979b9658c2616787bcc26f187f14b922fcd0bf61cb3f7fcc2a43634e",
-                "windows.exe": "7db547cb6bfa1722e89ca52a43426fb212aa53603a60256af25fb6e59ca12099",
+                "linux": "7b9a7dc321790e47a7b3759908e85da78f8b123e0e9f1248c0bd681253f9ba9b",
+                "macos": "bef03fbb7adb26e70d5521fddba6016dab75b19c584d7c9c9ba044cb71155fa8",
+                "windows.exe": "6d6517d967bfd7ea51c8b097f97a6e2a5d30bc0cc11dfe7e27a17fabb04ba329",
             },
         ),
     ),
@@ -179,9 +179,9 @@ TOOL_REGISTRY: list[ToolDependency] = [
             repo=TOOLS_REPO,
             asset_template="gopls-{platform_suffix}",
             sha256={
-                "linux": "76ecc01106266aa03f75c3ea857f6bd6a1da79b00abb6cb5a573b1cd5ecbdcb7",
-                "macos": "a12551ec82e8000c055a8e8e3447cbf22bd7c4b220d4e3802112a569e88a4965",
-                "windows.exe": "b739c89bcd3068257a5ac1be1b9b4978576f7731c7893fdc0b13577927bd6483",
+                "linux": "166b94c8f938391b93399bd5c07fbd75aaac77c7991fd6632b5f16a3b8f151b0",
+                "macos": "087a683aabc9e1d2a04e156447ccd1f1c7d551e75a3286099c666c3381efc43e",
+                "windows.exe": "1f9ea287d2162fee719e666cf09ee92260d62a5425301481f4327cbb5fa64113",
             },
         ),
     ),


### PR DESCRIPTION
## Summary

Two-commit bump that promotes tokei from 12.1.2 → 14.0.0 in the CodeBoarding tool chain.

The motivating gap: tokei 12.1.2 silently drops `.mojo` files from its language output, so `ProjectScanner` never sees Mojo even when a repo is ~95% Mojo by line count. Verified against [Lightbug-HQ/lightbug_http](https://github.com/Lightbug-HQ/lightbug_http) (10,470 Mojo LoC, 0 detected by old tokei → 10,470 detected by new tokei). This unblocks the in-flight Mojo language adapter work.

## Commits

1. **`chore(ci): bump tools release tag`** — only edits `.github/workflows/build-tools.yml` to set `TOOLS_TAG: tools-2026.05.31` so a workflow_dispatch produces a new release alongside the existing `tools-2026.04.05`.
2. **`chore(registry): pin tools-2026.05.31`** — bumps `tool_registry/registry.py`'s `TOOLS_TAG` to the new release and updates all six `sha256` entries (3 tokei + 3 gopls) to match the freshly-built binaries.

## What I did

- Dispatched [Build Tool Binaries run 26698490620](https://github.com/CodeBoarding/CodeBoarding/actions/runs/26698490620) against this branch. All 7 matrix jobs succeeded.
- Confirmed the new release exists at https://github.com/CodeBoarding/tools/releases/tag/tools-2026.05.31.
- Downloaded `tokei-macos`, verified sha256 matches workflow output, ran it: reports `tokei 14.0.0`, detects Mojo at 10,470 lines in `lightbug_http`.

## Schema compatibility check

Before pinning, I diffed `tokei -o json` output between 12.1.2 and 13.0.0 against the same `llama2.mojo` repo. Every field CodeBoarding's parser touches is identical:

| Access path | 12.1.2 | 13.0.0 |
|---|---|---|
| `tokei_data["{lang}"]` | ✅ | ✅ |
| `stats["code"]` | identical values | identical values |
| `stats["reports"]` shape | `[{name, stats}]` | `[{name, stats}]` |
| `tokei_data["Total"]["code"]` | ✅ | ✅ |

The v14 changelog (vs v13) lists no JSON schema changes. Real-world drift on existing repos is ~0.2% on shared languages (slightly more accurate comment/blank classification).

## Why gopls SHAs change despite GOPLS_VERSION not moving

`go install` produces non-deterministic binaries (embedded build timestamps + module paths). Rebuilding the same `gopls@v0.21.1` two months later yields different bytes, so the SHA pins shift even though the version pin is identical.

## Companion PRs

- #350 — `fix(installer): SHA-verify existing native binaries against the registry pin`. Required to actually deliver the new tokei to existing users — without it, anyone who installed CodeBoarding before today is stuck on the old binary forever because `install_native_tools` skipped re-fetch on `binary_path.exists()`. Recommend landing #350 first.

## Test plan

- [x] Workflow run succeeded, 7/7 jobs green.
- [x] New tokei binary downloaded, SHA verified, runs, recognizes Mojo.
- [x] `tests/test_tool_registry.py` + `tests/test_registry_coverage.py` — 116/116 passing on this branch.
- [ ] After merge: confirm an existing install picks up the new binary (requires #350 to land first).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build tools to the latest release version to ensure consistency and reliability across the build system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->