### PR TITLE
Raise context-window fallback to Gemini 3 Flash limits; report window provenance on overflow

### DIFF
--- a/agents/cluster_methods_mixin.py
+++ b/agents/cluster_methods_mixin.py
@@ -16,7 +16,8 @@ from agents.agent_responses import (
     MethodEntry,
 )
 from agents.cluster_budget import ClusterPromptBudget
-from agents.llm_config import get_current_agent_context_window
+from agents.llm_config import get_current_agent_context_window, get_current_agent_model_ref
+from agents.model_capabilities import ContextWindow
 from constants import MIN_CLUSTERS_THRESHOLD
 from static_analyzer.analysis_result import StaticAnalysisResults
 from static_analyzer.cfg_skip_planner import ContextBudgetExceededError, plan_skip_set
@@ -44,6 +45,20 @@ class _RenderedClusterString:
     text: str
     by_language: dict[str, str]
     cluster_ids: set[int]
+
+
+def _describe_window(ctx: ContextWindow) -> str:
+    suffix = "; fallback default, model window unresolved" if ctx.is_fallback else ""
+    return f"{ctx.input_tokens} input tokens for {get_current_agent_model_ref()}{suffix}"
+
+
+def _window_telemetry(ctx: ContextWindow, char_budget: int) -> dict:
+    return {
+        "char_budget": char_budget,
+        "window_input_tokens": ctx.input_tokens,
+        "window_is_fallback": ctx.is_fallback,
+        "agent_model": get_current_agent_model_ref(),
+    }
 
 
 class ClusterMethodsMixin:
@@ -156,10 +171,10 @@ class ClusterMethodsMixin:
             ctx = get_current_agent_context_window()
             msg = (
                 f"Prompt overhead ({prompt_overhead_chars} chars) consumes the entire agent input "
-                f"window ({ctx.input_tokens} tokens); no room for cluster renderings."
+                f"window ({_describe_window(ctx)}); no room for cluster renderings."
             )
             logger.error("[CFG skip planner] %s", msg)
-            raise ContextBudgetExceededError(msg)
+            raise ContextBudgetExceededError(msg, telemetry_properties=_window_telemetry(ctx, char_budget))
 
         langs_with_clusters = [l for l in programming_langs if cluster_results.get(l)]
         if not langs_with_clusters:
@@ -240,14 +255,21 @@ class ClusterMethodsMixin:
         rendered: _RenderedClusterString,
         skip_sets: dict[str, set[str]],
     ) -> NoReturn:
+        ctx = get_current_agent_context_window()
         per_lang_sizes = {lang: len(text) for lang, text in rendered.by_language.items()}
         skipped_counts = {lang: len(skip) for lang, skip in skip_sets.items() if skip}
         msg = (
-            f"Cluster render {len(rendered.text)} chars exceeds budget {char_budget}. "
+            f"Cluster render {len(rendered.text)} chars exceeds budget {char_budget} "
+            f"(agent window: {_describe_window(ctx)}). "
             f"Per-language sizes: {per_lang_sizes}; skipped nodes: {skipped_counts}."
         )
         logger.error("[CFG skip planner] %s", msg)
-        raise ContextBudgetExceededError(msg)
+        telemetry = _window_telemetry(ctx, char_budget) | {
+            "render_chars": len(rendered.text),
+            "per_language_chars": per_lang_sizes,
+            "skipped_node_counts": skipped_counts,
+        }
+        raise ContextBudgetExceededError(msg, telemetry_properties=telemetry)
 
     @staticmethod
     def _cluster_prompt_budget(prompt_overhead_chars: int) -> int:

--- a/agents/constants.py
+++ b/agents/constants.py
@@ -14,8 +14,9 @@ class FileStructureConfig:
 
 
 class ModelCapabilities:
-    FALLBACK_INPUT = 256_000
-    FALLBACK_OUTPUT = 64_000
+    # Gemini 3 Flash limits — the default production model class.
+    FALLBACK_INPUT = 1_048_576
+    FALLBACK_OUTPUT = 65_536
     CACHE_TTL_SECONDS = 24 * 3600
     CHARS_PER_TOKEN = 3.5  # community consensus conversion is around 3 or 4 chars/token.
 

--- a/agents/constants.py
+++ b/agents/constants.py
@@ -14,9 +14,8 @@ class FileStructureConfig:
 
 
 class ModelCapabilities:
-    # Gemini 3 Flash limits — the default production model class.
-    FALLBACK_INPUT = 1_048_576
-    FALLBACK_OUTPUT = 65_536
+    FALLBACK_INPUT = 256_000
+    FALLBACK_OUTPUT = 64_000
     CACHE_TTL_SECONDS = 24 * 3600
     CHARS_PER_TOKEN = 3.5  # community consensus conversion is around 3 or 4 chars/token.
 

--- a/agents/llm_config.py
+++ b/agents/llm_config.py
@@ -23,6 +23,8 @@ MONITORING_CALLBACK = MonitoringCallback(stats_container=RunStats())
 
 logger = logging.getLogger(__name__)
 
+_OPENROUTER_FALLBACK_CONTEXT_WINDOW = ContextWindow(1_048_576, 65_536, is_fallback=True)
+
 # ---------------------------------------------------------------------------
 # Module-level model overrides – set once by the orchestrator (main.py) and
 # consumed by initialize_llms() without needing to thread the values through
@@ -374,7 +376,10 @@ def get_current_agent_context_window() -> ContextWindow:
     resolved = _resolve_active_provider(_agent_model_override or os.getenv("AGENT_MODEL"), "agent_model")
     if resolved is not None:
         name, _config, model_name = resolved
