### PR TITLE
feat(mojo): add Mojo language support via pixi-installed mojo-lsp-server

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,4 +161,5 @@ markers = [
     "javascript_lang: marks tests for JavaScript language",
     "rust_lang: marks tests for Rust language",
     "csharp_lang: marks tests for C# language",
+    "mojo_lang: marks tests for Mojo language",
 ]

--- a/static_analyzer/__init__.py
+++ b/static_analyzer/__init__.py
@@ -155,6 +155,7 @@ def _lang_to_adapter_name(language: str) -> str | None:
         "csharp": "CSharp",
         "go": "Go",
         "java": "Java",
+        "mojo": "Mojo",
         "php": "PHP",
         "rust": "Rust",
     }

--- a/static_analyzer/constants.py
+++ b/static_analyzer/constants.py
@@ -24,6 +24,7 @@ class Language(StrEnum):
     RUST = "rust"
     CSHARP = "csharp"
     CPP = "cpp"
+    MOJO = "mojo"
 
 
 # File extensions per language. Every ``Language`` member appears here — keep
@@ -39,6 +40,7 @@ LANGUAGE_EXTENSIONS: dict[Language, tuple[str, ...]] = {
     Language.RUST: (".rs",),
     Language.CSHARP: (".cs",),
     Language.CPP: (".cpp", ".cc", ".cxx", ".hpp", ".hh", ".hxx", ".h"),
+    Language.MOJO: (".mojo",),
 }
 
 # Import-time invariant: every language has an extension list. Cheap check that

--- a/static_analyzer/constants.py
+++ b/static_analyzer/constants.py
@@ -40,8 +40,9 @@ LANGUAGE_EXTENSIONS: dict[Language, tuple[str, ...]] = {
     Language.RUST: (".rs",),
     Language.CSHARP: (".cs",),
     Language.CPP: (".cpp", ".cc", ".cxx", ".hpp", ".hh", ".hxx", ".h"),
-    # ``.🔥`` is Mojo's alternate extension; real repos ship it (lightbug_http).
-    Language.MOJO: (".mojo", ".🔥"),
+    # The fire-emoji (U+1F525) is Mojo's alternate extension; real repos ship
+    # it (lightbug_http). Escaped so the source file stays cp1252-encodable.
+    Language.MOJO: (".mojo", ".\U0001f525"),
 }
 
 # Import-time invariant: every language has an extension list. Cheap check that

--- a/static_analyzer/constants.py
+++ b/static_analyzer/constants.py
@@ -40,7 +40,8 @@ LANGUAGE_EXTENSIONS: dict[Language, tuple[str, ...]] = {
     Language.RUST: (".rs",),
     Language.CSHARP: (".cs",),
     Language.CPP: (".cpp", ".cc", ".cxx", ".hpp", ".hh", ".hxx", ".h"),
-    Language.MOJO: (".mojo",),
+    # ``.🔥`` is Mojo's alternate extension; real repos ship it (lightbug_http).
+    Language.MOJO: (".mojo", ".🔥"),
 }
 
 # Import-time invariant: every language has an extension list. Cheap check that

--- a/static_analyzer/engine/adapters/__init__.py
+++ b/static_analyzer/engine/adapters/__init__.py
@@ -6,6 +6,7 @@ from static_analyzer.engine.language_adapter import LanguageAdapter
 from static_analyzer.engine.adapters.csharp_adapter import CSharpAdapter
 from static_analyzer.engine.adapters.go_adapter import GoAdapter
 from static_analyzer.engine.adapters.java_adapter import JavaAdapter
+from static_analyzer.engine.adapters.mojo_adapter import MojoAdapter
 from static_analyzer.engine.adapters.php_adapter import PHPAdapter
 from static_analyzer.engine.adapters.python_adapter import PythonAdapter
 from static_analyzer.engine.adapters.rust_adapter import RustAdapter
@@ -18,6 +19,7 @@ ADAPTER_REGISTRY: dict[str, type[LanguageAdapter]] = {
     "CSharp": CSharpAdapter,
     "Go": GoAdapter,
     "Java": JavaAdapter,
+    "Mojo": MojoAdapter,
     "PHP": PHPAdapter,
     "Rust": RustAdapter,
 }

