### PR TITLE
Gate --binary-location native commands on runnability, self-healing the exec bit

### DIFF
--- a/tests/test_vscode_constants.py
+++ b/tests/test_vscode_constants.py
@@ -1,3 +1,4 @@
+import copy
 import os
 import platform
 import tempfile
@@ -233,6 +234,86 @@ class TestVSCodeConstants(unittest.TestCase):
         self.assertIn("command", php_config)
         self.assertEqual(php_config["languages"], ["php"])
         self.assertIn(".php", php_config["file_extensions"])
+
+
+class TestUpdateCommandPathsNativeGate(unittest.TestCase):
+    """Native binaries must only be wired as absolute paths when runnable (or repairable),
+    otherwise the bare name is kept so build_config's PATH fallback stays available."""
+
+    def setUp(self):
+        self._snapshot = copy.deepcopy(VSCODE_CONFIG)
+
+    def tearDown(self):
+        VSCODE_CONFIG.clear()
+        VSCODE_CONFIG.update(self._snapshot)
+
+    def _make_gopls(self, temp_dir, mode):
+        bin_dir = Path(temp_dir) / "bin" / "linux"
+        bin_dir.mkdir(parents=True)
+        gopls = bin_dir / "gopls"
+        gopls.write_text("#!/bin/sh\n")
+        os.chmod(gopls, mode)
+        return gopls
+
+    @patch("platform.system")
+    def test_executable_binary_wired_absolute(self, mock_system):
+        mock_system.return_value = "Linux"
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            gopls = self._make_gopls(temp_dir, 0o755)
+
+            update_command_paths(temp_dir)
+
+            self.assertEqual(VSCODE_CONFIG["lsp_servers"]["go"]["command"][0], str(gopls))
+
+    @patch("platform.system")
+    def test_repairs_lost_exec_bit(self, mock_system):
+        mock_system.return_value = "Linux"
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            gopls = self._make_gopls(temp_dir, 0o644)
+
+            update_command_paths(temp_dir)
+
+            self.assertEqual(VSCODE_CONFIG["lsp_servers"]["go"]["command"][0], str(gopls))
+            self.assertTrue(os.access(gopls, os.X_OK))
+
+    @patch("platform.system")
+    def test_missing_binary_keeps_bare_name(self, mock_system):
+        mock_system.return_value = "Linux"
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            update_command_paths(temp_dir)
+
+            self.assertEqual(VSCODE_CONFIG["lsp_servers"]["go"]["command"][0], "gopls")
+
+    @patch("platform.system")
+    def test_unrepairable_binary_keeps_bare_name(self, mock_system):
+        mock_system.return_value = "Linux"
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            gopls = self._make_gopls(temp_dir, 0o644)
+
+            with patch("os.chmod", side_effect=OSError("operation not permitted")):
+                update_command_paths(temp_dir)
+
+            self.assertEqual(VSCODE_CONFIG["lsp_servers"]["go"]["command"][0], "gopls")
+            self.assertFalse(os.access(gopls, os.X_OK))
+
+    @patch("platform.system")
+    def test_windows_exe_suffix_binary_wired_without_suffix(self, mock_system):
+        # Windows installs gopls.exe but the command keeps the suffix-less path;
+        # CreateProcess resolves it, so the gate must accept the .exe sibling.
+        mock_system.return_value = "Windows"
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            bin_dir = Path(temp_dir) / "bin" / "win"
+            bin_dir.mkdir(parents=True)
+            (bin_dir / "gopls.exe").write_text("")
+
+            update_command_paths(temp_dir)
+
+            self.assertEqual(VSCODE_CONFIG["lsp_servers"]["go"]["command"][0], str(bin_dir / "gopls"))
 
 
 if __name__ == "__main__":

--- a/tests/test_vscode_constants.py
+++ b/tests/test_vscode_constants.py
@@ -236,47 +236,58 @@ class TestVSCodeConstants(unittest.TestCase):
         self.assertIn(".php", php_config["file_extensions"])
 
 
