### PR TITLE
test: label pytest telemetry source

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+import os
+
+import pytest
+
+
+os.environ["CODEBOARDING_SOURCE"] = "tests"
+
+
+@pytest.fixture(autouse=True)
+def label_test_telemetry(monkeypatch):
+    monkeypatch.setenv("CODEBOARDING_SOURCE", "tests")


### PR DESCRIPTION
## Summary
- Configure pytest runs to set `CODEBOARDING_SOURCE=tests` so telemetry from tests is not classified as core usage.

## Test plan
- [x] `uv run pytest tests/test_telemetry_events.py -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test configuration setup to ensure consistent test environment behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->