### PR TITLE
feat: track LSP analysis performance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 - **Activate the venv in the repository to run python**: Always execute `source .venv/bin/activate` (or `.venv\Scripts\activate` on Windows) before running any Python commands. This ensures all dependencies are resolved correctly and the project is isolated.
 - **Use `uv run` for direct execution**: When running scripts without pre-activating the venv, use `uv run python <script>` or `uv run pytest --ignore=tests/integration` to leverage the virtual environment automatically.
 - **Verify Python version**: Ensure the Python version is 3.12 or higher (as specified in `.python_version`). Check with `python --version` after activating the venv.
-- **Static type checking** - we use mypy for static type checking of the CodeBoarding repo, we avoid the typing library where possible and use the default library types: dict, set, list etc. for Optional we use the | None notation.
+- **Static type checking** - we use mypy for static type checking of the CodeBoarding repo, we avoid the typing library where possible and use the default library types: dict, set, list etc. Avoid nullable types when a caller can pass an empty collection or concrete value instead. If a nullable type is truly necessary, use the `| None` notation.
 
 ### 2. Dependency and Repository Navigation
 - **Always use relative paths from repository root**: Reference files using paths like `src/components/file.ts` or `agents/tools/module.py` relative to `/Users/svilen/Documents/Projects/CodeBoarding/`. This ensures consistency across agent execution and makes file references portable.
@@ -15,7 +15,7 @@
 - **Run tests with coverage requirements**: Execute `uv run pytest --cov=. --cov-report=term --cov-fail-under=80 --ignore=tests/integration` to validate changes. The project enforces an 80% minimum code coverage threshold.
 - **Format and lint before commits**: Run `uv run black .` (line length: 120) and `uv run mypy .` to ensure code quality. These are enforced in pre-commit hooks and GitHub CI/CD workflows.
 - **Respect project structure**: Code is organized by functional domain (e.g., `agents/`, `static_analyzer/`, `output_generators/`, `monitoring/`). Place new code in the appropriate directory and follow existing module patterns.
-- **Add imports at the top of the file**: avoid function or class level imports - only consider them if they have significant impact on the execution.
+- **Add imports at the top of the file**: avoid function or class level imports. Do not use `if TYPE_CHECKING` import blocks; keep runtime imports explicit and resolve cycles by moving shared types or decoupling modules instead.
 - **Keep comments and docstrings terse**: write a one-line summary. Add a short `Why:` line only when the rationale is non-obvious. Do NOT narrate diff history (`"Previously X did Y"`), name internal bug tickets (`"V4 reproducer"`, `"Bug C"`), reference line numbers in third-party files (they rot), or re-state what type hints already say. If the prose is longer than the code it documents, delete the prose. See `REVIEW.md` §10 "Comment & Docstring Bloat" for the full checklist.
 - **Don't re-paste module docstrings across submodules**: a package-layout explanation belongs once in `__init__.py`, not copied into every sibling file.
 - **Test docstrings should add information**: if a test is named `test_rejects_none`, the docstring `"""Test that None is rejected."""` is pure noise — delete it. Only add a docstring when there's a non-obvious *reason* the test exists.

--- a/static_analyzer/__init__.py
+++ b/static_analyzer/__init__.py
@@ -23,6 +23,7 @@ from static_analyzer.lsp_client.diagnostics import FileDiagnosticsMap
 from static_analyzer.programming_language import ProgrammingLanguage
 from static_analyzer.scanner import ProjectScanner
 from static_analyzer.typescript_config_scanner import TypeScriptConfigScanner
+from telemetry.events import track_lsp_result
 from tool_registry import ensure_node_on_path
 from utils import get_artifact_dir
 
@@ -167,8 +168,8 @@ class StaticAnalyzer:
     def __init__(self, repository_path: Path):
         self.repository_path = repository_path.resolve()
         self.ignore_manager = RepoIgnoreManager(self.repository_path)
-        programming_langs = ProjectScanner(self.repository_path).scan()
-        self._engine_configs = _create_engine_configs(programming_langs, self.repository_path, self.ignore_manager)
+        self.programming_langs = ProjectScanner(self.repository_path).scan()
+        self._engine_configs = _create_engine_configs(self.programming_langs, self.repository_path, self.ignore_manager)
         self._engine_clients: list[tuple[EngineConfig, LSPClient]] = []
         self.collected_diagnostics: dict[Language, FileDiagnosticsMap] = {}
         self._clients_started: bool = False
