### PR TITLE
Treat non-executable native LSP binaries as not-installed and self-heal

### DIFF
--- a/static_analyzer/engine/lsp_client.py
+++ b/static_analyzer/engine/lsp_client.py
@@ -95,14 +95,21 @@ class LSPClient:
         """Start the LSP server process and perform initialization handshake."""
         env = os.environ.copy()
         env.update(self._extra_env)
-        self._process = subprocess.Popen(
-            self._command,
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
-            env=env,
-            cwd=str(self._project_root),
-        )
+        try:
+            self._process = subprocess.Popen(
+                self._command,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                env=env,
+                cwd=str(self._project_root),
+            )
+        except PermissionError as exc:
+            binary = self._command[0] if self._command else "<lsp>"
+            raise PermissionError(
+                f"LSP server binary is not executable: {binary}. Restart to reinstall, "
+                f"run 'chmod +x {binary}', or check that its directory is not mounted noexec."
+            ) from exc
 
         # Grab raw fd and close Python's BufferedReader immediately
         self._stdout_fd = os.dup(self._process.stdout.fileno())  # type: ignore[union-attr]

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -968,7 +968,9 @@ def _populate_complete_servers_dir(base_dir: Path) -> None:
     bin_dir.mkdir(parents=True, exist_ok=True)
     for dep in TOOL_REGISTRY:
         if dep.kind is ToolKind.NATIVE:
-            (bin_dir / f"{dep.binary_name}{exe_suffix()}").write_text("#!/bin/sh\n")
+            native = bin_dir / f"{dep.binary_name}{exe_suffix()}"
+            native.write_text("#!/bin/sh\n")
+            native.chmod(0o755)  # install_native_tools chmods natives; has_required_tools now checks X_OK
         elif dep.kind is ToolKind.NODE and dep.js_entry_file:
             entry_dir = base_dir / "node_modules" / dep.js_entry_parent / "lib"
             entry_dir.mkdir(parents=True, exist_ok=True)
@@ -1007,6 +1009,17 @@ class TestHasRequiredTools(unittest.TestCase):
             base_dir = Path(tmp)
             _populate_complete_servers_dir(base_dir)
             (platform_bin_dir(base_dir) / f"tokei{exe_suffix()}").unlink()
+            self.assertFalse(has_required_tools(base_dir))
+
+    def test_non_executable_native_binary_returns_false(self):
+        """A present-but-non-executable native binary reads as missing so
+        needs_install() re-arms the reinstall instead of trusting mere presence."""
+        if exe_suffix():  # Windows has no exec bit; native_binary_ok is existence-only there
+            self.skipTest("no exec bit on Windows")
+        with tempfile.TemporaryDirectory() as tmp:
+            base_dir = Path(tmp)
+            _populate_complete_servers_dir(base_dir)
+            (platform_bin_dir(base_dir) / f"gopls{exe_suffix()}").chmod(0o644)
             self.assertFalse(has_required_tools(base_dir))
 
     def test_missing_node_js_entry_returns_false(self):
@@ -1504,6 +1517,43 @@ class TestInstallNativeToolsCompressed(unittest.TestCase):
                 install_native_tools(target_dir, [compressed_dep])
             warning_text = "\n".join(logs.output)
             self.assertIn("Unsupported platform FreeBSD", warning_text)
+
+
+class TestInstallNativeToolsRepair(unittest.TestCase):
+    """install_native_tools repairs a present-but-non-executable binary in place."""
+
+    def test_existing_non_executable_binary_regains_exec_bit_without_redownload(self):
+        if exe_suffix():  # exec-bit semantics are POSIX-only
+            self.skipTest("no exec bit on Windows")
+
+        dep = ToolDependency(
+            key="tokei",
+            binary_name="tokei",
+            kind=ToolKind.NATIVE,
+            config_section=ConfigSection.LSP_SERVERS,
+            source=GitHubToolSource(tag="v1", repo="x/y", asset_template="tokei-{platform_suffix}"),
+        )
+
+        def fail_download(*args, **kwargs):
+            raise AssertionError("download_asset must not run for an already-present binary")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            target_dir = Path(tmp)
+            with (
+                patch("tool_registry.installers.platform.system", return_value="Linux"),
+                patch("tool_registry.installers.platform.machine", return_value="x86_64"),
+                patch("tool_registry.paths.platform.system", return_value="Linux"),
+                patch("tool_registry.installers.download_asset", side_effect=fail_download),
+            ):
+                binary_path = platform_bin_dir(target_dir) / "tokei"
+                binary_path.parent.mkdir(parents=True, exist_ok=True)
+                binary_path.write_text("#!/bin/sh\n")
+                binary_path.chmod(0o644)
+                self.assertEqual(binary_path.stat().st_mode & 0o111, 0, "precondition: not executable")
+
+                install_native_tools(target_dir, [dep])
+
+                self.assertEqual(binary_path.stat().st_mode & 0o111, 0o111)
 
 
 class TestRustRegistryEntry(unittest.TestCase):