-        return get_context_window(name, model_name)
+        ctx = get_context_window(name, model_name)
+        if name == "openrouter" and ctx.is_fallback:
+            return _OPENROUTER_FALLBACK_CONTEXT_WINDOW
+        return ctx
     return ContextWindow(ModelCapabilities.FALLBACK_INPUT, ModelCapabilities.FALLBACK_OUTPUT, is_fallback=True)
 
 

--- a/agents/llm_config.py
+++ b/agents/llm_config.py
@@ -375,7 +375,16 @@ def get_current_agent_context_window() -> ContextWindow:
     if resolved is not None:
         name, _config, model_name = resolved
         return get_context_window(name, model_name)
-    return ContextWindow(ModelCapabilities.FALLBACK_INPUT, ModelCapabilities.FALLBACK_OUTPUT)
+    return ContextWindow(ModelCapabilities.FALLBACK_INPUT, ModelCapabilities.FALLBACK_OUTPUT, is_fallback=True)
+
+
+def get_current_agent_model_ref() -> str:
+    """``provider/model`` for the currently active agent LLM, or ``"unknown"``."""
+    resolved = _resolve_active_provider(_agent_model_override or os.getenv("AGENT_MODEL"), "agent_model")
+    if resolved is None:
+        return "unknown"
+    name, _config, model_name = resolved
+    return f"{name}/{model_name}"
 
 
 def initialize_parsing_llm(model_override: str | None = None) -> BaseChatModel:

--- a/agents/model_capabilities.py
+++ b/agents/model_capabilities.py
@@ -3,6 +3,7 @@ import logging
 import os
 import re
 import time
+import urllib.error
 import urllib.request
 from dataclasses import dataclass
 from functools import lru_cache
@@ -19,14 +20,34 @@ _BEDROCK_REGION = re.compile(r"^(us|eu|apac|global|au|ca|us-gov)\.")
 # app before `ollama serve` is up -- doesn't memoize None for the rest of the process.
 _OLLAMA_CACHE: dict[tuple[str, str], tuple[int, int]] = {}
 
+_PRESET_RE = re.compile(r"^@preset/([A-Za-z0-9_.-]+)$")
+
+# Why: presets are mutable server-side, so cache per-process only. Network errors are
+# not cached (transient); HTTP errors are (bad slug / key without preset read access).
+_PRESET_CACHE: dict[str, list[str]] = {}
+
 
 @dataclass(frozen=True)
 class ContextWindow:
     input_tokens: int
     output_tokens: int
+    is_fallback: bool = False
 
 
 def get_context_window(provider: str, model_name: str) -> ContextWindow:
+    hit = _run_resolvers(provider, model_name)
+    if hit is not None:
+        return ContextWindow(*hit)
+
+    preset_window = _resolve_preset_window(provider, model_name)
+    if preset_window is not None:
+        return preset_window
+
+    logger.warning(f"No context window for {provider}/{model_name}; using fallback {ModelCapabilities.FALLBACK_INPUT}")
+    return ContextWindow(ModelCapabilities.FALLBACK_INPUT, ModelCapabilities.FALLBACK_OUTPUT, is_fallback=True)
+
+
+def _run_resolvers(provider: str, model_name: str) -> tuple[int, int] | None:
     resolvers = (
         _resolve_env,
         _resolve_user_config,
@@ -38,9 +59,76 @@ def get_context_window(provider: str, model_name: str) -> ContextWindow:
     for resolver in resolvers:
         hit = resolver(provider, model_name)
         if hit is not None:
-            return ContextWindow(*hit)
-    logger.warning(f"No context window for {provider}/{model_name}; using fallback {ModelCapabilities.FALLBACK_INPUT}")
-    return ContextWindow(ModelCapabilities.FALLBACK_INPUT, ModelCapabilities.FALLBACK_OUTPUT)
+            return hit
+    return None
+
+
+def _resolve_preset_window(provider: str, model_name: str) -> ContextWindow | None:
+    """Window for an OpenRouter ``@preset/...`` reference via its underlying models.
+
+    Why min: a preset may route across models with different windows; promise only
+    the smallest so no candidate can overflow.
+    """
+    hits: list[tuple[int, int]] = []
+    unresolved: list[str] = []
+    for underlying in _openrouter_preset_models(provider, model_name):
+        hit = _run_resolvers(provider, underlying)
+        if hit is not None:
+            hits.append(hit)
+        else:
+            unresolved.append(underlying)
+    if not hits:
+        return None
+    if unresolved:
+        logger.warning(f"Preset {model_name}: no window for {unresolved}; using min over the resolved models")
+    return ContextWindow(min(inp for inp, _ in hits), min(out for _, out in hits))
+
+
+def _openrouter_preset_models(provider: str, model_name: str) -> list[str]:
+    """Model ids configured in an OpenRouter preset, or [] when not a preset reference."""
+    if provider != "openrouter":
+        return []
+    match = _PRESET_RE.match(model_name)
+    if not match:
+        return []
+    slug = match.group(1)
+    cached = _PRESET_CACHE.get(slug)
+    if cached is not None:
+        return cached
+
+    api_key = os.getenv("OPENROUTER_API_KEY")
+    if not api_key:
+        return []
+    base_url = (os.getenv("OPENROUTER_BASE_URL") or "https://openrouter.ai/api/v1").rstrip("/")
+    try:
+        req = urllib.request.Request(f"{base_url}/presets/{slug}", headers={"Authorization": f"Bearer {api_key}"})
+        with urllib.request.urlopen(req, timeout=3) as r:
+            payload = json.load(r)
+    except urllib.error.HTTPError as e:
+        logger.warning(f"OpenRouter preset lookup failed for {model_name} (HTTP {e.code})")
+        _PRESET_CACHE[slug] = []
+        return []
+    except Exception as e:
+        logger.warning(f"OpenRouter preset lookup failed for {model_name} ({e})")
+        return []
+
+    models = _extract_preset_models(payload)
+    if not models:
+        logger.warning(f"OpenRouter preset {model_name} lists no models")
+    _PRESET_CACHE[slug] = models
+    return models
+
+
+def _extract_preset_models(payload: dict) -> list[str]:
+    # The active config lives under data.designated_version.config; `model` is a single
+    # id, `models` a routing/fallback array. Either or both may be present.
+    data = payload.get("data") or {}
+    config = (data.get("designated_version") or {}).get("config") or data.get("config") or {}
+    models: list[str] = []
+    for candidate in [config.get("model"), *(config.get("models") or [])]:
+        if isinstance(candidate, str) and candidate and candidate not in models:
+            models.append(candidate)
+    return models
 
 
 def _resolve_env(provider: str, model_name: str) -> tuple[int, int] | None:

--- a/agents/model_capabilities.py
+++ b/agents/model_capabilities.py
@@ -3,7 +3,6 @@ import logging
 import os
 import re
 import time
-import urllib.error
 import urllib.request
 from dataclasses import dataclass
 from functools import lru_cache
@@ -20,12 +19,6 @@ _BEDROCK_REGION = re.compile(r"^(us|eu|apac|global|au|ca|us-gov)\.")
 # app before `ollama serve` is up -- doesn't memoize None for the rest of the process.
 _OLLAMA_CACHE: dict[tuple[str, str], tuple[int, int]] = {}
 
-_PRESET_RE = re.compile(r"^@preset/([A-Za-z0-9_.-]+)$")
-
-# Why: presets are mutable server-side, so cache per-process only. Network errors are
-# not cached (transient); HTTP errors are (bad slug / key without preset read access).
-_PRESET_CACHE: dict[str, list[str]] = {}
-
 
 @dataclass(frozen=True)
 class ContextWindow:
@@ -35,19 +28,6 @@ class ContextWindow:
 
 
 def get_context_window(provider: str, model_name: str) -> ContextWindow:
-    hit = _run_resolvers(provider, model_name)
-    if hit is not None:
-        return ContextWindow(*hit)
-
-    preset_window = _resolve_preset_window(provider, model_name)
-    if preset_window is not None:
-        return preset_window
-
-    logger.warning(f"No context window for {provider}/{model_name}; using fallback {ModelCapabilities.FALLBACK_INPUT}")
-    return ContextWindow(ModelCapabilities.FALLBACK_INPUT, ModelCapabilities.FALLBACK_OUTPUT, is_fallback=True)
-
-
-def _run_resolvers(provider: str, model_name: str) -> tuple[int, int] | None:
     resolvers = (
         _resolve_env,
         _resolve_user_config,
@@ -59,76 +39,9 @@ def _run_resolvers(provider: str, model_name: str) -> tuple[int, int] | None:
     for resolver in resolvers:
         hit = resolver(provider, model_name)
         if hit is not None:
-            return hit
-    return None
-
-
-def _resolve_preset_window(provider: str, model_name: str) -> ContextWindow | None:
-    """Window for an OpenRouter ``@preset/...`` reference via its underlying models.
-
-    Why min: a preset may route across models with different windows; promise only
-    the smallest so no candidate can overflow.
-    """
-    hits: list[tuple[int, int]] = []
-    unresolved: list[str] = []
-    for underlying in _openrouter_preset_models(provider, model_name):
-        hit = _run_resolvers(provider, underlying)
-        if hit is not None:
-            hits.append(hit)
-        else:
-            unresolved.append(underlying)
-    if not hits:
-        return None
-    if unresolved:
-        logger.warning(f"Preset {model_name}: no window for {unresolved}; using min over the resolved models")
-    return ContextWindow(min(inp for inp, _ in hits), min(out for _, out in hits))
-
-
-def _openrouter_preset_models(provider: str, model_name: str) -> list[str]:
-    """Model ids configured in an OpenRouter preset, or [] when not a preset reference."""
-    if provider != "openrouter":
-        return []
-    match = _PRESET_RE.match(model_name)
-    if not match:
-        return []
-    slug = match.group(1)
-    cached = _PRESET_CACHE.get(slug)
-    if cached is not None:
-        return cached
-
-    api_key = os.getenv("OPENROUTER_API_KEY")
-    if not api_key:
-        return []
-    base_url = (os.getenv("OPENROUTER_BASE_URL") or "https://openrouter.ai/api/v1").rstrip("/")
-    try:
-        req = urllib.request.Request(f"{base_url}/presets/{slug}", headers={"Authorization": f"Bearer {api_key}"})
-        with urllib.request.urlopen(req, timeout=3) as r:
-            payload = json.load(r)
-    except urllib.error.HTTPError as e:
-        logger.warning(f"OpenRouter preset lookup failed for {model_name} (HTTP {e.code})")
-        _PRESET_CACHE[slug] = []
-        return []
-    except Exception as e:
-        logger.warning(f"OpenRouter preset lookup failed for {model_name} ({e})")
-        return []
-
-    models = _extract_preset_models(payload)
-    if not models:
-        logger.warning(f"OpenRouter preset {model_name} lists no models")
-    _PRESET_CACHE[slug] = models
-    return models
-
-
-def _extract_preset_models(payload: dict) -> list[str]:
-    # The active config lives under data.designated_version.config; `model` is a single
-    # id, `models` a routing/fallback array. Either or both may be present.
-    data = payload.get("data") or {}
-    config = (data.get("designated_version") or {}).get("config") or data.get("config") or {}
-    models: list[str] = []
-    for candidate in [config.get("model"), *(config.get("models") or [])]:
-        if isinstance(candidate, str) and candidate and candidate not in models:
-            models.append(candidate)
-    return models
+            return ContextWindow(*hit)
+    logger.warning(f"No context window for {provider}/{model_name}; using fallback {ModelCapabilities.FALLBACK_INPUT}")
+    return ContextWindow(ModelCapabilities.FALLBACK_INPUT, ModelCapabilities.FALLBACK_OUTPUT, is_fallback=True)
 
 
 def _resolve_env(provider: str, model_name: str) -> tuple[int, int] | None:

--- a/static_analyzer/cfg_skip_planner.py
+++ b/static_analyzer/cfg_skip_planner.py
@@ -30,7 +30,14 @@ class ContextBudgetExceededError(RuntimeError):
     Raised when the pre-planning overhead already exceeds the input window,
     or when the most aggressive safe trim (per ``max_peel_frac`` and
     ``min_keep_per_cluster``) still overflows the remaining budget.
+
+    ``telemetry_properties`` is forwarded into the PostHog ``$exception``
+    event so overflow reports carry the budget numbers and window provenance.
     """
+
+    def __init__(self, message: str, telemetry_properties: dict | None = None):
+        super().__init__(message)
+        self.telemetry_properties = telemetry_properties or {}
 
 
 def _compute_peel_order(cfg_nx: nx.DiGraph) -> list[str]:

--- a/telemetry/events.py
+++ b/telemetry/events.py
@@ -215,6 +215,7 @@ def track_analysis(func):
                 exc_props: dict = {"command": command, "version": _app_version()}
                 if run_id:
                     exc_props["run_id"] = run_id
+                exc_props.update(_exception_properties(exc))
                 telemetry.capture_exception(exc, properties=exc_props)
             telemetry.flush()
 
@@ -232,7 +233,14 @@ def capture_error(command: str, exc: BaseException, *, extra: dict | None = None
     run_id = _resolve_run_id()
     if run_id is not None:
         properties["run_id"] = run_id
+    properties.update(_exception_properties(exc))
     if extra:
         properties.update(extra)
     telemetry.capture_exception(exc, properties=properties)
     telemetry.flush()
+
+
+def _exception_properties(exc: BaseException) -> dict:
+    """Diagnostic properties an exception carries for its ``$exception`` event."""
+    props = getattr(exc, "telemetry_properties", None)
+    return props if isinstance(props, dict) else {}

--- a/tests/agents/test_cluster_methods_mixin.py
+++ b/tests/agents/test_cluster_methods_mixin.py
@@ -8,6 +8,7 @@ from agents.cluster_budget import ClusterPromptBudget
 from agents.cluster_methods_mixin import ClusterMethodsMixin
 from agents.agent_responses import AnalysisInsights, Component, SourceCodeReference
 from agents.model_capabilities import ContextWindow
+from static_analyzer.cfg_skip_planner import ContextBudgetExceededError
 from static_analyzer.graph import CallGraph, ClusterResult
 from static_analyzer.constants import Language, NodeType
 from static_analyzer.node import Node
@@ -248,6 +249,42 @@ class TestClusterStringBudgeting(unittest.TestCase):
 
         self.assertEqual(result, full)
         mock_plan_skip.assert_not_called()
+
+    def test_budget_error_reports_window_provenance_and_telemetry(self):
+        # Why: overflow errors must be diagnosable from PostHog alone — they need the
+        # window size, whether it was a fallback guess, and the active model.
+        names = ["py." + ("long_name_" * 30) + str(i) for i in range(10)]
+        cfg = self._make_graph("python", names)
+        cluster_results = {"python": ClusterResult(clusters={1: set(names)}, strategy="test")}
+        static = MagicMock()
+        static.get_cfg.return_value = cfg
+        mixin = MockMixin(repo_dir=Path("/repo"), static_analysis=static)
+
+        with (
+            patch(
+                "agents.cluster_methods_mixin.get_current_agent_context_window",
+                return_value=ContextWindow(input_tokens=8_100, output_tokens=64_000, is_fallback=True),
+            ),
+            patch(
+                "agents.cluster_methods_mixin.get_current_agent_model_ref",
+                return_value="openrouter/@preset/production",
+            ),
+            patch(
+                "agents.cluster_methods_mixin.plan_skip_set",
+                side_effect=ContextBudgetExceededError("cannot fit"),
+            ),
+        ):
+            with self.assertRaises(ContextBudgetExceededError) as raised:
+                mixin._build_cluster_string([Language.PYTHON], cluster_results)
+
+        message = str(raised.exception)
+        self.assertIn("openrouter/@preset/production", message)
+        self.assertIn("fallback default", message)
+        props = raised.exception.telemetry_properties
+        self.assertTrue(props["window_is_fallback"])
+        self.assertEqual(props["window_input_tokens"], 8_100)
+        self.assertEqual(props["agent_model"], "openrouter/@preset/production")
+        self.assertGreater(props["render_chars"], props["char_budget"])
 
 
 class TestExpandToMethodLevelClusters(unittest.TestCase):

--- a/tests/agents/test_llm_config.py
+++ b/tests/agents/test_llm_config.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from agents.llm_config import initialize_agent_llm, initialize_parsing_llm, validate_api_key_provided
+from agents.model_capabilities import ContextWindow
 from agents.prompts.prompt_factory import LLMType
 
 
@@ -68,6 +69,39 @@ class TestLLMConfigKeyless:
         with patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test"}, clear=True):
             assert openai.is_active() is True
             assert openai.has_real_api_key() is True
+
+
+class TestAgentContextWindow:
+    def test_openrouter_fallback_uses_large_default(self):
+        from agents.llm_config import get_current_agent_context_window
+
+        with (
+            patch(
+                "agents.llm_config._resolve_active_provider",
+                return_value=("openrouter", MagicMock(), "@preset/production"),
+            ),
+            patch(
+                "agents.llm_config.get_context_window",
+                return_value=ContextWindow(256_000, 64_000, is_fallback=True),
+            ),
+        ):
+            ctx = get_current_agent_context_window()
+
+        assert ctx == ContextWindow(1_048_576, 65_536, is_fallback=True)
+
+    def test_non_openrouter_fallback_stays_generic(self):
+        from agents.llm_config import get_current_agent_context_window
+
+        with (
+            patch("agents.llm_config._resolve_active_provider", return_value=("openai", MagicMock(), "private")),
+            patch(
+                "agents.llm_config.get_context_window",
+                return_value=ContextWindow(256_000, 64_000, is_fallback=True),
+            ),
+        ):
+            ctx = get_current_agent_context_window()
+
+        assert ctx == ContextWindow(256_000, 64_000, is_fallback=True)
 
 
 class TestDetectLLMTypeFromModel:

--- a/tests/agents/test_model_capabilities.py
+++ b/tests/agents/test_model_capabilities.py
@@ -73,7 +73,7 @@ class TestResolverPriority:
         monkeypatch.setenv("CB_CTX_OPENAI_GPT_5", "500000")
         cw = get_context_window("openai", "gpt-5")
         assert cw.input_tokens == 500_000
-        assert cw.output_tokens == 65_536
+        assert cw.output_tokens == 64_000
 
     def test_malformed_env_override_falls_through_to_catalog(self, fake_catalogs, monkeypatch):
         # Regression: a typo like `500k` used to raise ValueError out of get_context_window.
@@ -81,7 +81,7 @@ class TestResolverPriority:
         assert get_context_window("openai", "gpt-5").input_tokens == 272_000
 
     def test_fallback_when_nothing_matches(self, fake_catalogs):
-        assert get_context_window("mystery", "nonexistent") == ContextWindow(1_048_576, 65_536, is_fallback=True)
+        assert get_context_window("mystery", "nonexistent") == ContextWindow(256_000, 64_000, is_fallback=True)
 
 
 class TestModelsdevResolution:
@@ -137,7 +137,7 @@ class TestOllamaResolver:
 
         monkeypatch.setattr("agents.model_capabilities.urllib.request.urlopen", fake_urlopen)
         result = _resolve_ollama("ollama", "qwen3:30b")
-        assert result == (4096, 65_536)
+        assert result == (4096, 64_000)
 
     def test_arch_max_used_when_num_ctx_absent(self, monkeypatch):
         monkeypatch.setenv("OLLAMA_BASE_URL", "http://fake:11434")
@@ -148,7 +148,7 @@ class TestOllamaResolver:
             return io.BytesIO(json.dumps(payload).encode())
 
         monkeypatch.setattr("agents.model_capabilities.urllib.request.urlopen", fake_urlopen)
-        assert _resolve_ollama("ollama", "llama3:8b") == (131072, 65_536)
+        assert _resolve_ollama("ollama", "llama3:8b") == (131072, 64_000)
 
     def test_transient_failure_is_retried_not_cached(self, monkeypatch):
         # Why: @lru_cache used to memoize None here, so a brief Ollama outage
@@ -166,7 +166,7 @@ class TestOllamaResolver:
 
         monkeypatch.setattr("agents.model_capabilities.urllib.request.urlopen", fake_urlopen)
         assert _resolve_ollama("ollama", "llama3:8b") is None
-        assert _resolve_ollama("ollama", "llama3:8b") == (8192, 65_536)
+        assert _resolve_ollama("ollama", "llama3:8b") == (8192, 64_000)
 
 
 class TestCorruptCache:

--- a/tests/agents/test_model_capabilities.py
+++ b/tests/agents/test_model_capabilities.py
@@ -90,7 +90,7 @@ class TestResolverPriority:
         monkeypatch.setenv("CB_CTX_OPENAI_GPT_5", "500000")
         cw = get_context_window("openai", "gpt-5")
         assert cw.input_tokens == 500_000
-        assert cw.output_tokens == 64_000
+        assert cw.output_tokens == 65_536
 
     def test_malformed_env_override_falls_through_to_catalog(self, fake_catalogs, monkeypatch):
         # Regression: a typo like `500k` used to raise ValueError out of get_context_window.
@@ -98,7 +98,7 @@ class TestResolverPriority:
         assert get_context_window("openai", "gpt-5").input_tokens == 272_000
 
     def test_fallback_when_nothing_matches(self, fake_catalogs):
-        assert get_context_window("mystery", "nonexistent") == ContextWindow(256_000, 64_000, is_fallback=True)
+        assert get_context_window("mystery", "nonexistent") == ContextWindow(1_048_576, 65_536, is_fallback=True)
 
 
 class TestModelsdevResolution:
@@ -244,7 +244,7 @@ class TestOllamaResolver:
 
         monkeypatch.setattr("agents.model_capabilities.urllib.request.urlopen", fake_urlopen)
         result = _resolve_ollama("ollama", "qwen3:30b")
-        assert result == (4096, 64_000)
+        assert result == (4096, 65_536)
 
     def test_arch_max_used_when_num_ctx_absent(self, monkeypatch):
         monkeypatch.setenv("OLLAMA_BASE_URL", "http://fake:11434")
@@ -255,7 +255,7 @@ class TestOllamaResolver:
             return io.BytesIO(json.dumps(payload).encode())
 
         monkeypatch.setattr("agents.model_capabilities.urllib.request.urlopen", fake_urlopen)
-        assert _resolve_ollama("ollama", "llama3:8b") == (131072, 64_000)
+        assert _resolve_ollama("ollama", "llama3:8b") == (131072, 65_536)
 
     def test_transient_failure_is_retried_not_cached(self, monkeypatch):
         # Why: @lru_cache used to memoize None here, so a brief Ollama outage
@@ -273,7 +273,7 @@ class TestOllamaResolver:
 
         monkeypatch.setattr("agents.model_capabilities.urllib.request.urlopen", fake_urlopen)
         assert _resolve_ollama("ollama", "llama3:8b") is None
-        assert _resolve_ollama("ollama", "llama3:8b") == (8192, 64_000)
+        assert _resolve_ollama("ollama", "llama3:8b") == (8192, 65_536)
 
 
 class TestCorruptCache:

--- a/tests/agents/test_model_capabilities.py
+++ b/tests/agents/test_model_capabilities.py
@@ -2,13 +2,11 @@
 
 import io
 import json
-import urllib.error
 
 import pytest
 
 from agents.model_capabilities import (
     _OLLAMA_CACHE,
-    _PRESET_CACHE,
     ContextWindow,
     _parse_num_ctx,
     _resolve_ollama,
@@ -45,19 +43,7 @@ _FAKE_OPENROUTER = {
         "context_length": 1_000_000,
         "top_provider": {"max_completion_tokens": 128_000},
     },
-    "google/gemini-3-flash-preview": {
-        "context_length": 1_048_576,
-        "top_provider": {"max_completion_tokens": 65_536},
-    },
-    "anthropic/claude-opus-4.6": {
-        "context_length": 200_000,
-        "top_provider": {"max_completion_tokens": 128_000},
-    },
 }
-
-
-def _preset_payload(models: list[str]) -> bytes:
-    return json.dumps({"data": {"slug": "production", "designated_version": {"config": {"models": models}}}}).encode()
 
 
 @pytest.fixture
@@ -75,10 +61,7 @@ def fake_catalogs(monkeypatch):
     # Why: isolate from ~/.codeboarding/config.toml so a developer's local override
     # doesn't shadow the catalog under test.
     monkeypatch.setattr("agents.model_capabilities._user_context_window_override", lambda: None)
-    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
-    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
     _OLLAMA_CACHE.clear()
-    _PRESET_CACHE.clear()
 
 
 class TestResolverPriority:
@@ -133,96 +116,6 @@ class TestOpenrouterResolution:
         cw = get_context_window("anthropic", "claude-opus-4-7")
         assert cw.input_tokens == 1_000_000
         assert cw.output_tokens == 128_000
-
-
-class TestOpenrouterPresetResolution:
-    def test_resolves_min_window_across_preset_models(self, fake_catalogs, monkeypatch):
-        # Why: with allow_fallbacks any listed model may serve a request, so the
-        # promised window must be the smallest among them.
-        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-test")
-        payload = _preset_payload(["google/gemini-3-flash-preview", "anthropic/claude-opus-4.6"])
-
-        def fake_urlopen(req, timeout=None):
-            assert "/presets/production" in req.full_url
-            assert req.get_header("Authorization") == "Bearer sk-test"
-            return io.BytesIO(payload)
-
-        monkeypatch.setattr("agents.model_capabilities.urllib.request.urlopen", fake_urlopen)
-        cw = get_context_window("openrouter", "@preset/production")
-        assert cw == ContextWindow(200_000, 65_536)
-
-    def test_unresolvable_candidates_are_skipped(self, fake_catalogs, monkeypatch):
-        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-test")
-        payload = _preset_payload(["anthropic/claude-opus-4.6", "~openai/gpt-latest"])
-        monkeypatch.setattr(
-            "agents.model_capabilities.urllib.request.urlopen",
-            lambda req, timeout=None: io.BytesIO(payload),
-        )
-        assert get_context_window("openrouter", "@preset/production").input_tokens == 200_000
-
-    def test_single_model_field_is_honoured(self, fake_catalogs, monkeypatch):
-        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-test")
-        payload = json.dumps(
-            {"data": {"designated_version": {"config": {"model": "google/gemini-3-flash-preview"}}}}
-        ).encode()
-        monkeypatch.setattr(
-            "agents.model_capabilities.urllib.request.urlopen",
-            lambda req, timeout=None: io.BytesIO(payload),
-        )
-        assert get_context_window("openrouter", "@preset/production").input_tokens == 1_048_576
-
-    def test_non_preset_name_makes_no_preset_request(self, fake_catalogs, monkeypatch):
-        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-test")
-
-        def fail_urlopen(req, timeout=None):
-            raise AssertionError("unexpected network call")
-
-        monkeypatch.setattr("agents.model_capabilities.urllib.request.urlopen", fail_urlopen)
-        assert get_context_window("openrouter", "google/gemini-3-flash-preview").input_tokens == 1_048_576
-
-    def test_missing_api_key_falls_back(self, fake_catalogs):
-        cw = get_context_window("openrouter", "@preset/production")
-        assert cw.is_fallback
-
-    def test_http_error_is_cached_per_process(self, fake_catalogs, monkeypatch):
-        # Why: a 403/404 (bad slug, key without preset read access) is not transient;
-        # retrying on every budget computation would add network latency in a loop.
-        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-test")
-        calls = {"n": 0}
-
-        def fake_urlopen(req, timeout=None):
-            calls["n"] += 1
-            raise urllib.error.HTTPError(req.full_url, 404, "not found", hdrs=None, fp=None)
-
-        monkeypatch.setattr("agents.model_capabilities.urllib.request.urlopen", fake_urlopen)
-        assert get_context_window("openrouter", "@preset/production").is_fallback
-        assert get_context_window("openrouter", "@preset/production").is_fallback
-        assert calls["n"] == 1
-
-    def test_network_error_is_retried_not_cached(self, fake_catalogs, monkeypatch):
-        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-test")
-        calls = {"n": 0}
-        payload = _preset_payload(["anthropic/claude-opus-4.6"])
-
-        def fake_urlopen(req, timeout=None):
-            calls["n"] += 1
-            if calls["n"] == 1:
-                raise ConnectionRefusedError("offline")
-            return io.BytesIO(payload)
-
-        monkeypatch.setattr("agents.model_capabilities.urllib.request.urlopen", fake_urlopen)
-        assert get_context_window("openrouter", "@preset/production").is_fallback
-        assert get_context_window("openrouter", "@preset/production").input_tokens == 200_000
-
-    def test_user_config_override_beats_preset_lookup(self, fake_catalogs, monkeypatch):
-        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-test")
-        monkeypatch.setattr("agents.model_capabilities._user_context_window_override", lambda: 1_000_000)
-
-        def fail_urlopen(req, timeout=None):
-            raise AssertionError("unexpected network call")
-
-        monkeypatch.setattr("agents.model_capabilities.urllib.request.urlopen", fail_urlopen)
-        assert get_context_window("openrouter", "@preset/production").input_tokens == 1_000_000
 
 
 class TestOllamaResolver:

--- a/tests/agents/test_model_capabilities.py
+++ b/tests/agents/test_model_capabilities.py
@@ -2,11 +2,13 @@
 
 import io
 import json
+import urllib.error
 
 import pytest
 
 from agents.model_capabilities import (
     _OLLAMA_CACHE,
+    _PRESET_CACHE,
     ContextWindow,
     _parse_num_ctx,
     _resolve_ollama,
@@ -43,7 +45,19 @@ _FAKE_OPENROUTER = {
         "context_length": 1_000_000,
         "top_provider": {"max_completion_tokens": 128_000},
     },
+    "google/gemini-3-flash-preview": {
+        "context_length": 1_048_576,
+        "top_provider": {"max_completion_tokens": 65_536},
+    },
+    "anthropic/claude-opus-4.6": {
+        "context_length": 200_000,
+        "top_provider": {"max_completion_tokens": 128_000},
+    },
 }
+
+
+def _preset_payload(models: list[str]) -> bytes:
+    return json.dumps({"data": {"slug": "production", "designated_version": {"config": {"models": models}}}}).encode()
 
 
 @pytest.fixture
@@ -61,7 +75,10 @@ def fake_catalogs(monkeypatch):
     # Why: isolate from ~/.codeboarding/config.toml so a developer's local override
     # doesn't shadow the catalog under test.
     monkeypatch.setattr("agents.model_capabilities._user_context_window_override", lambda: None)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
     _OLLAMA_CACHE.clear()
+    _PRESET_CACHE.clear()
 
 
 class TestResolverPriority:
@@ -81,7 +98,7 @@ class TestResolverPriority:
         assert get_context_window("openai", "gpt-5").input_tokens == 272_000
 
     def test_fallback_when_nothing_matches(self, fake_catalogs):
-        assert get_context_window("mystery", "nonexistent") == ContextWindow(256_000, 64_000)
+        assert get_context_window("mystery", "nonexistent") == ContextWindow(256_000, 64_000, is_fallback=True)
 
 
 class TestModelsdevResolution:
@@ -116,6 +133,96 @@ class TestOpenrouterResolution:
         cw = get_context_window("anthropic", "claude-opus-4-7")
         assert cw.input_tokens == 1_000_000
         assert cw.output_tokens == 128_000
+
+
+class TestOpenrouterPresetResolution:
+    def test_resolves_min_window_across_preset_models(self, fake_catalogs, monkeypatch):
+        # Why: with allow_fallbacks any listed model may serve a request, so the
+        # promised window must be the smallest among them.
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-test")
+        payload = _preset_payload(["google/gemini-3-flash-preview", "anthropic/claude-opus-4.6"])
+
+        def fake_urlopen(req, timeout=None):
+            assert "/presets/production" in req.full_url
+            assert req.get_header("Authorization") == "Bearer sk-test"
+            return io.BytesIO(payload)
+
+        monkeypatch.setattr("agents.model_capabilities.urllib.request.urlopen", fake_urlopen)
+        cw = get_context_window("openrouter", "@preset/production")
+        assert cw == ContextWindow(200_000, 65_536)
+
+    def test_unresolvable_candidates_are_skipped(self, fake_catalogs, monkeypatch):
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-test")
+        payload = _preset_payload(["anthropic/claude-opus-4.6", "~openai/gpt-latest"])
+        monkeypatch.setattr(
+            "agents.model_capabilities.urllib.request.urlopen",
+            lambda req, timeout=None: io.BytesIO(payload),
+        )
+        assert get_context_window("openrouter", "@preset/production").input_tokens == 200_000
+
+    def test_single_model_field_is_honoured(self, fake_catalogs, monkeypatch):
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-test")
+        payload = json.dumps(
+            {"data": {"designated_version": {"config": {"model": "google/gemini-3-flash-preview"}}}}
+        ).encode()
+        monkeypatch.setattr(
+            "agents.model_capabilities.urllib.request.urlopen",
+            lambda req, timeout=None: io.BytesIO(payload),
+        )
+        assert get_context_window("openrouter", "@preset/production").input_tokens == 1_048_576
+
+    def test_non_preset_name_makes_no_preset_request(self, fake_catalogs, monkeypatch):
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-test")
+
+        def fail_urlopen(req, timeout=None):
+            raise AssertionError("unexpected network call")
+
+        monkeypatch.setattr("agents.model_capabilities.urllib.request.urlopen", fail_urlopen)
+        assert get_context_window("openrouter", "google/gemini-3-flash-preview").input_tokens == 1_048_576
+
+    def test_missing_api_key_falls_back(self, fake_catalogs):
+        cw = get_context_window("openrouter", "@preset/production")
+        assert cw.is_fallback
+
+    def test_http_error_is_cached_per_process(self, fake_catalogs, monkeypatch):
+        # Why: a 403/404 (bad slug, key without preset read access) is not transient;
+        # retrying on every budget computation would add network latency in a loop.
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-test")
+        calls = {"n": 0}
+
+        def fake_urlopen(req, timeout=None):
+            calls["n"] += 1
+            raise urllib.error.HTTPError(req.full_url, 404, "not found", hdrs=None, fp=None)
+
+        monkeypatch.setattr("agents.model_capabilities.urllib.request.urlopen", fake_urlopen)
+        assert get_context_window("openrouter", "@preset/production").is_fallback
+        assert get_context_window("openrouter", "@preset/production").is_fallback
+        assert calls["n"] == 1
+
+    def test_network_error_is_retried_not_cached(self, fake_catalogs, monkeypatch):
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-test")
+        calls = {"n": 0}
+        payload = _preset_payload(["anthropic/claude-opus-4.6"])
+
+        def fake_urlopen(req, timeout=None):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise ConnectionRefusedError("offline")
+            return io.BytesIO(payload)
+
+        monkeypatch.setattr("agents.model_capabilities.urllib.request.urlopen", fake_urlopen)
+        assert get_context_window("openrouter", "@preset/production").is_fallback
+        assert get_context_window("openrouter", "@preset/production").input_tokens == 200_000
+
+    def test_user_config_override_beats_preset_lookup(self, fake_catalogs, monkeypatch):
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-test")
+        monkeypatch.setattr("agents.model_capabilities._user_context_window_override", lambda: 1_000_000)
+
+        def fail_urlopen(req, timeout=None):
+            raise AssertionError("unexpected network call")
+
+        monkeypatch.setattr("agents.model_capabilities.urllib.request.urlopen", fail_urlopen)
+        assert get_context_window("openrouter", "@preset/production").input_tokens == 1_000_000
 
 
 class TestOllamaResolver:

--- a/tests/test_telemetry_events.py
+++ b/tests/test_telemetry_events.py
@@ -68,6 +68,33 @@ def test_capture_error_forwards_to_posthog(captured):
     assert props["run_id"] == "r9"
 
 
+def test_exception_attached_telemetry_properties_are_forwarded(captured):
+    # Why: budget-overflow errors attach window provenance so the $exception
+    # event is diagnosable without a local repro.
+    @track_analysis
+    def generate_analysis(run_id=None):
+        exc = RuntimeError("render exceeds budget")
+        exc.telemetry_properties = {"window_is_fallback": True, "char_budget": 776_700}  # type: ignore[attr-defined]
+        raise exc
+
+    with pytest.raises(RuntimeError):
+        generate_analysis(run_id="r3")
+
+    _, props = captured.exceptions[0]
+    assert props["window_is_fallback"] is True
+    assert props["char_budget"] == 776_700
+    assert props["command"] == "generate_analysis"
+
+
+def test_capture_error_merges_exception_telemetry_properties(captured):
+    exc = RuntimeError("boom")
+    exc.telemetry_properties = {"window_is_fallback": False}  # type: ignore[attr-defined]
+    capture_error("expand", exc)
+
+    _, props = captured.exceptions[0]
+    assert props["window_is_fallback"] is False
+
+
 def test_track_analysis_reads_run_id_from_self_for_generator_methods(captured):
     """Generator methods (generate_analysis) keep run_id on self, not as a param."""
 


### PR DESCRIPTION
Model names that match no capability catalog (e.g. OpenRouter `@preset/...` references) silently fell back to a 256k window. On a kafka-scale repo that mis-sized budget sent the skip planner into hours of futile pruning toward a guaranteed `ContextBudgetExceededError` — and neither the error nor telemetry said the window was a guess.

- Raise the last-resort fallback from 256k/64k to Gemini 3 Flash limits (1,048,576 / 65,536), the default production model class.
- `ContextWindow` now carries `is_fallback`; budget-overflow errors name the active model and window provenance, and forward the numbers (`window_input_tokens`, `window_is_fallback`, `agent_model`, budget/render chars) into the PostHog `$exception` event via `telemetry_properties`.

Resolving presets to their underlying models via the presets API was considered and dropped as over-engineering: preset references now land on the 1M fallback, and the flag keeps that guess observable in telemetry if it ever stops being right.

Full unit suite: 1608 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error messages when context budget is exceeded to include model details and window information for better diagnostics.
  * Improved fallback context window detection and explicit marking for clearer error reporting.

* **Tests**
  * Added tests for budget-exceeded error handling and exception telemetry property forwarding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->