### PR TITLE
feat: per-method and per-file content_hash in analysis.json

### DIFF
--- a/agents/agent_responses.py
+++ b/agents/agent_responses.py
@@ -250,6 +250,10 @@ class MethodEntry(BaseModel):
     start_line: int = Field(description="Starting line number in the file.")
     end_line: int = Field(description="Ending line number in the file.")
     node_type: str = Field(description="Node type name matching NodeType enum (e.g. METHOD, FUNCTION, CLASS).")
+    content_hash: str = Field(
+        default="",
+        description="Truncated SHA-256 of the method's source lines; '' when source was unavailable.",
+    )
 
     def __hash__(self) -> int:
         return hash(self.qualified_name)
@@ -286,6 +290,10 @@ class FileEntry(BaseModel):
     methods: list[MethodEntry] = Field(
         default_factory=list,
         description="Methods and functions in this file, sorted by start line.",
+    )
+    content_hash: str = Field(
+        default="",
+        description="Truncated SHA-256 of the entire file's bytes; '' when source was unavailable.",
     )
 
 

--- a/agents/cluster_methods_mixin.py
+++ b/agents/cluster_methods_mixin.py
@@ -1,3 +1,4 @@
+import hashlib
 import logging
 import os
 from collections import defaultdict
@@ -38,6 +39,32 @@ from static_analyzer.graph import CallGraph, ClusterResult
 from static_analyzer.node import Node
 
 logger = logging.getLogger(__name__)
+
+
+def _read_source_lines(repo_dir: Path, rel_path: str, cache: dict[str, list[str] | None]) -> list[str] | None:
+    """Read and cache a file's lines (repo-relative path). None if unreadable."""
+    if rel_path not in cache:
+        try:
+            # splitlines() normalizes line endings, so trailing-newline-only changes aren't detected.
+            cache[rel_path] = (repo_dir / rel_path).read_text(encoding="utf-8", errors="replace").splitlines()
+        except OSError:
+            cache[rel_path] = None
+    return cache[rel_path]
+
+
+def _hash_method_body(lines: list[str] | None, start_line: int, end_line: int) -> str:
+    """Truncated SHA-256 of source lines [start_line-1:end_line]. '' when unavailable."""
+    if lines is None or start_line < 1 or end_line < start_line:
+        return ""
+    body = "\n".join(lines[start_line - 1 : end_line])
+    return hashlib.sha256(body.encode("utf-8")).hexdigest()[:16]
+
+
+def _hash_whole_file(lines: list[str] | None) -> str:
+    """Truncated SHA-256 of the entire file's lines. '' when unavailable."""
+    if lines is None:
+        return ""
+    return hashlib.sha256("\n".join(lines).encode("utf-8")).hexdigest()[:16]
 
 
 @dataclass(frozen=True)
@@ -582,6 +609,8 @@ class ClusterMethodsMixin:
                 return len(candidate_parts) > len(current_parts)
             return len(candidate) > len(current)
 
+        source_cache: dict[str, list[str] | None] = {}
+
         for node in nodes:
             if node.type not in allowed_types:
                 continue
@@ -597,6 +626,11 @@ class ClusterMethodsMixin:
                 start_line=node.line_start,
                 end_line=node.line_end,
                 node_type=node.type.name,
+                content_hash=_hash_method_body(
+                    _read_source_lines(self.repo_dir, rel_path, source_cache),
+                    node.line_start,
+                    node.line_end,
+                ),
             )
 
             existing = by_file[rel_path].get(dedupe_key)
@@ -730,12 +764,16 @@ class ClusterMethodsMixin:
         logger.info(f"Node coverage: {assigned_nodes}/{total_nodes} ({pct:.1f}%) nodes assigned to components")
 
     def build_files_index(self, analysis: AnalysisInsights) -> dict[str, FileEntry]:
+        file_cache: dict[str, list[str] | None] = {}
         files: dict[str, FileEntry] = {}
         for component in analysis.components:
             for fmg in component.file_methods:
                 entry = files.get(fmg.file_path)
                 if entry is None:
-                    entry = FileEntry(methods=[])
+                    entry = FileEntry(
+                        methods=[],
+                        content_hash=_hash_whole_file(_read_source_lines(self.repo_dir, fmg.file_path, file_cache)),
+                    )
                     files[fmg.file_path] = entry
 
                 methods_by_qname = {m.qualified_name: m for m in entry.methods}

