### PR TITLE
feat: add LiteLLM proxy as a configurable LLM provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ On first run, CodeBoarding creates `~/.codeboarding/config.toml`. Set one provid
 # aws_bearer_token_bedrock  = "..."
 # ollama_base_url           = "http://localhost:11434"
 # openrouter_api_key        = "sk-..."
+# litellm_base_url          = "http://localhost:4000"  # LiteLLM proxy server URL (required)
+# litellm_api_key           = "sk-..."           # LiteLLM proxy server key (optional)
 
 [llm]
 # agent_model   = "gemini-3-flash"
@@ -144,7 +146,7 @@ python main.py full https://github.com/pytorch/pytorch
 ## Supported stack
 
 - Languages: Python, TypeScript, JavaScript, Java, Go, PHP, Rust, C#.
-- LLM providers: OpenAI, Anthropic, Google, Vercel AI Gateway, AWS Bedrock, Ollama, OpenRouter, and more.
+- LLM providers: OpenAI, Anthropic, Google, Vercel AI Gateway, AWS Bedrock, Ollama, OpenRouter, LiteLLM proxy, and more.
 
 ## Examples
 

--- a/agents/llm_config.py
+++ b/agents/llm_config.py
@@ -67,6 +67,9 @@ class LLMConfig:
     Configuration for LLM providers.
 
     Attributes:
+        activation_envs: Env vars that select this provider — active iff any is set.
+        api_key_env: Env var holding the provider's secret, or None when the
+                     underlying SDK reads its credentials from the environment itself.
         agent_model: The "agent" model used for complex reasoning and agentic tasks.
         parsing_model: The "parsing" model used for fast, cost-effective extraction and parsing tasks.
         agent_temperature: Temperature for the agent model. Defaults to 0 for deterministic behavior
@@ -77,40 +80,37 @@ class LLMConfig:
     """
 
     chat_class: Type[BaseChatModel]
-    api_key_env: str
+    activation_envs: list[str]
     agent_model: str
     parsing_model: str
     llm_type: LLMType
     agent_temperature: float = LLMDefaults.DEFAULT_AGENT_TEMPERATURE
     parsing_temperature: float = LLMDefaults.DEFAULT_PARSING_TEMPERATURE
     extra_args: dict[str, Any] = field(default_factory=dict)
-    alt_env_vars: list[str] = field(default_factory=list)
-    required_env_vars: list[str] = field(default_factory=list)
+    api_key_env: str | None = None
     keyless_capable: bool = False
     """Whether this provider can run without a real API key.
 
-    True for self-hosted / OpenAI-compatible endpoints where ``api_key_env`` (or
-    an ``alt_env_vars`` entry) is really a base-URL existence check rather than a
-    secret. When such a provider is the sole active one and no real key is set,
-    key validation warns instead of failing, and the client uses a placeholder.
+    True for self-hosted / OpenAI-compatible endpoints that accept
+    unauthenticated requests. When such a provider is the sole active one and
+    no real key is set, key validation warns instead of failing, and the
+    client uses a placeholder.
     """
 
     def get_api_key(self) -> str | None:
-        return os.getenv(self.api_key_env)
+        return os.getenv(self.api_key_env) if self.api_key_env else None
 
     def has_real_api_key(self) -> bool:
-        """True if the provider's primary API-key env var holds a value.
+        """True if the provider's API-key env var holds a value.
 
         Distinct from ``is_active()``: a keyless-capable provider can be active
-        via a base-URL ``alt_env_vars`` entry while having no real key here.
+        via a base-URL activation var while having no real key here.
         """
-        return bool(os.getenv(self.api_key_env))
+        return bool(self.api_key_env and os.getenv(self.api_key_env))
 
     def is_active(self) -> bool:
-        """Check if any of the environment variables (primary or alternate) are set."""
-        if os.getenv(self.api_key_env):
-            return True
-        return any(os.getenv(var) for var in self.alt_env_vars)
+        """Check if any of the activation environment variables are set."""
+        return any(os.getenv(var) for var in self.activation_envs)
 
     def get_resolved_extra_args(self) -> dict[str, Any]:
         resolved = {}