+_PRISTINE_VSCODE_CONFIG = copy.deepcopy(VSCODE_CONFIG)
+
+
 class TestUpdateCommandPathsNativeGate(unittest.TestCase):
     """Native binaries must only be wired as absolute paths when runnable (or repairable),
     otherwise the bare name is kept so build_config's PATH fallback stays available."""
 
     def setUp(self):
-        self._snapshot = copy.deepcopy(VSCODE_CONFIG)
+        self._restore_pristine()
 
     def tearDown(self):
-        VSCODE_CONFIG.clear()
-        VSCODE_CONFIG.update(self._snapshot)
+        self._restore_pristine()
 
-    def _make_gopls(self, temp_dir, mode):
+    def _restore_pristine(self):
+        VSCODE_CONFIG.clear()
+        VSCODE_CONFIG.update(copy.deepcopy(_PRISTINE_VSCODE_CONFIG))
+
+    def _make_binary(self, temp_dir, name, mode):
         bin_dir = Path(temp_dir) / "bin" / "linux"
-        bin_dir.mkdir(parents=True)
-        gopls = bin_dir / "gopls"
-        gopls.write_text("#!/bin/sh\n")
-        os.chmod(gopls, mode)
-        return gopls
+        bin_dir.mkdir(parents=True, exist_ok=True)
+        binary = bin_dir / name
+        binary.write_text("#!/bin/sh\n")
+        os.chmod(binary, mode)
+        return binary
 
     @patch("platform.system")
     def test_executable_binary_wired_absolute(self, mock_system):
         mock_system.return_value = "Linux"
 
         with tempfile.TemporaryDirectory() as temp_dir:
-            gopls = self._make_gopls(temp_dir, 0o755)
+            gopls = self._make_binary(temp_dir, "gopls", 0o755)
+            tokei = self._make_binary(temp_dir, "tokei", 0o755)
 
             update_command_paths(temp_dir)
 
             self.assertEqual(VSCODE_CONFIG["lsp_servers"]["go"]["command"][0], str(gopls))
+            self.assertEqual(VSCODE_CONFIG["tools"]["tokei"]["command"][0], str(tokei))
 
+    @unittest.skipIf(os.name == "nt", "exec-bit semantics are POSIX-only")
     @patch("platform.system")
     def test_repairs_lost_exec_bit(self, mock_system):
         mock_system.return_value = "Linux"
 
         with tempfile.TemporaryDirectory() as temp_dir:
-            gopls = self._make_gopls(temp_dir, 0o644)
+            gopls = self._make_binary(temp_dir, "gopls", 0o644)
 
-            update_command_paths(temp_dir)
+            with self.assertLogs("vscode_constants", level="INFO") as logs:
+                update_command_paths(temp_dir)
 
             self.assertEqual(VSCODE_CONFIG["lsp_servers"]["go"]["command"][0], str(gopls))
             self.assertTrue(os.access(gopls, os.X_OK))
+            self.assertTrue(any("Restored exec bit" in line for line in logs.output))
 
     @patch("platform.system")
     def test_missing_binary_keeps_bare_name(self, mock_system):
@@ -286,19 +297,72 @@ class TestUpdateCommandPathsNativeGate(unittest.TestCase):
             update_command_paths(temp_dir)
 
             self.assertEqual(VSCODE_CONFIG["lsp_servers"]["go"]["command"][0], "gopls")
+            self.assertEqual(VSCODE_CONFIG["tools"]["tokei"]["command"][0], "tokei")
 
+    @unittest.skipIf(os.name == "nt", "exec-bit semantics are POSIX-only")
     @patch("platform.system")
     def test_unrepairable_binary_keeps_bare_name(self, mock_system):
         mock_system.return_value = "Linux"
 
         with tempfile.TemporaryDirectory() as temp_dir:
-            gopls = self._make_gopls(temp_dir, 0o644)
+            gopls = self._make_binary(temp_dir, "gopls", 0o644)
 
