### PR TITLE
[smoke] CTA direct-extension links (do not merge)

### DIFF
--- a/.github/workflows/codeboarding.yml
+++ b/.github/workflows/codeboarding.yml
@@ -31,6 +31,7 @@ jobs:
        startsWith(github.event.comment.body, '/codeboarding') &&
        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
     steps:
-      - uses: CodeBoarding/CodeBoarding-action@v1
+      # Smoke test: pin the action to the CTA-direct-links commit (not yet on @v1).
+      - uses: CodeBoarding/CodeBoarding-action@fbc75940e50170c69c7ae0b04ed42b11d16e2f5e
         with:
           llm_api_key: ${{ secrets.OPENROUTER_API_KEY }}

--- a/.github/workflows/codeboarding.yml
+++ b/.github/workflows/codeboarding.yml
@@ -31,7 +31,7 @@ jobs:
        startsWith(github.event.comment.body, '/codeboarding') &&
        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
     steps:
-      # Smoke test: pin the action to the CTA-direct-links commit (not yet on @v1).
-      - uses: CodeBoarding/CodeBoarding-action@fbc75940e50170c69c7ae0b04ed42b11d16e2f5e
+      # Smoke test: pin the action to the clickable-CTA fix commit (not yet on @v1).
+      - uses: CodeBoarding/CodeBoarding-action@eed6a2632d039eb4e49a1dac611603f750a625f9
         with:
           llm_api_key: ${{ secrets.OPENROUTER_API_KEY }}

--- a/output_generators/markdown.py
+++ b/output_generators/markdown.py
@@ -155,3 +155,8 @@ def component_header(component_name: str, component_id: str, expanded_components
         return f"### {component_name} [[Expand]](./{sanitized_name}.md)"
     else:
         return f"### {component_name}"
+
+
+def _smoke_cta_marker() -> str:
+    """No-op marker so the CTA-links smoke-test PR has a changed source file."""
+    return "cta-smoke"


### PR DESCRIPTION
Smoke test for CodeBoarding/CodeBoarding-action#11 — the CTA now links straight to the extension when no click proxy is set.

- Action pinned to `fbc7594` (the CTA change; not yet on @v1).
- A no-op marker added so the analyzer sees a changed source file.

**Expected:** the architecture-review comment's footer shows `Open in VS Code →` (`vscode:extension/Codeboarding.codeboarding`) and `Get the extension →` (Marketplace), with **no** proxy query params. Throwaway — do not merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to use pinned action versions
  * Added internal testing utilities for smoke-test validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->