@@ -125,11 +125,11 @@ class LLMConfig:
 LLM_PROVIDERS = {
     "openai": LLMConfig(
         chat_class=ChatOpenAI,
+        activation_envs=["OPENAI_API_KEY", "OPENAI_BASE_URL"],
         api_key_env="OPENAI_API_KEY",
         agent_model="gpt-4o",
         parsing_model="gpt-4o-mini",
         llm_type=LLMType.GPT4,
-        alt_env_vars=["OPENAI_BASE_URL"],
         keyless_capable=True,
         extra_args={
             "base_url": lambda: os.getenv("OPENAI_BASE_URL"),
@@ -140,11 +140,11 @@ LLM_PROVIDERS = {
     ),
     "vercel": LLMConfig(
         chat_class=ChatOpenAI,
+        activation_envs=["VERCEL_API_KEY", "VERCEL_BASE_URL"],
         api_key_env="VERCEL_API_KEY",
         agent_model="google/gemini-3-flash",
         parsing_model="openai/gpt-5-mini",
         llm_type=LLMType.GEMINI_FLASH,
-        alt_env_vars=["VERCEL_BASE_URL"],
         extra_args={
             "base_url": lambda: os.getenv("VERCEL_BASE_URL", f"https://ai-gateway.vercel.sh/v1"),
             "max_tokens": None,
@@ -154,6 +154,7 @@ LLM_PROVIDERS = {
     ),
     "anthropic": LLMConfig(
         chat_class=ChatAnthropic,
+        activation_envs=["ANTHROPIC_API_KEY"],
         api_key_env="ANTHROPIC_API_KEY",
         agent_model="claude-sonnet-4-6",
         parsing_model="claude-haiku-4-5",
@@ -166,6 +167,7 @@ LLM_PROVIDERS = {
     ),
     "google": LLMConfig(
         chat_class=ChatGoogleGenerativeAI,
+        activation_envs=["GOOGLE_API_KEY"],
         api_key_env="GOOGLE_API_KEY",
         agent_model="gemini-3-flash-preview",
         parsing_model="gemini-3.1-flash-lite",
@@ -178,7 +180,8 @@ LLM_PROVIDERS = {
     ),
     "aws": LLMConfig(
         chat_class=ChatBedrockConverse,
-        api_key_env="AWS_BEARER_TOKEN_BEDROCK",  # Used for existence check
+        # No api_key_env: botocore reads AWS_BEARER_TOKEN_BEDROCK from the environment itself.
+        activation_envs=["AWS_BEARER_TOKEN_BEDROCK"],
         agent_model="anthropic.claude-sonnet-4-6",
         parsing_model="claude-haiku-4-5",
         llm_type=LLMType.CLAUDE_SONNET,
@@ -190,6 +193,7 @@ LLM_PROVIDERS = {
     ),
     "cerebras": LLMConfig(
         chat_class=ChatCerebras,
+        activation_envs=["CEREBRAS_API_KEY"],
         api_key_env="CEREBRAS_API_KEY",
         agent_model="zai-glm-4.7",
         parsing_model="gpt-oss-120b",
@@ -202,7 +206,11 @@ LLM_PROVIDERS = {
     ),
     "ollama": LLMConfig(
         chat_class=ChatOllama,
-        api_key_env="OLLAMA_BASE_URL",  # Used for existence check
+        # OLLAMA_HOST is Ollama's canonical host var; the client falls back to it
+        # when no base_url is passed, and sends OLLAMA_API_KEY (Ollama cloud) itself.
+        activation_envs=["OLLAMA_BASE_URL", "OLLAMA_HOST"],
+        api_key_env="OLLAMA_API_KEY",
+        keyless_capable=True,
         agent_model="qwen3:30b",
         parsing_model="qwen2.5:7b",
         llm_type=LLMType.GEMINI_FLASH,
@@ -214,11 +222,11 @@ LLM_PROVIDERS = {
     ),
     "deepseek": LLMConfig(
         chat_class=ChatOpenAI,
+        activation_envs=["DEEPSEEK_API_KEY", "DEEPSEEK_BASE_URL"],
         api_key_env="DEEPSEEK_API_KEY",
         agent_model="deepseek-chat",
         parsing_model="deepseek-chat",
         llm_type=LLMType.DEEPSEEK,
-        alt_env_vars=["DEEPSEEK_BASE_URL"],
         extra_args={
             "base_url": lambda: os.getenv("DEEPSEEK_BASE_URL", "https://api.deepseek.com/v1"),
             "max_tokens": None,
@@ -228,11 +236,11 @@ LLM_PROVIDERS = {
     ),
     "glm": LLMConfig(
         chat_class=ChatOpenAI,
+        activation_envs=["GLM_API_KEY", "GLM_BASE_URL"],
         api_key_env="GLM_API_KEY",
         agent_model="glm-4.7-flash",
         parsing_model="glm-4.7-flash",
         llm_type=LLMType.GLM,
-        alt_env_vars=["GLM_BASE_URL"],
         extra_args={
             "base_url": lambda: os.getenv("GLM_BASE_URL", "https://open.bigmodel.cn/api/paas/v4"),
             "max_tokens": None,
@@ -242,11 +250,11 @@ LLM_PROVIDERS = {
     ),
     "kimi": LLMConfig(
         chat_class=ChatOpenAI,
+        activation_envs=["KIMI_API_KEY", "KIMI_BASE_URL"],
         api_key_env="KIMI_API_KEY",
         agent_model="kimi-k2.5",
         parsing_model="kimi-k2.5",
         llm_type=LLMType.KIMI,
-        alt_env_vars=["KIMI_BASE_URL"],
         extra_args={
             "base_url": lambda: os.getenv("KIMI_BASE_URL", "https://api.moonshot.cn/v1"),
             "max_tokens": None,
@@ -256,6 +264,7 @@ LLM_PROVIDERS = {
     ),
     "openrouter": LLMConfig(
         chat_class=ChatOpenAI,
+        activation_envs=["OPENROUTER_API_KEY"],
         api_key_env="OPENROUTER_API_KEY",
         agent_model="google/gemini-3-flash-preview",
         parsing_model="google/gemini-3-flash-preview",
@@ -269,14 +278,13 @@ LLM_PROVIDERS = {
     ),
     "litellm": LLMConfig(
         chat_class=ChatOpenAI,
+        # Base URL only: a key alone must not select litellm, since there is no
+        # universal proxy endpoint to default to.
+        activation_envs=["LITELLM_BASE_URL"],
         api_key_env="LITELLM_API_KEY",
         agent_model="gpt-4o",
         parsing_model="gpt-4o-mini",
         llm_type=LLMType.GPT4,
-        alt_env_vars=["LITELLM_BASE_URL"],
-        # Required even when the key is set: a key-only config must fail fast
-        # instead of falling through to the default OpenAI endpoint.
-        required_env_vars=["LITELLM_BASE_URL"],
         keyless_capable=True,
         extra_args={
             "base_url": lambda: os.getenv("LITELLM_BASE_URL"),
@@ -288,6 +296,20 @@ LLM_PROVIDERS = {
 }
 
 
+def _all_activation_envs() -> list[str]:
+    return sorted({var for config in LLM_PROVIDERS.values() for var in config.activation_envs})
+
+
+def _inactive_key_hints() -> list[str]:
+    """Messages for providers whose API key is set but whose activation vars are not."""
+    return [
+        f"{config.api_key_env} is set, but the '{name}' provider activates via "
+        f"{' or '.join(config.activation_envs)}."
+        for name, config in LLM_PROVIDERS.items()
+        if config.has_real_api_key() and not config.is_active()
+    ]
+
+
 def _initialize_llm(
     model_override: str | None,
     model_attr: str,
@@ -297,20 +319,10 @@ def _initialize_llm(
 ) -> tuple[BaseChatModel, str]:
     resolved = _resolve_active_provider(model_override, model_attr)
     if resolved is None:
-        required_vars = []
-        for config in LLM_PROVIDERS.values():
-            required_vars.append(config.api_key_env)
-            required_vars.extend(config.alt_env_vars)
-
-        raise ValueError(
-            f"No valid LLM configuration found. Please set one of: {', '.join(sorted(set(required_vars)))}"
-        )
+        message = f"No valid LLM configuration found. Please set one of: {', '.join(_all_activation_envs())}."
+        raise ValueError(" ".join([message, *_inactive_key_hints()]))
 
     name, config, model_name = resolved
-
-    missing = [var for var in config.required_env_vars if not os.getenv(var)]
-    if missing:
-        raise LLMConfigError(f"The '{name}' provider requires {', '.join(missing)} to be set.")
 
     if init_factory:
         detected_llm_type = LLMType.from_model_name(model_name)
@@ -328,6 +340,8 @@ def _initialize_llm(
     }
     kwargs.update(config.get_resolved_extra_args())
 
+    # ChatBedrockConverse and ChatOllama take no api_key kwarg; their SDKs read
+    # AWS_BEARER_TOKEN_BEDROCK / OLLAMA_API_KEY from the environment directly.
     if name not in ["aws", "ollama"]:
         api_key = config.get_api_key()
         kwargs["api_key"] = api_key or "no-key-required"
@@ -355,20 +369,24 @@ class LLMConfigError(ValueError):
 def validate_api_key_provided() -> None:
     """Raise LLMConfigError if zero or more than one LLM provider is configured.
 
-    A provider is "active" when its API-key env var *or* a base-URL alternate
-    (``alt_env_vars``) is set. Keyless-capable providers (self-hosted /
-    OpenAI-compatible endpoints, e.g. an ``OPENAI_BASE_URL`` with no key) are
-    therefore valid: they are activated by their base URL, and the client falls
-    back to a placeholder key downstream. In that case we log a warning rather
-    than fail. Ambiguity detection (more than one active provider) is preserved
-    so a stray second key is still surfaced.
+    A provider is "active" when any of its ``activation_envs`` is set. Keyless-
+    capable providers (self-hosted / OpenAI-compatible endpoints, e.g. an
+    ``OPENAI_BASE_URL`` with no key) are therefore valid: they are activated by
+    their base URL, and the client falls back to a placeholder key downstream.
+    In that case we log a warning rather than fail. Ambiguity detection (more
+    than one active provider) is preserved so a stray second key is still
+    surfaced, and a key set for an inactive provider (e.g. LITELLM_API_KEY
+    without LITELLM_BASE_URL) is reported rather than silently ignored.
     """
+    hints = _inactive_key_hints()
     active = [name for name, config in LLM_PROVIDERS.items() if config.is_active()]
     if not active:
-        required = sorted({config.api_key_env for config in LLM_PROVIDERS.values()})
-        raise LLMConfigError(f"No LLM provider API key found. Set one of: {', '.join(required)}")
+        message = f"No LLM provider API key found. Set one of: {', '.join(_all_activation_envs())}."
+        raise LLMConfigError(" ".join([message, *hints]))
     if len(active) > 1:
         raise LLMConfigError(f"Multiple LLM provider keys detected ({', '.join(active)}); please set only one.")
+    for hint in hints:
+        logger.warning(hint)
 
     (name,) = active
     config = LLM_PROVIDERS[name]

--- a/agents/llm_config.py
+++ b/agents/llm_config.py
@@ -86,7 +86,6 @@ class LLMConfig:
     extra_args: dict[str, Any] = field(default_factory=dict)
     alt_env_vars: list[str] = field(default_factory=list)
     required_env_vars: list[str] = field(default_factory=list)
-    """Env vars that must be set when this provider is active (e.g. a mandatory base URL)."""
     keyless_capable: bool = False
     """Whether this provider can run without a real API key.
 
@@ -268,11 +267,6 @@ LLM_PROVIDERS = {
             "max_retries": 0,
         },
     ),
-    # LiteLLM proxy server: OpenAI-compatible gateway in front of any provider.
-    # LITELLM_BASE_URL (the proxy address) is mandatory; LITELLM_API_KEY is
-    # optional since some proxies are keyless. Model names are defined by the
-    # proxy, so AGENT_MODEL / PARSING_MODEL (or the [llm] section of config.toml)
-    # should normally override the placeholder defaults.
     "litellm": LLMConfig(
         chat_class=ChatOpenAI,
         api_key_env="LITELLM_API_KEY",

--- a/agents/llm_config.py
+++ b/agents/llm_config.py
@@ -266,6 +266,26 @@ LLM_PROVIDERS = {
             "max_retries": 0,
         },
     ),
+    # LiteLLM proxy server: OpenAI-compatible gateway in front of any provider.
+    # LITELLM_BASE_URL is the activation/mandatory variable (the proxy address,
+    # like Ollama); LITELLM_API_KEY is optional since some proxies are keyless.
+    # Model names are defined by the proxy, so AGENT_MODEL / PARSING_MODEL (or the
+    # [llm] section of config.toml) should normally override the placeholder defaults.
+    "litellm": LLMConfig(
+        chat_class=ChatOpenAI,
+        api_key_env="LITELLM_BASE_URL",
+        agent_model="gpt-4o",
+        parsing_model="gpt-4o-mini",
+        llm_type=LLMType.GPT4,
+        keyless_capable=True,
+        extra_args={
+            "base_url": lambda: os.getenv("LITELLM_BASE_URL"),
+            "api_key": lambda: os.getenv("LITELLM_API_KEY") or "no-key-required",
+            "max_tokens": None,
+            "timeout": None,
+            "max_retries": 0,
+        },
+    ),
 }
 
 
@@ -305,7 +325,7 @@ def _initialize_llm(
     }
     kwargs.update(config.get_resolved_extra_args())
 
-    if name not in ["aws", "ollama"]:
+    if name not in ["aws", "ollama", "litellm"]:
         api_key = config.get_api_key()
         kwargs["api_key"] = api_key or "no-key-required"
 

--- a/agents/llm_config.py
+++ b/agents/llm_config.py
@@ -67,7 +67,7 @@ class LLMConfig:
     Configuration for LLM providers.
 
     Attributes:
-        activation_envs: Env vars that select this provider — active iff any is set.
+        selection_envs: Env vars that select this provider — any one being set selects it.
         api_key_env: Env var holding the provider's secret, or None when the
                      underlying SDK reads its credentials from the environment itself.
         agent_model: The "agent" model used for complex reasoning and agentic tasks.
@@ -80,7 +80,7 @@ class LLMConfig:
     """
 
     chat_class: Type[BaseChatModel]
-    activation_envs: list[str]
+    selection_envs: list[str]
     agent_model: str
     parsing_model: str
     llm_type: LLMType
@@ -92,8 +92,8 @@ class LLMConfig:
     """Whether this provider can run without a real API key.
 
     True for self-hosted / OpenAI-compatible endpoints that accept
-    unauthenticated requests. When such a provider is the sole active one and
-    no real key is set, key validation warns instead of failing, and the
+    unauthenticated requests. When such a provider is the sole selected one
+    and no real key is set, key validation warns instead of failing, and the
     client uses a placeholder.
     """
 
@@ -103,14 +103,14 @@ class LLMConfig:
     def has_real_api_key(self) -> bool:
         """True if the provider's API-key env var holds a value.
 
-        Distinct from ``is_active()``: a keyless-capable provider can be active
-        via a base-URL activation var while having no real key here.
+        Distinct from ``is_selected_by_env()``: a keyless-capable provider can
+        be selected via a base-URL var while having no real key here.
         """
         return bool(self.get_api_key())
 
-    def is_active(self) -> bool:
-        """Check if any of the activation environment variables are set."""
-        return any(os.getenv(var) for var in self.activation_envs)
+    def is_selected_by_env(self) -> bool:
+        """True when any of this provider's selection env vars is set."""
+        return any(os.getenv(var) for var in self.selection_envs)
 
     def get_resolved_extra_args(self) -> dict[str, Any]:
         resolved = {}
@@ -125,7 +125,7 @@ class LLMConfig:
 LLM_PROVIDERS = {
     "openai": LLMConfig(
         chat_class=ChatOpenAI,
-        activation_envs=["OPENAI_API_KEY", "OPENAI_BASE_URL"],
+        selection_envs=["OPENAI_API_KEY", "OPENAI_BASE_URL"],
         api_key_env="OPENAI_API_KEY",
         agent_model="gpt-4o",
         parsing_model="gpt-4o-mini",
@@ -140,7 +140,7 @@ LLM_PROVIDERS = {
     ),
     "vercel": LLMConfig(
         chat_class=ChatOpenAI,
-        activation_envs=["VERCEL_API_KEY", "VERCEL_BASE_URL"],
+        selection_envs=["VERCEL_API_KEY", "VERCEL_BASE_URL"],
         api_key_env="VERCEL_API_KEY",
         agent_model="google/gemini-3-flash",
         parsing_model="openai/gpt-5-mini",
@@ -154,7 +154,7 @@ LLM_PROVIDERS = {
     ),
     "anthropic": LLMConfig(
         chat_class=ChatAnthropic,
-        activation_envs=["ANTHROPIC_API_KEY"],
+        selection_envs=["ANTHROPIC_API_KEY"],
         api_key_env="ANTHROPIC_API_KEY",
         agent_model="claude-sonnet-4-6",
         parsing_model="claude-haiku-4-5",
@@ -167,7 +167,7 @@ LLM_PROVIDERS = {
     ),
     "google": LLMConfig(
         chat_class=ChatGoogleGenerativeAI,
-        activation_envs=["GOOGLE_API_KEY"],
+        selection_envs=["GOOGLE_API_KEY"],
         api_key_env="GOOGLE_API_KEY",
         agent_model="gemini-3-flash-preview",
         parsing_model="gemini-3.1-flash-lite",
@@ -181,7 +181,7 @@ LLM_PROVIDERS = {
     "aws": LLMConfig(
         chat_class=ChatBedrockConverse,
         # No api_key_env: botocore reads AWS_BEARER_TOKEN_BEDROCK from the environment itself.
-        activation_envs=["AWS_BEARER_TOKEN_BEDROCK"],
+        selection_envs=["AWS_BEARER_TOKEN_BEDROCK"],
         agent_model="anthropic.claude-sonnet-4-6",
         parsing_model="claude-haiku-4-5",
         llm_type=LLMType.CLAUDE_SONNET,
@@ -193,7 +193,7 @@ LLM_PROVIDERS = {
     ),
     "cerebras": LLMConfig(
         chat_class=ChatCerebras,
-        activation_envs=["CEREBRAS_API_KEY"],
+        selection_envs=["CEREBRAS_API_KEY"],
         api_key_env="CEREBRAS_API_KEY",
         agent_model="zai-glm-4.7",
         parsing_model="gpt-oss-120b",
@@ -208,7 +208,7 @@ LLM_PROVIDERS = {
         chat_class=ChatOllama,
         # OLLAMA_HOST is Ollama's canonical host var; the client falls back to it
         # when no base_url is passed, and sends OLLAMA_API_KEY (Ollama cloud) itself.
-        activation_envs=["OLLAMA_BASE_URL", "OLLAMA_HOST"],
+        selection_envs=["OLLAMA_BASE_URL", "OLLAMA_HOST"],
         api_key_env="OLLAMA_API_KEY",
         keyless_capable=True,
         agent_model="qwen3:30b",
@@ -222,7 +222,7 @@ LLM_PROVIDERS = {
     ),
     "deepseek": LLMConfig(
         chat_class=ChatOpenAI,
-        activation_envs=["DEEPSEEK_API_KEY", "DEEPSEEK_BASE_URL"],
+        selection_envs=["DEEPSEEK_API_KEY", "DEEPSEEK_BASE_URL"],
         api_key_env="DEEPSEEK_API_KEY",
         agent_model="deepseek-chat",
         parsing_model="deepseek-chat",
@@ -236,7 +236,7 @@ LLM_PROVIDERS = {
     ),
     "glm": LLMConfig(
         chat_class=ChatOpenAI,
-        activation_envs=["GLM_API_KEY", "GLM_BASE_URL"],
+        selection_envs=["GLM_API_KEY", "GLM_BASE_URL"],
         api_key_env="GLM_API_KEY",
         agent_model="glm-4.7-flash",
         parsing_model="glm-4.7-flash",
@@ -250,7 +250,7 @@ LLM_PROVIDERS = {
     ),
     "kimi": LLMConfig(
         chat_class=ChatOpenAI,
-        activation_envs=["KIMI_API_KEY", "KIMI_BASE_URL"],
+        selection_envs=["KIMI_API_KEY", "KIMI_BASE_URL"],
         api_key_env="KIMI_API_KEY",
         agent_model="kimi-k2.5",
         parsing_model="kimi-k2.5",
@@ -264,7 +264,7 @@ LLM_PROVIDERS = {
     ),
     "openrouter": LLMConfig(
         chat_class=ChatOpenAI,
-        activation_envs=["OPENROUTER_API_KEY"],
+        selection_envs=["OPENROUTER_API_KEY"],
         api_key_env="OPENROUTER_API_KEY",
         agent_model="google/gemini-3-flash-preview",
         parsing_model="google/gemini-3-flash-preview",
@@ -280,7 +280,7 @@ LLM_PROVIDERS = {
         chat_class=ChatOpenAI,
         # Base URL only: a key alone must not select litellm, since there is no
         # universal proxy endpoint to default to.
-        activation_envs=["LITELLM_BASE_URL"],
+        selection_envs=["LITELLM_BASE_URL"],
         api_key_env="LITELLM_API_KEY",
         agent_model="gpt-4o",
         parsing_model="gpt-4o-mini",
@@ -296,18 +296,23 @@ LLM_PROVIDERS = {
 }
 
 
-def _all_activation_envs() -> list[str]:
-    return sorted({var for config in LLM_PROVIDERS.values() for var in config.activation_envs})
+def _all_selection_envs() -> list[str]:
+    return sorted({var for config in LLM_PROVIDERS.values() for var in config.selection_envs})
 
 
-def _inactive_key_hints() -> list[str]:
-    """Messages for providers whose API key is set but whose activation vars are not."""
+def _unselected_key_hints() -> list[str]:
+    """Messages for providers whose API key is set but which nothing selects."""
     return [
-        f"{config.api_key_env} is set, but the '{name}' provider activates via "
-        f"{' or '.join(config.activation_envs)}."
+        f"{config.api_key_env} is set, but the '{name}' provider is selected by "
+        f"{' or '.join(config.selection_envs)}."
         for name, config in LLM_PROVIDERS.items()
-        if config.has_real_api_key() and not config.is_active()
+        if config.has_real_api_key() and not config.is_selected_by_env()
     ]
+
+
+def selected_providers() -> list[str]:
+    """Names of providers the environment currently selects."""
+    return [name for name, config in LLM_PROVIDERS.items() if config.is_selected_by_env()]
 
 
 def _initialize_llm(
@@ -317,10 +322,10 @@ def _initialize_llm(
     log_prefix: str,
     init_factory: bool = False,
 ) -> tuple[BaseChatModel, str]:
-    resolved = _resolve_active_provider(model_override, model_attr)
+    resolved = _resolve_selected_provider(model_override, model_attr)
     if resolved is None:
-        message = f"No valid LLM configuration found. Please set one of: {', '.join(_all_activation_envs())}."
-        raise ValueError(" ".join([message, *_inactive_key_hints()]))
+        message = f"No valid LLM configuration found. Please set one of: {', '.join(_all_selection_envs())}."
+        raise ValueError(" ".join([message, *_unselected_key_hints()]))
 
     name, config, model_name = resolved
 
@@ -350,13 +355,13 @@ def _initialize_llm(
     return model, model_name
 
 
-def _resolve_active_provider(
+def _resolve_selected_provider(
     model_override: str | None,
     model_attr: str,
 ) -> tuple[str, LLMConfig, str] | None:
-    """Return the active provider, config, and resolved model name."""
+    """Return the selected provider, config, and resolved model name."""
     for name, config in LLM_PROVIDERS.items():
-        if not config.is_active():
+        if not config.is_selected_by_env():
             continue
         return name, config, model_override or getattr(config, model_attr)
     return None
@@ -367,32 +372,32 @@ class LLMConfigError(ValueError):
 
 
 def validate_api_key_provided() -> None:
-    """Raise LLMConfigError if zero or more than one LLM provider is configured.
+    """Raise LLMConfigError unless exactly one LLM provider is selected.
 
-    A provider is "active" when any of its ``activation_envs`` is set. Keyless-
+    A provider is selected when any of its ``selection_envs`` is set. Keyless-
     capable providers (self-hosted / OpenAI-compatible endpoints, e.g. an
-    ``OPENAI_BASE_URL`` with no key) are therefore valid: they are activated by
+    ``OPENAI_BASE_URL`` with no key) are therefore valid: they are selected by
     their base URL, and the client falls back to a placeholder key downstream.
     In that case we log a warning rather than fail. Ambiguity detection (more
-    than one active provider) is preserved so a stray second key is still
-    surfaced, and a key set for an inactive provider (e.g. LITELLM_API_KEY
+    than one selected provider) is preserved so a stray second key is still
+    surfaced, and a key set for an unselected provider (e.g. LITELLM_API_KEY
     without LITELLM_BASE_URL) is reported rather than silently ignored.
     """
-    hints = _inactive_key_hints()
-    active = [name for name, config in LLM_PROVIDERS.items() if config.is_active()]
-    if not active:
-        message = f"No LLM provider API key found. Set one of: {', '.join(_all_activation_envs())}."
+    hints = _unselected_key_hints()
+    selected = selected_providers()
+    if not selected:
+        message = f"No LLM provider selected. Set one of: {', '.join(_all_selection_envs())}."
         raise LLMConfigError(" ".join([message, *hints]))
-    if len(active) > 1:
-        raise LLMConfigError(f"Multiple LLM provider keys detected ({', '.join(active)}); please set only one.")
+    if len(selected) > 1:
+        raise LLMConfigError(f"Multiple LLM providers selected ({', '.join(selected)}); please set only one.")
     for hint in hints:
         logger.warning(hint)
 
-    (name,) = active
+    (name,) = selected
     config = LLM_PROVIDERS[name]
     if config.keyless_capable and not config.has_real_api_key():
         logger.warning(
-            "Provider '%s' is active via a base URL with no %s set; "
+            "Provider '%s' is selected via a base URL with no %s set; "
             "treating as a keyless local endpoint (a placeholder key is used).",
             name,
             config.api_key_env,
@@ -406,13 +411,13 @@ def initialize_agent_llm(model_override: str | None = None) -> BaseChatModel:
 
 
 def get_current_agent_context_window() -> ContextWindow:
-    """Context window for the currently active agent provider/model.
+    """Context window for the currently selected agent provider/model.
 
-    Resolves the first active provider (same rule as ``_initialize_llm``) on
+    Resolves the first selected provider (same rule as ``_initialize_llm``) on
     every call. ``get_context_window`` handles its own caching, so this is
     cheap enough to call without a module-level cache.
     """
-    resolved = _resolve_active_provider(_agent_model_override or os.getenv("AGENT_MODEL"), "agent_model")
+    resolved = _resolve_selected_provider(_agent_model_override or os.getenv("AGENT_MODEL"), "agent_model")
     if resolved is not None:
         name, _config, model_name = resolved
         return get_context_window(name, model_name)

--- a/agents/llm_config.py
+++ b/agents/llm_config.py
@@ -106,7 +106,7 @@ class LLMConfig:
         Distinct from ``is_active()``: a keyless-capable provider can be active
         via a base-URL activation var while having no real key here.
         """
-        return bool(self.api_key_env and os.getenv(self.api_key_env))
+        return bool(self.get_api_key())
 
     def is_active(self) -> bool:
         """Check if any of the activation environment variables are set."""

--- a/agents/llm_config.py
+++ b/agents/llm_config.py
@@ -85,6 +85,8 @@ class LLMConfig:
     parsing_temperature: float = LLMDefaults.DEFAULT_PARSING_TEMPERATURE
     extra_args: dict[str, Any] = field(default_factory=dict)
     alt_env_vars: list[str] = field(default_factory=list)
+    required_env_vars: list[str] = field(default_factory=list)
+    """Env vars that must be set when this provider is active (e.g. a mandatory base URL)."""
     keyless_capable: bool = False
     """Whether this provider can run without a real API key.
 
@@ -267,20 +269,23 @@ LLM_PROVIDERS = {
         },
     ),
     # LiteLLM proxy server: OpenAI-compatible gateway in front of any provider.
-    # LITELLM_BASE_URL is the activation/mandatory variable (the proxy address,
-    # like Ollama); LITELLM_API_KEY is optional since some proxies are keyless.
-    # Model names are defined by the proxy, so AGENT_MODEL / PARSING_MODEL (or the
-    # [llm] section of config.toml) should normally override the placeholder defaults.
+    # LITELLM_BASE_URL (the proxy address) is mandatory; LITELLM_API_KEY is
+    # optional since some proxies are keyless. Model names are defined by the
+    # proxy, so AGENT_MODEL / PARSING_MODEL (or the [llm] section of config.toml)
+    # should normally override the placeholder defaults.
     "litellm": LLMConfig(
         chat_class=ChatOpenAI,
-        api_key_env="LITELLM_BASE_URL",
+        api_key_env="LITELLM_API_KEY",
         agent_model="gpt-4o",
         parsing_model="gpt-4o-mini",
         llm_type=LLMType.GPT4,
+        alt_env_vars=["LITELLM_BASE_URL"],
+        # Required even when the key is set: a key-only config must fail fast
+        # instead of falling through to the default OpenAI endpoint.
+        required_env_vars=["LITELLM_BASE_URL"],
         keyless_capable=True,
         extra_args={
             "base_url": lambda: os.getenv("LITELLM_BASE_URL"),
-            "api_key": lambda: os.getenv("LITELLM_API_KEY") or "no-key-required",
             "max_tokens": None,
             "timeout": None,
             "max_retries": 0,
@@ -309,6 +314,10 @@ def _initialize_llm(
 
     name, config, model_name = resolved
 
+    missing = [var for var in config.required_env_vars if not os.getenv(var)]
+    if missing:
+        raise LLMConfigError(f"The '{name}' provider requires {', '.join(missing)} to be set.")
+
     if init_factory:
         detected_llm_type = LLMType.from_model_name(model_name)
         initialize_global_factory(detected_llm_type)
@@ -325,7 +334,7 @@ def _initialize_llm(
     }
     kwargs.update(config.get_resolved_extra_args())
 
-    if name not in ["aws", "ollama", "litellm"]:
+    if name not in ["aws", "ollama"]:
         api_key = config.get_api_key()
         kwargs["api_key"] = api_key or "no-key-required"
 

--- a/agents/model_capabilities.py
+++ b/agents/model_capabilities.py
@@ -81,9 +81,12 @@ def _user_context_window_override() -> int | None:
 def _resolve_ollama(provider: str, model_name: str) -> tuple[int, int] | None:
     if provider != "ollama":
         return None
-    base = os.getenv("OLLAMA_BASE_URL")
+    base = os.getenv("OLLAMA_BASE_URL") or os.getenv("OLLAMA_HOST")
     if not base:
         return None
+    if "://" not in base:
+        # OLLAMA_HOST conventionally allows bare host:port.
+        base = f"http://{base}"
     return _ollama_show(model_name, base.rstrip("/"))
 
 

--- a/tests/agents/test_llm_config.py
+++ b/tests/agents/test_llm_config.py
@@ -51,6 +51,10 @@ class TestValidateApiKeyProvided:
             with pytest.raises(ValueError, match="Multiple LLM provider keys detected"):
                 validate_api_key_provided()
 
+    def test_litellm_proxy_base_url_passes(self):
+        with patch.dict(os.environ, {"LITELLM_BASE_URL": "http://localhost:4000"}, clear=True):
+            validate_api_key_provided()  # should not raise; base URL activates the proxy
+
 
 class TestLLMConfigKeyless:
     def test_openai_is_keyless_capable(self):
@@ -68,6 +72,48 @@ class TestLLMConfigKeyless:
         with patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test"}, clear=True):
             assert openai.is_active() is True
             assert openai.has_real_api_key() is True
+
+
+class TestLiteLLMProvider:
+    """The litellm provider proxies an OpenAI-compatible server via base_url."""
+
+    @patch("agents.prompts.prompt_factory.initialize_global_factory")
+    @patch("agents.agent.MONITORING_CALLBACK")
+    def test_uses_proxy_base_url_and_key(self, mock_monitoring_callback, mock_init_factory):
+        from agents.llm_config import LLM_PROVIDERS, initialize_llms
+
+        env = {
+            "LITELLM_API_KEY": "sk-litellm-test",
+            "LITELLM_BASE_URL": "http://localhost:4000",
+            "AGENT_MODEL": "my-proxy-model",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            litellm_config = LLM_PROVIDERS["litellm"]
+            mock_llm = MagicMock()
+            with patch.object(litellm_config, "chat_class", return_value=mock_llm) as mock_chat_class:
+                initialize_llms()
+
+                agent_kwargs = mock_chat_class.call_args_list[0][1]
+                assert agent_kwargs["model"] == "my-proxy-model"
+                assert agent_kwargs["base_url"] == "http://localhost:4000"
+                assert agent_kwargs["api_key"] == "sk-litellm-test"
+
+    @patch("agents.prompts.prompt_factory.initialize_global_factory")
+    @patch("agents.agent.MONITORING_CALLBACK")
+    def test_keyless_proxy_uses_placeholder_key(self, mock_monitoring_callback, mock_init_factory):
+        # Base URL alone activates the proxy; a placeholder key is sent when none is set.
+        from agents.llm_config import LLM_PROVIDERS, initialize_llms
+
+        env = {"LITELLM_BASE_URL": "http://localhost:4000", "AGENT_MODEL": "my-proxy-model"}
+        with patch.dict(os.environ, env, clear=True):
+            litellm_config = LLM_PROVIDERS["litellm"]
+            mock_llm = MagicMock()
+            with patch.object(litellm_config, "chat_class", return_value=mock_llm) as mock_chat_class:
+                initialize_llms()
+
+                agent_kwargs = mock_chat_class.call_args_list[0][1]
+                assert agent_kwargs["base_url"] == "http://localhost:4000"
+                assert agent_kwargs["api_key"] == "no-key-required"
 
 
 class TestDetectLLMTypeFromModel:

--- a/tests/agents/test_llm_config.py
+++ b/tests/agents/test_llm_config.py
@@ -5,7 +5,14 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from agents.llm_config import initialize_agent_llm, initialize_parsing_llm, validate_api_key_provided
+from agents.llm_config import (
+    LLM_PROVIDERS,
+    LLMConfigError,
+    initialize_agent_llm,
+    initialize_llms,
+    initialize_parsing_llm,
+    validate_api_key_provided,
+)
 from agents.prompts.prompt_factory import LLMType
 
 
@@ -58,13 +65,9 @@ class TestValidateApiKeyProvided:
 
 class TestLLMConfigKeyless:
     def test_openai_is_keyless_capable(self):
-        from agents.llm_config import LLM_PROVIDERS
-
         assert LLM_PROVIDERS["openai"].keyless_capable is True
 
     def test_has_real_api_key_distinguishes_from_is_active(self):
-        from agents.llm_config import LLM_PROVIDERS
-
         openai = LLM_PROVIDERS["openai"]
         with patch.dict(os.environ, {"OPENAI_BASE_URL": "http://127.0.0.1:8000/v1"}, clear=True):
             assert openai.is_active() is True
@@ -80,8 +83,6 @@ class TestLiteLLMProvider:
     @patch("agents.prompts.prompt_factory.initialize_global_factory")
     @patch("agents.agent.MONITORING_CALLBACK")
     def test_uses_proxy_base_url_and_key(self, mock_monitoring_callback, mock_init_factory):
-        from agents.llm_config import LLM_PROVIDERS, initialize_llms
-
         env = {
             "LITELLM_API_KEY": "sk-litellm-test",
             "LITELLM_BASE_URL": "http://localhost:4000",
@@ -102,8 +103,6 @@ class TestLiteLLMProvider:
     @patch("agents.agent.MONITORING_CALLBACK")
     def test_keyless_proxy_uses_placeholder_key(self, mock_monitoring_callback, mock_init_factory):
         # Base URL alone activates the proxy; a placeholder key is sent when none is set.
-        from agents.llm_config import LLM_PROVIDERS, initialize_llms
-
         env = {"LITELLM_BASE_URL": "http://localhost:4000", "AGENT_MODEL": "my-proxy-model"}
         with patch.dict(os.environ, env, clear=True):
             litellm_config = LLM_PROVIDERS["litellm"]
@@ -114,6 +113,15 @@ class TestLiteLLMProvider:
                 agent_kwargs = mock_chat_class.call_args_list[0][1]
                 assert agent_kwargs["base_url"] == "http://localhost:4000"
                 assert agent_kwargs["api_key"] == "no-key-required"
+
+    @patch("agents.prompts.prompt_factory.initialize_global_factory")
+    @patch("agents.agent.MONITORING_CALLBACK")
+    def test_key_without_base_url_raises(self, mock_monitoring_callback, mock_init_factory):
+        # A key alone must not fall through to the default OpenAI endpoint.
+        env = {"LITELLM_API_KEY": "sk-litellm-test", "AGENT_MODEL": "my-proxy-model"}
+        with patch.dict(os.environ, env, clear=True):
+            with pytest.raises(LLMConfigError, match="LITELLM_BASE_URL"):
+                initialize_llms()
 
 
 class TestDetectLLMTypeFromModel:

--- a/tests/agents/test_llm_config.py
+++ b/tests/agents/test_llm_config.py
@@ -106,6 +106,14 @@ class TestLLMConfigKeyless:
     def test_openai_is_keyless_capable(self):
         assert LLM_PROVIDERS["openai"].keyless_capable is True
 
+    def test_empty_string_key_is_not_a_real_key(self):
+        # Empty env values must keep meaning "unset", matching is_active() and
+        # the `api_key or "no-key-required"` fallback.
+        openai = LLM_PROVIDERS["openai"]
+        env = {"OPENAI_BASE_URL": "http://127.0.0.1:8000/v1", "OPENAI_API_KEY": ""}
+        with patch.dict(os.environ, env, clear=True):
+            assert openai.has_real_api_key() is False
+
     def test_has_real_api_key_distinguishes_from_is_active(self):
         openai = LLM_PROVIDERS["openai"]
         with patch.dict(os.environ, {"OPENAI_BASE_URL": "http://127.0.0.1:8000/v1"}, clear=True):

--- a/tests/agents/test_llm_config.py
+++ b/tests/agents/test_llm_config.py
@@ -19,7 +19,7 @@ from agents.prompts.prompt_factory import LLMType
 class TestValidateApiKeyProvided:
     def test_no_keys_raises_value_error(self):
         with patch.dict(os.environ, {}, clear=True):
-            with pytest.raises(ValueError, match="No LLM provider API key found"):
+            with pytest.raises(ValueError, match="No LLM provider selected"):
                 validate_api_key_provided()
 
     def test_single_key_passes(self):
@@ -28,7 +28,7 @@ class TestValidateApiKeyProvided:
 
     def test_multiple_keys_raises_value_error(self):
         with patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test", "ANTHROPIC_API_KEY": "sk-ant-test"}, clear=True):
-            with pytest.raises(ValueError, match="Multiple LLM provider keys detected"):
+            with pytest.raises(ValueError, match="Multiple LLM providers selected"):
                 validate_api_key_provided()
 
     def test_base_url_without_key_passes_with_warning(self, caplog):
@@ -55,7 +55,7 @@ class TestValidateApiKeyProvided:
         # Multi-key detection is preserved even when a base URL is set.
         env = {"OPENAI_BASE_URL": "http://127.0.0.1:8000/v1", "ANTHROPIC_API_KEY": "sk-ant-test"}
         with patch.dict(os.environ, env, clear=True):
-            with pytest.raises(ValueError, match="Multiple LLM provider keys detected"):
+            with pytest.raises(ValueError, match="Multiple LLM providers selected"):
                 validate_api_key_provided()
 
     def test_litellm_proxy_base_url_passes(self):
@@ -65,7 +65,7 @@ class TestValidateApiKeyProvided:
     def test_litellm_key_without_base_url_raises_with_hint(self):
         # A key alone does not activate litellm; the error must point at the missing URL.
         with patch.dict(os.environ, {"LITELLM_API_KEY": "sk-litellm-test"}, clear=True):
-            with pytest.raises(LLMConfigError, match="activates via LITELLM_BASE_URL"):
+            with pytest.raises(LLMConfigError, match="is selected by LITELLM_BASE_URL"):
                 validate_api_key_provided()
 
     def test_stray_inactive_key_warns_but_passes(self, caplog):
@@ -79,25 +79,25 @@ class TestValidateApiKeyProvided:
         assert any("LITELLM_API_KEY is set" in r.message for r in caplog.records)
 
 
-class TestProviderActivation:
+class TestProviderSelection:
     def test_ollama_activates_via_ollama_host(self):
         ollama = LLM_PROVIDERS["ollama"]
         with patch.dict(os.environ, {"OLLAMA_HOST": "127.0.0.1:11434"}, clear=True):
-            assert ollama.is_active() is True
+            assert ollama.is_selected_by_env() is True
             assert ollama.has_real_api_key() is False
 
     def test_ollama_cloud_key_is_a_real_key(self):
         ollama = LLM_PROVIDERS["ollama"]
         env = {"OLLAMA_BASE_URL": "https://ollama.com", "OLLAMA_API_KEY": "ok-test"}
         with patch.dict(os.environ, env, clear=True):
-            assert ollama.is_active() is True
+            assert ollama.is_selected_by_env() is True
             assert ollama.has_real_api_key() is True
 
     def test_aws_has_no_api_key_env(self):
         # botocore consumes AWS_BEARER_TOKEN_BEDROCK directly; it is never passed as a kwarg.
         aws = LLM_PROVIDERS["aws"]
         with patch.dict(os.environ, {"AWS_BEARER_TOKEN_BEDROCK": "bearer-test"}, clear=True):
-            assert aws.is_active() is True
+            assert aws.is_selected_by_env() is True
             assert aws.get_api_key() is None
             assert aws.has_real_api_key() is False
 
@@ -107,20 +107,20 @@ class TestLLMConfigKeyless:
         assert LLM_PROVIDERS["openai"].keyless_capable is True
 
     def test_empty_string_key_is_not_a_real_key(self):
-        # Empty env values must keep meaning "unset", matching is_active() and
+        # Empty env values must keep meaning "unset", matching is_selected_by_env() and
         # the `api_key or "no-key-required"` fallback.
         openai = LLM_PROVIDERS["openai"]
         env = {"OPENAI_BASE_URL": "http://127.0.0.1:8000/v1", "OPENAI_API_KEY": ""}
         with patch.dict(os.environ, env, clear=True):
             assert openai.has_real_api_key() is False
 
-    def test_has_real_api_key_distinguishes_from_is_active(self):
+    def test_has_real_api_key_distinguishes_from_is_selected_by_env(self):
         openai = LLM_PROVIDERS["openai"]
         with patch.dict(os.environ, {"OPENAI_BASE_URL": "http://127.0.0.1:8000/v1"}, clear=True):
-            assert openai.is_active() is True
+            assert openai.is_selected_by_env() is True
             assert openai.has_real_api_key() is False
         with patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test"}, clear=True):
-            assert openai.is_active() is True
+            assert openai.is_selected_by_env() is True
             assert openai.has_real_api_key() is True
 
 
@@ -167,7 +167,7 @@ class TestLiteLLMProvider:
         # A key alone must not select litellm and fall through to the default OpenAI endpoint.
         env = {"LITELLM_API_KEY": "sk-litellm-test", "AGENT_MODEL": "my-proxy-model"}
         with patch.dict(os.environ, env, clear=True):
-            with pytest.raises(ValueError, match="activates via LITELLM_BASE_URL"):
+            with pytest.raises(ValueError, match="is selected by LITELLM_BASE_URL"):
                 initialize_llms()
 
 
@@ -407,7 +407,7 @@ class TestEnvironmentVariables:
         """Test that model_override parameter takes precedence over default in initialize_agent_llm()."""
         # Setup mock provider
         mock_config = MagicMock()
-        mock_config.is_active.return_value = True
+        mock_config.is_selected_by_env.return_value = True
         mock_config.agent_model = "gpt-4o"  # Default model
         mock_config.agent_temperature = 0.1
         mock_config.get_api_key.return_value = "test-key"
@@ -472,7 +472,7 @@ class TestEnvironmentVariables:
         """Test that model_override parameter takes precedence over default in initialize_parsing_llm()."""
         # Setup mock provider
         mock_config = MagicMock()
-        mock_config.is_active.return_value = True
+        mock_config.is_selected_by_env.return_value = True
         mock_config.parsing_model = "gpt-4o-mini"  # Default parsing model
         mock_config.parsing_temperature = 0
         mock_config.get_api_key.return_value = "test-key"
@@ -525,7 +525,7 @@ class TestMonitoringIntegration:
 
         # Setup mock provider
         mock_config = MagicMock()
-        mock_config.is_active.return_value = True
+        mock_config.is_selected_by_env.return_value = True
         mock_config.agent_model = "gpt-4o"
         mock_config.agent_temperature = 0.1
         mock_config.get_api_key.return_value = "test-key"

--- a/tests/agents/test_llm_config.py
+++ b/tests/agents/test_llm_config.py
@@ -62,6 +62,45 @@ class TestValidateApiKeyProvided:
         with patch.dict(os.environ, {"LITELLM_BASE_URL": "http://localhost:4000"}, clear=True):
             validate_api_key_provided()  # should not raise; base URL activates the proxy
 
+    def test_litellm_key_without_base_url_raises_with_hint(self):
+        # A key alone does not activate litellm; the error must point at the missing URL.
+        with patch.dict(os.environ, {"LITELLM_API_KEY": "sk-litellm-test"}, clear=True):
+            with pytest.raises(LLMConfigError, match="activates via LITELLM_BASE_URL"):
+                validate_api_key_provided()
+
+    def test_stray_inactive_key_warns_but_passes(self, caplog):
+        # A leftover key for an inactive provider is reported, not treated as ambiguity.
+        import logging
+
+        env = {"OPENAI_API_KEY": "sk-test", "LITELLM_API_KEY": "sk-litellm-test"}
+        with patch.dict(os.environ, env, clear=True):
+            with caplog.at_level(logging.WARNING, logger="agents.llm_config"):
+                validate_api_key_provided()  # should not raise
+        assert any("LITELLM_API_KEY is set" in r.message for r in caplog.records)
+
+
+class TestProviderActivation:
+    def test_ollama_activates_via_ollama_host(self):
+        ollama = LLM_PROVIDERS["ollama"]
+        with patch.dict(os.environ, {"OLLAMA_HOST": "127.0.0.1:11434"}, clear=True):
+            assert ollama.is_active() is True
+            assert ollama.has_real_api_key() is False
+
+    def test_ollama_cloud_key_is_a_real_key(self):
+        ollama = LLM_PROVIDERS["ollama"]
+        env = {"OLLAMA_BASE_URL": "https://ollama.com", "OLLAMA_API_KEY": "ok-test"}
+        with patch.dict(os.environ, env, clear=True):
+            assert ollama.is_active() is True
+            assert ollama.has_real_api_key() is True
+
+    def test_aws_has_no_api_key_env(self):
+        # botocore consumes AWS_BEARER_TOKEN_BEDROCK directly; it is never passed as a kwarg.
+        aws = LLM_PROVIDERS["aws"]
+        with patch.dict(os.environ, {"AWS_BEARER_TOKEN_BEDROCK": "bearer-test"}, clear=True):
+            assert aws.is_active() is True
+            assert aws.get_api_key() is None
+            assert aws.has_real_api_key() is False
+
 
 class TestLLMConfigKeyless:
     def test_openai_is_keyless_capable(self):
@@ -117,10 +156,10 @@ class TestLiteLLMProvider:
     @patch("agents.prompts.prompt_factory.initialize_global_factory")
     @patch("agents.agent.MONITORING_CALLBACK")
     def test_key_without_base_url_raises(self, mock_monitoring_callback, mock_init_factory):
-        # A key alone must not fall through to the default OpenAI endpoint.
+        # A key alone must not select litellm and fall through to the default OpenAI endpoint.
         env = {"LITELLM_API_KEY": "sk-litellm-test", "AGENT_MODEL": "my-proxy-model"}
         with patch.dict(os.environ, env, clear=True):
-            with pytest.raises(LLMConfigError, match="LITELLM_BASE_URL"):
+            with pytest.raises(ValueError, match="activates via LITELLM_BASE_URL"):
                 initialize_llms()
 
 

--- a/tests/test_user_config.py
+++ b/tests/test_user_config.py
@@ -78,6 +78,27 @@ class TestUserConfigApplyToEnv:
             os.environ.clear()
             os.environ.update(original)
 
+    def test_injects_litellm_proxy_key_and_base_url(self):
+        cfg = UserConfig(
+            provider=ProviderUserConfig(
+                litellm_api_key="sk-litellm-test",
+                litellm_base_url="http://localhost:4000",
+            )
+        )
+
+        original = os.environ.copy()
+        try:
+            os.environ.pop("LITELLM_API_KEY", None)
+            os.environ.pop("LITELLM_BASE_URL", None)
+
+            cfg.apply_to_env()
+
+            assert os.environ["LITELLM_API_KEY"] == "sk-litellm-test"
+            assert os.environ["LITELLM_BASE_URL"] == "http://localhost:4000"
+        finally:
+            os.environ.clear()
+            os.environ.update(original)
+
     def test_shell_openai_base_url_takes_precedence(self):
         cfg = UserConfig(provider=ProviderUserConfig(openai_base_url="http://config-value/v1"))
 

--- a/tests/test_user_config.py
+++ b/tests/test_user_config.py
@@ -1,6 +1,15 @@
 import os
 
-from user_config import ProviderUserConfig, UserConfig, ensure_config_template, load_user_config
+from agents.llm_config import LLM_PROVIDERS
+from user_config import (
+    _PROVIDER_ENDPOINTS,
+    _PROVIDER_SECRETS,
+    CONFIG_TEMPLATE,
+    ProviderUserConfig,
+    UserConfig,
+    ensure_config_template,
+    load_user_config,
+)
 
 
 class TestUserConfigApplyToEnv:
@@ -163,3 +172,49 @@ class TestEnsureConfigTemplate:
         text = path.read_text()
         assert "[llm]" in text
         assert "context_window" in text
+
+
+class TestProviderEnvContract:
+    """config.toml must be able to select every provider and store every secret."""
+
+    def test_every_provider_selectable_from_config_toml(self):
+        mapped = set((_PROVIDER_SECRETS | _PROVIDER_ENDPOINTS).values())
+        for name, config in LLM_PROVIDERS.items():
+            assert mapped & set(config.selection_envs), (
+                f"Provider '{name}' cannot be selected from config.toml: none of its "
+                f"selection_envs {config.selection_envs} has an entry. Add one to "
+                f"_PROVIDER_SECRETS or _PROVIDER_ENDPOINTS in user_config.py."
+            )
+
+    def test_every_secret_storable_in_config_toml(self):
+        for name, config in LLM_PROVIDERS.items():
+            if config.api_key_env:
+                assert config.api_key_env in _PROVIDER_SECRETS.values(), (
+                    f"Secret {config.api_key_env} for provider '{name}' has no config.toml key. "
+                    f"Keys belong in config.toml, not shell profiles - add "
+                    f"'{config.api_key_env.lower()}' to _PROVIDER_SECRETS in user_config.py."
+                )
+
+    def test_secrets_are_secrets_and_endpoints_are_endpoints(self):
+        # The bucket names are the documentation - keep them honest.
+        key_envs = {c.api_key_env for c in LLM_PROVIDERS.values() if c.api_key_env}
+        # Credentials consumed by the SDK itself rather than passed as a kwarg
+        # (api_key_env=None), e.g. botocore reading AWS_BEARER_TOKEN_BEDROCK.
+        sdk_credential_envs = {v for c in LLM_PROVIDERS.values() if c.api_key_env is None for v in c.selection_envs}
+        stray_secrets = set(_PROVIDER_SECRETS.values()) - key_envs - sdk_credential_envs
+        assert (
+            not stray_secrets
+        ), f"_PROVIDER_SECRETS entries no provider reads as a credential: {sorted(stray_secrets)}"
+        selection_envs = {v for c in LLM_PROVIDERS.values() for v in c.selection_envs}
+        stray_endpoints = set(_PROVIDER_ENDPOINTS.values()) - (selection_envs - set(_PROVIDER_SECRETS.values()))
+        assert (
+            not stray_endpoints
+        ), f"_PROVIDER_ENDPOINTS entries that are not non-secret selection vars: {sorted(stray_endpoints)}"
+
+    def test_entries_are_discoverable_and_loadable(self):
+        for key, env in (_PROVIDER_SECRETS | _PROVIDER_ENDPOINTS).items():
+            assert key == env.lower(), f"config key '{key}' must be the lowercase of '{env}'"
+            assert (
+                key in ProviderUserConfig.__dataclass_fields__
+            ), f"'{key}' is mapped but not a ProviderUserConfig field - apply_to_env would silently skip it."
+            assert key in CONFIG_TEMPLATE, f"'{key}' is missing from CONFIG_TEMPLATE - users cannot discover it."

--- a/user_config.py
+++ b/user_config.py
@@ -31,6 +31,8 @@ _PROVIDER_KEY_TO_ENV: dict[str, str] = {
     "kimi_api_key": "KIMI_API_KEY",
     "ollama_base_url": "OLLAMA_BASE_URL",
     "openrouter_api_key": "OPENROUTER_API_KEY",
+    "litellm_api_key": "LITELLM_API_KEY",
+    "litellm_base_url": "LITELLM_BASE_URL",
 }
 
 # Template written to ~/.codeboarding/config.toml on first install.
@@ -55,6 +57,8 @@ CONFIG_TEMPLATE = """\
 # kimi_api_key              = "..."
 # ollama_base_url           = "http://localhost:11434"
 # openrouter_api_key        = "sk..."
+# litellm_base_url          = "http://localhost:4000"  # LiteLLM proxy server URL (required)
+# litellm_api_key           = "sk-..."           # LiteLLM proxy server key (optional)
 
 # Optional: override the default models chosen by the active provider.
 # If omitted, each provider's built-in defaults are used.
@@ -81,6 +85,8 @@ class ProviderUserConfig:
     kimi_api_key: str | None = None
     ollama_base_url: str | None = None
     openrouter_api_key: str | None = None
+    litellm_api_key: str | None = None
+    litellm_base_url: str | None = None
 
 
 @dataclass
@@ -128,6 +134,8 @@ def load_user_config(path: Path = CONFIG_PATH) -> UserConfig:
             kimi_api_key=provider_data.get("kimi_api_key") or None,
             ollama_base_url=provider_data.get("ollama_base_url") or None,
             openrouter_api_key=provider_data.get("openrouter_api_key") or None,
+            litellm_api_key=provider_data.get("litellm_api_key") or None,
+            litellm_base_url=provider_data.get("litellm_base_url") or None,
         ),
         llm=LLMUserConfig(
             agent_model=llm_data.get("agent_model") or None,

--- a/user_config.py
+++ b/user_config.py
@@ -30,6 +30,7 @@ _PROVIDER_KEY_TO_ENV: dict[str, str] = {
     "glm_api_key": "GLM_API_KEY",
     "kimi_api_key": "KIMI_API_KEY",
     "ollama_base_url": "OLLAMA_BASE_URL",
+    "ollama_api_key": "OLLAMA_API_KEY",
     "openrouter_api_key": "OPENROUTER_API_KEY",
     "litellm_api_key": "LITELLM_API_KEY",
     "litellm_base_url": "LITELLM_BASE_URL",
@@ -56,6 +57,7 @@ CONFIG_TEMPLATE = """\
 # glm_api_key               = "..."
 # kimi_api_key              = "..."
 # ollama_base_url           = "http://localhost:11434"
+# ollama_api_key            = "..."              # only for Ollama cloud (https://ollama.com)
 # openrouter_api_key        = "sk..."
 # litellm_base_url          = "http://localhost:4000"  # LiteLLM proxy server URL (required)
 # litellm_api_key           = "sk-..."           # LiteLLM proxy server key (optional)
@@ -84,6 +86,7 @@ class ProviderUserConfig:
     glm_api_key: str | None = None
     kimi_api_key: str | None = None
     ollama_base_url: str | None = None
+    ollama_api_key: str | None = None
     openrouter_api_key: str | None = None
     litellm_api_key: str | None = None
     litellm_base_url: str | None = None
@@ -133,6 +136,7 @@ def load_user_config(path: Path = CONFIG_PATH) -> UserConfig:
             glm_api_key=provider_data.get("glm_api_key") or None,
             kimi_api_key=provider_data.get("kimi_api_key") or None,
             ollama_base_url=provider_data.get("ollama_base_url") or None,
+            ollama_api_key=provider_data.get("ollama_api_key") or None,
             openrouter_api_key=provider_data.get("openrouter_api_key") or None,
             litellm_api_key=provider_data.get("litellm_api_key") or None,
             litellm_base_url=provider_data.get("litellm_base_url") or None,

--- a/user_config.py
+++ b/user_config.py
@@ -16,11 +16,14 @@ from pathlib import Path
 
 CONFIG_PATH = Path.home() / ".codeboarding" / "config.toml"
 
-# Mapping from config.toml key names to the env var each provider reads.
-# These are the canonical env var names used in agents/llm_config.py.
-_PROVIDER_KEY_TO_ENV: dict[str, str] = {
+# Both dicts feed config.toml's [provider] table; values are injected into
+# os.environ at startup. Provider selection itself is decided solely by
+# LLMConfig.selection_envs in agents/llm_config.py — membership here only
+# controls what can live in config.toml (contract-tested in tests/test_user_config.py).
+
+# Secrets: one per provider that accepts a key (api_key_env in agents/llm_config.py).
+_PROVIDER_SECRETS: dict[str, str] = {
     "openai_api_key": "OPENAI_API_KEY",
-    "openai_base_url": "OPENAI_BASE_URL",
     "anthropic_api_key": "ANTHROPIC_API_KEY",
     "google_api_key": "GOOGLE_API_KEY",
     "vercel_api_key": "VERCEL_API_KEY",
@@ -29,12 +32,20 @@ _PROVIDER_KEY_TO_ENV: dict[str, str] = {
     "deepseek_api_key": "DEEPSEEK_API_KEY",
     "glm_api_key": "GLM_API_KEY",
     "kimi_api_key": "KIMI_API_KEY",
-    "ollama_base_url": "OLLAMA_BASE_URL",
     "ollama_api_key": "OLLAMA_API_KEY",
     "openrouter_api_key": "OPENROUTER_API_KEY",
     "litellm_api_key": "LITELLM_API_KEY",
+}
+
+# Endpoints with no built-in default — the user must say where the server is.
+# Defaulted base URLs (vercel, deepseek, glm, kimi) are shell-override-only on purpose.
+_PROVIDER_ENDPOINTS: dict[str, str] = {
+    "openai_base_url": "OPENAI_BASE_URL",
+    "ollama_base_url": "OLLAMA_BASE_URL",
     "litellm_base_url": "LITELLM_BASE_URL",
 }
+
+_PROVIDER_KEY_TO_ENV: dict[str, str] = _PROVIDER_SECRETS | _PROVIDER_ENDPOINTS
 
 # Template written to ~/.codeboarding/config.toml on first install.
 CONFIG_TEMPLATE = """\


### PR DESCRIPTION
## What
Adds a `litellm` LLM provider that targets an OpenAI-compatible [LiteLLM proxy server](https://docs.litellm.ai/docs/simple_proxy), configured via `LITELLM_API_KEY` and `LITELLM_BASE_URL`.

- `agents/llm_config.py` — new `litellm` entry in `LLM_PROVIDERS`, reusing `ChatOpenAI` pointed at the proxy's base URL.
- `user_config.py` — `litellm_api_key` / `litellm_base_url` added to the `[provider]` schema, env-var mapping, loader, and generated `config.toml` template.
- `README.md` — documented the new keys and added LiteLLM proxy to the supported providers list.
- Tests in `tests/agents/test_llm_config.py` and `tests/test_user_config.py`.

## Why
Users running a LiteLLM proxy (a single gateway in front of many providers) couldn't point CodeBoarding at it without abusing the generic OpenAI provider and manually overriding the base URL. A first-class `litellm` provider makes this a documented, supported path — consistent with the existing gateway providers (deepseek, glm, kimi, openrouter). Since a LiteLLM proxy is OpenAI-compatible, no new dependency is required.

## How (tested)
- `uv run pytest --ignore=tests/integration tests/agents/test_llm_config.py tests/test_user_config.py` — 102 passed
- `black --check` — clean
- `mypy` — clean on changed files

New tests cover: provider key validation, config→env injection of the proxy key/URL, and that `base_url`/`api_key`/`model` are wired through to the chat client.

## Usage
```toml
# ~/.codeboarding/config.toml
[provider]
litellm_api_key  = "sk-..."                 # LiteLLM server key
litellm_base_url = "http://localhost:4000"  # LiteLLM server URL

[llm]
agent_model   = "your-proxy-model"
parsing_model = "your-proxy-parsing-model"
```
Or via env vars: `LITELLM_API_KEY`, `LITELLM_BASE_URL`, `AGENT_MODEL`, `PARSING_MODEL` (shell env takes precedence over the config file). Model names are defined by your proxy, so set `agent_model`/`parsing_model` to match — the placeholder defaults (`gpt-4o`/`gpt-4o-mini`) will be rejected if your proxy doesn't expose them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added LiteLLM proxy as a supported LLM provider (keyless-capable; configurable via base URL and optional API key).
  * User config now supports LiteLLM keys and base URL and will inject them into the environment when applied.

* **Documentation**
  * Updated docs and sample config to include LiteLLM proxy settings.

* **Bug Fixes**
  * Normalized Ollama host/base-URL handling to accept host-only values.

* **Tests**
  * Added tests for LiteLLM initialization, key/base-url validation, and config env injection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->