-            with patch("os.chmod", side_effect=OSError("operation not permitted")):
-                update_command_paths(temp_dir)
+            with self.assertLogs("vscode_constants", level="WARNING") as logs:
+                with patch("os.chmod", side_effect=OSError("operation not permitted")):
+                    update_command_paths(temp_dir)
 
             self.assertEqual(VSCODE_CONFIG["lsp_servers"]["go"]["command"][0], "gopls")
             self.assertFalse(os.access(gopls, os.X_OK))
+            self.assertTrue(any("chmod failed" in line for line in logs.output))
+
+    @patch("platform.system")
+    def test_directory_named_like_binary_keeps_bare_name(self, mock_system):
+        # A traversable directory passes an exists()+X_OK gate; only isfile keeps
+        # it from being wired as the command and failing EACCES at Popen.
+        mock_system.return_value = "Linux"
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            (Path(temp_dir) / "bin" / "linux" / "gopls").mkdir(parents=True)
+
+            update_command_paths(temp_dir)
+
+            self.assertEqual(VSCODE_CONFIG["lsp_servers"]["go"]["command"][0], "gopls")
+
+    @unittest.skipIf(os.name == "nt", "symlink creation requires privileges on Windows")
+    @patch("platform.system")
+    def test_symlinked_non_executable_binary_not_chmodded(self, mock_system):
+        mock_system.return_value = "Linux"
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            target = Path(temp_dir) / "victim"
+            target.write_text("private")
+            os.chmod(target, 0o600)
+            bin_dir = Path(temp_dir) / "bin" / "linux"
+            bin_dir.mkdir(parents=True)
+            (bin_dir / "gopls").symlink_to(target)
+
+            update_command_paths(temp_dir)
+
+            self.assertEqual(VSCODE_CONFIG["lsp_servers"]["go"]["command"][0], "gopls")
+            self.assertEqual(os.stat(target).st_mode & 0o777, 0o600)
+
+    @patch("platform.system")
+    def test_reinvocation_revalidates_from_bare_name(self, mock_system):
+        mock_system.return_value = "Linux"
+
+        with tempfile.TemporaryDirectory() as old_dir:
+            self._make_binary(old_dir, "gopls", 0o755)
+            update_command_paths(old_dir)
+
+        # old_dir is gone: a second call must fall back to the bare name, not
+        # keep the stale absolute path that would disable the PATH fallback.
+        with tempfile.TemporaryDirectory() as new_dir:
+            update_command_paths(new_dir)
+            self.assertEqual(VSCODE_CONFIG["lsp_servers"]["go"]["command"][0], "gopls")
+
+            gopls = self._make_binary(new_dir, "gopls", 0o755)
+            update_command_paths(new_dir)
+            self.assertEqual(VSCODE_CONFIG["lsp_servers"]["go"]["command"][0], str(gopls))
 
     @patch("platform.system")
     def test_windows_exe_suffix_binary_wired_without_suffix(self, mock_system):
@@ -314,6 +378,15 @@ class TestUpdateCommandPathsNativeGate(unittest.TestCase):
             update_command_paths(temp_dir)
 
             self.assertEqual(VSCODE_CONFIG["lsp_servers"]["go"]["command"][0], str(bin_dir / "gopls"))
+
+    @patch("platform.system")
+    def test_windows_missing_binary_keeps_bare_name(self, mock_system):
+        mock_system.return_value = "Windows"
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            update_command_paths(temp_dir)
+
+            self.assertEqual(VSCODE_CONFIG["lsp_servers"]["go"]["command"][0], "gopls")
 
 
 if __name__ == "__main__":

--- a/vscode_constants.py
+++ b/vscode_constants.py
@@ -1,5 +1,8 @@
+import logging
 import os
 import platform
+
+logger = logging.getLogger(__name__)
 
 
 def get_bin_path(bin_dir):
@@ -10,6 +13,30 @@ def get_bin_path(bin_dir):
             f"Unsupported platform: {system}. The extension currently supports Windows, macOS, and Linux."
         )
     return os.path.join(bin_dir, "bin", subdirs[system])
