### PR TITLE
ci: add CodeBoarding architecture-review workflow

### DIFF
--- a/.github/workflows/codeboarding.yml
+++ b/.github/workflows/codeboarding.yml
@@ -1,0 +1,33 @@
+name: CodeBoarding review
+
+on:
+  pull_request:
+    # Generate once, when the PR becomes reviewable, not on every push.
+    types: [opened, reopened, ready_for_review]
+  issue_comment:
+    # Enables refreshing on demand by commenting /codeboarding.
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: codeboarding-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    # PR events (non-draft), or a /codeboarding comment from a trusted collaborator.
+    if: >
+      (github.event_name == 'pull_request' && github.event.pull_request.draft == false) ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request != null &&
+       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
+    steps:
+      # TODO: switch to @v1 once the action is published to the Marketplace.
+      - uses: CodeBoarding/CodeBoarding-action@docs/readme-codeboarding-style
+        with:
+          llm_api_key: ${{ secrets.OPENROUTER_API_KEY }}

--- a/.github/workflows/codeboarding.yml
+++ b/.github/workflows/codeboarding.yml
@@ -28,7 +28,6 @@ jobs:
        startsWith(github.event.comment.body, '/codeboarding') &&
        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
     steps:
-      # TODO: switch to @v1 once the action is published to the Marketplace.
-      - uses: CodeBoarding/CodeBoarding-action@docs/readme-codeboarding-style
+      - uses: CodeBoarding/CodeBoarding-action@v1
         with:
           llm_api_key: ${{ secrets.OPENROUTER_API_KEY }}

--- a/.github/workflows/codeboarding.yml
+++ b/.github/workflows/codeboarding.yml
@@ -25,6 +25,7 @@ jobs:
     if: >
       (github.event_name == 'pull_request' && github.event.pull_request.draft == false) ||
       (github.event_name == 'issue_comment' && github.event.issue.pull_request != null &&
+       startsWith(github.event.comment.body, '/codeboarding') &&
        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
     steps:
       # TODO: switch to @v1 once the action is published to the Marketplace.


### PR DESCRIPTION
Run the CodeBoarding action on PRs: posts a sticky comment with a Mermaid diagram of architectural changes (one comment, 'analyzing…' up front then edited in place with the result). Generated once per PR (open/reopen/ready), refreshable via a /codeboarding comment from a trusted collaborator. Needs the OPENROUTER_API_KEY repo secret.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a CI workflow to run automated review checks on pull requests and on triggerable issue comments.
  * Workflow respects draft PRs and only runs for trusted triggers, enforces per-PR concurrency, uses minimal permissions, and includes a 60-minute job timeout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->