### PR TITLE
Fix C# LSP startup on modern .NET

### DIFF
--- a/static_analyzer/__init__.py
+++ b/static_analyzer/__init__.py
@@ -252,7 +252,7 @@ class StaticAnalyzer:
                 # via ``wait_for_workspace_ready`` so the language-name
                 # check doesn't keep growing.
                 if adapter.wait_for_workspace_ready:
-                    engine_client.wait_for_server_ready(timeout=adapter.workspace_ready_timeout)
+                    engine_client.wait_for_server_ready()
                     logger.info(f"{adapter.language} workspace ready: {time.monotonic() - t_lsp_started:.1f}s")
 
                 started.append((engine_config, engine_client))

--- a/static_analyzer/__init__.py
+++ b/static_analyzer/__init__.py
@@ -246,7 +246,7 @@ class StaticAnalyzer:
                 t_lsp_started = time.monotonic()
                 logger.info(f"{adapter.language} LSP start: {t_lsp_started - t_start:.1f}s")
 
-                # Some LSP servers (JDTLS, rust-analyzer, csharp-ls) load
+                # Some LSP servers (JDTLS, rust-analyzer) load
                 # workspace metadata asynchronously and only respond to
                 # cross-file queries once that's complete. Adapters opt in
                 # via ``wait_for_workspace_ready`` so the language-name

--- a/static_analyzer/__init__.py
+++ b/static_analyzer/__init__.py
@@ -44,6 +44,10 @@ class EngineConfig:
     source_files: list[Path] = field(default_factory=list)
 
 
+class StaticAnalysisFatalError(RuntimeError):
+    """Raised when continuing would produce misleading cached analysis."""
+
+
 def _create_engine_configs(
     programming_languages: list[ProgrammingLanguage],
     repository_path: Path,
@@ -213,6 +217,7 @@ class StaticAnalyzer:
         started: list[tuple[EngineConfig, LSPClient]] = []
         attempted: list[str] = []
         failed_languages: list[str] = []
+        failed_details: list[str] = []
 
         for engine_config in self._engine_configs:
             adapter, project_path = engine_config.adapter, engine_config.project_path
@@ -226,7 +231,7 @@ class StaticAnalyzer:
                 adapter.prepare_project(project_path)
                 command = adapter.get_lsp_command(project_path)
                 init_options = adapter.get_lsp_init_options(self.ignore_manager)
-                extra_env = adapter.get_lsp_env()
+                extra_env = adapter.get_lsp_env(project_path)
                 # Node-based LSPs spawn child ``node`` processes by name; on
                 # a Node-less host the embedded runtime's dir must be on PATH.
                 ensure_node_on_path(command, extra_env)
@@ -257,12 +262,13 @@ class StaticAnalyzer:
 
                 started.append((engine_config, engine_client))
 
-            except Exception:
+            except Exception as exc:
                 logger.exception(
                     f"Failed to start engine LSP client for {adapter.language}; "
                     f"skipping this language and continuing"
                 )
                 failed_languages.append(adapter.language)
+                failed_details.append(f"{adapter.language}: {exc}")
                 if engine_client is not None:
                     try:
                         engine_client.shutdown()
@@ -273,13 +279,18 @@ class StaticAnalyzer:
 
         if not started:
             self._clients_started = False
-            raise RuntimeError(f"Failed to start any engine LSP client (attempted: {', '.join(attempted) or 'none'})")
+            details = f"; failures: {'; '.join(failed_details)}" if failed_details else ""
+            raise RuntimeError(
+                f"Failed to start any engine LSP client (attempted: {', '.join(attempted) or 'none'}){details}"
+            )
 
         if failed_languages:
+            details = f" Details: {'; '.join(failed_details)}." if failed_details else ""
             logger.warning(
                 f"Proceeding with partial LSP coverage. "
                 f"Failed: {', '.join(failed_languages)}. "
-                f"Started: {', '.join(s.adapter.language for s, _ in started)}"
+                f"Started: {', '.join(s.adapter.language for s, _ in started)}."
+                f"{details}"
             )
 
         self._engine_clients = started
@@ -530,10 +541,11 @@ class StaticAnalyzer:
                 )
                 results = self._update_cached_results(cached_results, cached_sha)
 
+        self._validate_analysis_results(results)
+        results.diagnostics = self.collected_diagnostics
         self._cached_results = results
         self._pending_source_sha = source_sha
         self._pending_cache_dir = cache_dir
-        results.diagnostics = self.collected_diagnostics
         return results
 
     def _run_full_lsp_pass(self) -> StaticAnalysisResults:
@@ -563,6 +575,8 @@ class StaticAnalyzer:
                     analysis=analysis,
                     diagnostics=self.collected_diagnostics.get(adapter.language_enum, {}),
                 )