--- a/static_analyzer/engine/adapters/mojo_adapter.py
+++ b/static_analyzer/engine/adapters/mojo_adapter.py
@@ -1,0 +1,40 @@
+"""Mojo language adapter using mojo-lsp-server (Modular)."""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+from static_analyzer.constants import Language
+from static_analyzer.engine.language_adapter import LanguageAdapter
+
+
+class MojoAdapter(LanguageAdapter):
+
+    @property
+    def language(self) -> str:
+        return "Mojo"
+
+    @property
+    def language_enum(self) -> Language:
+        return Language.MOJO
+
+    @property
+    def lsp_command(self) -> list[str]:
+        return ["mojo-lsp-server"]
+
+    @property
+    def language_id(self) -> str:
+        return "mojo"
+
+    def get_lsp_command(self, project_root: Path) -> list[str]:
+        """Raise with an install hint if no resolvable ``mojo-lsp-server`` is reachable."""
+        command = super().get_lsp_command(project_root)
+        if shutil.which(command[0]) is None:
+            raise RuntimeError(
+                "mojo-lsp-server not found. Install via `codeboarding-setup` "
+                "(requires `pixi` on PATH; install from https://pixi.sh) or "
+                "manually with `pixi global install --channel "
+                "https://conda.modular.com/max --expose mojo-lsp-server mojo`."
+            )
+        return command

--- a/static_analyzer/engine/adapters/mojo_adapter.py
+++ b/static_analyzer/engine/adapters/mojo_adapter.py
@@ -8,6 +8,31 @@ from pathlib import Path
 from static_analyzer.constants import Language
 from static_analyzer.engine.language_adapter import LanguageAdapter
 
+# Past any real source column; keeps the symbol's final line fully inside
+# its range during containment checks.
+_LINE_END_CHAR = 10_000
+
+
+def _extend_sibling_ranges(siblings: list[dict], parent_end_line: int) -> None:
+    """Extend declaration-line-only ranges to the next sibling's start.
+
+    Mojo is indentation-structured, so a symbol's body runs until the next
+    sibling declaration (or the parent's end). Symbols with real multi-line
+    ranges are left untouched.
+    """
+    ordered = sorted((s for s in siblings if s.get("range")), key=lambda s: s["range"]["start"]["line"])
+    for i, sym in enumerate(ordered):
+        rng = sym["range"]
+        if i + 1 < len(ordered):
+            sibling_end = ordered[i + 1]["range"]["start"]["line"] - 1
+        else:
+            sibling_end = parent_end_line
+        if rng["end"]["line"] <= rng["start"]["line"]:
+            rng["end"] = {"line": max(sibling_end, rng["start"]["line"]), "character": _LINE_END_CHAR}
+        children = sym.get("children") or []
+        if children:
+            _extend_sibling_ranges(children, rng["end"]["line"])
+
 
 class MojoAdapter(LanguageAdapter):
 
@@ -35,6 +60,22 @@ class MojoAdapter(LanguageAdapter):
                 "mojo-lsp-server not found. Install via `codeboarding-setup` "
                 "(requires `pixi` on PATH; install from https://pixi.sh) or "
                 "manually with `pixi global install --channel "
-                "https://conda.modular.com/max --expose mojo-lsp-server mojo`."
+                "https://conda.modular.com/max --channel conda-forge "
+                "--expose mojo-lsp-server mojo`."
             )
         return command
+
+    def postprocess_document_symbols(self, symbols: list[dict], file_path: Path) -> list[dict]:
+        """Synthesize body extents for mojo-lsp-server's degenerate ranges.
+
+        Why: the server reports ``range == selectionRange`` (declaration line
+        only) for every symbol, so call-site containment never matches and the
+        call graph comes out empty without this.
+        """
+        try:
+            text = file_path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            return symbols
+        last_line = max(0, len(text.splitlines()) - 1)
+        _extend_sibling_ranges(symbols, last_line)
+        return symbols

--- a/static_analyzer/engine/call_graph_builder.py
+++ b/static_analyzer/engine/call_graph_builder.py
@@ -161,6 +161,7 @@ class CallGraphBuilder:
                 symbols = probe_result
             else:
                 symbols = self._lsp.document_symbol(file_path)
+            symbols = self._adapter.postprocess_document_symbols(symbols, file_path)
             self._symbol_table.register_symbols(file_path, symbols, parent_chain=[], project_root=self._root)
             pbar.set_postfix(symbols=len(self._symbol_table.symbols))
             pbar.update(1)

--- a/static_analyzer/engine/language_adapter.py
+++ b/static_analyzer/engine/language_adapter.py
@@ -78,6 +78,15 @@ class LanguageAdapter(ABC):
         """LSP language identifier for textDocument/didOpen."""
         return self.language.lower()
 
