### PR TITLE
Skip LSP startup when the static-analysis pkl is fresh

### DIFF
--- a/static_analyzer/__init__.py
+++ b/static_analyzer/__init__.py
@@ -374,18 +374,11 @@ class StaticAnalyzer:
         return cached_results
 
     def load_cache_if_fresh(self, cache_dir: Path) -> StaticAnalysisResults | None:
-        """Serve the SHA-tagged pkl without LSP clients when git reports no relevant changes.
+        """Serve the SHA-tagged pkl without LSP clients, or None when not safely fresh.
 
-        LSP-free freshness probe: load the pkl + tag SHA, ask git which files
-        changed since that SHA per engine config, and keep only files matching
-        that adapter's extensions (the same filter the warm-start re-LSP
-        applies). A hit means a warm start would merge in nothing, so LSP
-        startup — workspace-ready waits included — can be skipped entirely.
-
-        Returns None (callers fall back to ``start_clients()`` + ``analyze()``)
-        when the pkl or tag is absent, any config has relevant changed files,
-        git cannot diff against the tag SHA, or the
-        ``CODEBOARDING_DISABLE_CACHE_REUSE`` kill switch is set.
+        Why: when git reports no changed source files since the pkl's tag SHA,
+        a warm start would merge in nothing — so LSP startup (workspace-ready
+        waits included) is skippable.
         """
         if self._cached_results is not None:
             return self._cached_results
@@ -405,9 +398,8 @@ class StaticAnalyzer:
     def _probe_and_load_fresh_cache(self, cache_dir: Path) -> StaticAnalysisResults | None:
         """Freshness probe + load, cheapest check first.
 
-        The tag SHA and git diffs are consulted before the (multi-MB) pkl is
-        unpickled so a miss — the common case for incremental users — costs
-        only a tag read and one git subprocess set per engine config.
+        Why: a miss — the common case for incremental users — costs only a
+        tag read and git diffs, never the multi-MB unpickle.
         """
         cache = StaticAnalysisCache(cache_dir, self.repository_path)
         cached_sha = cache.read_tag_sha()
@@ -434,17 +426,12 @@ class StaticAnalyzer:
                     "falling back to LSP analysis"
                 )
                 return None
-        warm_start = cache.load_with_sha()
-        if warm_start is None:
+        # SHA-gated load: misses if another process re-saved since the probe.
+        cached_results = cache.get(expected_sha=cached_sha)
+        if cached_results is None:
             return None
-        cached_results, loaded_sha = warm_start
-        if loaded_sha != cached_sha:
-            # Another process saved a newer pkl between the tag probe and the
-            # load; the diff above no longer vouches for it.
-            return None
-        # A language whose config vanished (e.g. a deleted sub-project) leaves
-        # no diff to inspect — a warm start would drop its bucket, so the
-        # fast path must not serve it.
+        # A vanished language config (deleted sub-project) leaves no diff to
+        # vouch for its cached bucket — a warm start would drop it.
         config_languages = {ec.adapter.language_enum for ec in self._engine_configs}
         stale_languages = set(cached_results.get_languages()) - config_languages
         if stale_languages:
@@ -582,10 +569,9 @@ class StaticAnalyzer:
         (cluster cache populated by the abstraction agent) reach disk in one
         save instead of two. ``source_sha`` is stashed for that save.
 
-        Clients must be running before calling this method — unless the pkl
-        is fresh (``load_cache_if_fresh`` hit), in which case the cached
-        results are served without any LSP. Use ``start_clients()`` or the
-        context manager (``with StaticAnalyzer(...) as sa:``) for the rest.
+        Clients must be running before calling this method unless
+        ``load_cache_if_fresh`` hits, in which case the cached results are
+        served without LSP.
         """
         if not self._clients_started:
             if not skip_cache:

--- a/static_analyzer/__init__.py
+++ b/static_analyzer/__init__.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -372,6 +373,92 @@ class StaticAnalyzer:
             self.collected_diagnostics = cached_results.diagnostics
         return cached_results
 
