### PR TITLE
fix: retain supported languages in scanner

### DIFF
--- a/static_analyzer/scanner.py
+++ b/static_analyzer/scanner.py
@@ -80,7 +80,7 @@ class ProjectScanner:
             )
 
             logger.debug(f"Found: {pl}")
-            if pl.percentage >= 1:
+            if pl.is_supported_lang():
                 programming_languages.append(pl)
 
         self.all_text_files = all_files


### PR DESCRIPTION
We have a much better multi-language support now, so I removed the ignorance of a small PL as they might have a big impact on the whole system.

Further in use-cases with ML datasets, the csv/json files will overpower the acutal source code resulting in no analysis.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved programming language detection accuracy in project scans by refining how supported languages are identified and reported in analysis results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->