### PR TITLE
[smoke] verify clickable CTA link (do not merge)

### DIFF
--- a/.github/workflows/codeboarding.yml
+++ b/.github/workflows/codeboarding.yml
@@ -31,6 +31,7 @@ jobs:
        startsWith(github.event.comment.body, '/codeboarding') &&
        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
     steps:
-      - uses: CodeBoarding/CodeBoarding-action@v1
+      # Smoke test: pin the action to the clickable-CTA fix commit (not yet on @v1).
+      - uses: CodeBoarding/CodeBoarding-action@eed6a2632d039eb4e49a1dac611603f750a625f9
         with:
           llm_api_key: ${{ secrets.OPENROUTER_API_KEY }}

--- a/output_generators/markdown.py
+++ b/output_generators/markdown.py
@@ -155,3 +155,8 @@ def component_header(component_name: str, component_id: str, expanded_components
         return f"### {component_name} [[Expand]](./{sanitized_name}.md)"
     else:
         return f"### {component_name}"
+
+
+def _smoke_verify_marker() -> str:
+    """No-op marker so the clickable-CTA verification PR has a changed source file."""
+    return "cta-verify"


### PR DESCRIPTION
Fresh smoke test for the clickable-CTA fix (CodeBoarding-action @eed6a26).

**Expected:** the architecture-review comment footer shows `Open in VS Code →` as a **clickable** link to the VS Code Marketplace, and **no** `Get the extension` line. Throwaway — do not merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration for improved reliability
  * Added internal verification utilities for testing purposes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->