### PR TITLE
Update CodeBoarding workflow configuration

### DIFF
--- a/.github/workflows/codeboarding-sync.yml
+++ b/.github/workflows/codeboarding-sync.yml
@@ -38,3 +38,8 @@ jobs:
         with:
           mode: sync
           force_full: ${{ inputs.force_full || false }}
+          # Free tier needs no secret — these fall through to the hosted OIDC tier when
+          # unset. Add either repo secret (Settings → Secrets and variables → Actions)
+          # for more/unmetered usage; no YAML edit required.
+          llm_api_key: ${{ secrets.OPENROUTER_API_KEY }}   # BYO LLM provider key (OpenRouter)
+          license_key: ${{ secrets.CODEBOARDING_LICENSE }}  # CodeBoarding paid plan

--- a/.github/workflows/codeboarding.yml
+++ b/.github/workflows/codeboarding.yml
@@ -2,46 +2,37 @@ name: CodeBoarding review
 
 on:
   pull_request:
-    # Generate once when the PR becomes reviewable; 'closed' only cancels an
-    # in-flight review (see concurrency below), it doesn't start one.
     types: [opened, reopened, ready_for_review, closed]
   issue_comment:
-    # Enables refreshing on demand by commenting /codeboarding.
     types: [created]
 
-permissions:
-  # write lets the action commit the generated .codeboarding/analysis.json back to
-  # the PR branch so the comment links to the webview diff (same-repo PRs). Drop to
-  # `read` to keep the comment without that link.
-  contents: write
-  pull-requests: write
-  issues: write
+# No workflow-level permissions: each job requests only what it needs (least
+# privilege), so the default token starts with none.
+permissions: {}
 
 concurrency:
   group: codeboarding-${{ github.event.pull_request.number || github.event.issue.number }}
-  # Only a PR close cancels a running review. Bot comments (issue_comment) and
-  # re-triggers must NOT cancel it — they queue behind the running review instead.
   cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action == 'closed' }}
 
 jobs:
   review:
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    # PR events (non-draft), or a /codeboarding comment from a trusted collaborator.
+    permissions:
+      contents: read        # check out the repo + read the committed baseline (no writes in review mode)
+      pull-requests: write  # post the architecture-diff PR comment
+      issues: write         # the /codeboarding issue_comment trigger + comment API
+      id-token: write       # mint a GitHub OIDC token for the free hosted tier (write is the only level for id-token)
     if: >
       (github.event_name == 'pull_request' && github.event.action != 'closed' && github.event.pull_request.draft == false) ||
       (github.event_name == 'issue_comment' && github.event.issue.pull_request != null &&
        startsWith(github.event.comment.body, '/codeboarding') &&
        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))
     steps:
-      - uses: actions/create-github-app-token@v3
-        id: codeboarding-app-token
-        if: vars.CODEBOARDING_APP_CLIENT_ID != ''
-        continue-on-error: true
-        with:
-          client-id: ${{ vars.CODEBOARDING_APP_CLIENT_ID }}
-          private-key: ${{ secrets.CODEBOARDING_APP_PRIVATE_KEY }}
       - uses: CodeBoarding/CodeBoarding-action@v1
         with:
-          github_token: ${{ steps.codeboarding-app-token.outputs.token || github.token }}
-          llm_api_key: ${{ secrets.OPENROUTER_API_KEY }}
+          # Free tier needs no secret — these fall through to the hosted OIDC tier when
+          # unset. Add either repo secret (Settings → Secrets and variables → Actions)
+          # for more/unmetered usage; no YAML edit required.
+          llm_api_key: ${{ secrets.OPENROUTER_API_KEY }}   # BYO LLM provider key (OpenRouter)
+          license_key: ${{ secrets.CODEBOARDING_LICENSE }}  # CodeBoarding paid plan


### PR DESCRIPTION
This PR updates your existing [CodeBoarding](https://codeboarding.org) workflow
configuration (`codeboarding.yml` and `codeboarding-sync.yml`) to the current recommended shape. It regenerates the file(s)
so they:

- grant `id-token: write`, so the **free hosted tier** works with no secret, and
- wire the `OPENROUTER_API_KEY` and `CODEBOARDING_LICENSE` repository secrets, so
  adding either one is picked up automatically (the action only reads these from its
  inputs — without the wiring a configured secret would silently go unused).

Only CodeBoarding’s own workflow files are touched. If you’d customized one of these,
review the diff before merging.

— opened for you by CodeBoarding

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to enhance CodeBoarding integration with additional authentication credentials.
  * Improved GitHub Actions security configuration by removing workflow-level permissions and implementing job-scoped least-privilege access controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->