+    def postprocess_document_symbols(self, symbols: list[dict], file_path: Path) -> list[dict]:
+        """Hook to repair server quirks in documentSymbol output before registration.
+
+        Default: identity. Override when a server's response shape breaks a
+        downstream assumption (e.g. declaration-line-only ranges that defeat
+        call-site containment).
+        """
+        return symbols
+
     def build_qualified_name(
         self,
         file_path: Path,

--- a/tests/static_analyzer/test_mojo_adapter.py
+++ b/tests/static_analyzer/test_mojo_adapter.py
@@ -1,0 +1,92 @@
+"""Tests for the Mojo language adapter."""
+
+import shutil
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from static_analyzer.constants import Language
+from static_analyzer.engine.adapters.mojo_adapter import MojoAdapter
+
+
+class TestGetLspCommandBinaryCheck:
+
+    def test_raises_when_binary_missing(self, tmp_path: Path) -> None:
+        with patch("static_analyzer.engine.adapters.mojo_adapter.shutil.which", return_value=None):
+            with pytest.raises(RuntimeError, match=r"mojo-lsp-server not found.*pixi"):
+                MojoAdapter().get_lsp_command(tmp_path)
+
+    def test_uses_resolved_command_when_present(self, tmp_path: Path) -> None:
+        real_which = shutil.which
+        resolved = "/opt/codeboarding/pm-tools/mojo/bin/mojo-lsp-server"
+
+        def selective(name: str) -> str | None:
+            return resolved if name == resolved else real_which(name)
+
+        lsp_servers = {"mojo": {"command": [resolved]}}
+        with (
+            patch("static_analyzer.engine.adapters.mojo_adapter.shutil.which", side_effect=selective),
+            patch("static_analyzer.engine.language_adapter.get_config", return_value=lsp_servers),
+        ):
+            cmd = MojoAdapter().get_lsp_command(tmp_path)
+        assert cmd == [resolved]
+
+    def test_falls_back_to_bare_command_when_on_path(self, tmp_path: Path) -> None:
+        with (
+            patch(
+                "static_analyzer.engine.adapters.mojo_adapter.shutil.which",
+                return_value="/usr/local/bin/mojo-lsp-server",
+            ),
+            patch("static_analyzer.engine.language_adapter.get_config", return_value={}),
+        ):
+            cmd = MojoAdapter().get_lsp_command(tmp_path)
+        assert cmd == ["mojo-lsp-server"]
+
+
+class TestMojoAdapterProperties:
+
+    def test_language(self):
+        assert MojoAdapter().language == "Mojo"
+
+    def test_language_enum(self):
+        assert MojoAdapter().language_enum is Language.MOJO
+
+    def test_file_extensions(self):
+        assert MojoAdapter().file_extensions == (".mojo",)
+
+    def test_lsp_command(self):
+        assert MojoAdapter().lsp_command == ["mojo-lsp-server"]
+
+    def test_language_id(self):
+        assert MojoAdapter().language_id == "mojo"
+
+    def test_config_key_defaults_to_language_id(self):
+        assert MojoAdapter().config_key == "mojo"
+
+
+class TestQualifiedNameInherited:
+    """Locks in that MojoAdapter does NOT override build_qualified_name —
+    Mojo's symbol model is Python-shaped and the base dotted-module logic
+    is intentional. Catches accidental overrides that would break call-graph
+    edges by emitting differently-shaped qualified names."""
+
+    def test_top_level_function(self, tmp_path: Path) -> None:
+        qn = MojoAdapter().build_qualified_name(
+            file_path=tmp_path / "pkg" / "service.mojo",
+            symbol_name="run",
+            symbol_kind=12,
+            parent_chain=[],
+            project_root=tmp_path,
+        )
+        assert qn == "pkg.service.run"
+
+    def test_struct_method(self, tmp_path: Path) -> None:
+        qn = MojoAdapter().build_qualified_name(
+            file_path=tmp_path / "models" / "user.mojo",
+            symbol_name="greet",
+            symbol_kind=6,
+            parent_chain=[("User", 23)],
+            project_root=tmp_path,
+        )
+        assert qn == "models.user.User.greet"

--- a/tests/static_analyzer/test_mojo_adapter.py
+++ b/tests/static_analyzer/test_mojo_adapter.py
@@ -53,7 +53,7 @@ class TestMojoAdapterProperties:
         assert MojoAdapter().language_enum is Language.MOJO
 
     def test_file_extensions(self):
-        assert MojoAdapter().file_extensions == (".mojo", ".🔥")
+        assert MojoAdapter().file_extensions == (".mojo", ".\U0001f525")
 
     def test_lsp_command(self):
         assert MojoAdapter().lsp_command == ["mojo-lsp-server"]

--- a/tests/static_analyzer/test_mojo_adapter.py
+++ b/tests/static_analyzer/test_mojo_adapter.py
@@ -53,7 +53,7 @@ class TestMojoAdapterProperties:
         assert MojoAdapter().language_enum is Language.MOJO
 
     def test_file_extensions(self):
-        assert MojoAdapter().file_extensions == (".mojo",)
+        assert MojoAdapter().file_extensions == (".mojo", ".🔥")
 
     def test_lsp_command(self):
         assert MojoAdapter().lsp_command == ["mojo-lsp-server"]
@@ -90,3 +90,51 @@ class TestQualifiedNameInherited:
             project_root=tmp_path,
         )
         assert qn == "models.user.User.greet"
