### PR TITLE
fix: getFileStructure dir default + omit temperature for sampling-free Anthropic models

### DIFF
--- a/agents/llm_config.py
+++ b/agents/llm_config.py
@@ -25,6 +25,23 @@ logger = logging.getLogger(__name__)
 
 _OPENROUTER_FALLBACK_CONTEXT_WINDOW = ContextWindow(1_048_576, 65_536, is_fallback=True)
 
+# Model families that reject sampling params (temperature/top_p/top_k) with HTTP 400.
+# Why: Anthropic removed them starting with Opus 4.7; sending temperature (even 0) 400s.
+# Substrings match bare IDs and Bedrock-prefixed forms (e.g. us.anthropic.claude-opus-4-8-v1:0).
+_SAMPLING_PARAM_FREE_MODEL_SUBSTRINGS = (
+    "claude-opus-4-7",
+    "claude-opus-4-8",
+    "claude-fable-5",
+    "claude-mythos-5",
+)
+
+
+def _model_accepts_temperature(model_name: str) -> bool:
+    """False for models that reject sampling params; temperature must be omitted for those."""
+    lowered = model_name.lower()
+    return not any(s in lowered for s in _SAMPLING_PARAM_FREE_MODEL_SUBSTRINGS)
+
+
 # ---------------------------------------------------------------------------
 # Module-level model overrides – set once by the orchestrator (main.py) and
 # consumed by initialize_llms() without needing to thread the values through