+
+
+def _runnable_native(path: str) -> bool:
+    """True when a native binary exists and is executable, restoring a lost exec bit when possible.
+
+    Why: a mode-dropping unpack/copy leaves the binary at 0644; wiring its absolute
+    path into the command guarantees EACCES at Popen and disables the PATH fallback
+    in tool_registry.build_config. Mirrors the repair in tool_registry.installers
+    (not imported from there: tool_registry.manifest imports this module).
+    """
+    if platform.system().lower() == "windows":
+        # No exec bit on Windows; Popen resolves the suffix-less path to .exe itself.
+        return os.path.exists(path) or os.path.exists(path + ".exe")
+    if not os.path.exists(path):
+        return False
+    if os.access(path, os.X_OK):
+        return True
+    try:
+        os.chmod(path, 0o755)
+        logger.info("Restored exec bit on %s", path)
+        return True
+    except OSError:
+        logger.warning("%s exists but is not executable and chmod failed; check ownership/mount", path)
+        return False
 
 
 def update_command_paths(bin_dir):
@@ -52,7 +79,11 @@ def update_command_paths(bin_dir):
                     cmd[0] = "java"
             elif "command" in value:
                 if isinstance(cmd, list) and cmd:
-                    cmd[0] = os.path.join(bin_path, cmd[0])
+                    candidate = os.path.join(bin_path, cmd[0])
+                    # Keep the bare name when the binary is unusable so the PATH
+                    # fallback in tool_registry.build_config stays available.
+                    if _runnable_native(candidate):
+                        cmd[0] = candidate
 
             # Apply Windows-specific node prefix for specified languages
             # Use VSCode's bundled Node.js (passed via CODEBOARDING_NODE_PATH) so users

--- a/vscode_constants.py
+++ b/vscode_constants.py
@@ -22,13 +22,12 @@ def _runnable_native(path: str) -> bool:
     fallback disabled. Mirrors the tool_registry.installers repair (not imported from
     there: tool_registry.manifest imports this module).
     """
-    if platform.system().lower() == "windows":
-        # No exec bit on Windows; Popen resolves the suffix-less path to .exe itself.
-        return os.path.isfile(path) or os.path.isfile(path + ".exe")
-    if not os.path.isfile(path):
+    windows = platform.system().lower() == "windows"
+    # On Windows the .exe sibling counts; Popen resolves the suffix-less path itself.
+    if not (os.path.isfile(path) or (windows and os.path.isfile(path + ".exe"))):
         logger.info("No runnable binary at %s; keeping the bare command for PATH lookup", path)
         return False
-    if os.access(path, os.X_OK):
+    if windows or os.access(path, os.X_OK):
         return True
     if os.path.islink(path):
         logger.warning("%s is a symlink without exec permission; refusing to chmod it", path)

--- a/vscode_constants.py
+++ b/vscode_constants.py
@@ -16,20 +16,23 @@ def get_bin_path(bin_dir):
 
 
 def _runnable_native(path: str) -> bool:
-    """True when a native binary exists and is executable, restoring a lost exec bit when possible.
+    """True when a native binary is a runnable file, restoring a lost exec bit when possible.
 
-    Why: a mode-dropping unpack/copy leaves the binary at 0644; wiring its absolute
-    path into the command guarantees EACCES at Popen and disables the PATH fallback
-    in tool_registry.build_config. Mirrors the repair in tool_registry.installers
-    (not imported from there: tool_registry.manifest imports this module).
+    Why: a 0644 binary wired as an absolute path fails EACCES at Popen with the PATH
+    fallback disabled. Mirrors the tool_registry.installers repair (not imported from
+    there: tool_registry.manifest imports this module).
     """
     if platform.system().lower() == "windows":
         # No exec bit on Windows; Popen resolves the suffix-less path to .exe itself.
-        return os.path.exists(path) or os.path.exists(path + ".exe")
-    if not os.path.exists(path):
+        return os.path.isfile(path) or os.path.isfile(path + ".exe")
+    if not os.path.isfile(path):
+        logger.info("No runnable binary at %s; keeping the bare command for PATH lookup", path)
         return False
     if os.access(path, os.X_OK):
         return True