+
+
+def _sym(name: str, kind: int, line: int, end_line: int | None = None, children: list | None = None) -> dict:
+    end = end_line if end_line is not None else line
+    return {
+        "name": name,
+        "kind": kind,
+        "range": {"start": {"line": line, "character": 0}, "end": {"line": end, "character": 10}},
+        "selectionRange": {"start": {"line": line, "character": 3}, "end": {"line": line, "character": 8}},
+        "children": children or [],
+    }
+
+
+class TestPostprocessDocumentSymbols:
+    """mojo-lsp-server reports range == selectionRange (declaration line only),
+    which defeats call-site containment and yields empty call graphs. The
+    adapter must extend each degenerate range to the next sibling's start."""
+
+    def _run(self, symbols: list[dict], tmp_path: Path, n_lines: int = 100) -> list[dict]:
+        f = tmp_path / "mod.mojo"
+        f.write_text("\n".join(f"# line {i}" for i in range(n_lines)))
+        return MojoAdapter().postprocess_document_symbols(symbols, f)
+
+    def test_extends_to_next_sibling(self, tmp_path: Path) -> None:
+        syms = self._run([_sym("a", 12, 0), _sym("b", 12, 10)], tmp_path)
+        assert syms[0]["range"]["end"]["line"] == 9
+        assert syms[1]["range"]["end"]["line"] == 99
+
+    def test_last_sibling_extends_to_file_end(self, tmp_path: Path) -> None:
+        syms = self._run([_sym("a", 12, 5)], tmp_path, n_lines=42)
+        assert syms[0]["range"]["end"]["line"] == 41
+
+    def test_children_bounded_by_parent(self, tmp_path: Path) -> None:
+        struct = _sym("S", 23, 10, children=[_sym("m1", 6, 12), _sym("m2", 6, 20)])
+        syms = self._run([struct, _sym("after", 12, 30)], tmp_path)
+        assert syms[0]["range"]["end"]["line"] == 29
+        m1, m2 = syms[0]["children"]
+        assert m1["range"]["end"]["line"] == 19
+        assert m2["range"]["end"]["line"] == 29
+
+    def test_real_multi_line_ranges_untouched(self, tmp_path: Path) -> None:
+        syms = self._run([_sym("a", 12, 0, end_line=7), _sym("b", 12, 10)], tmp_path)
+        assert syms[0]["range"]["end"] == {"line": 7, "character": 10}
+
+    def test_unreadable_file_returns_symbols_unchanged(self, tmp_path: Path) -> None:
+        syms = [_sym("a", 12, 0)]
+        out = MojoAdapter().postprocess_document_symbols(syms, tmp_path / "missing.mojo")
+        assert out[0]["range"]["end"]["line"] == 0

--- a/tests/test_registry_coverage.py
+++ b/tests/test_registry_coverage.py
@@ -287,6 +287,7 @@ class TestLspAdapterAndLanguageEnumParity(unittest.TestCase):
         "php": "PHP",
         "csharp": "CSharp",
         "java": "Java",
+        "mojo": "Mojo",
         "rust": "Rust",
     }
 
@@ -372,23 +373,24 @@ class TestPackageManagerSourceInvariants(unittest.TestCase):
                 )
 
     def test_every_pm_dep_has_exactly_one_tool_path_placeholder(self):