--- a/agents/incremental_agent.py
+++ b/agents/incremental_agent.py
@@ -6,6 +6,7 @@ create new ones with a ``parent_id``. Stitching back into the live tree
 """
 
 import logging
+import os
 from enum import StrEnum
 from pathlib import Path
 
@@ -28,7 +29,7 @@ from agents.agent_responses import (
     index_components_by_id,
     iter_components,
 )
-from agents.cluster_methods_mixin import ClusterMethodsMixin
+from agents.cluster_methods_mixin import ClusterMethodsMixin, _hash_method_body, _read_source_lines
 from agents.prompts import get_incremental_grouping_message, get_scope_relations_message, get_system_message
 from agents.validation import (
     ValidationContext,
@@ -571,8 +572,8 @@ def repopulate_touched_scopes(
     if not redetail_ids:
         return touched_scopes
 
-    node_lookup = _build_node_lookup(helpers.static_analysis, cluster_results)
     repo_dir = helpers.repo_dir
+    node_lookup = _build_node_lookup(helpers.static_analysis, cluster_results, repo_dir)
 
     if any(c.component_id in redetail_ids for c in root_analysis.components):
         touched_scopes.add("")
@@ -592,9 +593,12 @@ def repopulate_touched_scopes(
     return touched_scopes
 
 
-def _build_node_lookup(static_analysis, cluster_results: dict[str, ClusterResult]) -> dict[str, MethodEntry]:
-    """Map qname -> ``MethodEntry`` built from the live CFG (fresh file/line metadata)."""
+def _build_node_lookup(
+    static_analysis, cluster_results: dict[str, ClusterResult], repo_dir: Path
+) -> dict[str, MethodEntry]:
+    """Map qname -> ``MethodEntry`` built from the live CFG (fresh file/line metadata + content_hash)."""
     lookup: dict[str, MethodEntry] = {}
+    source_cache: dict[str, list[str] | None] = {}
     for language in cluster_results:
         try:
             cfg = static_analysis.get_cfg(Language(language))
@@ -603,11 +607,17 @@ def _build_node_lookup(static_analysis, cluster_results: dict[str, ClusterResult
         for qname, node in cfg.nodes.items():
             if qname in lookup:
                 continue
+            rel_path = os.path.relpath(node.file_path, repo_dir) if os.path.isabs(node.file_path) else node.file_path
             lookup[qname] = MethodEntry(
                 qualified_name=qname,
                 start_line=node.line_start,
                 end_line=node.line_end,
                 node_type=node.type.name,
+                content_hash=_hash_method_body(
+                    _read_source_lines(repo_dir, rel_path, source_cache),
+                    node.line_start,
+                    node.line_end,
+                ),
             )
     return lookup
 

--- a/diagram_analysis/analysis_json.py
+++ b/diagram_analysis/analysis_json.py
@@ -94,6 +94,10 @@ class MethodIndexEntry(BaseModel):
     start_line: int = Field(description="Starting line number in the file.")
     end_line: int = Field(description="Ending line number in the file.")
     type: str = Field(description="Node type name (METHOD, FUNCTION, CLASS, ...).")
+    content_hash: str = Field(
+        default="",
+        description="Truncated SHA-256 of the method's source lines; '' when unknown.",
+    )
 
 
 class ComponentFileMethodGroupJson(BaseModel):
@@ -113,6 +117,10 @@ class FileEntryJson(BaseModel):
     method_keys: list[str] = Field(
         default_factory=list,
         description="Keys into ``methods_index`` ('<file_path>|<qualified_name>'), in declaration order.",
+    )
+    content_hash: str = Field(
+        default="",
+        description="Truncated SHA-256 of the entire file's bytes; '' when unknown.",
     )
 
 
@@ -187,6 +195,7 @@ def _build_methods_index_from_files(files_index: dict[str, FileEntry]) -> dict[s
                 start_line=method.start_line,
                 end_line=method.end_line,
                 type=method.node_type,
+                content_hash=method.content_hash,
             )
     return methods_index
 
@@ -195,6 +204,7 @@ def _build_file_entry_json_from_files(files_index: dict[str, FileEntry]) -> dict
     return {
         file_path: FileEntryJson(
             method_keys=[_method_key(file_path, m.qualified_name) for m in entry.methods],
+            content_hash=entry.content_hash,
         )
         for file_path, entry in files_index.items()
     }
@@ -222,6 +232,7 @@ def _hydrate_component_methods_from_refs(
                         start_line=indexed.start_line,
                         end_line=indexed.end_line,
                         node_type=indexed.type,
+                        content_hash=indexed.content_hash,
                     )
                 )
 
@@ -450,9 +461,13 @@ def _reconstruct_files_index(
                     start_line=indexed.start_line,
                     end_line=indexed.end_line,
                     node_type=indexed.type,
+                    content_hash=indexed.content_hash,
                 )
             )
-        files_index[file_path] = FileEntry(methods=methods)
+        files_index[file_path] = FileEntry(
+            methods=methods,
+            content_hash=entry_raw.get("content_hash", ""),
+        )
     return files_index
 
 

--- a/tests/agents/test_incremental_agent.py
+++ b/tests/agents/test_incremental_agent.py
@@ -642,6 +642,39 @@ class TestRefreshComponentFileMethodsPathNormalization(unittest.TestCase):
         )
 
 
+class TestBuildNodeLookupContentHash(unittest.TestCase):
+    """``_build_node_lookup`` must stamp ``content_hash`` so an incremental
+    refresh doesn't round-trip-wipe a previously-computed hash to ''."""
+
+    def test_method_entry_carries_content_hash_when_source_available(self) -> None:
+        import tempfile
+        from pathlib import Path
+
+        from agents.cluster_methods_mixin import _hash_method_body
+        from agents.incremental_agent import _build_node_lookup
+        from static_analyzer.constants import NodeType
+        from static_analyzer.node import Node
+
+        source = "def foo():\n    return 1\n\n\ndef bar():\n    return 2\n"
+        with tempfile.TemporaryDirectory() as tmp:
+            repo_dir = Path(tmp)
+            (repo_dir / "mod.py").write_text(source, encoding="utf-8")
+
+            node = Node("mod.foo", NodeType.FUNCTION, "mod.py", 1, 2)
+            cfg = MagicMock(nodes={"mod.foo": node})
+            static_analysis = MagicMock()
+            static_analysis.get_cfg.return_value = cfg
+
+            lookup = _build_node_lookup(static_analysis, {"python": ClusterResult()}, repo_dir)
+
+            entry = lookup["mod.foo"]
+            self.assertNotEqual(entry.content_hash, "")
+            self.assertEqual(
+                entry.content_hash,
+                _hash_method_body(source.splitlines(), 1, 2),
+            )
+
+
 class TestIncrementalAgentToolkit(unittest.TestCase):
     """Constructor wiring: routing should never see the full ReAct toolkit.
 

--- a/tests/diagram_analysis/test_content_hash.py
+++ b/tests/diagram_analysis/test_content_hash.py
@@ -1,0 +1,122 @@
+import hashlib
+from pathlib import Path
+
+from agents.agent_responses import FileEntry, MethodEntry
+from agents.agent_responses import FileEntry as _FileEntry
+from agents.cluster_methods_mixin import _hash_method_body, _hash_whole_file, _read_source_lines
+from diagram_analysis.analysis_json import (
+    FileEntryJson,
+    MethodIndexEntry,
+    _build_file_entry_json_from_files,
+    _build_methods_index_from_files,
+    _reconstruct_files_index,
+)
+
+
+def test_method_entry_content_hash_defaults_empty():
+    m = MethodEntry(qualified_name="m.foo", start_line=1, end_line=2, node_type="FUNCTION")
+    assert m.content_hash == ""
+
+
+def test_method_entry_content_hash_roundtrips_value():
+    m = MethodEntry(qualified_name="m.foo", start_line=1, end_line=2, node_type="FUNCTION", content_hash="deadbeef")
+    assert m.content_hash == "deadbeef"
+
+
+def test_method_index_entry_content_hash_defaults_empty():
+    e = MethodIndexEntry(file_path="m.py", qualified_name="m.foo", start_line=1, end_line=2, type="FUNCTION")
+    assert e.content_hash == ""
+
+
+def test_build_methods_index_copies_content_hash():
+    files_index = {
+        "m.py": FileEntry(
+            methods=[
+                MethodEntry(
+                    qualified_name="m.foo", start_line=1, end_line=2, node_type="FUNCTION", content_hash="abc123"
+                )
+            ]
+        )
+    }
+    idx = _build_methods_index_from_files(files_index)
+    assert idx["m.py|m.foo"].content_hash == "abc123"
+
+
+def test_reconstruct_files_index_copies_content_hash():
+    methods_index = {
+        "m.py|m.foo": MethodIndexEntry(
+            file_path="m.py", qualified_name="m.foo", start_line=1, end_line=2, type="FUNCTION", content_hash="abc123"
+        )
+    }
+    files_raw = {"m.py": {"method_keys": ["m.py|m.foo"]}}
+    files_index = _reconstruct_files_index(files_raw, methods_index)
+    assert files_index["m.py"].methods[0].content_hash == "abc123"
+
+
+def test_hash_method_body_hashes_line_range():
+    lines = ["def foo():", "    return 1", "", "def bar():", "    return 2"]
+    expected = hashlib.sha256("def foo():\n    return 1".encode("utf-8")).hexdigest()[:16]
+    assert _hash_method_body(lines, 1, 2) == expected
+
+
+def test_hash_method_body_empty_on_bad_range():
+    assert _hash_method_body(["a", "b"], 0, 2) == ""
+    assert _hash_method_body(["a", "b"], 3, 2) == ""
+    assert _hash_method_body(None, 1, 2) == ""
+
+
+def test_read_source_lines_missing_file_returns_none(tmp_path: Path):
+    cache: dict[str, list[str] | None] = {}
+    assert _read_source_lines(tmp_path, "nope.py", cache) is None
+
+
+def test_read_source_lines_reads_and_caches(tmp_path: Path):
+    (tmp_path / "f.py").write_text("a\nb\nc\n", encoding="utf-8")
+    cache: dict[str, list[str] | None] = {}
+    assert _read_source_lines(tmp_path, "f.py", cache) == ["a", "b", "c"]
+    assert "f.py" in cache
+
+
+def test_file_entry_content_hash_defaults_empty():
+    assert _FileEntry(methods=[]).content_hash == ""
+
+
+def test_file_entry_content_hash_roundtrips_value():
+    assert _FileEntry(methods=[], content_hash="ff00ff00").content_hash == "ff00ff00"
+
+
+def test_file_entry_json_content_hash_defaults_empty():
+    assert FileEntryJson(method_keys=[]).content_hash == ""
+
+
+def test_file_entry_json_build_copies_content_hash():
+    files_index = {"m.py": FileEntry(methods=[], content_hash="abc123")}
+    out = _build_file_entry_json_from_files(files_index)
+    assert out["m.py"].content_hash == "abc123"
+
+
+def test_reconstruct_files_index_restores_file_content_hash():
+    files_raw = {"m.py": {"method_keys": [], "content_hash": "abc123"}}
+    files_index = _reconstruct_files_index(files_raw, {})
+    assert files_index["m.py"].content_hash == "abc123"
+
+
+def test_reconstruct_files_index_missing_file_hash_defaults_empty():
+    files_raw = {"m.py": {"method_keys": []}}
+    files_index = _reconstruct_files_index(files_raw, {})
+    assert files_index["m.py"].content_hash == ""
+
+
+def test_hash_whole_file_hashes_all_lines():
+    lines = ["import os", "", "PI = 3.14"]
+    expected = hashlib.sha256("import os\n\nPI = 3.14".encode("utf-8")).hexdigest()[:16]
+    assert _hash_whole_file(lines) == expected
+
+
+def test_hash_whole_file_none_is_empty():
+    assert _hash_whole_file(None) == ""
+
+
+def test_hash_whole_file_empty_is_hash_of_empty_not_sentinel():
+    assert _hash_whole_file([]) == hashlib.sha256(b"").hexdigest()[:16]
+    assert _hash_whole_file([]) != ""


### PR DESCRIPTION
Records a content fingerprint (hash) of every method body and every whole file into analysis.json, computed while analysis runs and preserved across saves. This lets the diff later detect when a method's code or a file's contents change. Older files without fingerprints fall back to current behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

**New Features**
- Added deterministic content hashing for methods and whole files to support reliable incremental updates.
- Included `content_hash` in analysis outputs and JSON persistence, with restoration during rehydration.
- Incremental scope repopulation now populates method entries with source-derived hash values when available.

**Tests**
- Added/expanded test coverage for hash generation, defaulting behavior, JSON propagation/restoration, and edge cases.

**Chores**
- Regenerated the health report JSON with updated metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->