### PR TITLE
Surface LSP server failures and right-size C# workspace-ready waits

### DIFF
--- a/static_analyzer/__init__.py
+++ b/static_analyzer/__init__.py
@@ -251,7 +251,8 @@ class StaticAnalyzer:
                 # via ``wait_for_workspace_ready`` so the language-name
                 # check doesn't keep growing.
                 if adapter.wait_for_workspace_ready:
-                    engine_client.wait_for_server_ready()
+                    ready_timeout = max(adapter.get_probe_timeout_minimum(), 300)
+                    engine_client.wait_for_server_ready(timeout=ready_timeout)
                     logger.info(f"{adapter.language} workspace ready: {time.monotonic() - t_lsp_started:.1f}s")
 
                 started.append((engine_config, engine_client))

--- a/static_analyzer/engine/lsp_client.py
+++ b/static_analyzer/engine/lsp_client.py
@@ -64,6 +64,7 @@ class LSPClient:
         self._request_id = 0
         self._msg_queue: queue.Queue[dict] = queue.Queue()
         self._reader_thread: threading.Thread | None = None
+        self._stderr_thread: threading.Thread | None = None
         self._shutdown_event = threading.Event()
         self._write_lock = threading.Lock()
 
@@ -100,7 +101,7 @@ class LSPClient:
                 self._command,
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
-                stderr=subprocess.DEVNULL,
+                stderr=subprocess.PIPE,
                 env=env,
                 cwd=str(self._project_root),
             )
@@ -110,6 +111,12 @@ class LSPClient:
                 f"LSP server binary is not executable: {binary}. Restart to reinstall, "
                 f"run 'chmod +x {binary}', or check that its directory is not mounted noexec."
             ) from exc
+
+        # Drain the server's stderr to the debug log. Why: workspace servers
+        # (e.g. csharp-ls) report load progress and fatal MSBuild/runtime errors
+        # only on stderr; discarding it (DEVNULL) hid a silent project-load hang.
+        self._stderr_thread = threading.Thread(target=self._drain_stderr, name="lsp-stderr", daemon=True)
+        self._stderr_thread.start()
 
         # Grab raw fd and close Python's BufferedReader immediately
         self._stdout_fd = os.dup(self._process.stdout.fileno())  # type: ignore[union-attr]
@@ -184,6 +191,22 @@ class LSPClient:
             )
 
         return init_result
+
+    def _drain_stderr(self) -> None:
+        """Forward the LSP server's stderr to the debug log line by line."""
+        proc = self._process
+        if proc is None or proc.stderr is None:
+            return
+        label = Path(self._command[0]).name if self._command else "lsp"
+        try:
+            for raw in iter(proc.stderr.readline, b""):
+                if self._shutdown_event.is_set():
+                    break
+                line = raw.decode("utf-8", "replace").rstrip()
+                if line:
+                    logger.debug("[%s] %s", label, line)
+        except (ValueError, OSError):
+            pass
 
     def shutdown(self) -> None:
         """Send shutdown request and exit notification, then terminate process."""

--- a/tests/static_analyzer/test_static_analyzer_start_clients.py
+++ b/tests/static_analyzer/test_static_analyzer_start_clients.py
@@ -23,6 +23,7 @@ def _make_adapter(language: str, *, wait_for_workspace_ready: bool = False) -> L
     adapter.get_lsp_init_options.return_value = {}
     adapter.get_lsp_env.return_value = {}
     adapter.get_workspace_settings.return_value = {}
+    adapter.get_probe_timeout_minimum.return_value = 0
     adapter.wait_for_workspace_ready = wait_for_workspace_ready
     return cast(LanguageAdapter, adapter)
 


### PR DESCRIPTION
Language servers' stderr was sent to `DEVNULL`, so failures like csharp-ls/Roslyn stalling on project load were completely invisible; this drains each server's stderr to the debug log instead. It also bounds the workspace-ready wait by the adapter's own `get_probe_timeout_minimum` (C#/Roslyn → 600s) instead of a hardcoded 300s, so large solutions aren't cut off early.

**Testing:** Touched-area unit tests pass (117), and an end-to-end C# analysis of the `csharp_edge_cases_project` fixture produced a correct 36-node / 34-edge call graph (Program.Main hub, virtual dispatch resolved, the intentional dead-code class isolated).

Companion (wrapper) PR: CodeBoarding/CodeBoarding-wrapper#56

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Language server diagnostic and error messages are now captured and logged during startup (previously discarded).

* **Tests**
  * Updated test mocks for LSP startup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->