### PR TITLE
test: CodeBoarding architecture-diff action smoke test (do not merge)

### DIFF
--- a/.github/workflows/codeboarding.yml
+++ b/.github/workflows/codeboarding.yml
@@ -1,0 +1,30 @@
+name: CodeBoarding review
+
+on:
+  pull_request:
+    # Generate ONCE, when the PR becomes reviewable — not on every push.
+    types: [opened, reopened, ready_for_review]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: codeboarding-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    if: >
+      (github.event_name == 'pull_request' && github.event.pull_request.draft == false) ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request != null &&
+       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
+    steps:
+      - uses: CodeBoarding/CodeBoarding-action@feat/mermaid-architecture-diff
+        with:
+          llm_api_key: ${{ secrets.OPENROUTER_API_KEY }}

--- a/.github/workflows/codeboarding.yml
+++ b/.github/workflows/codeboarding.yml
@@ -25,6 +25,6 @@ jobs:
       (github.event_name == 'issue_comment' && github.event.issue.pull_request != null &&
        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
     steps:
-      - uses: CodeBoarding/CodeBoarding-action@feat/mermaid-architecture-diff
+      - uses: CodeBoarding/CodeBoarding-action@docs/readme-codeboarding-style
         with:
           llm_api_key: ${{ secrets.OPENROUTER_API_KEY }}

--- a/output_generators/markdown.py
+++ b/output_generators/markdown.py
@@ -155,3 +155,12 @@ def component_header(component_name: str, component_id: str, expanded_components
         return f"### {component_name} [[Expand]](./{sanitized_name}.md)"
     else:
         return f"### {component_name}"
+
+
+def _codeboarding_action_smoke_marker() -> str:
+    """Temporary marker added by an end-to-end test of the CodeBoarding PR action.
+
+    Pure, side-effect-free, and unreferenced — safe to delete. It exists only so the
+    architecture diff has a changed method in the Rendering & Output Engine component.
+    """
+    return "codeboarding-action-smoke-test"


### PR DESCRIPTION
End-to-end verification of the `CodeBoarding-action` PR review workflow (`feat/mermaid-architecture-diff`).

- Adds `.github/workflows/codeboarding.yml` (pinned to the action's feature branch).
- Adds a throwaway no-op function in `output_generators/markdown.py` so the architecture diff has a real change to render (expect **Rendering & Output Engine** highlighted as modified).

**Do not merge** — will be closed once the action posts its diagram comment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated code review workflow for pull requests and issue comments
  * Added temporary testing marker to output generation module

<!-- end of auto-generated comment: release notes by coderabbit.ai -->