### PR TITLE
Add CodeBoarding architecture analysis

### DIFF
--- a/.github/workflows/codeboarding-sync.yml
+++ b/.github/workflows/codeboarding-sync.yml
@@ -1,0 +1,40 @@
+name: CodeBoarding sync
+
+on:
+  push:
+    branches: ['main']
+    # Loop guard: don't re-trigger on the files this workflow itself commits.
+    # Listed explicitly (not '.codeboarding/**') so editing your own
+    # .codeboarding/.codeboardingignore still regenerates the baseline.
+    paths-ignore:
+      - '.codeboarding/*.md'
+      - '.codeboarding/analysis.json'
+      - '.codeboarding/codeboarding_version.json'
+      - '.codeboarding/health/**'
+      - 'docs/development/architecture.md'
+  workflow_dispatch:
+    inputs:
+      force_full:
+        description: 'Ignore the committed baseline and rebuild it from scratch (full analysis).'
+        type: boolean
+        required: false
+        default: false
+
+permissions:
+  contents: write   # commit the generated baseline + docs to the branch
+  id-token: write   # mint a GitHub OIDC token for the free hosted tier (omit if you set a key/license)
+
+concurrency:
+  # Serialize against itself so a push landing mid-run can't make two commits.
+  group: codeboarding-sync
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: CodeBoarding/CodeBoarding-action@v1
+        with:
+          mode: sync
+          force_full: ${{ inputs.force_full || false }}


### PR DESCRIPTION
This PR completes your [CodeBoarding](https://codeboarding.org) setup by adding the missing
**sync workflow** (`codeboarding-sync.yml`). On every push to your default branch it commits
`.codeboarding/analysis.json` — your architecture baseline — so the
[CodeBoarding viewer](https://app.codeboarding.org) has something to open and PR reviews have
a baseline to diff against. (Adding only the review workflow leaves the viewer with no analysis.)

### Works out of the box
Just merge it — the Action runs on the **free tier**, with no extra setup. The
`id-token: write` permission lets it identify your repo to CodeBoarding’s hosted LLM,
metered per account against a weekly limit.

### Want more, or unmetered, usage?
Add an LLM provider key — OpenRouter (`OPENROUTER_API_KEY`), Anthropic, OpenAI, Google,
AWS Bedrock, etc. — or a `CODEBOARDING_LICENSE`, as a repository secret under
**Settings → Secrets and variables → Actions**, then pass it to the action via `llm_api_key`
(+ `llm_provider`) or `license_key`. See the
[provider list](https://github.com/CodeBoarding/CodeBoarding-action#more-usage). Optional —
the free tier needs nothing.

— opened for you by CodeBoarding

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added GitHub Actions workflow to automate syncing on pushes to the main branch with manual trigger support and concurrency controls to prevent overlapping runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->