+            except StaticAnalysisFatalError:
+                raise
             except Exception as e:
                 logger.error(f"Error during engine analysis for {adapter.language}: {e}")
                 track_lsp_result(
@@ -723,11 +737,38 @@ class StaticAnalyzer:
         builder = CallGraphBuilder(engine_client, adapter, project_path)
         engine_result = builder.build(source_files)
         logger.info(f"CallGraphBuilder.build() for {adapter.language}: {time.monotonic() - t_build_start:.1f}s")
+        if adapter.fail_on_empty_symbols is True and not builder.symbol_table.symbols:
+            raise StaticAnalysisFatalError(
+                f"{adapter.language} analysis produced 0 symbols across {len(source_files)} source files in "
+                f"{project_path}. This usually means the language server failed to load the workspace; "
+                "not caching empty analysis."
+            )
 
         t_convert = time.monotonic()
         result = convert_to_codeboarding_format(builder.symbol_table, engine_result, adapter)
         logger.info(f"convert_to_codeboarding_format for {adapter.language}: {time.monotonic() - t_convert:.1f}s")
         return result
+
+    def _validate_analysis_results(self, results: StaticAnalysisResults) -> None:
+        """Reject non-empty language buckets that would otherwise cache zero-symbol output."""
+        for engine_config, _ in self._engine_clients:
+            adapter = engine_config.adapter
+            if adapter.fail_on_empty_symbols is not True:
+                continue
+            language = adapter.language_enum
+            source_files = results.get_source_files(language)
+            if not source_files:
+                continue
+            try:
+                node_count = len(results.get_cfg(language).nodes)
+            except ValueError:
+                node_count = 0
+            if node_count == 0:
+                raise StaticAnalysisFatalError(
+                    f"{adapter.language} analysis has 0 symbols across {len(source_files)} source files. "
+                    "Delete any stale .codeboarding/static_analysis.pkl after fixing the SDK/LSP issue; "
+                    "not caching empty analysis."
+                )
 
 
 def get_static_analysis(

--- a/static_analyzer/__init__.py
+++ b/static_analyzer/__init__.py
@@ -252,7 +252,7 @@ class StaticAnalyzer:
                 # via ``wait_for_workspace_ready`` so the language-name
                 # check doesn't keep growing.
                 if adapter.wait_for_workspace_ready:
-                    engine_client.wait_for_server_ready()
+                    engine_client.wait_for_server_ready(timeout=adapter.workspace_ready_timeout)
                     logger.info(f"{adapter.language} workspace ready: {time.monotonic() - t_lsp_started:.1f}s")
 
                 started.append((engine_config, engine_client))

--- a/static_analyzer/csharp_config_scanner.py
+++ b/static_analyzer/csharp_config_scanner.py
@@ -1,7 +1,7 @@
 """Scanner for C# / .NET project configurations.
 
-Detects solution files (.sln), project files (.csproj), and standalone
-C# source trees to support mono-repo analysis with csharp-ls.
+Detects solution files (.sln/.slnx), project files (.csproj), and
+standalone C# source trees to support mono-repo analysis with csharp-ls.
 """
 
 import logging
@@ -10,6 +10,8 @@ from pathlib import Path
 from repo_utils.ignore import RepoIgnoreManager
 
 logger = logging.getLogger(__name__)
+
+SOLUTION_GLOBS: tuple[str, ...] = ("*.sln", "*.slnx")
 
 
 class CSharpProjectConfig:
@@ -31,8 +33,10 @@ class CSharpConfigScanner:
     """Scan a repository for C# / .NET project configurations.
 
     Scanning priority:
-        1. ``.sln`` files — solution-level roots (csharp-ls uses these
-           to discover all referenced projects automatically).
+        1. ``.sln`` / ``.slnx`` files — solution-level roots (csharp-ls
+           uses these to discover all referenced projects automatically).
+           ``.slnx`` is the XML-based replacement Visual Studio adopted in
+           2024; modern .NET repos (e.g. Spectre.Console) ship only it.
         2. Standalone ``.csproj`` files not already covered by a solution.
         3. Fallback to the repository root when ``.cs`` files exist but
            no solution or project files are found.
@@ -64,15 +68,18 @@ class CSharpConfigScanner:
         # 3. Fallback: .cs files exist but no project infrastructure
         if not configs and self._has_cs_files(self.repo_path):
             logger.warning(
-                f"No .sln or .csproj found in {self.repo_path}, but C# files detected. Analysis will be limited."
+                f"No .sln/.slnx or .csproj found in {self.repo_path}, but C# files detected. Analysis will be limited."
             )
             configs.append(CSharpProjectConfig(self.repo_path, "none"))
 
         return configs
 
     def _find_solution_roots(self) -> list[Path]:
-        """Find directories containing .sln files."""
-        return sorted({p.parent for p in self.repo_path.rglob("*.sln") if p.is_file()})
+        """Find directories containing ``.sln`` or ``.slnx`` files."""
+        roots: set[Path] = set()
+        for pattern in SOLUTION_GLOBS:
+            roots.update(p.parent for p in self.repo_path.rglob(pattern) if p.is_file())
+        return sorted(roots)
 
     def _find_project_roots(self) -> list[Path]:
         """Find directories containing .csproj files."""

--- a/static_analyzer/dotnet_sdk.py
+++ b/static_analyzer/dotnet_sdk.py
@@ -1,0 +1,327 @@
+"""Private .NET SDK resolution for C# static analysis.
+
+The adapter needs two things that are easy to conflate:
+
+* the repository's SDK, as selected by ``global.json``;
+* a .NET 10 SDK/runtime capable of installing and running ``csharp-ls``.
+
+This module lets the .NET CLI make SDK-selection decisions, and only falls
+back to a private install under ``~/.codeboarding/dotnet`` when the current
+host cannot satisfy them.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import platform
+import shutil
+import subprocess
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+
+from tool_registry import exe_suffix, user_data_dir
+
+logger = logging.getLogger(__name__)
+
+TOOL_SDK_MAJOR = 10
+TOOL_SDK_CHANNEL = "10.0"
+DOTNET_INSTALL_TIMEOUT = 1800
+DOTNET_PROBE_TIMEOUT = 30
+
+_INSTALL_SCRIPT_URL = "https://dot.net/v1/dotnet-install.sh"
+_INSTALL_SCRIPT_PS1_URL = "https://dot.net/v1/dotnet-install.ps1"
+
+
+class DotnetSdkError(RuntimeError):
+    """Raised when CodeBoarding cannot provide a usable .NET SDK."""
+
+
+@dataclass(frozen=True)
+class DotnetSdkResolution:
+    dotnet_path: str
+    env: dict[str, str]
+    source: str
+    global_json: Path | None = None
+    requested_version: str | None = None
+    installed: bool = False
+
+
+@dataclass(frozen=True)
+class _Probe:
+    ok: bool
+    stdout: str = ""
+    stderr: str = ""
+
+
+def dotnet_install_dir() -> Path:
+    return user_data_dir() / "dotnet"
+
+
+def private_dotnet_path(install_dir: Path | None = None) -> Path:
+    return (install_dir or dotnet_install_dir()) / f"dotnet{exe_suffix()}"
+
+
+def find_global_json(project_root: Path) -> Path | None:
+    """Return the nearest ancestor ``global.json`` that .NET would consider."""
+    current = project_root.resolve()
+    for directory in (current, *current.parents):
+        candidate = directory / "global.json"
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def read_global_sdk_version(global_json: Path) -> str | None:
+    try:
+        payload = json.loads(global_json.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    version = payload.get("sdk", {}).get("version")
+    return version if isinstance(version, str) and version else None
+
+
+def resolve_dotnet_sdk(project_root: Path) -> DotnetSdkResolution:
+    """Resolve or install the .NET SDK set needed for a C# project."""
+    project_root = project_root.resolve()
+    global_json = find_global_json(project_root)
+    requested_version = read_global_sdk_version(global_json) if global_json else None
+
+    install_dir = dotnet_install_dir()
+    private_dotnet = private_dotnet_path(install_dir)
+    private_env = _private_dotnet_env(install_dir)
+
+    private_probe = _probe_dotnet(private_dotnet, project_root, private_env) if private_dotnet.exists() else None
+    if private_probe and private_probe.ok and _has_sdk_major(private_dotnet, project_root, private_env, TOOL_SDK_MAJOR):
+        return DotnetSdkResolution(
+            dotnet_path=str(private_dotnet),
+            env=private_env,
+            source="private",
+            global_json=global_json,
+            requested_version=requested_version,
+        )
+
+    system_dotnet = shutil.which("dotnet")
+    if system_dotnet:
+        system_env = system_dotnet_env(Path(system_dotnet))
+        system_probe = _probe_dotnet(Path(system_dotnet), project_root, system_env)
+        if system_probe.ok and _has_sdk_major(Path(system_dotnet), project_root, system_env, TOOL_SDK_MAJOR):
+            return DotnetSdkResolution(
+                dotnet_path=system_dotnet,
+                env=system_env,
+                source="system",
+                global_json=global_json,
+                requested_version=requested_version,
+            )
+
+    installed = False
+    if global_json and not (private_probe and private_probe.ok):
+        if requested_version is None:
+            raise DotnetSdkError(
+                f"{global_json} exists but does not contain sdk.version. "
+                "Install a compatible .NET SDK or fix global.json before analyzing C#."
+            )
+        _install_from_global_json(global_json, install_dir)
+        installed = True
+
+    if not _has_sdk_major(private_dotnet, project_root, private_env, TOOL_SDK_MAJOR):
+        _install_channel(TOOL_SDK_CHANNEL, install_dir)
+        installed = True
+
+    final_probe = _probe_dotnet(private_dotnet, project_root, private_env)
+    if not final_probe.ok:
+        detail = (final_probe.stderr or final_probe.stdout).strip()
+        pinned = f" required by {global_json}" if global_json else ""
+        raise DotnetSdkError(
+            f"Unable to resolve the .NET SDK{pinned}. "
+            f"Install the SDK manually or retry with network access. {detail[-500:]}"
+        )
+    if not _has_sdk_major(private_dotnet, project_root, private_env, TOOL_SDK_MAJOR):
+        raise DotnetSdkError(
+            f"Unable to install a .NET {TOOL_SDK_MAJOR} SDK for csharp-ls under {install_dir}. "
+            "Install .NET 10.0+ manually and retry."
+        )
+
+    return DotnetSdkResolution(
+        dotnet_path=str(private_dotnet),
+        env=private_env,
+        source="private",
+        global_json=global_json,
+        requested_version=requested_version,
+        installed=installed,
+    )
+
+
+def system_dotnet_env(dotnet_path: Path | None = None) -> dict[str, str]:
+    """Return DOTNET_ROOT for known system layouts when the user has not set one."""
+    if os.environ.get("DOTNET_ROOT"):
+        return {}
+    if dotnet_path is None:
+        found = shutil.which("dotnet")
+        if not found:
+            return {}
+        dotnet = Path(found)
+    else:
+        dotnet = dotnet_path
+    if not str(dotnet):
+        return {}
+    try:
+        resolved = dotnet.resolve()
+    except OSError:
+        return {}
+
+    candidates = [
+        resolved.parent,
+        resolved.parent.parent / "libexec",
+    ]
+    for candidate in candidates:
+        if not (candidate / f"dotnet{exe_suffix()}").exists():
+            continue
+        if candidate.name == "libexec" or (candidate / "sdk").is_dir() or (candidate / "shared").is_dir():
+            return {"DOTNET_ROOT": str(candidate)}
+    return {}
+
+
+def _private_dotnet_env(install_dir: Path) -> dict[str, str]:
+    path = os.environ.get("PATH", "")
+    return {
+        "DOTNET_ROOT": str(install_dir),
+        "PATH": str(install_dir) + (os.pathsep + path if path else ""),
+    }
+
+
+def _merged_env(extra: dict[str, str]) -> dict[str, str]:
+    env = os.environ.copy()
+    env.update(extra)
+    return env
+
+
+def _probe_dotnet(dotnet_path: Path, cwd: Path, env: dict[str, str]) -> _Probe:
+    try:
+        result = subprocess.run(
+            [str(dotnet_path), "--version"],
+            cwd=str(cwd),
+            env=_merged_env(env),
+            capture_output=True,
+            text=True,
+            timeout=DOTNET_PROBE_TIMEOUT,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return _Probe(False, stderr=str(exc))
+    return _Probe(result.returncode == 0, result.stdout, result.stderr)
+
+
+def _has_sdk_major(dotnet_path: Path, cwd: Path, env: dict[str, str], major: int) -> bool:
+    if not dotnet_path.exists() and dotnet_path.is_absolute():
+        return False
+    try:
+        result = subprocess.run(
+            [str(dotnet_path), "--list-sdks"],
+            cwd=str(cwd),
+            env=_merged_env(env),
+            capture_output=True,
+            text=True,
+            timeout=DOTNET_PROBE_TIMEOUT,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    if result.returncode != 0:
+        return False
+    for line in result.stdout.splitlines():
+        version = line.split(maxsplit=1)[0]
+        try:
+            if int(version.split(".", 1)[0]) >= major:
+                return True
+        except (IndexError, ValueError):
+            continue
+    return False
+
+
+def _install_from_global_json(global_json: Path, install_dir: Path) -> None:
+    logger.info("Installing .NET SDK from %s into %s", global_json, install_dir)
+    _run_install_script(["--jsonfile", str(global_json)], install_dir)
+
+
+def _install_channel(channel: str, install_dir: Path) -> None:
+    logger.info("Installing .NET SDK channel %s into %s", channel, install_dir)
+    _run_install_script(["--channel", channel], install_dir)
+
+
+def _run_install_script(args: list[str], install_dir: Path) -> None:
+    install_dir.mkdir(parents=True, exist_ok=True)
+    script = _download_install_script()
+    if platform.system() == "Windows":
+        powershell = shutil.which("pwsh") or shutil.which("powershell") or "powershell"
+        ps_args = _to_powershell_install_args(args)
+        cmd = [
+            powershell,
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            str(script),
+            *ps_args,
+            "-InstallDir",
+            str(install_dir),
+            "-NoPath",
+        ]
+    else:
+        cmd = [
+            shutil.which("bash") or "sh",
+            str(script),
+            *args,
+            "--install-dir",
+            str(install_dir),
+            "--no-path",
+        ]
+    result = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=DOTNET_INSTALL_TIMEOUT,
+        check=False,
+    )
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip()
+        raise DotnetSdkError(f"dotnet-install failed (exit {result.returncode}): {detail[-1000:]}")
+
+
+def _download_install_script() -> Path:
+    scripts_dir = user_data_dir() / "dotnet-install"
+    scripts_dir.mkdir(parents=True, exist_ok=True)
+    if platform.system() == "Windows":
+        target = scripts_dir / "dotnet-install.ps1"
+        url = _INSTALL_SCRIPT_PS1_URL
+    else:
+        target = scripts_dir / "dotnet-install.sh"
+        url = _INSTALL_SCRIPT_URL
+    if target.exists():
+        return target
+
+    tmp = target.with_name(target.name + ".tmp")
+    try:
+        with urllib.request.urlopen(url, timeout=60) as response:
+            tmp.write_bytes(response.read())
+    except (OSError, urllib.error.URLError) as exc:
+        tmp.unlink(missing_ok=True)
+        raise DotnetSdkError(f"Could not download {url}: {exc}") from exc
+    os.replace(tmp, target)
+    if platform.system() != "Windows":
+        target.chmod(0o755)
+    return target
+
+
+def _to_powershell_install_args(args: list[str]) -> list[str]:
+    converted: list[str] = []
+    mapping = {
+        "--jsonfile": "-JsonFile",
+        "--channel": "-Channel",
+    }
+    for arg in args:
+        converted.append(mapping.get(arg, arg))
+    return converted

--- a/static_analyzer/engine/adapters/csharp_adapter.py
+++ b/static_analyzer/engine/adapters/csharp_adapter.py
@@ -120,6 +120,18 @@ class CSharpAdapter(LanguageAdapter):
         return True
 
     @property
+    def workspace_ready_timeout(self) -> int:
+        """csharp-ls 0.20.0 emits a solution-loaded notification only when
+        it finds a ``.sln``/``.slnx`` in the workspace folder. For
+        per-csproj launches (or when the Roslyn MSBuild loader silently
+        skips an unsupported format) it never emits anything. Cap the
+        wait at 60s so analysis proceeds promptly instead of stalling
+        the full default (300s) per discovered project — see
+        ``LSPClient.wait_for_server_ready``.
+        """
+        return 60
+
+    @property
     def probe_before_open(self) -> bool:
         """csharp-ls loads all files from the .sln — didOpen before workspace load kills it."""
         return True
@@ -196,22 +208,30 @@ class CSharpAdapter(LanguageAdapter):
             logger.warning("dotnet restore could not be invoked: %s", exc)
 
     def get_lsp_env(self) -> dict[str, str]:
-        """Set DOTNET_ROOT when not already in the environment.
+        """Set DOTNET_ROOT and DOTNET_ROLL_FORWARD when not already in the environment.
 
         csharp-ls requires the .NET runtime to be discoverable. On systems
         where the SDK is installed via a package manager (e.g. Homebrew on
         macOS), the ``DOTNET_ROOT`` variable may not be set, causing
         csharp-ls to fail at startup.  This resolves the runtime location
         from the ``dotnet`` binary on PATH.
+
+        DOTNET_ROLL_FORWARD=Major: csharp-ls 0.20.0 on NuGet only ships a
+        net9.0 build (no net10.0 tools/), so ``dotnet tool install --framework
+        net10.0`` silently produces a binary whose runtimeconfig pins
+        Microsoft.NETCore.App 9.0.0. Without rollForward, exit code 150 on
+        systems that have only the .NET 10 runtime.
         """
-        if os.environ.get("DOTNET_ROOT"):
-            return {}
-        dotnet = shutil.which("dotnet")
-        if dotnet:
-            dotnet_root = Path(dotnet).resolve().parent.parent / "libexec"
-            if dotnet_root.is_dir():
-                return {"DOTNET_ROOT": str(dotnet_root)}
-        return {}
+        env: dict[str, str] = {}
+        if not os.environ.get("DOTNET_ROOT"):
+            dotnet = shutil.which("dotnet")
+            if dotnet:
+                dotnet_root = Path(dotnet).resolve().parent.parent / "libexec"
+                if dotnet_root.is_dir():
+                    env["DOTNET_ROOT"] = str(dotnet_root)
+        if not os.environ.get("DOTNET_ROLL_FORWARD"):
+            env["DOTNET_ROLL_FORWARD"] = "Major"
+        return env
 
     def is_reference_worthy(self, symbol_kind: int) -> bool:
         """Include namespaces in reference tracking (similar to PHP modules)."""

--- a/static_analyzer/engine/adapters/csharp_adapter.py
+++ b/static_analyzer/engine/adapters/csharp_adapter.py
@@ -128,11 +128,6 @@ class CSharpAdapter(LanguageAdapter):
         return False
 
     @property
-    def workspace_ready_timeout(self) -> int:
-        """Retained for compatibility if C# startup waits are re-enabled."""
-        return 60
-
-    @property
     def probe_before_open(self) -> bool:
         """csharp-ls loads all files from the .sln — didOpen before workspace load kills it."""
         return True
@@ -217,11 +212,9 @@ class CSharpAdapter(LanguageAdapter):
         csharp-ls to fail at startup.  This resolves the runtime location
         from the ``dotnet`` binary on PATH.
 
-        DOTNET_ROLL_FORWARD=Major: csharp-ls 0.20.0 on NuGet only ships a
-        net9.0 build (no net10.0 tools/), so ``dotnet tool install --framework
-        net10.0`` silently produces a binary whose runtimeconfig pins
-        Microsoft.NETCore.App 9.0.0. Without rollForward, exit code 150 on
-        systems that have only the .NET 10 runtime.
+        DOTNET_ROLL_FORWARD=Major allows the dotnet-hosted csharp-ls tool to
+        start when the installed runtime is newer than the runtime targeted by
+        the tool package.
         """
         env: dict[str, str] = {}
         if not os.environ.get("DOTNET_ROOT"):

--- a/static_analyzer/engine/adapters/csharp_adapter.py
+++ b/static_analyzer/engine/adapters/csharp_adapter.py
@@ -10,8 +10,18 @@ from pathlib import Path
 
 from repo_utils.ignore import RepoIgnoreManager
 from static_analyzer.constants import Language, NodeType
+from static_analyzer.dotnet_sdk import DotnetSdkError, resolve_dotnet_sdk, system_dotnet_env
 from static_analyzer.engine.language_adapter import LanguageAdapter
 from static_analyzer.engine.lsp_client import LSPClient
+from tool_registry import (
+    TOOL_REGISTRY,
+    ToolKind,
+    acquire_lock,
+    get_servers_dir,
+    install_package_manager_tools,
+    package_manager_tool_is_current,
+    package_manager_tool_path,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -35,14 +45,48 @@ class CSharpAdapter(LanguageAdapter):
         return "csharp"
 
     def get_lsp_command(self, project_root: Path) -> list[str]:
-        """Fail fast if the .NET SDK is missing — csharp-ls needs dotnet+MSBuild to load Roslyn."""
-        if shutil.which("dotnet") is None:
-            raise RuntimeError(
-                ".NET SDK not found on PATH. csharp-ls requires the .NET SDK "
-                "to index C# projects. Install it from "
-                "https://dotnet.microsoft.com/download and re-run the analysis."
-            )
+        """Resolve the .NET SDK and ensure the managed csharp-ls install is current."""
+        try:
+            resolution = resolve_dotnet_sdk(project_root)
+        except DotnetSdkError as exc:
+            raise RuntimeError(str(exc)) from exc
+
+        self._ensure_csharp_ls_installed(project_root, resolution.dotnet_path, resolution.env)
         return super().get_lsp_command(project_root)
+
+    def _ensure_csharp_ls_installed(self, project_root: Path, dotnet_path: str, dotnet_env: dict[str, str]) -> None:
+        dep = next((d for d in TOOL_REGISTRY if d.key == "csharp" and d.kind is ToolKind.PACKAGE_MANAGER), None)
+        if dep is None:
+            return
+
+        servers_dir = get_servers_dir()
+        managed_path = package_manager_tool_path(servers_dir, dep)
+        if managed_path is not None and package_manager_tool_is_current(servers_dir, dep):
+            return
+
+        command = super().get_lsp_command(project_root)
+        if managed_path is None and command and shutil.which(command[0]):
+            return
+
+        servers_dir.mkdir(parents=True, exist_ok=True)
+        lock_path = servers_dir / ".download.lock"
+        env = os.environ.copy()
+        env.update(dotnet_env)
+        with open(lock_path, "w") as lock_fd:
+            acquire_lock(lock_fd)
+            if package_manager_tool_is_current(servers_dir, dep):
+                return
+            install_package_manager_tools(
+                servers_dir,
+                [dep],
+                manager_overrides={"dotnet": dotnet_path},
+                env=env,
+            )
+        if not package_manager_tool_is_current(servers_dir, dep):
+            raise RuntimeError(
+                "csharp-ls could not be installed. CodeBoarding needs csharp-ls 0.24.0 and a .NET 10 SDK "
+                "to analyze C# projects."
+            )
 
     def build_qualified_name(
         self,
@@ -151,9 +195,6 @@ class CSharpAdapter(LanguageAdapter):
         defined`` diagnostics for every file. Restore is idempotent and
         only writes under ``obj/`` (which we already gitignore).
         """
-        if shutil.which("dotnet") is None:
-            logger.info("Skipping dotnet restore: dotnet not on PATH")
-            return
         # Find solution or csproj/fsproj at the project_root level
         target = next(iter(project_root.glob("*.sln")), None)
         if target is None:
@@ -166,11 +207,16 @@ class CSharpAdapter(LanguageAdapter):
             logger.debug("No solution/project file found at %s; skipping restore", project_root)
             return
 
+        try:
+            resolution = resolve_dotnet_sdk(project_root)
+        except DotnetSdkError as exc:
+            raise RuntimeError(str(exc)) from exc
+
         env = os.environ.copy()
-        env.update(self.get_lsp_env())
+        env.update(resolution.env)
         try:
             result = subprocess.run(
-                ["dotnet", "restore", str(target.name), "--nologo", "--verbosity", "minimal"],
+                [resolution.dotnet_path, "restore", str(target.name), "--nologo", "--verbosity", "minimal"],
                 cwd=str(project_root),
                 env=env,
                 capture_output=True,
@@ -191,29 +237,27 @@ class CSharpAdapter(LanguageAdapter):
         except OSError as exc:
             logger.warning("dotnet restore could not be invoked: %s", exc)
 
-    def get_lsp_env(self) -> dict[str, str]:
-        """Set DOTNET_ROOT and DOTNET_ROLL_FORWARD when not already in the environment.
+    def get_lsp_env(self, project_root: Path | None = None) -> dict[str, str]:
+        """Return the .NET environment needed by csharp-ls.
 
-        csharp-ls requires the .NET runtime to be discoverable. On systems
-        where the SDK is installed via a package manager (e.g. Homebrew on
-        macOS), the ``DOTNET_ROOT`` variable may not be set, causing
-        csharp-ls to fail at startup.  This resolves the runtime location
-        from the ``dotnet`` binary on PATH.
-
-        DOTNET_ROLL_FORWARD=Major allows the dotnet-hosted csharp-ls tool to
-        start when the installed runtime is newer than the runtime targeted by
-        the tool package.
+        With a project root, this may point at CodeBoarding's private SDK
+        hive. Without one, preserve the branch's legacy Homebrew/system
+        DOTNET_ROOT and DOTNET_ROLL_FORWARD behavior for older callers.
         """
-        env: dict[str, str] = {}
-        if not os.environ.get("DOTNET_ROOT"):
-            dotnet = shutil.which("dotnet")
-            if dotnet:
-                dotnet_root = Path(dotnet).resolve().parent.parent / "libexec"
-                if dotnet_root.is_dir():
-                    env["DOTNET_ROOT"] = str(dotnet_root)
+        if project_root is not None:
+            try:
+                return resolve_dotnet_sdk(project_root).env
+            except DotnetSdkError as exc:
+                raise RuntimeError(str(exc)) from exc
+        dotnet = shutil.which("dotnet")
+        env = system_dotnet_env(Path(dotnet)) if dotnet else {}
         if not os.environ.get("DOTNET_ROLL_FORWARD"):
             env["DOTNET_ROLL_FORWARD"] = "Major"
         return env
+
+    @property
+    def fail_on_empty_symbols(self) -> bool:
+        return True
 
     def is_reference_worthy(self, symbol_kind: int) -> bool:
         """Include namespaces in reference tracking (similar to PHP modules)."""

--- a/static_analyzer/engine/adapters/csharp_adapter.py
+++ b/static_analyzer/engine/adapters/csharp_adapter.py
@@ -117,18 +117,19 @@ class CSharpAdapter(LanguageAdapter):
 
     @property
     def wait_for_workspace_ready(self) -> bool:
-        return True
+        """Skip the startup workspace-ready gate for csharp-ls.
+
+        csharp-ls does not consistently emit a solution/workspace-loaded signal
+        when CodeBoarding launches it per project directory. Waiting here makes
+        otherwise usable projects fail before the later probe/diagnostics waits
+        can run. Keep those later C#-specific waits instead; they use real LSP
+        requests/diagnostic quiescence and have larger timeouts.
+        """
+        return False
 
     @property
     def workspace_ready_timeout(self) -> int:
-        """csharp-ls 0.20.0 emits a solution-loaded notification only when
-        it finds a ``.sln``/``.slnx`` in the workspace folder. For
-        per-csproj launches (or when the Roslyn MSBuild loader silently
-        skips an unsupported format) it never emits anything. Cap the
-        wait at 60s so analysis proceeds promptly instead of stalling
-        the full default (300s) per discovered project — see
-        ``LSPClient.wait_for_server_ready``.
-        """
+        """Retained for compatibility if C# startup waits are re-enabled."""
         return 60
 
     @property

--- a/static_analyzer/engine/adapters/csharp_adapter.py
+++ b/static_analyzer/engine/adapters/csharp_adapter.py
@@ -116,18 +116,6 @@ class CSharpAdapter(LanguageAdapter):
         }
 
     @property
-    def wait_for_workspace_ready(self) -> bool:
-        """Skip the startup workspace-ready gate for csharp-ls.
-
-        csharp-ls does not consistently emit a solution/workspace-loaded signal
-        when CodeBoarding launches it per project directory. Waiting here makes
-        otherwise usable projects fail before the later probe/diagnostics waits
-        can run. Keep those later C#-specific waits instead; they use real LSP
-        requests/diagnostic quiescence and have larger timeouts.
-        """
-        return False
-
-    @property
     def probe_before_open(self) -> bool:
         """csharp-ls loads all files from the .sln — didOpen before workspace load kills it."""
         return True

--- a/static_analyzer/engine/adapters/go_adapter.py
+++ b/static_analyzer/engine/adapters/go_adapter.py
@@ -175,7 +175,7 @@ class GoAdapter(LanguageAdapter):
             "ui.diagnostic.staticcheck": True,
         }
 
-    def get_lsp_env(self) -> dict[str, str]:
+    def get_lsp_env(self, project_root: Path | None = None) -> dict[str, str]:
         """Tune Go GC for lower peak memory at the cost of more CPU.
 
         ``GOGC=50`` makes the garbage collector run more frequently (default

--- a/static_analyzer/engine/language_adapter.py
+++ b/static_analyzer/engine/language_adapter.py
@@ -169,19 +169,6 @@ class LanguageAdapter(ABC):
         return False
 
     @property
-    def workspace_ready_timeout(self) -> int:
-        """Seconds to wait for the workspace-ready signal before proceeding anyway.
-
-        Only consulted when ``wait_for_workspace_ready`` is True. The
-        default (300s = 5 min) matches the ``LSPClient.wait_for_server_ready``
-        default and is sized for slow Roslyn/JDT workspace loads on large
-        repos. Adapters whose readiness signal is unreliable (or whose
-        per-project workspaces are small) should override with a shorter
-        value so analysis proceeds promptly without it.
-        """
-        return 300
-
-    @property
     def probe_before_open(self) -> bool:
         """If True, send the sync probe BEFORE bulk didOpen notifications.
 

--- a/static_analyzer/engine/language_adapter.py
+++ b/static_analyzer/engine/language_adapter.py
@@ -191,6 +191,11 @@ class LanguageAdapter(ABC):
         """
         return 0
 
+    @property
+    def fail_on_empty_symbols(self) -> bool:
+        """If True, a non-empty project producing zero symbols is fatal."""
+        return False
+
     def wait_for_diagnostics(self, client: LSPClient) -> None:
         """Block until the LSP server is done publishing diagnostics for didOpen'd files.
 
@@ -208,7 +213,7 @@ class LanguageAdapter(ABC):
         """
         return None
 
-    def get_lsp_env(self) -> dict[str, str]:
+    def get_lsp_env(self, project_root: Path | None = None) -> dict[str, str]:
         """Return extra environment variables for the LSP server process."""
         return {}
 

--- a/static_analyzer/engine/language_adapter.py
+++ b/static_analyzer/engine/language_adapter.py
@@ -169,6 +169,19 @@ class LanguageAdapter(ABC):
         return False
 
     @property
+    def workspace_ready_timeout(self) -> int:
+        """Seconds to wait for the workspace-ready signal before proceeding anyway.
+
+        Only consulted when ``wait_for_workspace_ready`` is True. The
+        default (300s = 5 min) matches the ``LSPClient.wait_for_server_ready``
+        default and is sized for slow Roslyn/JDT workspace loads on large
+        repos. Adapters whose readiness signal is unreliable (or whose
+        per-project workspaces are small) should override with a shorter
+        value so analysis proceeds promptly without it.
+        """
+        return 300
+
+    @property
     def probe_before_open(self) -> bool:
         """If True, send the sync probe BEFORE bulk didOpen notifications.
 

--- a/tests/static_analyzer/test_csharp_adapter.py
+++ b/tests/static_analyzer/test_csharp_adapter.py
@@ -235,17 +235,28 @@ class TestLspConfiguration:
         adapter = CSharpAdapter()
         assert adapter.get_probe_timeout_minimum() > 300
 
+    def test_workspace_ready_timeout_shorter_than_default(self):
+        # Why: csharp-ls's solution-loaded notification only fires when a
+        # .sln/.slnx is found in the workspace folder. The default 300s
+        # wait stalls analysis when the notification never arrives.
+        adapter = CSharpAdapter()
+        assert adapter.workspace_ready_timeout < 300
+
 
 class TestLspEnv:
-    """Tests for DOTNET_ROOT resolution."""
+    """Tests for DOTNET_ROOT and DOTNET_ROLL_FORWARD resolution."""
 
-    def test_returns_empty_when_dotnet_root_set(self, monkeypatch):
+    def test_skips_dotnet_root_when_already_set(self, monkeypatch):
         monkeypatch.setenv("DOTNET_ROOT", "/usr/share/dotnet")
+        monkeypatch.delenv("DOTNET_ROLL_FORWARD", raising=False)
         adapter = CSharpAdapter()
-        assert adapter.get_lsp_env() == {}
+        env = adapter.get_lsp_env()
+        assert "DOTNET_ROOT" not in env
+        assert env.get("DOTNET_ROLL_FORWARD") == "Major"
 
     def test_resolves_dotnet_root_from_path(self, monkeypatch, tmp_path):
         monkeypatch.delenv("DOTNET_ROOT", raising=False)
+        monkeypatch.delenv("DOTNET_ROLL_FORWARD", raising=False)
         # Simulate Homebrew layout: bin/dotnet -> Cellar/.../libexec/dotnet
         libexec = tmp_path / "opt" / "dotnet" / "libexec"
         libexec.mkdir(parents=True)
@@ -259,11 +270,28 @@ class TestLspEnv:
         env = adapter.get_lsp_env()
         assert env.get("DOTNET_ROOT") == str(libexec)
 
-    def test_returns_empty_when_dotnet_not_found(self, monkeypatch):
+    def test_skips_dotnet_root_when_dotnet_not_found(self, monkeypatch):
         monkeypatch.delenv("DOTNET_ROOT", raising=False)
+        monkeypatch.delenv("DOTNET_ROLL_FORWARD", raising=False)
         monkeypatch.setattr("shutil.which", lambda _: None)
         adapter = CSharpAdapter()
-        assert adapter.get_lsp_env() == {}
+        env = adapter.get_lsp_env()
+        assert "DOTNET_ROOT" not in env
+
+    def test_sets_roll_forward_when_unset(self, monkeypatch):
+        # Why: csharp-ls 0.20.0 nupkg ships only tools/net9.0/, so the
+        # installed binary pins Microsoft.NETCore.App 9.0.0. Without
+        # DOTNET_ROLL_FORWARD=Major it exits 150 on .NET-10-only hosts.
+        monkeypatch.delenv("DOTNET_ROLL_FORWARD", raising=False)
+        monkeypatch.setenv("DOTNET_ROOT", "/usr/share/dotnet")
+        adapter = CSharpAdapter()
+        assert adapter.get_lsp_env()["DOTNET_ROLL_FORWARD"] == "Major"
+
+    def test_preserves_user_roll_forward(self, monkeypatch):
+        monkeypatch.setenv("DOTNET_ROLL_FORWARD", "LatestMajor")
+        monkeypatch.setenv("DOTNET_ROOT", "/usr/share/dotnet")
+        adapter = CSharpAdapter()
+        assert "DOTNET_ROLL_FORWARD" not in adapter.get_lsp_env()
 
 
 class TestReferenceTracking:

--- a/tests/static_analyzer/test_csharp_adapter.py
+++ b/tests/static_analyzer/test_csharp_adapter.py
@@ -242,10 +242,6 @@ class TestLspConfiguration:
         adapter = CSharpAdapter()
         assert adapter.wait_for_workspace_ready is False
 
-    def test_workspace_ready_timeout_shorter_than_default_if_reenabled(self):
-        adapter = CSharpAdapter()
-        assert adapter.workspace_ready_timeout < 300
-
 
 class TestLspEnv:
     """Tests for DOTNET_ROOT and DOTNET_ROLL_FORWARD resolution."""
@@ -273,6 +269,7 @@ class TestLspEnv:
         adapter = CSharpAdapter()
         env = adapter.get_lsp_env()
         assert env.get("DOTNET_ROOT") == str(libexec)
+        assert env.get("DOTNET_ROLL_FORWARD") == "Major"
 
     def test_skips_dotnet_root_when_dotnet_not_found(self, monkeypatch):
         monkeypatch.delenv("DOTNET_ROOT", raising=False)
@@ -281,6 +278,7 @@ class TestLspEnv:
         adapter = CSharpAdapter()
         env = adapter.get_lsp_env()
         assert "DOTNET_ROOT" not in env
+        assert env.get("DOTNET_ROLL_FORWARD") == "Major"
 
     def test_sets_roll_forward_when_unset(self, monkeypatch):
         # Why: csharp-ls is a dotnet tool, and older installs may pin a

--- a/tests/static_analyzer/test_csharp_adapter.py
+++ b/tests/static_analyzer/test_csharp_adapter.py
@@ -235,10 +235,14 @@ class TestLspConfiguration:
         adapter = CSharpAdapter()
         assert adapter.get_probe_timeout_minimum() > 300
 
-    def test_workspace_ready_timeout_shorter_than_default(self):
-        # Why: csharp-ls's solution-loaded notification only fires when a
-        # .sln/.slnx is found in the workspace folder. The default 300s
-        # wait stalls analysis when the notification never arrives.
+    def test_skips_initial_workspace_ready_wait(self):
+        # Why: csharp-ls does not consistently emit a startup workspace-ready
+        # signal for per-csproj launches. C# relies on the later probe and
+        # diagnostics waits instead.
+        adapter = CSharpAdapter()
+        assert adapter.wait_for_workspace_ready is False
+
+    def test_workspace_ready_timeout_shorter_than_default_if_reenabled(self):
         adapter = CSharpAdapter()
         assert adapter.workspace_ready_timeout < 300
 
@@ -279,9 +283,9 @@ class TestLspEnv:
         assert "DOTNET_ROOT" not in env
 
     def test_sets_roll_forward_when_unset(self, monkeypatch):
-        # Why: csharp-ls 0.20.0 nupkg ships only tools/net9.0/, so the
-        # installed binary pins Microsoft.NETCore.App 9.0.0. Without
-        # DOTNET_ROLL_FORWARD=Major it exits 150 on .NET-10-only hosts.
+        # Why: csharp-ls is a dotnet tool, and older installs may pin a
+        # runtime not present on the host. Roll-forward keeps setup resilient
+        # across supported .NET SDK/runtime combinations.
         monkeypatch.delenv("DOTNET_ROLL_FORWARD", raising=False)
         monkeypatch.setenv("DOTNET_ROOT", "/usr/share/dotnet")
         adapter = CSharpAdapter()

--- a/tests/static_analyzer/test_csharp_adapter.py
+++ b/tests/static_analyzer/test_csharp_adapter.py
@@ -8,7 +8,12 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from static_analyzer.constants import Language, NodeType
+from static_analyzer.dotnet_sdk import DotnetSdkError, DotnetSdkResolution
 from static_analyzer.engine.adapters.csharp_adapter import CSharpAdapter
+
+
+def _dotnet_resolution(dotnet_path: str = "/usr/bin/dotnet", env: dict[str, str] | None = None) -> DotnetSdkResolution:
+    return DotnetSdkResolution(dotnet_path=dotnet_path, env=env or {}, source="system")
 
 
 class TestGetLspCommandDotnetCheck:
@@ -20,31 +25,24 @@ class TestGetLspCommandDotnetCheck:
     ``RustAdapter`` enforces a cargo toolchain.
     """
 
-    def test_raises_when_dotnet_missing(self, tmp_path: Path) -> None:
-        real_which = shutil.which
-
-        def selective(name: str) -> str | None:
-            if name == "dotnet":
-                return None
-            return real_which(name)
-
-        with patch("static_analyzer.engine.adapters.csharp_adapter.shutil.which", side_effect=selective):
-            with pytest.raises(RuntimeError, match=r"\.NET SDK not found.*dotnet\.microsoft\.com"):
+    def test_raises_when_sdk_cannot_be_resolved(self, tmp_path: Path) -> None:
+        with patch(
+            "static_analyzer.engine.adapters.csharp_adapter.resolve_dotnet_sdk",
+            side_effect=DotnetSdkError(".NET SDK not found"),
+        ):
+            with pytest.raises(RuntimeError, match=r"\.NET SDK not found"):
                 CSharpAdapter().get_lsp_command(tmp_path)
 
     def test_returns_command_when_dotnet_present(self, tmp_path: Path) -> None:
-        real_which = shutil.which
-
-        def selective(name: str) -> str | None:
-            if name == "dotnet":
-                return "/usr/local/bin/dotnet"
-            return real_which(name)
-
         resolved = "/opt/codeboarding/pm-tools/csharp/csharp-ls"
         lsp_servers = {"csharp": {"command": [resolved]}}
 
         with (
-            patch("static_analyzer.engine.adapters.csharp_adapter.shutil.which", side_effect=selective),
+            patch(
+                "static_analyzer.engine.adapters.csharp_adapter.resolve_dotnet_sdk",
+                return_value=_dotnet_resolution("/usr/local/bin/dotnet"),
+            ),
+            patch.object(CSharpAdapter, "_ensure_csharp_ls_installed"),
             patch("static_analyzer.engine.language_adapter.get_config", return_value=lsp_servers),
         ):
             cmd = CSharpAdapter().get_lsp_command(tmp_path)
@@ -74,6 +72,10 @@ class TestCSharpAdapterProperties:
     def test_language_id(self):
         adapter = CSharpAdapter()
         assert adapter.language_id == "csharp"
+
+    def test_fails_on_empty_symbols(self):
+        adapter = CSharpAdapter()
+        assert adapter.fail_on_empty_symbols is True
 
     def test_config_key_defaults_to_language_id(self):
         adapter = CSharpAdapter()
@@ -295,6 +297,14 @@ class TestLspEnv:
         adapter = CSharpAdapter()
         assert "DOTNET_ROLL_FORWARD" not in adapter.get_lsp_env()
 
+    def test_project_env_uses_resolved_sdk(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            "static_analyzer.engine.adapters.csharp_adapter.resolve_dotnet_sdk",
+            lambda _root: _dotnet_resolution("/private/dotnet", {"DOTNET_ROOT": "/private"}),
+        )
+        adapter = CSharpAdapter()
+        assert adapter.get_lsp_env(tmp_path) == {"DOTNET_ROOT": "/private"}
+
 
 class TestReferenceTracking:
     """Tests for symbol filtering behavior."""
@@ -336,28 +346,32 @@ class TestPrepareProject:
 
     def test_runs_dotnet_restore_when_csproj_present(self, tmp_path, monkeypatch):
         (tmp_path / "Foo.csproj").write_text("<Project />")
-        monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/dotnet" if name == "dotnet" else None)
 
         called = {}
 
         def fake_run(cmd, **kwargs):
             called["cmd"] = cmd
             called["cwd"] = kwargs.get("cwd")
+            called["env"] = kwargs.get("env")
             return MagicMock(returncode=0, stdout="", stderr="")
 
         monkeypatch.setattr(
             "static_analyzer.engine.adapters.csharp_adapter.subprocess.run",
             fake_run,
         )
+        monkeypatch.setattr(
+            "static_analyzer.engine.adapters.csharp_adapter.resolve_dotnet_sdk",
+            lambda _root: _dotnet_resolution("/opt/dotnet/dotnet", {"DOTNET_ROOT": "/opt/dotnet"}),
+        )
         CSharpAdapter().prepare_project(tmp_path)
-        assert called["cmd"][:2] == ["dotnet", "restore"]
+        assert called["cmd"][:2] == ["/opt/dotnet/dotnet", "restore"]
         assert called["cmd"][2] == "Foo.csproj"
         assert called["cwd"] == str(tmp_path)
+        assert called["env"]["DOTNET_ROOT"] == "/opt/dotnet"
 
     def test_prefers_solution_over_csproj(self, tmp_path, monkeypatch):
         (tmp_path / "Foo.sln").write_text("")
         (tmp_path / "Foo.csproj").write_text("<Project />")
-        monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/dotnet" if name == "dotnet" else None)
 
         called = {}
 
@@ -369,24 +383,32 @@ class TestPrepareProject:
             "static_analyzer.engine.adapters.csharp_adapter.subprocess.run",
             fake_run,
         )
+        monkeypatch.setattr(
+            "static_analyzer.engine.adapters.csharp_adapter.resolve_dotnet_sdk",
+            lambda _root: _dotnet_resolution(),
+        )
         CSharpAdapter().prepare_project(tmp_path)
         assert called["cmd"][2] == "Foo.sln"
 
     def test_skips_when_no_project_file(self, tmp_path, monkeypatch):
-        monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/dotnet" if name == "dotnet" else None)
-
         def fake_run(*_args, **_kwargs):
             raise AssertionError("subprocess.run should not be called")
+
+        def fake_resolve(*_args, **_kwargs):
+            raise AssertionError("resolve_dotnet_sdk should not be called")
 
         monkeypatch.setattr(
             "static_analyzer.engine.adapters.csharp_adapter.subprocess.run",
             fake_run,
+        )
+        monkeypatch.setattr(
+            "static_analyzer.engine.adapters.csharp_adapter.resolve_dotnet_sdk",
+            fake_resolve,
         )
         CSharpAdapter().prepare_project(tmp_path)  # no exception
 
-    def test_skips_when_dotnet_not_on_path(self, tmp_path, monkeypatch):
+    def test_raises_when_sdk_unavailable(self, tmp_path, monkeypatch):
         (tmp_path / "Foo.csproj").write_text("<Project />")
-        monkeypatch.setattr("shutil.which", lambda _: None)
 
         def fake_run(*_args, **_kwargs):
             raise AssertionError("subprocess.run should not be called")
@@ -395,11 +417,15 @@ class TestPrepareProject:
             "static_analyzer.engine.adapters.csharp_adapter.subprocess.run",
             fake_run,
         )
-        CSharpAdapter().prepare_project(tmp_path)
+        monkeypatch.setattr(
+            "static_analyzer.engine.adapters.csharp_adapter.resolve_dotnet_sdk",
+            lambda _root: (_ for _ in ()).throw(DotnetSdkError("compatible .NET SDK was not found")),
+        )
+        with pytest.raises(RuntimeError, match="compatible .NET SDK"):
+            CSharpAdapter().prepare_project(tmp_path)
 
     def test_swallows_restore_failure(self, tmp_path, monkeypatch):
         (tmp_path / "Foo.csproj").write_text("<Project />")
-        monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/dotnet" if name == "dotnet" else None)
 
         def fake_run(cmd, **kwargs):
             return MagicMock(returncode=1, stdout="", stderr="boom")
@@ -408,12 +434,15 @@ class TestPrepareProject:
             "static_analyzer.engine.adapters.csharp_adapter.subprocess.run",
             fake_run,
         )
+        monkeypatch.setattr(
+            "static_analyzer.engine.adapters.csharp_adapter.resolve_dotnet_sdk",
+            lambda _root: _dotnet_resolution(),
+        )
         # Should not raise — restore failures are warnings, not aborts.
         CSharpAdapter().prepare_project(tmp_path)
 
     def test_handles_subprocess_timeout(self, tmp_path, monkeypatch):
         (tmp_path / "Foo.csproj").write_text("<Project />")
-        monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/dotnet" if name == "dotnet" else None)
 
         def fake_run(cmd, **kwargs):
             raise subprocess.TimeoutExpired(cmd=cmd, timeout=1)
@@ -421,5 +450,9 @@ class TestPrepareProject:
         monkeypatch.setattr(
             "static_analyzer.engine.adapters.csharp_adapter.subprocess.run",
             fake_run,
+        )
+        monkeypatch.setattr(
+            "static_analyzer.engine.adapters.csharp_adapter.resolve_dotnet_sdk",
+            lambda _root: _dotnet_resolution(),
         )
         CSharpAdapter().prepare_project(tmp_path)  # no exception

--- a/tests/static_analyzer/test_csharp_config_scanner.py
+++ b/tests/static_analyzer/test_csharp_config_scanner.py
@@ -38,11 +38,7 @@ class TestCSharpConfigScanner:
         assert projects[0].project_type == "solution"
 
     def test_scan_slnx_solution_file(self, tmp_path: Path):
-        """``.slnx`` is the XML-based replacement for ``.sln`` adopted by
-        Visual Studio in 2024. Modern .NET repos (e.g. Spectre.Console)
-        ship only the .slnx; missing it caused per-csproj LSP launches
-        that stall on csharp-ls's solution-loaded notification.
-        """
+        """Ensure .slnx files are recognized to avoid per-project fallback scanning."""
         (tmp_path / "MyApp.slnx").write_text("<Solution/>")
         sub = tmp_path / "src" / "Api"
         sub.mkdir(parents=True)

--- a/tests/static_analyzer/test_csharp_config_scanner.py
+++ b/tests/static_analyzer/test_csharp_config_scanner.py
@@ -37,6 +37,24 @@ class TestCSharpConfigScanner:
         assert projects[0].root == tmp_path
         assert projects[0].project_type == "solution"
 
+    def test_scan_slnx_solution_file(self, tmp_path: Path):
+        """``.slnx`` is the XML-based replacement for ``.sln`` adopted by
+        Visual Studio in 2024. Modern .NET repos (e.g. Spectre.Console)
+        ship only the .slnx; missing it caused per-csproj LSP launches
+        that stall on csharp-ls's solution-loaded notification.
+        """
+        (tmp_path / "MyApp.slnx").write_text("<Solution/>")
+        sub = tmp_path / "src" / "Api"
+        sub.mkdir(parents=True)
+        (sub / "Api.csproj").write_text("<Project/>")
+
+        scanner = CSharpConfigScanner(tmp_path)
+        projects = scanner.scan()
+
+        assert len(projects) == 1
+        assert projects[0].root == tmp_path
+        assert projects[0].project_type == "solution"
+
     def test_scan_csproj_file(self, tmp_path: Path):
         (tmp_path / "MyApp.csproj").write_text('<Project Sdk="Microsoft.NET.Sdk"/>')
         scanner = CSharpConfigScanner(tmp_path)

--- a/tests/static_analyzer/test_dotnet_sdk.py
+++ b/tests/static_analyzer/test_dotnet_sdk.py
@@ -1,0 +1,108 @@
+import subprocess
+from pathlib import Path
+
+from static_analyzer import dotnet_sdk
+
+
+def _proc(returncode: int = 0, stdout: str = "", stderr: str = "") -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+def test_find_global_json_uses_nearest_ancestor(tmp_path):
+    (tmp_path / "global.json").write_text('{"sdk": {"version": "10.0.100"}}')
+    nested = tmp_path / "src" / "App"
+    nested.mkdir(parents=True)
+    (tmp_path / "src" / "global.json").write_text('{"sdk": {"version": "10.0.301"}}')
+
+    assert dotnet_sdk.find_global_json(nested) == tmp_path / "src" / "global.json"
+    assert dotnet_sdk.read_global_sdk_version(tmp_path / "src" / "global.json") == "10.0.301"
+
+
+def test_resolve_uses_satisfying_system_dotnet(tmp_path, monkeypatch):
+    calls = []
+    system_dotnet = tmp_path / "system" / "dotnet"
+    system_dotnet.parent.mkdir()
+    system_dotnet.write_text("")
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        if cmd[1] == "--version":
+            return _proc(stdout="10.0.301\n")
+        if cmd[1] == "--list-sdks":
+            return _proc(stdout="10.0.301 [/usr/share/dotnet/sdk]\n")
+        raise AssertionError(cmd)
+
+    monkeypatch.setattr(dotnet_sdk, "user_data_dir", lambda: tmp_path / "home")
+    monkeypatch.setattr(dotnet_sdk.shutil, "which", lambda name: str(system_dotnet) if name == "dotnet" else None)
+    monkeypatch.setattr(dotnet_sdk.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        dotnet_sdk, "_run_install_script", lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError)
+    )
+
+    resolution = dotnet_sdk.resolve_dotnet_sdk(tmp_path)
+
+    assert resolution.dotnet_path == str(system_dotnet)
+    assert resolution.source == "system"
+    assert [c[1] for c in calls] == ["--version", "--list-sdks"]
+
+
+def test_resolve_installs_global_json_sdk_when_system_is_unsatisfied(tmp_path, monkeypatch):
+    (tmp_path / "global.json").write_text('{"sdk": {"version": "10.0.301", "allowPrerelease": false}}')
+    home = tmp_path / "home"
+    installed = []
+
+    def fake_install(args, install_dir):
+        installed.append(args)
+        install_dir.mkdir(parents=True, exist_ok=True)
+        dotnet = install_dir / "dotnet"
+        dotnet.write_text("")
+        dotnet.chmod(0o755)
+
+    def fake_run(cmd, **kwargs):
+        if cmd[1] == "--version":
+            return _proc(stdout="10.0.301\n") if Path(cmd[0]).exists() else _proc(returncode=1, stderr="missing")
+        if cmd[1] == "--list-sdks":
+            return _proc(stdout="10.0.301 [/private/sdk]\n") if Path(cmd[0]).exists() else _proc(returncode=1)
+        raise AssertionError(cmd)
+
+    monkeypatch.setattr(dotnet_sdk, "user_data_dir", lambda: home)
+    monkeypatch.setattr(dotnet_sdk.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(dotnet_sdk.subprocess, "run", fake_run)
+    monkeypatch.setattr(dotnet_sdk, "_run_install_script", fake_install)
+
+    resolution = dotnet_sdk.resolve_dotnet_sdk(tmp_path)
+
+    assert installed == [["--jsonfile", str(tmp_path / "global.json")]]
+    assert resolution.dotnet_path == str(home / "dotnet" / "dotnet")
+    assert resolution.env["DOTNET_ROOT"] == str(home / "dotnet")
+    assert resolution.installed is True
+
+
+def test_resolve_installs_tool_sdk_when_no_dotnet_exists(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    installed = []
+
+    def fake_install(args, install_dir):
+        installed.append(args)
+        install_dir.mkdir(parents=True, exist_ok=True)
+        dotnet = install_dir / "dotnet"
+        dotnet.write_text("")
+        dotnet.chmod(0o755)
+
+    def fake_run(cmd, **kwargs):
+        if cmd[1] == "--version":
+            return _proc(stdout="10.0.100\n") if Path(cmd[0]).exists() else _proc(returncode=1)
+        if cmd[1] == "--list-sdks":
+            return _proc(stdout="10.0.100 [/private/sdk]\n") if Path(cmd[0]).exists() else _proc(returncode=1)
+        raise AssertionError(cmd)
+
+    monkeypatch.setattr(dotnet_sdk, "user_data_dir", lambda: home)
+    monkeypatch.setattr(dotnet_sdk.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(dotnet_sdk.subprocess, "run", fake_run)
+    monkeypatch.setattr(dotnet_sdk, "_run_install_script", fake_install)
+
+    resolution = dotnet_sdk.resolve_dotnet_sdk(tmp_path)
+
+    assert installed == [["--channel", "10.0"]]
+    assert resolution.source == "private"
+    assert resolution.installed is True

--- a/tests/static_analyzer/test_static_analyzer_start_clients.py
+++ b/tests/static_analyzer/test_static_analyzer_start_clients.py
@@ -12,7 +12,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from static_analyzer import EngineConfig, StaticAnalyzer
+from static_analyzer import EngineConfig, StaticAnalysisFatalError, StaticAnalyzer
+from static_analyzer.analysis_result import StaticAnalysisResults
 from static_analyzer.constants import Language
 from static_analyzer.engine.language_adapter import LanguageAdapter
 
@@ -86,11 +87,35 @@ class TestStartClientsGracefulDegradation:
         bad_cs.start.side_effect = TimeoutError("omnisharp timed out")
 
         with patch("static_analyzer.LSPClient", side_effect=[bad_py, bad_cs]):
-            with pytest.raises(RuntimeError, match=r"attempted:.*Python.*CSharp"):
+            with pytest.raises(RuntimeError, match=r"attempted:.*Python.*CSharp.*pyright missing") as exc:
                 analyzer.start_clients()
 
+        assert "omnisharp timed out" in str(exc.value)
         assert analyzer._clients_started is False
         assert analyzer._engine_clients == []
+
+    def test_validate_rejects_empty_symbol_csharp_result(self, analyzer: StaticAnalyzer, tmp_path: Path) -> None:
+        cs_adapter = _make_adapter("CSharp")
+        cs_adapter.language_enum = Language.CSHARP
+        cs_adapter.fail_on_empty_symbols = True
+        analyzer._engine_clients = [(EngineConfig(cs_adapter, tmp_path), MagicMock())]
+
+        results = StaticAnalysisResults()
+        results.add_source_files(Language.CSHARP, [str(tmp_path / "Program.cs")])
+
+        with pytest.raises(StaticAnalysisFatalError, match="0 symbols"):
+            analyzer._validate_analysis_results(results)
+
+    def test_validate_ignores_empty_non_opted_language(self, analyzer: StaticAnalyzer, tmp_path: Path) -> None:
+        py_adapter = _make_adapter("Python")
+        py_adapter.language_enum = Language.PYTHON
+        py_adapter.fail_on_empty_symbols = False
+        analyzer._engine_clients = [(EngineConfig(py_adapter, tmp_path), MagicMock())]
+
+        results = StaticAnalysisResults()
+        results.add_source_files(Language.PYTHON, [str(tmp_path / "app.py")])
+
+        analyzer._validate_analysis_results(results)
 
     def test_all_success_records_no_failures(self, analyzer: StaticAnalyzer, tmp_path: Path) -> None:
         py_adapter = _make_adapter("Python")

--- a/tests/static_analyzer/test_static_analyzer_start_clients.py
+++ b/tests/static_analyzer/test_static_analyzer_start_clients.py
@@ -19,12 +19,17 @@ from static_analyzer.engine.language_adapter import LanguageAdapter
 
 
 def _make_adapter(
-    language: str, *, wait_for_workspace_ready: bool = False, language_enum: Language | None = None
+    language: str,
+    *,
+    wait_for_workspace_ready: bool = False,
+    language_enum: Language | None = None,
+    fail_on_empty_symbols: bool = False,
 ) -> LanguageAdapter:
     adapter = MagicMock(name=f"{language}Adapter")
     adapter.language = language
     if language_enum is not None:
         adapter.language_enum = language_enum
+    adapter.fail_on_empty_symbols = fail_on_empty_symbols
     adapter.get_lsp_command.return_value = [f"{language.lower()}-lsp"]
     adapter.get_lsp_init_options.return_value = {}
     adapter.get_lsp_env.return_value = {}
@@ -95,9 +100,7 @@ class TestStartClientsGracefulDegradation:
         assert analyzer._engine_clients == []
 
     def test_validate_rejects_empty_symbol_csharp_result(self, analyzer: StaticAnalyzer, tmp_path: Path) -> None:
-        cs_adapter = _make_adapter("CSharp")
-        cs_adapter.language_enum = Language.CSHARP
-        cs_adapter.fail_on_empty_symbols = True
+        cs_adapter = _make_adapter("CSharp", language_enum=Language.CSHARP, fail_on_empty_symbols=True)
         analyzer._engine_clients = [(EngineConfig(cs_adapter, tmp_path), MagicMock())]
 
         results = StaticAnalysisResults()
@@ -107,9 +110,7 @@ class TestStartClientsGracefulDegradation:
             analyzer._validate_analysis_results(results)
 
     def test_validate_ignores_empty_non_opted_language(self, analyzer: StaticAnalyzer, tmp_path: Path) -> None:
-        py_adapter = _make_adapter("Python")
-        py_adapter.language_enum = Language.PYTHON
-        py_adapter.fail_on_empty_symbols = False
+        py_adapter = _make_adapter("Python", language_enum=Language.PYTHON, fail_on_empty_symbols=False)
         analyzer._engine_clients = [(EngineConfig(py_adapter, tmp_path), MagicMock())]
 
         results = StaticAnalysisResults()

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -45,9 +45,12 @@ from tool_registry import (
 )
 from tool_registry import PackageManagerToolSource
 from tool_registry.installers import (
+    PACKAGE_MANAGER_TOOL_STAMP,
     _extract_compressed_binary,
     install_package_manager_tools,
+    package_manager_tool_fingerprint,
     package_manager_tool_dir,
+    package_manager_tool_is_current,
     resolve_native_asset_name,
 )
 from tool_registry.registry import ConfigSection, ToolDependency, ToolSource
@@ -982,6 +985,9 @@ def _populate_complete_servers_dir(base_dir: Path) -> None:
             pm_dir = bin_dir / "pm-tools" / subdir
             pm_dir.mkdir(parents=True, exist_ok=True)
             (pm_dir / f"{dep.binary_name}{exe_suffix()}").write_text("#!/bin/sh\n")
+            (pm_dir / PACKAGE_MANAGER_TOOL_STAMP).write_text(
+                json.dumps({"fingerprint": package_manager_tool_fingerprint(dep)})
+            )
 
 
 class TestHasRequiredTools(unittest.TestCase):
@@ -1649,6 +1655,7 @@ class TestInstallPackageManagerTools(unittest.TestCase):
             self.assertNotIn("{tool_path}", invoked_cmd)
             self.assertNotIn("{tag}", invoked_cmd)
             self.assertTrue(binary_path.exists())
+            self.assertTrue(package_manager_tool_is_current(base, dep))
 
     def test_idempotent_when_binary_already_present(self):
         dep = self._csharp_dep()
@@ -1657,6 +1664,9 @@ class TestInstallPackageManagerTools(unittest.TestCase):
             install_dir = package_manager_tool_dir(base, dep)
             install_dir.mkdir(parents=True, exist_ok=True)
             (install_dir / f"csharp-ls{exe_suffix()}").write_text("pre-existing")
+            (install_dir / PACKAGE_MANAGER_TOOL_STAMP).write_text(
+                json.dumps({"fingerprint": package_manager_tool_fingerprint(dep)})
+            )
 
             with (
                 patch("tool_registry.installers.shutil.which", return_value="/usr/bin/dotnet"),
@@ -1664,6 +1674,30 @@ class TestInstallPackageManagerTools(unittest.TestCase):
             ):
                 install_package_manager_tools(base, [dep])
             mock_run.assert_not_called()
+
+    def test_reinstalls_when_stamp_missing(self):
+        dep = self._csharp_dep()
+        with tempfile.TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            install_dir = package_manager_tool_dir(base, dep)
+            binary_path = install_dir / f"csharp-ls{exe_suffix()}"
+            install_dir.mkdir(parents=True, exist_ok=True)
+            binary_path.write_text("stale")
+
+            def fake_run(cmd, **_kwargs):
+                binary_path.parent.mkdir(parents=True, exist_ok=True)
+                binary_path.write_text("fresh")
+                return MagicMock(returncode=0, stdout="", stderr="")
+
+            with (
+                patch("tool_registry.installers.shutil.which", return_value="/usr/bin/dotnet"),
+                patch("tool_registry.installers.subprocess.run", side_effect=fake_run) as mock_run,
+            ):
+                install_package_manager_tools(base, [dep])
+
+            mock_run.assert_called_once()
+            self.assertEqual(binary_path.read_text(), "fresh")
+            self.assertTrue(package_manager_tool_is_current(base, dep))
 
     def test_reports_failure_when_manager_exits_nonzero(self):
         dep = self._csharp_dep()

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -1692,13 +1692,19 @@ class TestInstallPackageManagerTools(unittest.TestCase):
         assert isinstance(csharp.source, PackageManagerToolSource)
         self.assertIn(csharp.source.tag, tools_fingerprint())
 
-    def test_csharp_registry_targets_net10_framework(self):
-        """C# package-manager install must target .NET 10 during full migration."""
+    def test_csharp_registry_targets_net9_framework(self):
+        """C# install must request net9.0 because csharp-ls 0.20.0 ships
+        only ``tools/net9.0/``. Asking for net10.0 is silently downgraded
+        and obscures what was actually installed. The runtime-side
+        ``DOTNET_ROLL_FORWARD=Major`` env var (set by ``CSharpAdapter``)
+        is what lets the resulting net9.0 binary run on a host with only
+        the .NET 10 runtime.
+        """
         csharp = next(d for d in TOOL_REGISTRY if d.key == "csharp")
         assert isinstance(csharp.source, PackageManagerToolSource)
         self.assertIn("--framework", csharp.source.install_args)
         framework_idx = csharp.source.install_args.index("--framework") + 1
-        self.assertEqual(csharp.source.install_args[framework_idx], "net10.0")
+        self.assertEqual(csharp.source.install_args[framework_idx], "net9.0")
 
 
 if __name__ == "__main__":

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -1600,7 +1600,7 @@ class TestInstallPackageManagerTools(unittest.TestCase):
             kind=ToolKind.PACKAGE_MANAGER,
             config_section=ConfigSection.LSP_SERVERS,
             source=PackageManagerToolSource(
-                tag="0.20.0",
+                tag="0.24.0",
                 manager_binary="dotnet",
                 install_args=("tool", "install", "csharp-ls", "--version", "{tag}", "--tool-path", "{tool_path}"),
             ),
@@ -1645,7 +1645,7 @@ class TestInstallPackageManagerTools(unittest.TestCase):
             self.assertEqual(invoked_cmd[0], "dotnet")
             # Placeholders must be substituted: {tool_path} -> install dir, {tag} -> source.tag.
             self.assertIn(str(install_dir), invoked_cmd)
-            self.assertIn("0.20.0", invoked_cmd)
+            self.assertIn("0.24.0", invoked_cmd)
             self.assertNotIn("{tool_path}", invoked_cmd)
             self.assertNotIn("{tag}", invoked_cmd)
             self.assertTrue(binary_path.exists())
@@ -1692,19 +1692,14 @@ class TestInstallPackageManagerTools(unittest.TestCase):
         assert isinstance(csharp.source, PackageManagerToolSource)
         self.assertIn(csharp.source.tag, tools_fingerprint())
 
-    def test_csharp_registry_targets_net9_framework(self):
-        """C# install must request net9.0 because csharp-ls 0.20.0 ships
-        only ``tools/net9.0/``. Asking for net10.0 is silently downgraded
-        and obscures what was actually installed. The runtime-side
-        ``DOTNET_ROLL_FORWARD=Major`` env var (set by ``CSharpAdapter``)
-        is what lets the resulting net9.0 binary run on a host with only
-        the .NET 10 runtime.
+    def test_csharp_registry_uses_modern_default_framework(self):
+        """C# install should let dotnet select the package's default target
+        framework so newer csharp-ls packages can run natively on modern SDKs.
         """
         csharp = next(d for d in TOOL_REGISTRY if d.key == "csharp")
         assert isinstance(csharp.source, PackageManagerToolSource)
-        self.assertIn("--framework", csharp.source.install_args)
-        framework_idx = csharp.source.install_args.index("--framework") + 1
-        self.assertEqual(csharp.source.install_args[framework_idx], "net9.0")
+        self.assertNotIn("--framework", csharp.source.install_args)
+        self.assertEqual(csharp.source.tag, "0.24.0")
 
 
 if __name__ == "__main__":

--- a/tool_registry/__init__.py
+++ b/tool_registry/__init__.py
@@ -68,5 +68,6 @@ from .installers import (  # noqa: F401
     install_tools,
     nodeenv_needs_unofficial_builds,
     package_manager_tool_dir,
+    package_manager_tool_is_current,
 )
 from .manifest import package_manager_tool_path  # noqa: F401

--- a/tool_registry/installers.py
+++ b/tool_registry/installers.py
@@ -5,6 +5,7 @@ The only module in the package with filesystem side effects.
 
 import gzip
 import hashlib
+import json
 import logging
 import os
 import platform
@@ -40,6 +41,8 @@ from .registry import (
 )
 
 logger = logging.getLogger(__name__)
+
+PACKAGE_MANAGER_TOOL_STAMP = ".codeboarding-tool.json"
 
 
 # -- Download primitive -------------------------------------------------------
@@ -281,10 +284,58 @@ def package_manager_tool_dir(target_dir: Path, dep: ToolDependency) -> Path:
     return platform_bin_dir(target_dir) / "pm-tools" / subdir
 
 
+def package_manager_tool_fingerprint(dep: ToolDependency) -> str:
+    """Stable install fingerprint for one PACKAGE_MANAGER tool."""
+    source = dep.source
+    if not isinstance(source, PackageManagerToolSource):
+        return ""
+    return json.dumps(
+        {
+            "key": dep.key,
+            "binary": dep.binary_name,
+            "manager": source.manager_binary,
+            "tag": source.tag,
+            "install_args": list(source.install_args),
+        },
+        sort_keys=True,
+    )
+
+
+def package_manager_tool_is_current(target_dir: Path, dep: ToolDependency) -> bool:
+    """Return True when a PACKAGE_MANAGER tool binary and version stamp match."""
+    if not isinstance(dep.source, PackageManagerToolSource):
+        return False
+    try:
+        install_dir = package_manager_tool_dir(target_dir, dep)
+    except RuntimeError:
+        return False
+    binary_path = install_dir / f"{dep.binary_name}{exe_suffix()}"
+    stamp_path = install_dir / PACKAGE_MANAGER_TOOL_STAMP
+    if not binary_path.exists() or not stamp_path.exists():
+        return False
+    try:
+        payload = json.loads(stamp_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+    return payload.get("fingerprint") == package_manager_tool_fingerprint(dep)
+
+
+def _write_package_manager_tool_stamp(install_dir: Path, dep: ToolDependency) -> None:
+    stamp_path = install_dir / PACKAGE_MANAGER_TOOL_STAMP
+    tmp = stamp_path.with_name(stamp_path.name + ".tmp")
+    payload = {
+        "fingerprint": package_manager_tool_fingerprint(dep),
+    }
+    tmp.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    os.replace(tmp, stamp_path)
+
+
 def install_package_manager_tools(
     target_dir: Path,
     deps: list[ToolDependency],
     on_progress: ProgressCallback | None = None,
+    manager_overrides: dict[str, str] | None = None,
+    env: dict[str, str] | None = None,
 ) -> None:
     """Install each dep by invoking its declared package manager.
 
@@ -306,27 +357,37 @@ def install_package_manager_tools(
         if on_progress:
             on_progress(dep.binary_name, i, len(pm_deps))
         source = cast(PackageManagerToolSource, dep.source)
-        if not shutil.which(source.manager_binary):
+        manager_binary = (manager_overrides or {}).get(source.manager_binary, source.manager_binary)
+        manager_available = (
+            Path(manager_binary).exists()
+            if Path(manager_binary).is_absolute()
+            else shutil.which(manager_binary) is not None
+        )
+        if not manager_available:
             logger.warning(
                 "  %s: %s not found on PATH; skipping install. Users must install it before running analysis.",
                 dep.binary_name,
-                source.manager_binary,
+                manager_binary,
             )
             continue
         install_dir = pm_root / (dep.archive_subdir or dep.key)
         binary_path = install_dir / f"{dep.binary_name}{exe_suffix()}"
-        if binary_path.exists():
+        if package_manager_tool_is_current(target_dir, dep):
             logger.info("  %s: already installed, skipping", dep.binary_name)
             continue
+        if install_dir.exists():
+            logger.info("  %s: install fingerprint changed, reinstalling", dep.binary_name)
+            shutil.rmtree(install_dir, ignore_errors=True)
         install_dir.mkdir(parents=True, exist_ok=True)
         args = [arg.format(tool_path=str(install_dir), tag=source.tag) for arg in source.install_args]
         try:
             result = subprocess.run(
-                [source.manager_binary, *args],
+                [manager_binary, *args],
                 capture_output=True,
                 text=True,
                 check=False,
                 timeout=600,
+                env=env,
             )
             if result.returncode != 0:
                 # A failed install can leave partial files that would
@@ -352,6 +413,7 @@ def install_package_manager_tools(
                 continue
             if platform.system() != "Windows":
                 os.chmod(binary_path, 0o755)
+            _write_package_manager_tool_stamp(install_dir, dep)
             logger.info("  %s: installed via %s", dep.binary_name, source.manager_binary)
         except subprocess.TimeoutExpired:
             shutil.rmtree(install_dir, ignore_errors=True)

--- a/tool_registry/manifest.py
+++ b/tool_registry/manifest.py
@@ -19,7 +19,7 @@ else:
 
 from vscode_constants import VSCODE_CONFIG, find_runnable
 
-from .installers import package_manager_tool_dir
+from .installers import package_manager_tool_dir, package_manager_tool_is_current
 from .paths import exe_suffix, get_servers_dir, native_binary_ok, platform_bin_dir, preferred_node_path
 from .registry import (
     PINNED_NODE_VERSION,
@@ -220,7 +220,7 @@ def resolve_config(base_dir: Path) -> dict[str, Any]:
 
         elif dep.kind is ToolKind.PACKAGE_MANAGER:
             binary_path = package_manager_tool_path(base_dir, dep)
-            if binary_path is not None and binary_path.exists():
+            if binary_path is not None and package_manager_tool_is_current(base_dir, dep):
                 cmd = cast(list[str], config[dep.config_section][dep.key]["command"])
                 cmd[0] = str(binary_path)
 
@@ -316,8 +316,8 @@ def has_required_tools(base_dir: Path) -> bool:
             if binary_path is None:
                 logger.info("has_required_tools: %s unsupported on this host; skipping check", dep.key)
                 continue
-            if not binary_path.exists():
-                logger.info("has_required_tools: %s missing at %s", dep.key, binary_path)
+            if not package_manager_tool_is_current(base_dir, dep):
+                logger.info("has_required_tools: %s missing or stale at %s", dep.key, binary_path)
                 return False
 
         elif dep.kind is ToolKind.NODE:

--- a/tool_registry/registry.py
+++ b/tool_registry/registry.py
@@ -214,9 +214,9 @@ TOOL_REGISTRY: list[ToolDependency] = [
     ),
     # csharp-ls ships only as a NuGet dotnet-tool; installed via ``dotnet tool install``.
     # Pin to 0.24.0 so C# document symbols work reliably for modern .NET 10
-    # repositories. Older 0.20.0 installs target net9.0 and can start via
-    # roll-forward on .NET-10-only hosts, but may time out or return no symbols
-    # for large SDK-style solutions.
+    # repositories. ``--tool-path`` avoids a misleading "DotnetToolSettings.xml
+    # not found" error when no local manifest is present; the package's default
+    # target framework is selected by dotnet.
     ToolDependency(
         key="csharp",
         binary_name="csharp-ls",

--- a/tool_registry/registry.py
+++ b/tool_registry/registry.py
@@ -213,22 +213,17 @@ TOOL_REGISTRY: list[ToolDependency] = [
         js_entry_parent="intelephense",
     ),
     # csharp-ls ships only as a NuGet dotnet-tool; installed via ``dotnet tool install``.
-    # Pinned 0.20.0: 0.21.0+ has a malformed NuGet upstream.
-    # ``--framework net9.0`` matches what the 0.20.0 nupkg actually ships
-    # (only ``tools/net9.0/`` is present); ``--framework net10.0`` is
-    # silently ignored and produces the same net9.0 binary. The launched
-    # binary's runtimeconfig pins ``Microsoft.NETCore.App 9.0.0``; the
-    # CSharpAdapter sets ``DOTNET_ROLL_FORWARD=Major`` at launch so hosts
-    # with only the .NET 10 runtime can still run it. ``--tool-path``
-    # avoids a misleading "DotnetToolSettings.xml not found" error when no
-    # local manifest is present.
+    # Pin to 0.24.0 so C# document symbols work reliably for modern .NET 10
+    # repositories. Older 0.20.0 installs target net9.0 and can start via
+    # roll-forward on .NET-10-only hosts, but may time out or return no symbols
+    # for large SDK-style solutions.
     ToolDependency(
         key="csharp",
         binary_name="csharp-ls",
         kind=ToolKind.PACKAGE_MANAGER,
         config_section=ConfigSection.LSP_SERVERS,
         source=PackageManagerToolSource(
-            tag="0.20.0",
+            tag="0.24.0",
             manager_binary="dotnet",
             install_args=(
                 "tool",
@@ -236,8 +231,6 @@ TOOL_REGISTRY: list[ToolDependency] = [
                 "csharp-ls",
                 "--version",
                 "{tag}",
-                "--framework",
-                "net9.0",
                 "--tool-path",
                 "{tool_path}",
             ),

--- a/tool_registry/registry.py
+++ b/tool_registry/registry.py
@@ -214,9 +214,14 @@ TOOL_REGISTRY: list[ToolDependency] = [
     ),
     # csharp-ls ships only as a NuGet dotnet-tool; installed via ``dotnet tool install``.
     # Pinned 0.20.0: 0.21.0+ has a malformed NuGet upstream.
-    # During .NET 10 migration we request ``--framework net10.0``; ``--tool-path``
-    # avoids a misleading "DotnetToolSettings.xml not found" error when no local
-    # manifest is present.
+    # ``--framework net9.0`` matches what the 0.20.0 nupkg actually ships
+    # (only ``tools/net9.0/`` is present); ``--framework net10.0`` is
+    # silently ignored and produces the same net9.0 binary. The launched
+    # binary's runtimeconfig pins ``Microsoft.NETCore.App 9.0.0``; the
+    # CSharpAdapter sets ``DOTNET_ROLL_FORWARD=Major`` at launch so hosts
+    # with only the .NET 10 runtime can still run it. ``--tool-path``
+    # avoids a misleading "DotnetToolSettings.xml not found" error when no
+    # local manifest is present.
     ToolDependency(
         key="csharp",
         binary_name="csharp-ls",
@@ -232,7 +237,7 @@ TOOL_REGISTRY: list[ToolDependency] = [
                 "--version",
                 "{tag}",
                 "--framework",
-                "net10.0",
+                "net9.0",
                 "--tool-path",
                 "{tool_path}",
             ),


### PR DESCRIPTION
## What changed

- Detect `.slnx` files as C# solution roots so modern .NET repos are analyzed once at the solution level instead of as many separate `.csproj` roots.
- Add adapter-level C# startup handling so CodeBoarding no longer blocks on an unreliable startup workspace-ready signal before the later probe and diagnostics waits run.
- Bump the managed `csharp-ls` install to `0.24.0` and let `dotnet tool install` choose the package default target framework.

## Why

On a .NET 10-only host, the current `csharp-ls 0.20.0` install can succeed but the resulting binary still targets `Microsoft.NETCore.App 9.0.0` and exits with code 150 at launch. Modern `.slnx` repositories are also missed by the scanner, which makes CodeBoarding fall back to per-project C# analysis and multiplies startup waits.

## Verification

- `uv run pytest tests/static_analyzer/test_csharp_adapter.py tests/static_analyzer/test_csharp_config_scanner.py tests/test_tool_registry.py -q`
- Real `dotnet tool install csharp-ls --version 0.20.0 --framework net10.0 --tool-path ...` on a .NET 10-only host installs but the binary exits 150 without roll-forward.
- Real `dotnet tool install csharp-ls --version 0.24.0 --tool-path ...` installs and runs on the same host.
- Real `.slnx` repo check against `wc3-platform-main-clean`: current scanner returns one solution root; main-style `*.sln` scanning returns eight `.csproj` roots.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detects .slnx solution files for C# projects.
  * Per-project .NET SDK resolution and automatic install when required.

* **Improvements**
  * Upgraded csharp-ls tooling to v0.24.0 and improved environment/restore handling for C# projects.
  * Package-manager installs are fingerprinted to avoid unnecessary reinstalls.
  * Adapter readiness and DOTNET env behavior made more robust.

* **Bug Fixes**
  * Prevents caching empty/invalid analysis results when language servers fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->