+    if os.path.islink(path):
+        logger.warning("%s is a symlink without exec permission; refusing to chmod it", path)
+        return False
     try:
         os.chmod(path, 0o755)
         logger.info("Restored exec bit on %s", path)
@@ -79,11 +82,12 @@ def update_command_paths(bin_dir):
                     cmd[0] = "java"
             elif "command" in value:
                 if isinstance(cmd, list) and cmd:
-                    candidate = os.path.join(bin_path, cmd[0])
-                    # Keep the bare name when the binary is unusable so the PATH
-                    # fallback in tool_registry.build_config stays available.
-                    if _runnable_native(candidate):
-                        cmd[0] = candidate
+                    # Re-derive from the bare tool name (re-entry may have left an
+                    # absolute path); keep it bare when the binary is unusable so the
+                    # PATH fallback in tool_registry.build_config stays available.
+                    bare = os.path.basename(cmd[0])
+                    candidate = os.path.join(bin_path, bare)
+                    cmd[0] = candidate if _runnable_native(candidate) else bare
 
             # Apply Windows-specific node prefix for specified languages
             # Use VSCode's bundled Node.js (passed via CODEBOARDING_NODE_PATH) so users


### PR DESCRIPTION
## Problem

#354 fixed the `PermissionError [Errno 13]` on a non-executable gopls for the default servers-dir flow, but the `--binary-location` flow bypasses all of it: `bootstrap_environment` calls `update_config(binary_location)` *instead of* `ensure_tools()` (so no install and no chmod self-heal), and `update_command_paths` rewrote native-tool commands (gopls, csharp-ls, rust-analyzer, tokei) to absolute paths under `<binary_location>/bin/<platform>/` with no exists/X_OK check. A binary left at 0644 by a mode-dropping unpack then reached `Popen` as an absolute path and failed with EACCES — and because the path was absolute, `build_config`'s PATH fallback was disabled, so retries failed deterministically. Reproducible on main by pointing `--binary-location` at `~/.codeboarding/servers`, which yields the exact traceback from the original report. The same bypass is reachable via `health_main` and the Pro wrapper's `_apply_binary_location`/serve path.

## Fix

`update_command_paths` now only commits the absolute path when the binary is actually runnable, via a new `_runnable_native()` gate that:

- requires a regular file (`isfile`, not `exists` — a traversable *directory* named like the tool passes an exists+X_OK check and recreates the same EACCES-with-dead-fallback failure)
- restores a lost exec bit in place (`chmod 0o755`), mirroring the `tool_registry.installers` repair, but refuses to chmod through a symlink since `binary_location` is caller-supplied
- on Windows accepts the `.exe` sibling of the suffix-less path that `CreateProcess` resolves
- keeps the bare command name on failure (logged), so `build_config`'s PATH fallback stays available — failure parity with the default servers-dir path

The candidate is re-derived from the bare tool name on every call, so re-invocation re-validates against the current bin dir instead of trusting a stale absolute path from an earlier call.

The helper lives in `vscode_constants.py` (stdlib-only) rather than `tool_registry.paths` because `tool_registry.manifest` imports this module — importing back would be circular.

## Tests

New `TestUpdateCommandPathsNativeGate` covers: executable binary wired absolute (gopls + tokei, i.e. both config sections), exec-bit repair (with log assertion), missing binary keeps the bare name (POSIX and Windows), unrepairable binary keeps the bare name (chmod failure, with warning assertion), directory and symlink impostors rejected, re-invocation after the old location disappears, and the Windows `.exe`-sibling contract. Exec-bit tests are skipped on Windows hosts where chmod can't drop executability.

Full unit suite passes (1612 passed, 28 skipped); black and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for native command path handling, covering executable binaries, permission repair, missing or non-executable binaries, directory/name collisions, symlink edge cases, reinvocation behavior, and Windows-specific resolution.

* **Improvements**
  * Smarter handling of native command paths: prefer absolute paths only for runnable binaries, fall back to bare command names otherwise, with permission-repair attempts and better Windows compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->