--- a/tool_registry/installers.py
+++ b/tool_registry/installers.py
@@ -206,6 +206,19 @@ def install_native_tools(
             continue
         binary_path = bin_dir / f"{dep.binary_name}{exe_suffix()}"
         if binary_path.exists():
+            # Repair a binary that exists but lost its exec bit (a crash before
+            # the post-download chmod, or a mode-dropping copy/restore) — cheap
+            # vs a re-download, and breaks the "skip forever" EACCES loop.
+            if system != "Windows" and not os.access(binary_path, os.X_OK):
+                try:
+                    os.chmod(binary_path, 0o755)
+                    logger.info("  %s: restored exec bit on existing binary", dep.binary_name)
+                except OSError:
+                    logger.warning(
+                        "  %s: present but not executable and chmod failed (%s); check ownership/mount",
+                        dep.binary_name,
+                        binary_path,
+                    )
             logger.info("  %s: already installed, skipping", dep.binary_name)
             continue
         source = dep.source

--- a/tool_registry/manifest.py
+++ b/tool_registry/manifest.py
@@ -20,7 +20,7 @@ else:
 from vscode_constants import VSCODE_CONFIG, find_runnable
 
 from .installers import package_manager_tool_dir
-from .paths import exe_suffix, get_servers_dir, platform_bin_dir, preferred_node_path
+from .paths import exe_suffix, get_servers_dir, native_binary_ok, platform_bin_dir, preferred_node_path
 from .registry import (
     PINNED_NODE_VERSION,
     TOOL_REGISTRY,
@@ -214,7 +214,7 @@ def resolve_config(base_dir: Path) -> dict[str, Any]:
     for dep in TOOL_REGISTRY:
         if dep.kind is ToolKind.NATIVE:
             binary_path = bin_dir / f"{dep.binary_name}{native_ext}"
-            if binary_path.exists():
+            if native_binary_ok(binary_path):
                 cmd = cast(list[str], config[dep.config_section][dep.key]["command"])
                 cmd[0] = str(binary_path)
 
@@ -295,8 +295,8 @@ def has_required_tools(base_dir: Path) -> bool:
                 logger.info("has_required_tools: %s unavailable on this host; skipping check", dep.key)
                 continue
             binary_path = platform_bin_dir(base_dir) / f"{dep.binary_name}{exe_suffix()}"
-            if not binary_path.exists():
-                logger.info("has_required_tools: %s missing at %s", dep.key, binary_path)
+            if not native_binary_ok(binary_path):
+                logger.info("has_required_tools: %s missing or not executable at %s", dep.key, binary_path)
                 return False
 
         elif dep.kind is ToolKind.PACKAGE_MANAGER:

--- a/tool_registry/paths.py
+++ b/tool_registry/paths.py
@@ -40,6 +40,19 @@ def platform_bin_dir(base: Path) -> Path:
     return base / "bin" / subdir
 
 
+def native_binary_ok(path: Path) -> bool:
+    """True when a native binary is present and (on POSIX) executable.
+
+    Existence alone is insufficient: a binary published at mode 0644 (the
+    download temp's mode survives os.replace until the post-download chmod) or
+    copied/restored without its mode is readable but not executable, which
+    fails at Popen with EACCES. Mirrors the embedded-node X_OK check.
+    """
+    if not path.exists():
+        return False
+    return platform.system() == "Windows" or os.access(path, os.X_OK)
+
+
 # -- User data directory ------------------------------------------------------
 
 


### PR DESCRIPTION
A native LSP binary (e.g. `gopls`) that exists on disk but lacks the execute bit caused a permanent `PermissionError [Errno 13]` at `Popen`, because the exec bit was only set on a fresh download while every "is it installed?" gate (`has_required_tools`, `resolve_config`, the install skip-on-exists branch) checked existence alone — so `needs_install()` stayed `False` and the documented restart→reinstall recovery was a no-op. This redefines "installed" for native binaries as exists-**and**-executable (re-arming `needs_install()` plus an in-place `chmod` repair so a binary that lost its `+x` self-heals on the next install instead of failing forever), and wraps the LSP `Popen` to raise an actionable error for the environmental causes (noexec mount / ownership) that code can't fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clearer error messages provide actionable guidance when tool startup encounters permission issues
  * Native tool binaries are now validated to ensure they are executable and ready to run
  * Non-executable native tool binaries are automatically repaired on non-Windows systems, restoring proper permissions without requiring re-download

<!-- end of auto-generated comment: release notes by coderabbit.ai -->