-        """The installer substitutes ``{tool_path}`` with the managed install
-        dir. Zero placeholders means the tool lands in the package manager's
-        default location (polluting the user's global namespace, and
-        ``has_required_tools`` won't find it). Multiple placeholders is a
-        copy-paste bug.
+        """``{tool_path}`` must be consumed exactly once across install_args + env.
+
+        Zero: tool lands in the package manager's default location.
+        Multiple: copy-paste bug.
         """
         for dep in self._pm_deps():
             source = dep.source
             assert isinstance(source, PackageManagerToolSource)
             with self.subTest(dep=dep.key):
-                placeholder_count = sum(arg.count("{tool_path}") for arg in source.install_args)
+                args_count = sum(arg.count("{tool_path}") for arg in source.install_args)
+                env_count = sum(value.count("{tool_path}") for _, value in source.env)
+                placeholder_count = args_count + env_count
                 self.assertEqual(
                     placeholder_count,
                     1,
-                    f"{dep.key}: expected exactly one '{{tool_path}}' placeholder in "
-                    f"install_args, found {placeholder_count}. "
-                    f"install_args={list(source.install_args)!r}",
+                    f"{dep.key}: expected exactly one '{{tool_path}}' placeholder across "
+                    f"install_args + env, found {placeholder_count}. "
+                    f"install_args={list(source.install_args)!r} env={list(source.env)!r}",
                 )
 
 

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -978,8 +978,9 @@ def _populate_complete_servers_dir(base_dir: Path) -> None:
         elif dep.kind is ToolKind.PACKAGE_MANAGER:
             subdir = dep.archive_subdir or dep.key
             pm_dir = bin_dir / "pm-tools" / subdir
-            pm_dir.mkdir(parents=True, exist_ok=True)
-            (pm_dir / f"{dep.binary_name}{exe_suffix()}").write_text("#!/bin/sh\n")
+            binary_dir = pm_dir / dep.binary_subpath if dep.binary_subpath else pm_dir
+            binary_dir.mkdir(parents=True, exist_ok=True)
+            (binary_dir / f"{dep.binary_name}{exe_suffix()}").write_text("#!/bin/sh\n")
 
 
 class TestHasRequiredTools(unittest.TestCase):
@@ -1008,6 +1009,21 @@ class TestHasRequiredTools(unittest.TestCase):
             _populate_complete_servers_dir(base_dir)
             (platform_bin_dir(base_dir) / f"tokei{exe_suffix()}").unlink()
             self.assertFalse(has_required_tools(base_dir))
+
+    def test_pm_binary_subpath_is_honored(self):
+        """PACKAGE_MANAGER deps with ``binary_subpath`` (mojo: ``bin``) must
+        find their binary at ``<install_dir>/<binary_subpath>/<name>``, not
+        at ``<install_dir>/<name>``. Without this, ``has_required_tools``
+        returns False on a successful install and ``needs_install`` loops
+        forever re-running the package manager."""
+        mojo_dep = next((d for d in TOOL_REGISTRY if d.key == "mojo"), None)
+        self.assertIsNotNone(mojo_dep, "mojo registry entry expected")
+        self.assertEqual(mojo_dep.binary_subpath, "bin")
+        install_dir = package_manager_tool_dir(Path("/tmp/example"), mojo_dep)
+        from tool_registry.manifest import package_manager_tool_path
+
+        binary_path = package_manager_tool_path(Path("/tmp/example"), mojo_dep)
+        self.assertEqual(binary_path, install_dir / "bin" / f"mojo-lsp-server{exe_suffix()}")
 
     def test_missing_node_js_entry_returns_false(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -1649,6 +1665,64 @@ class TestInstallPackageManagerTools(unittest.TestCase):
         self.assertIn("--framework", csharp.source.install_args)
         framework_idx = csharp.source.install_args.index("--framework") + 1
         self.assertEqual(csharp.source.install_args[framework_idx], "net10.0")
+
+    def test_env_param_redirects_pixi_home(self):
+        """Mojo's ``env=(("PIXI_HOME", "{tool_path}"),)`` must be passed to
+        subprocess.run with the install dir substituted, so pixi's global
+        install state stays inside ``install_dir`` instead of leaking into
+        the user's ``~/.pixi``."""
+        dep = next((d for d in TOOL_REGISTRY if d.key == "mojo"), None)
+        self.assertIsNotNone(dep, "mojo registry entry expected")
+        with (
+            tempfile.TemporaryDirectory() as tmp,
+            patch("tool_registry.installers.platform.system", return_value="Linux"),
+            patch("tool_registry.installers.platform.machine", return_value="x86_64"),
+            patch("tool_registry.paths.platform.system", return_value="Linux"),
+        ):
+            base = Path(tmp)
+            install_dir = package_manager_tool_dir(base, dep)
+            binary_path = install_dir / dep.binary_subpath / f"mojo-lsp-server{exe_suffix()}"
+
+            def fake_run(cmd, **kwargs):
+                binary_path.parent.mkdir(parents=True, exist_ok=True)
+                binary_path.write_text("fake mojo-lsp-server")
+                result = MagicMock()
+                result.returncode = 0
+                result.stdout = result.stderr = ""
+                return result
+
+            with (
+                patch("tool_registry.installers.shutil.which", return_value="/usr/bin/pixi"),
+                patch("tool_registry.installers.subprocess.run", side_effect=fake_run) as mock_run,
+            ):
+                install_package_manager_tools(base, [dep])
+            env = mock_run.call_args.kwargs.get("env")
+            self.assertIsNotNone(env, "env kwarg must be passed when source.env is populated")
+            self.assertEqual(env["PIXI_HOME"], str(install_dir))
+
+    def test_env_param_omitted_for_csharp(self):
+        """csharp-ls has no ``env=`` in its source — subprocess.run must
+        receive ``env=None`` so it inherits os.environ unchanged."""
+        dep = self._csharp_dep()
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            install_dir = package_manager_tool_dir(base, dep)
+            binary_path = install_dir / f"csharp-ls{exe_suffix()}"
+
+            def fake_run(cmd, **kwargs):
+                binary_path.parent.mkdir(parents=True, exist_ok=True)
+                binary_path.write_text("fake")
+                result = MagicMock()
+                result.returncode = 0
+                result.stdout = result.stderr = ""
+                return result
+
+            with (
+                patch("tool_registry.installers.shutil.which", return_value="/usr/bin/dotnet"),
+                patch("tool_registry.installers.subprocess.run", side_effect=fake_run) as mock_run,
+            ):
+                install_package_manager_tools(base, [dep])
+            self.assertIsNone(mock_run.call_args.kwargs.get("env"))
 
 
 if __name__ == "__main__":

