### PR TITLE
fix(ci): only cancel the CodeBoarding review on PR close, not on bot comments

### DIFF
--- a/.github/workflows/codeboarding.yml
+++ b/.github/workflows/codeboarding.yml
@@ -2,8 +2,9 @@ name: CodeBoarding review
 
 on:
   pull_request:
-    # Generate once, when the PR becomes reviewable, not on every push.
-    types: [opened, reopened, ready_for_review]
+    # Generate once when the PR becomes reviewable; 'closed' only cancels an
+    # in-flight review (see concurrency below), it doesn't start one.
+    types: [opened, reopened, ready_for_review, closed]
   issue_comment:
     # Enables refreshing on demand by commenting /codeboarding.
     types: [created]
@@ -15,7 +16,9 @@ permissions:
 
 concurrency:
   group: codeboarding-${{ github.event.pull_request.number || github.event.issue.number }}
-  cancel-in-progress: true
+  # Only a PR close cancels a running review. Bot comments (issue_comment) and
+  # re-triggers must NOT cancel it — they queue behind the running review instead.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action == 'closed' }}
 
 jobs:
   review:
@@ -23,7 +26,7 @@ jobs:
     timeout-minutes: 60
     # PR events (non-draft), or a /codeboarding comment from a trusted collaborator.
     if: >
-      (github.event_name == 'pull_request' && github.event.pull_request.draft == false) ||
+      (github.event_name == 'pull_request' && github.event.action != 'closed' && github.event.pull_request.draft == false) ||
       (github.event_name == 'issue_comment' && github.event.issue.pull_request != null &&
        startsWith(github.event.comment.body, '/codeboarding') &&
        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))


### PR DESCRIPTION
Bot comments (Qodo/CodeRabbit) were cancelling the in-progress architecture review: each comment fires `issue_comment`, which entered the same concurrency group and `cancel-in-progress: true` killed the running review (the comment-run's job then skips). 

Fix: cancel-in-progress only for `pull_request: closed`; subscribe to `closed` (it cancels via concurrency but the job skips, so it never starts a review). Comments and re-triggers now queue behind a running review instead of cancelling it. Found via the v1 smoke test (PR #362).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to improve handling of concurrent review processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->