### PR TITLE
ci: post CodeBoarding review comments as codeboarding-review[bot]

### DIFF
--- a/.github/workflows/codeboarding.yml
+++ b/.github/workflows/codeboarding.yml
@@ -31,10 +31,6 @@ jobs:
        startsWith(github.event.comment.body, '/codeboarding') &&
        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
     steps:
-      # Post the review as codeboarding-review[bot] instead of github-actions[bot].
-      # Falls back to the workflow token when the app credentials are missing or
-      # the mint fails. Uses CODEBOARDING_APP_CLIENT_ID, not the org-level
-      # CODEBOARDING_APP_ID — that is a different app with no key in Actions.
       - uses: actions/create-github-app-token@v3
         id: codeboarding-app-token
         if: vars.CODEBOARDING_APP_CLIENT_ID != ''

--- a/.github/workflows/codeboarding.yml
+++ b/.github/workflows/codeboarding.yml
@@ -31,6 +31,18 @@ jobs:
        startsWith(github.event.comment.body, '/codeboarding') &&
        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
     steps:
+      # Post the review as codeboarding-review[bot] instead of github-actions[bot].
+      # Falls back to the workflow token when the app credentials are missing or
+      # the mint fails. Uses CODEBOARDING_APP_CLIENT_ID, not the org-level
+      # CODEBOARDING_APP_ID — that is a different app with no key in Actions.
+      - uses: actions/create-github-app-token@v3
+        id: codeboarding-app-token
+        if: vars.CODEBOARDING_APP_CLIENT_ID != ''
+        continue-on-error: true
+        with:
+          client-id: ${{ vars.CODEBOARDING_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CODEBOARDING_APP_PRIVATE_KEY }}
       - uses: CodeBoarding/CodeBoarding-action@v1
         with:
+          github_token: ${{ steps.codeboarding-app-token.outputs.token || github.token }}
           llm_api_key: ${{ secrets.OPENROUTER_API_KEY }}


### PR DESCRIPTION
Wires the CodeBoarding Review GitHub App identity into the review workflow: mints an app installation token (`actions/create-github-app-token@v3`) and passes it to the action's `github_token` input, so the PR architecture-review comment is authored by `codeboarding-review[bot]` instead of `github-actions[bot]`. Falls back to the workflow token when credentials are unavailable. Same pattern as CodeBoarding-action#19, where this is already working (smoke-tested on CodeBoarding-action#20/#21).

**This PR is also its own smoke test** — `pull_request` runs use the PR branch's workflow, so once the `CODEBOARDING_APP_PRIVATE_KEY` secret is added to this repo and the PR is marked ready for review, the comment below should appear under the app identity.

Prerequisites (one done, one pending):
- [x] Repo variable `CODEBOARDING_APP_CLIENT_ID` = `Iv23linrVBtHypkrmEFa` (set)
- [ ] Repo secret `CODEBOARDING_APP_PRIVATE_KEY` — same PEM as on CodeBoarding-action

Deliberately **not** using the org-level `CODEBOARDING_APP_ID` variable (`Iv23liI1erFCZLemAWLd`): that's a different app with no private key available to Actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI authentication to attempt an alternate app-based token and gracefully fall back to the standard token when unavailable.
  * Made the token step tolerant of failure to reduce CI interruptions and improve workflow reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->