@@ -546,17 +547,32 @@ class StaticAnalyzer:
         for engine_config, engine_client in self._engine_clients:
             adapter, project_path = engine_config.adapter, engine_config.project_path
             language = adapter.language_enum
+            t_lang_start = time.monotonic()
             try:
-                t_lang_start = time.monotonic()
                 logger.info(f"Starting engine analysis for {adapter.language} in {project_path}")
                 analysis = self._run_full_analysis(engine_config, engine_client)
                 self._absorb_into_results(results, language, analysis)
-                logger.info(
-                    f"Engine analysis for {adapter.language} completed in {time.monotonic() - t_lang_start:.1f}s"
-                )
+                duration_ms = round((time.monotonic() - t_lang_start) * 1000)
+                logger.info(f"Engine analysis for {adapter.language} completed in {duration_ms / 1000:.1f}s")
                 self._collect_diagnostics_for(adapter, engine_client, analysis)
+                track_lsp_result(
+                    language=adapter.language_enum.value,
+                    loc=self._loc_for_adapter(adapter),
+                    status="success",
+                    duration_ms=duration_ms,
+                    analysis=analysis,
+                    diagnostics=self.collected_diagnostics.get(adapter.language_enum, {}),
+                )
             except Exception as e:
                 logger.error(f"Error during engine analysis for {adapter.language}: {e}")
+                track_lsp_result(
+                    language=adapter.language_enum.value,
+                    loc=self._loc_for_adapter(adapter),
+                    status="error",
+                    duration_ms=round((time.monotonic() - t_lang_start) * 1000),
+                    analysis={},
+                    diagnostics={},
+                )
         logger.info(f"Static analysis complete: {results}")
         return results
 
@@ -578,6 +594,7 @@ class StaticAnalyzer:
             adapter, project_path = engine_config.adapter, engine_config.project_path
             language = adapter.language_enum
             cached_lang_dict = self._extract_language_dict(cached_results, language)
+            t_lang_start = time.monotonic()
             try:
                 changed_files = set(get_changed_files_since(project_path, cached_sha))
             except Exception as e:
@@ -597,6 +614,14 @@ class StaticAnalyzer:
 
             self._absorb_into_results(results, language, analysis)
             self._collect_diagnostics_for(adapter, engine_client, analysis)
+            track_lsp_result(
+                language=adapter.language_enum.value,
+                loc=self._loc_for_adapter(adapter),
+                status="success",
+                duration_ms=round((time.monotonic() - t_lang_start) * 1000),
+                analysis=analysis,
+                diagnostics=self.collected_diagnostics.get(adapter.language_enum, {}),
+            )
         return results
 
     def _extract_language_dict(self, cached_results: StaticAnalysisResults, language: Language) -> dict:
@@ -656,6 +681,16 @@ class StaticAnalyzer:
                 f"(cache={len(cache_diags)}, live={len(live_diags)})"
             )
         self.collected_diagnostics[adapter.language_enum] = merged_diags