--- a/tool_registry/installers.py
+++ b/tool_registry/installers.py
@@ -292,6 +292,14 @@ def install_package_manager_tools(
     for i, dep in enumerate(pm_deps, 1):
         if on_progress:
             on_progress(dep.binary_name, i, len(pm_deps))
+        if not dep.is_available_on_host():
+            logger.warning(
+                "  %s: upstream has no package for this host (%s/%s); skipping",
+                dep.binary_name,
+                platform.system(),
+                platform.machine(),
+            )
+            continue
         source = cast(PackageManagerToolSource, dep.source)
         if not shutil.which(source.manager_binary):
             logger.warning(
@@ -301,12 +309,17 @@ def install_package_manager_tools(
             )
             continue
         install_dir = pm_root / (dep.archive_subdir or dep.key)
-        binary_path = install_dir / f"{dep.binary_name}{exe_suffix()}"
+        binary_dir = install_dir / dep.binary_subpath if dep.binary_subpath else install_dir
+        binary_path = binary_dir / f"{dep.binary_name}{exe_suffix()}"
         if binary_path.exists():
             logger.info("  %s: already installed, skipping", dep.binary_name)
             continue
         install_dir.mkdir(parents=True, exist_ok=True)
-        args = [arg.format(tool_path=str(install_dir), tag=source.tag) for arg in source.install_args]
+        fmt = dict(tool_path=str(install_dir), tag=source.tag)
+        args = [arg.format(**fmt) for arg in source.install_args]
+        subprocess_env = os.environ.copy()
+        for key, value in source.env:
+            subprocess_env[key] = value.format(**fmt)
         try:
             result = subprocess.run(
                 [source.manager_binary, *args],
@@ -314,6 +327,7 @@ def install_package_manager_tools(
                 text=True,
                 check=False,
                 timeout=600,
+                env=subprocess_env if source.env else None,
             )
             if result.returncode != 0:
                 # A failed install can leave partial files that would

--- a/tool_registry/manifest.py
+++ b/tool_registry/manifest.py
@@ -195,9 +195,11 @@ def package_manager_tool_path(base_dir: Path, dep: ToolDependency) -> Path | Non
     hard crash.
     """
     try:
-        return package_manager_tool_dir(base_dir, dep) / f"{dep.binary_name}{exe_suffix()}"
+        install_dir = package_manager_tool_dir(base_dir, dep)
     except RuntimeError:
         return None
+    binary_dir = install_dir / dep.binary_subpath if dep.binary_subpath else install_dir
+    return binary_dir / f"{dep.binary_name}{exe_suffix()}"
 
 
 def resolve_config(base_dir: Path) -> dict[str, Any]:

--- a/tool_registry/registry.py
+++ b/tool_registry/registry.py
@@ -295,13 +295,19 @@ TOOL_REGISTRY: list[ToolDependency] = [
         config_section=ConfigSection.LSP_SERVERS,
         binary_subpath="bin",
         source=PackageManagerToolSource(
-            tag="25.5",
+            # Modular re-versioned ``mojo`` to a 1.0 scheme and purged the 25.x
+            # builds from the channel; 1.0.0b1 also depends on python>=3.10,
+            # which only conda-forge provides — without that channel the solve
+            # fails with "no candidates were found for python".
+            tag="1.0.0b1",
             manager_binary="pixi",
             install_args=(
                 "global",
                 "install",
                 "--channel",
                 "https://conda.modular.com/max",
+                "--channel",
+                "conda-forge",
                 "--expose",
                 "mojo-lsp-server",
                 "mojo={tag}",

--- a/tool_registry/registry.py
+++ b/tool_registry/registry.py
@@ -118,9 +118,15 @@ class PackageManagerToolSource(ToolSource):
     Why: some LSPs ship only as language-package-manager packages, not as standalone binaries.
     """
 
-    manager_binary: str = ""  # e.g. "dotnet"
-    # Placeholders substituted at install time: ``{tool_path}`` -> managed install dir; ``{tag}`` -> source.tag.
+    manager_binary: str = ""
+    # ``{tool_path}`` and ``{tag}`` placeholders are substituted at install time.
     install_args: tuple[str, ...] = ()
+    # Empty = available on every host. Populate when upstream only publishes
+    # for a subset (e.g. no Windows native build).
+    supported_platforms: tuple[tuple[str, str], ...] = ()
+    # Same substitution as ``install_args``. Use to redirect package-manager
+    # state into ``install_dir`` (e.g. pixi's ``PIXI_HOME``).
+    env: tuple[tuple[str, str], ...] = ()
 
 
 @dataclass(frozen=True)
@@ -136,20 +142,22 @@ class ToolDependency:
     archive_subdir: str = ""
     js_entry_file: str = ""
     js_entry_parent: str = ""
+    # ``binary_name`` location relative to install dir. Empty = ``<install_dir>/<binary>``;
+    # ``"bin"`` for package managers that drop shims in a ``bin/`` subdir.
+    binary_subpath: str = ""
 
     def is_available_on_host(self) -> bool:
-        """True unless this is an arch-aware NATIVE dep whose override map
-        excludes the running ``(system, machine)`` (e.g. rust-analyzer on
-        Linux/riscv64). Consulted by both the installer and
-        ``has_required_tools`` to keep them in sync.
-        """
-        if self.kind is not ToolKind.NATIVE:
-            return True
-        if not isinstance(self.source, GitHubToolSource):
-            return True
-        if not self.source.asset_arch_overrides:
-            return True
-        return (platform.system(), platform.machine()) in self.source.asset_arch_overrides
+        """True unless an arch-aware dep excludes the running ``(system, machine)``."""
+        host = (platform.system(), platform.machine())
+        if self.kind is ToolKind.NATIVE and isinstance(self.source, GitHubToolSource):
+            if not self.source.asset_arch_overrides:
+                return True
+            return host in self.source.asset_arch_overrides
+        if self.kind is ToolKind.PACKAGE_MANAGER and isinstance(self.source, PackageManagerToolSource):
+            if not self.source.supported_platforms:
+                return True
+            return host in self.source.supported_platforms
+        return True
 
 
 TOOL_REGISTRY: list[ToolDependency] = [
@@ -271,5 +279,40 @@ TOOL_REGISTRY: list[ToolDependency] = [
                 ("Windows", "ARM64"): "rust-analyzer-aarch64-pc-windows-msvc.zip",
             },
         ),
+    ),
+    # mojo-lsp-server only ships inside Modular's ``mojo`` conda package
+    # (compiler + stdlib + LSP; smaller than the full ``max`` SDK).
+    # Why: the pixi shim under ``$PIXI_HOME/bin/`` is a dynamic-linker
+    # wrapper for the binary in ``$PIXI_HOME/envs/mojo/bin/``; ``binary_subpath``
+    # tells the rest of the registry to look in ``bin/``.
+    # Prerequisite: pinned tokei must recognize ``.mojo`` for ProjectScanner
+    # to surface Mojo as a detected language — requires tokei >= 13.0.0-alpha.8
+    # (TOOLS_TAG bump in flight).
+    ToolDependency(
+        key="mojo",
+        binary_name="mojo-lsp-server",
+        kind=ToolKind.PACKAGE_MANAGER,
+        config_section=ConfigSection.LSP_SERVERS,
+        binary_subpath="bin",
+        source=PackageManagerToolSource(
+            tag="25.5",
+            manager_binary="pixi",
+            install_args=(
+                "global",
+                "install",
+                "--channel",
+                "https://conda.modular.com/max",
+                "--expose",
+                "mojo-lsp-server",
+                "mojo={tag}",
+            ),
+            env=(("PIXI_HOME", "{tool_path}"),),
+            supported_platforms=(
+                ("Linux", "x86_64"),
+                ("Linux", "aarch64"),
+                ("Darwin", "arm64"),
+            ),
+        ),
+        archive_subdir="mojo",
     ),
 ]

--- a/vscode_constants.py
+++ b/vscode_constants.py
@@ -130,6 +130,18 @@ VSCODE_CONFIG = {
             # and surfaces in error messages when the binary cannot be located.
             "install_commands": "codeboarding-setup (downloads rust-analyzer automatically)",
         },
+        "mojo": {
+            "name": "Mojo Language Server",
+            "command": ["mojo-lsp-server"],
+            "languages": ["mojo"],
+            "file_extensions": [".mojo"],
+            # mojo-lsp-server is installed via `pixi global install` by
+            # tool_registry. Requires `pixi` on PATH; no native Windows or
+            # macOS x86_64 build exists.
+            "install_commands": (
+                "codeboarding-setup (installs mojo-lsp-server via pixi; " "requires pixi from https://pixi.sh)"
+            ),
+        },
     },
     "tools": {
         "tokei": {

--- a/vscode_constants.py
+++ b/vscode_constants.py
@@ -134,7 +134,7 @@ VSCODE_CONFIG = {
             "name": "Mojo Language Server",
             "command": ["mojo-lsp-server"],
             "languages": ["mojo"],
-            "file_extensions": [".mojo", ".🔥"],
+            "file_extensions": [".mojo", ".\U0001f525"],
             # mojo-lsp-server is installed via `pixi global install` by
             # tool_registry. Requires `pixi` on PATH; no native Windows or
             # macOS x86_64 build exists.

--- a/vscode_constants.py
+++ b/vscode_constants.py
@@ -134,7 +134,7 @@ VSCODE_CONFIG = {
             "name": "Mojo Language Server",
             "command": ["mojo-lsp-server"],
             "languages": ["mojo"],
-            "file_extensions": [".mojo"],
+            "file_extensions": [".mojo", ".🔥"],
             # mojo-lsp-server is installed via `pixi global install` by
             # tool_registry. Requires `pixi` on PATH; no native Windows or
             # macOS x86_64 build exists.


### PR DESCRIPTION
Wires Mojo into the existing static-analysis pipeline:

- Language.MOJO enum + .mojo extension (constants.py).
- MojoAdapter: inherits the base dotted-module qualified-name logic (Mojo's symbol model is Python-shaped); raises with an install hint when mojo-lsp-server isn't reachable.
- Registry entry: PACKAGE_MANAGER kind via `pixi global install` from the Modular conda channel. Three small schema extensions on the surrounding types support this:
    - ToolDependency.binary_subpath — pixi drops shims in $PIXI_HOME/bin/ rather than $PIXI_HOME/, unlike dotnet's --tool-path.
    - PackageManagerToolSource.env — redirects PIXI_HOME into install_dir so the install is self-contained (mirrors --tool-path in spirit).
    - PackageManagerToolSource.supported_platforms — Mojo ships no native Windows or macOS x86_64 build; the existing NATIVE asset_arch_overrides gating pattern is generalised to PM deps too. All three default to empty / unset; csharp-ls behaviour is unchanged.
- Installer + manifest + adapter-registry + vscode-config + adapter-name map updated symmetrically; registry-coverage parity tests extended.

Functionally inert today because the pinned tokei (12.1.2) doesn't recognize .mojo files — ProjectScanner won't surface Mojo until TOOLS_TAG bumps to a release built from tokei >= 13.0.0-alpha.8 (PR in flight on bump-tools-tokei-v14). Documented inline in the Mojo ToolDependency comment.

Integration fixture deferred — generating ground-truth references for the fixture project requires a host with `pixi` + the `mojo` conda package installed locally, which CI doesn't have today. The mojo_lang pytest marker is registered for the follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Mojo language support with LSP integration and VS Code configuration (emoji-aware file extensions).
  * Installer support for Mojo tooling, with platform availability and install-path handling.

* **Bug Fixes / Improvements**
  * Improved symbol range handling for Mojo to yield more accurate code navigation.

* **Tests**
  * Added comprehensive tests for Mojo adapter, LSP command resolution, symbol postprocessing, and installer behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->