+    def load_cache_if_fresh(self, cache_dir: Path) -> StaticAnalysisResults | None:
+        """Serve the SHA-tagged pkl without LSP clients when git reports no relevant changes.
+
+        LSP-free freshness probe: load the pkl + tag SHA, ask git which files
+        changed since that SHA per engine config, and keep only files matching
+        that adapter's extensions (the same filter the warm-start re-LSP
+        applies). A hit means a warm start would merge in nothing, so LSP
+        startup — workspace-ready waits included — can be skipped entirely.
+
+        Returns None (callers fall back to ``start_clients()`` + ``analyze()``)
+        when the pkl or tag is absent, any config has relevant changed files,
+        git cannot diff against the tag SHA, or the
+        ``CODEBOARDING_DISABLE_CACHE_REUSE`` kill switch is set.
+        """
+        if self._cached_results is not None:
+            return self._cached_results
+        if os.getenv("CODEBOARDING_DISABLE_CACHE_REUSE", "").lower() in ("1", "true", "yes"):
+            logger.info("CODEBOARDING_DISABLE_CACHE_REUSE set; skipping LSP-free cache fast path")
+            return None
+        if not self._engine_configs:
+            return None
+        # The probe must never be the thing that fails a run — any error here
+        # (lock timeout, corrupt tag, git trouble) just means "no fast path".
+        try:
+            return self._probe_and_load_fresh_cache(cache_dir)
+        except Exception:
+            logger.warning("load_cache_if_fresh: probe failed; falling back to LSP analysis", exc_info=True)
+            return None
+
+    def _probe_and_load_fresh_cache(self, cache_dir: Path) -> StaticAnalysisResults | None:
+        """Freshness probe + load, cheapest check first.
+
+        The tag SHA and git diffs are consulted before the (multi-MB) pkl is
+        unpickled so a miss — the common case for incremental users — costs
+        only a tag read and one git subprocess set per engine config.
+        """
+        cache = StaticAnalysisCache(cache_dir, self.repository_path)
+        cached_sha = cache.read_tag_sha()
+        if cached_sha is None:
+            return None
+        for engine_config in self._engine_configs:
+            adapter, project_path = engine_config.adapter, engine_config.project_path
+            try:
+                changed_files = get_changed_files_since(project_path, cached_sha)
+            except Exception as e:
+                logger.info(
+                    f"load_cache_if_fresh: git diff against cached SHA failed for {adapter.language}: {e}; "
+                    "falling back to LSP analysis"
+                )
+                return None
+            relevant = [
+                f
+                for f in changed_files
+                if f.suffix in adapter.file_extensions and not self.ignore_manager.should_ignore(f)
+            ]
+            if relevant:
+                logger.info(
+                    f"load_cache_if_fresh: {len(relevant)} changed {adapter.language} file(s) since cached SHA; "
+                    "falling back to LSP analysis"
+                )
+                return None
+        warm_start = cache.load_with_sha()
+        if warm_start is None:
+            return None
+        cached_results, loaded_sha = warm_start
+        if loaded_sha != cached_sha:
+            # Another process saved a newer pkl between the tag probe and the
+            # load; the diff above no longer vouches for it.
+            return None
+        # A language whose config vanished (e.g. a deleted sub-project) leaves
+        # no diff to inspect — a warm start would drop its bucket, so the
+        # fast path must not serve it.
+        config_languages = {ec.adapter.language_enum for ec in self._engine_configs}
+        stale_languages = set(cached_results.get_languages()) - config_languages
+        if stale_languages:
+            logger.info(
+                "load_cache_if_fresh: cached language(s) %s no longer configured; falling back to LSP analysis",
+                ", ".join(str(lang) for lang in stale_languages),
+            )
+            return None
+        logger.info("static_analysis_cache: outcome=freshhit (cached_sha=%s); LSP startup skipped", cached_sha)
+        self._cached_results = cached_results
+        self._pending_cache_dir = cache_dir
+        self.collected_diagnostics = cached_results.diagnostics
+        return cached_results
+
     def notify_file_changed(self, file_path: Path, content: str) -> None:
         """Notify the LSP server that the editor has saved new content for a file.
 
@@ -495,10 +582,18 @@ class StaticAnalyzer:
         (cluster cache populated by the abstraction agent) reach disk in one
         save instead of two. ``source_sha`` is stashed for that save.
 
-        Clients must be running before calling this method. Use ``start_clients()``
-        or the context manager (``with StaticAnalyzer(...) as sa:``).
+        Clients must be running before calling this method — unless the pkl
+        is fresh (``load_cache_if_fresh`` hit), in which case the cached
+        results are served without any LSP. Use ``start_clients()`` or the
+        context manager (``with StaticAnalyzer(...) as sa:``) for the rest.
         """
         if not self._clients_started:
+            if not skip_cache:
+                fresh = self.load_cache_if_fresh(cache_dir)
+                if fresh is not None:
+                    self._pending_source_sha = source_sha
+                    self._pending_cache_dir = cache_dir
+                    return fresh
             raise RuntimeError(
                 "LSP clients are not running. Call start_clients() or use StaticAnalyzer as a context manager "
                 "('with StaticAnalyzer(...) as sa:') before calling analyze()."
@@ -703,7 +798,9 @@ def get_static_analysis(
 ) -> StaticAnalysisResults:
     """CLI orchestrator: get static analysis results with full LSP lifecycle management.
 
-    Starts LSP clients, runs analysis, and stops clients — all in one call.
+    Probes the SHA-tagged pkl first (LSP-free); on a fresh hit no LSP client
+    is ever started. Otherwise starts LSP clients, runs analysis, and stops
+    clients — all in one call.
 
     Args:
         repo_path: Path to the repository to analyze.
@@ -720,6 +817,10 @@ def get_static_analysis(
         StaticAnalysisResults reflecting the live source state.
     """
     analyzer = StaticAnalyzer(repo_path)
+    if not skip_cache:
+        cached_results = analyzer.load_cache_if_fresh(cache_dir)
+        if cached_results is not None:
+            return cached_results
     with analyzer:
         results = analyzer.analyze(skip_cache=skip_cache, source_sha=source_sha, cache_dir=cache_dir)
     results.diagnostics = analyzer.collected_diagnostics

--- a/tests/static_analyzer/test_static_analyzer_fresh_cache.py
+++ b/tests/static_analyzer/test_static_analyzer_fresh_cache.py
@@ -41,8 +41,11 @@ def analyzer(tmp_path: Path) -> StaticAnalyzer:
 
 @pytest.fixture
 def cache_dir(tmp_path: Path) -> Path:
+    """Pkl tagged "abc123" with a Python bucket, so hits also prove bucket matching."""
     d = tmp_path / ".codeboarding"
-    StaticAnalysisCache(d, tmp_path).save(StaticAnalysisResults(), source_sha="abc123")
+    results = StaticAnalysisResults()
+    results.add_source_files(Language.PYTHON, [str(tmp_path / "a.py")])
+    StaticAnalysisCache(d, tmp_path).save(results, source_sha="abc123")
     return d
 
 
@@ -58,7 +61,7 @@ class TestLoadCacheIfFresh:
         assert analyzer.collected_diagnostics == result.diagnostics
 
     def test_changed_source_file_misses(self, analyzer: StaticAnalyzer, cache_dir: Path, tmp_path: Path) -> None:
-        """A relevant change — including a deletion, the path need not exist — falls back to LSP."""
+        """The path need not exist — deletions are relevant changes too."""
         with patch("static_analyzer.get_changed_files_since", return_value={tmp_path / "src" / "main.py"}):
             assert analyzer.load_cache_if_fresh(cache_dir) is None
         assert analyzer._cached_results is None
@@ -103,27 +106,15 @@ class TestLoadCacheIfFresh:
         with patch("static_analyzer.get_changed_files_since", return_value={tmp_path / "app.ts"}):
             assert analyzer.load_cache_if_fresh(cache_dir) is None
 
-    def test_removed_language_bucket_misses(self, analyzer: StaticAnalyzer, tmp_path: Path) -> None:
+    def test_removed_language_bucket_misses(self, analyzer: StaticAnalyzer, cache_dir: Path, tmp_path: Path) -> None:
         """A cached language with no current engine config has no diff to vouch for it — fall back."""
-        d = tmp_path / ".codeboarding"
-        results = StaticAnalysisResults()
-        results.add_source_files(Language.PYTHON, [str(tmp_path / "a.py")])
-        StaticAnalysisCache(d, tmp_path).save(results, source_sha="abc123")
         analyzer._engine_configs = [EngineConfig(_make_adapter("TypeScript", (".ts",), Language.TYPESCRIPT), tmp_path)]
         with patch("static_analyzer.get_changed_files_since", return_value=set()):
-            assert analyzer.load_cache_if_fresh(d) is None
-
-    def test_cached_language_with_matching_config_hits(self, analyzer: StaticAnalyzer, tmp_path: Path) -> None:
-        d = tmp_path / ".codeboarding"
-        results = StaticAnalysisResults()
-        results.add_source_files(Language.PYTHON, [str(tmp_path / "a.py")])
-        StaticAnalysisCache(d, tmp_path).save(results, source_sha="abc123")
-        with patch("static_analyzer.get_changed_files_since", return_value=set()):
-            assert analyzer.load_cache_if_fresh(d) is not None
+            assert analyzer.load_cache_if_fresh(cache_dir) is None
 
     def test_concurrent_resave_with_different_sha_misses(self, analyzer: StaticAnalyzer, cache_dir: Path) -> None:
-        """If the pkl is re-saved between the tag probe and the load, the diff no longer vouches for it."""
-        with patch.object(StaticAnalysisCache, "load_with_sha", return_value=(StaticAnalysisResults(), "newer-sha")):
+        """The SHA-gated unpickle misses when the pkl is re-saved between the tag probe and the load."""
+        with patch.object(StaticAnalysisCache, "get", return_value=None):
             with patch("static_analyzer.get_changed_files_since", return_value=set()):
                 assert analyzer.load_cache_if_fresh(cache_dir) is None
 
@@ -133,7 +124,7 @@ class TestLoadCacheIfFresh:
 
     def test_miss_does_not_unpickle(self, analyzer: StaticAnalyzer, cache_dir: Path, tmp_path: Path) -> None:
         """A miss caused by changed files must cost only the tag read + git diff, not the pkl load."""
-        with patch.object(StaticAnalysisCache, "load_with_sha") as load:
+        with patch.object(StaticAnalysisCache, "get") as load:
             with patch("static_analyzer.get_changed_files_since", return_value={tmp_path / "main.py"}):
                 assert analyzer.load_cache_if_fresh(cache_dir) is None
         load.assert_not_called()

--- a/tests/static_analyzer/test_static_analyzer_fresh_cache.py
+++ b/tests/static_analyzer/test_static_analyzer_fresh_cache.py
@@ -1,0 +1,198 @@
+"""Tests for the LSP-free fresh-pkl fast path (``load_cache_if_fresh``).
+
+Covers the contract that a SHA-tagged pkl with no relevant changed files is
+served without starting any LSP client, while a relevant change, a git diff
+failure, or the cache-reuse kill switch falls back to the normal LSP path.
+"""
+
+from pathlib import Path
+from subprocess import CalledProcessError
+from typing import cast
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from static_analyzer import EngineConfig, StaticAnalyzer, get_static_analysis
+from static_analyzer.analysis_cache import StaticAnalysisCache
+from static_analyzer.analysis_result import StaticAnalysisResults
+from static_analyzer.constants import Language
+from static_analyzer.engine.language_adapter import LanguageAdapter
+
+
+def _make_adapter(
+    language: str, extensions: tuple[str, ...], language_enum: Language = Language.PYTHON
+) -> LanguageAdapter:
+    adapter = MagicMock(name=f"{language}Adapter")
+    adapter.language = language
+    adapter.file_extensions = extensions
+    adapter.language_enum = language_enum
+    return cast(LanguageAdapter, adapter)
+
+
+@pytest.fixture
+def analyzer(tmp_path: Path) -> StaticAnalyzer:
+    # Bypass ProjectScanner / config discovery — we inject _engine_configs directly.
+    with patch("static_analyzer.ProjectScanner") as scanner_cls:
+        scanner_cls.return_value.scan.return_value = []
+        sa = StaticAnalyzer(tmp_path)
+    sa._engine_configs = [EngineConfig(_make_adapter("Python", (".py",)), tmp_path)]
+    return sa
+
+
+@pytest.fixture
+def cache_dir(tmp_path: Path) -> Path:
+    d = tmp_path / ".codeboarding"
+    StaticAnalysisCache(d, tmp_path).save(StaticAnalysisResults(), source_sha="abc123")
+    return d
+
+
+class TestLoadCacheIfFresh:
+    def test_zero_changed_files_serves_pkl(self, analyzer: StaticAnalyzer, cache_dir: Path, tmp_path: Path) -> None:
+        with patch("static_analyzer.get_changed_files_since", return_value=set()) as diff:
+            result = analyzer.load_cache_if_fresh(cache_dir)
+
+        assert result is not None
+        diff.assert_called_once_with(tmp_path, "abc123")
+        assert analyzer._cached_results is result
+        assert analyzer._pending_cache_dir == cache_dir
+        assert analyzer.collected_diagnostics == result.diagnostics
+
+    def test_changed_source_file_misses(self, analyzer: StaticAnalyzer, cache_dir: Path, tmp_path: Path) -> None:
+        """A relevant change — including a deletion, the path need not exist — falls back to LSP."""
+        with patch("static_analyzer.get_changed_files_since", return_value={tmp_path / "src" / "main.py"}):
+            assert analyzer.load_cache_if_fresh(cache_dir) is None
+        assert analyzer._cached_results is None
+
+    def test_changed_non_source_files_still_hit(
+        self, analyzer: StaticAnalyzer, cache_dir: Path, tmp_path: Path
+    ) -> None:
+        with patch(
+            "static_analyzer.get_changed_files_since", return_value={tmp_path / "README.md", tmp_path / "Makefile"}
+        ):
+            assert analyzer.load_cache_if_fresh(cache_dir) is not None
+
+    def test_changed_ignored_source_file_still_hits(
+        self, analyzer: StaticAnalyzer, cache_dir: Path, tmp_path: Path
+    ) -> None:
+        with patch("static_analyzer.get_changed_files_since", return_value={tmp_path / ".venv" / "lib" / "site.py"}):
+            assert analyzer.load_cache_if_fresh(cache_dir) is not None
+
+    def test_git_diff_failure_misses(self, analyzer: StaticAnalyzer, cache_dir: Path) -> None:
+        with patch("static_analyzer.get_changed_files_since", side_effect=CalledProcessError(128, "git")):
+            assert analyzer.load_cache_if_fresh(cache_dir) is None
+
+    def test_absent_pkl_misses(self, analyzer: StaticAnalyzer, tmp_path: Path) -> None:
+        assert analyzer.load_cache_if_fresh(tmp_path / "no-cache-here") is None
+
+    def test_no_engine_configs_misses(self, analyzer: StaticAnalyzer, cache_dir: Path) -> None:
+        analyzer._engine_configs = []
+        assert analyzer.load_cache_if_fresh(cache_dir) is None
+
+    def test_kill_switch_misses(
+        self, analyzer: StaticAnalyzer, cache_dir: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CODEBOARDING_DISABLE_CACHE_REUSE", "1")
+        with patch("static_analyzer.get_changed_files_since", return_value=set()):
+            assert analyzer.load_cache_if_fresh(cache_dir) is None
+
+    def test_change_in_any_config_misses(self, analyzer: StaticAnalyzer, cache_dir: Path, tmp_path: Path) -> None:
+        analyzer._engine_configs = [
+            EngineConfig(_make_adapter("Python", (".py",)), tmp_path),
+            EngineConfig(_make_adapter("TypeScript", (".ts", ".tsx"), Language.TYPESCRIPT), tmp_path),
+        ]
+        with patch("static_analyzer.get_changed_files_since", return_value={tmp_path / "app.ts"}):
+            assert analyzer.load_cache_if_fresh(cache_dir) is None
+
+    def test_removed_language_bucket_misses(self, analyzer: StaticAnalyzer, tmp_path: Path) -> None:
+        """A cached language with no current engine config has no diff to vouch for it — fall back."""
+        d = tmp_path / ".codeboarding"
+        results = StaticAnalysisResults()
+        results.add_source_files(Language.PYTHON, [str(tmp_path / "a.py")])
+        StaticAnalysisCache(d, tmp_path).save(results, source_sha="abc123")
+        analyzer._engine_configs = [EngineConfig(_make_adapter("TypeScript", (".ts",), Language.TYPESCRIPT), tmp_path)]
+        with patch("static_analyzer.get_changed_files_since", return_value=set()):
+            assert analyzer.load_cache_if_fresh(d) is None
+
+    def test_cached_language_with_matching_config_hits(self, analyzer: StaticAnalyzer, tmp_path: Path) -> None:
+        d = tmp_path / ".codeboarding"
+        results = StaticAnalysisResults()
+        results.add_source_files(Language.PYTHON, [str(tmp_path / "a.py")])
+        StaticAnalysisCache(d, tmp_path).save(results, source_sha="abc123")
+        with patch("static_analyzer.get_changed_files_since", return_value=set()):
+            assert analyzer.load_cache_if_fresh(d) is not None
+
+    def test_concurrent_resave_with_different_sha_misses(self, analyzer: StaticAnalyzer, cache_dir: Path) -> None:
+        """If the pkl is re-saved between the tag probe and the load, the diff no longer vouches for it."""
+        with patch.object(StaticAnalysisCache, "load_with_sha", return_value=(StaticAnalysisResults(), "newer-sha")):
+            with patch("static_analyzer.get_changed_files_since", return_value=set()):
+                assert analyzer.load_cache_if_fresh(cache_dir) is None
+
+    def test_probe_error_falls_back_instead_of_raising(self, analyzer: StaticAnalyzer, cache_dir: Path) -> None:
+        with patch.object(StaticAnalysisCache, "read_tag_sha", side_effect=TimeoutError("lock held")):
+            assert analyzer.load_cache_if_fresh(cache_dir) is None
+
+    def test_miss_does_not_unpickle(self, analyzer: StaticAnalyzer, cache_dir: Path, tmp_path: Path) -> None:
+        """A miss caused by changed files must cost only the tag read + git diff, not the pkl load."""
+        with patch.object(StaticAnalysisCache, "load_with_sha") as load:
+            with patch("static_analyzer.get_changed_files_since", return_value={tmp_path / "main.py"}):
+                assert analyzer.load_cache_if_fresh(cache_dir) is None
+        load.assert_not_called()
+
+    def test_memoized_results_win_over_disk(self, analyzer: StaticAnalyzer, tmp_path: Path) -> None:
+        """Same contract as ``load_from_disk_cache``: an in-memory result is never replaced by a re-unpickle."""
+        preset = StaticAnalysisResults()
+        analyzer._cached_results = preset
+        assert analyzer.load_cache_if_fresh(tmp_path / "no-cache-here") is preset
+
+
+class TestAnalyzeFreshCacheFastPath:
+    def test_analyze_without_clients_serves_fresh_pkl(self, analyzer: StaticAnalyzer, cache_dir: Path) -> None:
+        with patch("static_analyzer.get_changed_files_since", return_value=set()):
+            result = analyzer.analyze(cache_dir=cache_dir, source_sha="def456")
+
+        assert result is analyzer._cached_results
+        assert analyzer._pending_source_sha == "def456"
+        assert analyzer._pending_cache_dir == cache_dir
+        assert analyzer._clients_started is False
+
+    def test_analyze_without_clients_stale_pkl_raises(
+        self, analyzer: StaticAnalyzer, cache_dir: Path, tmp_path: Path
+    ) -> None:
+        with patch("static_analyzer.get_changed_files_since", return_value={tmp_path / "x.py"}):
+            with pytest.raises(RuntimeError, match="LSP clients are not running"):
+                analyzer.analyze(cache_dir=cache_dir)
+
+    def test_analyze_without_clients_skip_cache_raises(self, analyzer: StaticAnalyzer, cache_dir: Path) -> None:
+        with patch("static_analyzer.get_changed_files_since", return_value=set()):
+            with pytest.raises(RuntimeError, match="LSP clients are not running"):
+                analyzer.analyze(cache_dir=cache_dir, skip_cache=True)
+
+
+class TestGetStaticAnalysisFastPath:
+    def test_fresh_hit_never_starts_clients(self, tmp_path: Path) -> None:
+        sentinel = StaticAnalysisResults()
+        with patch("static_analyzer.StaticAnalyzer") as analyzer_cls:
+            instance = analyzer_cls.return_value
+            instance.load_cache_if_fresh.return_value = sentinel
+            result = get_static_analysis(tmp_path, cache_dir=tmp_path / ".codeboarding")
+
+        assert result is sentinel
+        instance.__enter__.assert_not_called()
+        instance.analyze.assert_not_called()
+
+    def test_miss_falls_back_to_lsp_lifecycle(self, tmp_path: Path) -> None:
+        with patch("static_analyzer.StaticAnalyzer") as analyzer_cls:
+            instance = analyzer_cls.return_value
+            instance.load_cache_if_fresh.return_value = None
+            get_static_analysis(tmp_path, cache_dir=tmp_path / ".codeboarding")
+
+        instance.__enter__.assert_called_once()
+        instance.analyze.assert_called_once()
+
+    def test_skip_cache_bypasses_fast_path(self, tmp_path: Path) -> None:
+        with patch("static_analyzer.StaticAnalyzer") as analyzer_cls:
+            instance = analyzer_cls.return_value
+            get_static_analysis(tmp_path, cache_dir=tmp_path / ".codeboarding", skip_cache=True)
+
+        instance.load_cache_if_fresh.assert_not_called()
+        instance.analyze.assert_called_once()


### PR DESCRIPTION
Every analyze path paid full LSP startup (workspace-ready waits up to 300s per Java/Rust/C# config, dotnet restore, diagnostics waits) before the pkl was consulted, because `analyze()` requires running clients and only then reads the cache.

This adds `StaticAnalyzer.load_cache_if_fresh` — an LSP-free freshness probe (tag SHA → git diff per engine config, filtered to adapter extensions → unpickle) — and wires it in so a fresh pkl with no relevant changes is served without spawning any LSP:

- `get_static_analysis()` probes before entering the client lifecycle.
- `analyze()` tries the fast path before raising when clients aren't started; behavior with running clients is unchanged.

Guards: removed-language buckets, concurrent re-saves, and probe errors all fall back to the normal LSP path; `CODEBOARDING_DISABLE_CACHE_REUSE` disables the fast path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fast cache path: returns cached analysis results when sources are unchanged, honors the cache-reuse disable switch, and respects skip-cache behavior. CLI now probes the fresh cache first and returns immediately on a hit.
* **Tests**
  * Added comprehensive tests covering cache hits/misses, git probing failures, skip-cache behavior, in-memory memoization, pending-state handling, and CLI fast-path behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->