+
+    def _loc_for_adapter(self, adapter: LanguageAdapter) -> int:
+        """Return scanner LOC that should have been covered by this adapter."""
+        adapter_name = adapter.language.lower()
+        total = 0
+        for pl in self.programming_langs:
+            mapped = _lang_to_adapter_name(pl.language)
+            if mapped is not None and mapped.lower() == adapter_name:
+                total += pl.size
+        return total
 
     def _run_full_analysis(self, engine_config: EngineConfig, engine_client: LSPClient) -> dict:
         """Run a full analysis using the engine pipeline.

--- a/telemetry/events.py
+++ b/telemetry/events.py
@@ -10,6 +10,7 @@ so we get structured error tracking instead of hand-rolled trace formatting.
 from __future__ import annotations
 
 import functools
+import logging
 import os
 import time
 
@@ -17,12 +18,19 @@ from contextvars import ContextVar
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 
-from telemetry.schemas import AnalysisCompleted, AnalysisStarted, LanguageStat, RepoScanned, TokenSnapshot
+from telemetry.schemas import (
+    AnalysisCompleted,
+    AnalysisStarted,
+    LanguageStat,
+    LspAnalysisResult,
+    RepoScanned,
+    TokenSnapshot,
+)
 from telemetry.service import telemetry
 
 from agents.llm_config import MONITORING_CALLBACK
 
-from static_analyzer.programming_language import ProgrammingLanguage
+logger = logging.getLogger(__name__)
 
 # Current analysis run_id, set by ``track_analysis`` for the duration of a run
 # so nested emitters (e.g. the scanner's ``repo_scanned``) can tag the same id
@@ -62,7 +70,7 @@ def _token_usage() -> TokenSnapshot:
         return TokenSnapshot()
 
 
-def track_tech_stack(repo_path: str | Path, total_loc: int, languages: list[ProgrammingLanguage]) -> None:
+def track_tech_stack(repo_path: str | Path, total_loc: int, languages: list) -> None:
     """Emit one ``repo_scanned`` event with lines-of-code and tech stack."""
     key = str(repo_path)
     if key in _scanned_repos:
@@ -81,6 +89,72 @@ def track_tech_stack(repo_path: str | Path, total_loc: int, languages: list[Prog
         stack=",".join(sorted(pl.language for pl in languages)),
     )
     telemetry.capture("repo_scanned", event.model_dump(exclude_none=True))
+
+
+def track_lsp_result(
+    *,
+    language: str,
+    loc: int,
+    status: str,
+    duration_ms: int,
+    analysis: dict,
+    diagnostics: dict,
+) -> None:
+    """Emit one ``lsp_analysis_result`` event for a language analysis pass."""
+    call_graph = analysis.get("call_graph")
+    missing_call_graph = call_graph is None
+    node_count = len(call_graph.nodes) if call_graph is not None else 0
+    edge_count = len(call_graph.edges) if call_graph is not None else 0
+    source_files = analysis.get("source_files")
+    missing_source_files = source_files is None
+    if source_files is None:
+        source_files = []
+    references = analysis.get("references", [])
+    if not diagnostics:
+        diagnostics = analysis.get("diagnostics") or {}
+    diagnostic_count = sum(len(items) for items in diagnostics.values()) if diagnostics else 0
+
+    zero_nodes_with_loc = loc > 0 and node_count == 0
+    zero_edges_with_loc = loc > 0 and edge_count == 0
+    missing_summary = missing_call_graph or missing_source_files
+    quality_status = "error" if zero_nodes_with_loc else "warning" if zero_edges_with_loc or missing_summary else "ok"
+
+    issues = []
+    if zero_nodes_with_loc:
+        issues.append("zero nodes despite LOC")
+    if zero_edges_with_loc:
+        issues.append("zero edges despite LOC")
+    if missing_call_graph:
+        issues.append("missing call graph")
+    if missing_source_files:
+        issues.append("missing source files")
+    if zero_nodes_with_loc:
+        logger.error("LSP analysis result for %s is unhealthy: %s", language, ", ".join(issues))
+    elif issues:
+        logger.warning(
+            "LSP analysis result for %s is degraded: %s",
+            language,
+            ", ".join(issues),
+        )
+
+    event = LspAnalysisResult(
+        version=_app_version(),
+        run_id=_resolve_run_id(),
+        language=language,
+        loc=loc,
+        status=status,
+        duration_ms=duration_ms,
+        source_file_count=len(source_files),
+        node_count=node_count,
+        edge_count=edge_count,
+        reference_count=len(references),
+        diagnostic_file_count=len(diagnostics),
+        diagnostic_count=diagnostic_count,
+        quality_status=quality_status,
+        zero_nodes_with_loc=zero_nodes_with_loc,
+        zero_edges_with_loc=zero_edges_with_loc,
+    )
+    telemetry.capture("lsp_analysis_result", event.model_dump(exclude_none=True))
 
 
 def track_analysis(func):

--- a/telemetry/schemas.py
+++ b/telemetry/schemas.py
@@ -22,6 +22,24 @@ class RepoScanned(BaseModel):
     run_id: str | None = None
 
 
+class LspAnalysisResult(BaseModel):
+    version: str
+    language: str
+    loc: int
+    status: str
+    duration_ms: int
+    source_file_count: int = 0
+    node_count: int = 0
+    edge_count: int = 0
+    reference_count: int = 0
+    diagnostic_file_count: int = 0
+    diagnostic_count: int = 0
+    quality_status: str = "ok"
+    zero_nodes_with_loc: bool = False
+    zero_edges_with_loc: bool = False
+    run_id: str | None = None
+
+
 class AnalysisStarted(BaseModel):
     command: str
     version: str

--- a/tests/static_analyzer/test_static_analyzer_start_clients.py
+++ b/tests/static_analyzer/test_static_analyzer_start_clients.py
@@ -13,12 +13,17 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from static_analyzer import EngineConfig, StaticAnalyzer
+from static_analyzer.constants import Language
 from static_analyzer.engine.language_adapter import LanguageAdapter
 
 
-def _make_adapter(language: str, *, wait_for_workspace_ready: bool = False) -> LanguageAdapter:
+def _make_adapter(
+    language: str, *, wait_for_workspace_ready: bool = False, language_enum: Language | None = None
+) -> LanguageAdapter:
     adapter = MagicMock(name=f"{language}Adapter")
     adapter.language = language
+    if language_enum is not None:
+        adapter.language_enum = language_enum
     adapter.get_lsp_command.return_value = [f"{language.lower()}-lsp"]
     adapter.get_lsp_init_options.return_value = {}
     adapter.get_lsp_env.return_value = {}

--- a/tests/test_telemetry_events.py
+++ b/tests/test_telemetry_events.py
@@ -3,7 +3,7 @@ from types import SimpleNamespace
 import pytest
 
 import telemetry.events as events
-from telemetry.events import capture_error, track_analysis
+from telemetry.events import capture_error, track_analysis, track_lsp_result
 
 
 @pytest.fixture
@@ -111,6 +111,44 @@ def test_repo_scanned_reads_run_id_from_env_without_track_analysis(captured, mon
     events.track_tech_stack("/env-repo", 100, [])
 
     assert props_for(captured, "repo_scanned")["run_id"] == "env-run"
+
+
+def test_lsp_analysis_result_marks_zero_nodes_as_error(captured, monkeypatch):
+    monkeypatch.setenv("CODEBOARDING_RUN_ID", "lsp-run")
+
+    analysis = {
+        "call_graph": SimpleNamespace(nodes={}, edges=[]),
+        "source_files": ["a.py", "b.py"],
+    }
+
+    track_lsp_result(
+        language="python",
+        loc=42,
+        status="success",
+        duration_ms=250,
+        analysis=analysis,
+        diagnostics={},
+    )
+
+    props = props_for(captured, "lsp_analysis_result")
+    assert props["run_id"] == "lsp-run"
+    assert props["language"] == "python"
+    assert "project_path" not in props
+    assert props["source_file_count"] == 2
+    assert props["quality_status"] == "error"
+    assert props["zero_nodes_with_loc"] is True
+    assert props["zero_edges_with_loc"] is True
+
+
+def test_lsp_analysis_result_warns_when_summary_fields_missing(captured, caplog):
+    track_lsp_result(language="python", loc=0, status="error", duration_ms=10, analysis={}, diagnostics={})
+
+    assert "LSP analysis result for python is degraded: missing call graph, missing source files" in caplog.text
+    props = props_for(captured, "lsp_analysis_result")
+    assert props["source_file_count"] == 0
+    assert props["node_count"] == 0
+    assert props["edge_count"] == 0
+    assert props["quality_status"] == "warning"
 
 
 def test_track_analysis_env_run_id_overrides_self(captured, monkeypatch):


### PR DESCRIPTION
## Summary
- Add anonymized `lsp_analysis_result` telemetry for each LSP language analysis pass.
- Track language, scanner LOC, run status, duration, source file count, node/edge counts, reference count, and diagnostic counts.
- Classify suspicious LSP outcomes in telemetry and logs:
  - `quality_status=error` when LOC exists but nodes are zero.
  - `quality_status=warning` when LOC exists but edges are zero.
- Keep repository/project paths out of the analytics payload.

## Test plan
- [x] `uv run black telemetry/events.py telemetry/schemas.py static_analyzer/__init__.py tests/test_telemetry_events.py`
- [x] `uv run mypy telemetry static_analyzer/__init__.py tests/test_telemetry_events.py`
- [x] `uv run pytest tests/test_telemetry_events.py tests/static_analyzer/test_static_analyzer_start_clients.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced telemetry tracking for code analysis results, including performance metrics, diagnostic counts, and analysis quality status.
  * Improved error detection and reporting for analysis runs with quality status flagging.

* **Tests**
  * Added test coverage for telemetry event emission and quality status tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->