@@ -341,10 +358,9 @@ def _initialize_llm(
 
     logger.info(f"Using {name.title()} {log_prefix}LLM with model: {model_name}")
 
-    kwargs = {
-        "model": model_name,
-        "temperature": getattr(config, temperature_attr),
-    }
+    kwargs: dict[str, Any] = {"model": model_name}
+    if _model_accepts_temperature(model_name):
+        kwargs["temperature"] = getattr(config, temperature_attr)
     kwargs.update(config.get_resolved_extra_args())
 
     # ChatBedrockConverse and ChatOllama take no api_key kwarg; their SDKs read

--- a/agents/tools/read_file_structure.py
+++ b/agents/tools/read_file_structure.py
@@ -36,7 +36,7 @@ class FileStructureTool(BaseRepoTool):
         # Ensure they are sorted by depth for is_subsequence logic
         return sorted(dirs, key=lambda x: len(x.parts))
 
-    def _run(self, dir: str) -> str:
+    def _run(self, dir: str = ".") -> str:
         """
         Run the tool with the given input.
         """

--- a/tests/agents/test_llm_config.py
+++ b/tests/agents/test_llm_config.py
@@ -8,6 +8,7 @@ import pytest
 from agents.llm_config import (
     LLM_PROVIDERS,
     LLMConfigError,
+    _model_accepts_temperature,
     initialize_agent_llm,
     initialize_llms,
     initialize_parsing_llm,
@@ -542,6 +543,50 @@ class TestEnvironmentVariables:
                     # Second call is for parsing LLM
                     parsing_call_kwargs = mock_chat_class.call_args_list[1][1]
                     assert parsing_call_kwargs["model"] == "gpt-4o-mini"
+
+
+class TestTemperatureGating:
+    """temperature must be omitted for Anthropic models that reject sampling params (Opus 4.7+)."""
+
+    @pytest.mark.parametrize(
+        "model_name",
+        [
+            "claude-opus-4-7",
+            "claude-opus-4-8",
+            "claude-fable-5",
+            "claude-mythos-5",
+            "anthropic.claude-opus-4-8",  # Bedrock prefix
+            "us.anthropic.claude-opus-4-8-v1:0",  # Bedrock with region
+            "CLAUDE-OPUS-4-8",  # case-insensitive
+        ],
+    )
+    def test_sampling_param_free_models_omit_temperature(self, model_name):
+        assert _model_accepts_temperature(model_name) is False
+
+    @pytest.mark.parametrize(
+        "model_name",
+        ["claude-sonnet-4-6", "claude-haiku-4-5", "anthropic.claude-sonnet-4-6", "gpt-4o", "gemini-3-flash"],
+    )
+    def test_other_models_accept_temperature(self, model_name):
+        assert _model_accepts_temperature(model_name) is True
+
+    @patch("agents.prompts.prompt_factory.initialize_global_factory")
+    @patch("agents.agent.MONITORING_CALLBACK")
+    def test_opus_built_without_temperature_attr(self, mock_monitoring_callback, mock_init_factory):
+        # Offline: ChatAnthropic built without temperature exposes .temperature == None.
+        env = {"ANTHROPIC_API_KEY": "sk-ant-test", "AGENT_MODEL": "claude-opus-4-8"}
+        with patch.dict(os.environ, env, clear=True):
+            agent_llm = initialize_agent_llm("claude-opus-4-8")
+            assert agent_llm.temperature is None
+
+    @patch("agents.prompts.prompt_factory.initialize_global_factory")
+    @patch("agents.agent.MONITORING_CALLBACK")
+    def test_sonnet_built_with_zero_temperature(self, mock_monitoring_callback, mock_init_factory):
+        # Offline: a sampling-capable model keeps the deterministic temperature=0.
+        env = {"ANTHROPIC_API_KEY": "sk-ant-test", "AGENT_MODEL": "claude-sonnet-4-6"}
+        with patch.dict(os.environ, env, clear=True):
+            agent_llm = initialize_agent_llm("claude-sonnet-4-6")
+            assert agent_llm.temperature == 0.0
 
 
 class TestMonitoringIntegration:

--- a/tests/agents/test_llm_config.py
+++ b/tests/agents/test_llm_config.py
@@ -572,21 +572,25 @@ class TestTemperatureGating:
 
     @patch("agents.prompts.prompt_factory.initialize_global_factory")
     @patch("agents.agent.MONITORING_CALLBACK")
-    def test_opus_built_without_temperature_attr(self, mock_monitoring_callback, mock_init_factory):
+    def test_opus_built_without_temperature_attr(
+        self, mock_monitoring_callback: MagicMock, mock_init_factory: MagicMock
+    ) -> None:
         # Offline: ChatAnthropic built without temperature exposes .temperature == None.
         env = {"ANTHROPIC_API_KEY": "sk-ant-test", "AGENT_MODEL": "claude-opus-4-8"}
         with patch.dict(os.environ, env, clear=True):
             agent_llm = initialize_agent_llm("claude-opus-4-8")
-            assert agent_llm.temperature is None
+            assert getattr(agent_llm, "temperature") is None
 
     @patch("agents.prompts.prompt_factory.initialize_global_factory")
     @patch("agents.agent.MONITORING_CALLBACK")
-    def test_sonnet_built_with_zero_temperature(self, mock_monitoring_callback, mock_init_factory):
+    def test_sonnet_built_with_zero_temperature(
+        self, mock_monitoring_callback: MagicMock, mock_init_factory: MagicMock
+    ) -> None:
         # Offline: a sampling-capable model keeps the deterministic temperature=0.
         env = {"ANTHROPIC_API_KEY": "sk-ant-test", "AGENT_MODEL": "claude-sonnet-4-6"}
         with patch.dict(os.environ, env, clear=True):
             agent_llm = initialize_agent_llm("claude-sonnet-4-6")
-            assert agent_llm.temperature == 0.0
+            assert getattr(agent_llm, "temperature") == 0.0
 
 
 class TestMonitoringIntegration:

--- a/tests/agents/tools/test_file_structure_tool.py
+++ b/tests/agents/tools/test_file_structure_tool.py
@@ -1,3 +1,4 @@
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -40,3 +41,21 @@ class TestFileStructureTool(unittest.TestCase):
         self.assertTrue(len(content) > 0)
         # If it's an error, it should mention "Error" or if it's a fallback, show "file tree"
         self.assertTrue("Error" in content or "file tree" in content)
+
+
+class TestFileStructureToolDefaultDir(unittest.TestCase):
+    def test_run_without_dir_argument_defaults_to_root(self):
+        # The args schema makes `dir` optional (default "."), so the agent may call
+        # the tool with no arguments. _run must honor that default rather than raise.
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            (repo / "module.py").write_text("x = 1\n")
+            tool = FileStructureTool(context=RepoContext(repo_dir=repo, ignore_manager=RepoIgnoreManager(repo)))
+
+            direct = tool._run()
+            self.assertIn("The file tree", direct)
+            self.assertIn("module.py", direct)
+
+            # The agent invokes tools with empty args; this is the path that failed in production.
+            via_invoke = tool.invoke({})
+            self.assertIn("The file tree", via_invoke)


### PR DESCRIPTION
## Description

Fixes two latent bugs in the LLM path: `getFileStructure` required a positional `dir` even though its args schema defaults to `"."`, so the agent's empty-args tool calls raised `TypeError` and burned the full retry budget before recovering. And `_initialize_llm` always passed `temperature`, which returns a 400 on Anthropic models that removed sampling params (Opus 4.7+/4.8 and the Claude 5 family) — it now omits `temperature` for those models while still sending `temperature=0` to models that accept it (sonnet-4-6/haiku-4-5, OpenAI/Google/etc.).

## How it was tested

Added offline regression tests (`TestFileStructureToolDefaultDir`, `TestTemperatureGating`) and ran the affected suites — 124 passed, 3 skipped, with `mypy` and `black` clean. Verified the temperature behavior against the live Anthropic API with minimal calls: `claude-opus-4-7`/`4-8` return a 400 when `temperature` is sent and succeed without it, while `claude-haiku-4-5`/`sonnet-4-6` accept it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with certain Anthropic Claude models by automatically omitting unsupported sampling parameters (including temperature) when required.

* **New Features**
  * File structure tool now defaults to the project root directory when no directory is specified.

* **Tests**
  * Added coverage to verify correct sampling-parameter handling for Claude model variants.
  * Added coverage to confirm the file structure tool’s default directory behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->