### PR TITLE
Iterative analysis itearation

### DIFF
--- a/static_analyzer/analysis_cache.py
+++ b/static_analyzer/analysis_cache.py
@@ -29,6 +29,9 @@ from typing import TYPE_CHECKING, Any
 
 from filelock import FileLock
 
+from static_analyzer.constants import NodeType
+from static_analyzer.engine.source_inspector import SourceInspector
+from static_analyzer.engine.utils import uri_to_path
 from static_analyzer.graph import CallGraph
 from static_analyzer.lsp_client.diagnostics import FileDiagnosticsMap
 from static_analyzer.node import Node
@@ -36,6 +39,8 @@ from utils import to_absolute_path, to_relative_path
 
 if TYPE_CHECKING:
     from static_analyzer.analysis_result import StaticAnalysisResults
+    from static_analyzer.engine.language_adapter import LanguageAdapter
+    from static_analyzer.engine.lsp_client import LSPClient
 
 logger = logging.getLogger(__name__)
 
@@ -54,6 +59,9 @@ _LEGACY_CACHE_SUBDIR = "cache"
 # v2: StaticAnalysisResults switched from dict-of-dicts to LanguageResults
 # dataclass storage. v1 pickles will be treated as cache misses and re-run.
 _TAG_VERSION = "v2"
+_INVALIDATED_CROSS_BOUNDARY_EDGES = "_invalidated_cross_boundary_edges"
+_INVALIDATED_FILES = "_invalidated_files"
+InvalidatedEdge = tuple[str, str, Node, Node]
 
 
 class StaticAnalysisCache:
@@ -336,14 +344,16 @@ def invalidate_files(analysis_result: dict[str, Any], changed_files: set[Path]) 
     """Return a copy of *analysis_result* with every entry from *changed_files* removed.
 
     Drops nodes whose ``file_path`` is in the change set, cascades edges that
-    reference dropped nodes, drops class hierarchies and references from the
-    same files, prunes package relations to surviving files, and filters
-    ``source_files`` / ``diagnostics`` accordingly. Raises ``ValueError`` if
-    the result has dangling edges or references after filtering.
+    reference dropped nodes, remembers cross-boundary edges for later LSP
+    validation, drops class hierarchies and references from the same files,
+    prunes package relations to surviving files, and filters ``source_files`` /
+    ``diagnostics`` accordingly. Raises ``ValueError`` if the result has
+    dangling edges or references after filtering.
     """
     changed_file_strs = {str(path) for path in changed_files}
 
     call_graph: CallGraph = analysis_result["call_graph"]
+    invalidated_edges = _collect_cross_boundary_edges(call_graph, changed_file_strs)
     filtered_cg = call_graph.filter(lambda node: node.file_path not in changed_file_strs)
 
     updated_result: dict[str, Any] = {
@@ -352,6 +362,8 @@ def invalidate_files(analysis_result: dict[str, Any], changed_files: set[Path]) 
         "package_relations": {},
         "references": [],
         "source_files": [],
+        _INVALIDATED_CROSS_BOUNDARY_EDGES: invalidated_edges,
+        _INVALIDATED_FILES: changed_file_strs,
     }
 
     if "diagnostics" in analysis_result:
@@ -392,13 +404,21 @@ def invalidate_files(analysis_result: dict[str, Any], changed_files: set[Path]) 
     return updated_result
 
 
-def merge_results(cached_result: dict[str, Any], new_result: dict[str, Any]) -> dict[str, Any]:
+def merge_results(
+    cached_result: dict[str, Any],
+    new_result: dict[str, Any],
+    *,
+    adapter: "LanguageAdapter | None" = None,
+    engine_client: "LSPClient | None" = None,
+) -> dict[str, Any]:
     """Union ``cached_result`` (post-invalidation) with ``new_result`` (fresh re-LSP).
 
     For overlapping keys (same file appearing in both), the new result wins
     for class hierarchies, packages, references, and diagnostics. Call-graph
-    nodes from both sides merge; edges from either side that reference
-    nodes present in the merged graph are kept.
+    nodes from both sides merge; edges from either side that reference nodes
+    present in the merged graph are kept. Cross-boundary edges removed during
+    invalidation are validated through LSP and restored only when they still
+    exist.
     """
     merged_result: dict[str, Any] = {
         "call_graph": cached_result["call_graph"].union(new_result["call_graph"]),
@@ -436,7 +456,188 @@ def merge_results(cached_result: dict[str, Any], new_result: dict[str, Any]) -> 
     if merged_diagnostics:
         merged_result["diagnostics"] = merged_diagnostics
 
+    invalidated_edges: list[InvalidatedEdge] = cached_result.get(_INVALIDATED_CROSS_BOUNDARY_EDGES, [])
+    invalidated_files: set[str] = cached_result.get(_INVALIDATED_FILES, set())
+    if invalidated_edges and adapter is not None and engine_client is not None:
+        _restore_persisted_cross_boundary_edges(
+            merged_result,
+            invalidated_edges,
+            invalidated_files,
+            adapter,
+            engine_client,
+        )
+
     return merged_result
+
+
+def _collect_cross_boundary_edges(call_graph: CallGraph, changed_file_strs: set[str]) -> list[InvalidatedEdge]:
+    edges: list[InvalidatedEdge] = []
+    for edge in call_graph.edges:
+        src_node = edge.src_node
+        dst_node = edge.dst_node
+        src_changed = src_node.file_path in changed_file_strs
+        dst_changed = dst_node.file_path in changed_file_strs
+        if src_changed != dst_changed:
+            edges.append((edge.get_source(), edge.get_destination(), src_node, dst_node))
+    return edges
+
+
+def _restore_persisted_cross_boundary_edges(
+    merged_analysis: dict[str, Any],
+    candidate_edges: list[InvalidatedEdge],
+    changed_file_strs: set[str],
+    adapter: "LanguageAdapter",
+    engine_client: "LSPClient",
+) -> None:
+    call_graph: CallGraph = merged_analysis["call_graph"]
+    source_inspector = SourceInspector()
+    restored = 0
+    checked = 0
+    references_cache: dict[str, list[dict]] = {}
+    definitions_cache: dict[str, list[list[dict]]] = {}
+
+    for src_name, dst_name, _old_src_node, _old_dst_node in candidate_edges:
+        if not call_graph.has_node(src_name) or not call_graph.has_node(dst_name):
+            continue
+
+        src_node = call_graph.nodes.get(src_name)
+        dst_node = call_graph.nodes.get(dst_name)
+        if src_node is None or dst_node is None:
+            continue
+
+        checked += 1
+        refs = references_cache.get(dst_name)
+        if refs is None:
+            try:
+                engine_client.did_open(Path(dst_node.file_path), adapter.language_id)
+                refs = engine_client.references(Path(dst_node.file_path), dst_node.line_start - 1, dst_node.col_start)
+            except Exception:
+                logger.debug("Failed to validate references for %s", dst_name, exc_info=True)
+                refs = []
+            references_cache[dst_name] = refs
+
+        edge_exists = _edge_reference_still_exists(src_node, dst_node, refs, adapter, source_inspector)
+        if not edge_exists and src_node.file_path in changed_file_strs:
+            edge_exists = _outbound_definition_edge_still_exists(
+                src_node, dst_node, definitions_cache, engine_client, source_inspector
+            )
+
+        if edge_exists:
+            try:
+                call_graph.add_edge(src_name, dst_name)
+                restored += 1
+            except ValueError:
+                logger.debug("Failed to restore edge %s -> %s", src_name, dst_name, exc_info=True)
+
+    logger.info(
+        "Validated %d cross-boundary cached edge(s), restored %d/%d",
+        len(candidate_edges),
+        restored,
+        checked,
+    )
+
+
+def _edge_reference_still_exists(
+    src_node: Node,
+    dst_node: Node,
+    refs: list[dict],
+    adapter: "LanguageAdapter",
+    source_inspector: SourceInspector,
+) -> bool:
+    for ref in refs:
+        ref_file = uri_to_path(ref.get("uri", ""))
+        if ref_file is None or str(ref_file) != src_node.file_path:
+            continue
+
+        ref_range = ref.get("range", {})
+        ref_start = ref_range.get("start", {})
+        ref_end = ref_range.get("end", {})
+        ref_line = ref_start.get("line", -1)
+        ref_char = ref_start.get("character", -1)
+        ref_end_char = ref_end.get("character", -1)
+        if not _position_inside_node(src_node, ref_line, ref_char):
+            continue
+        if not _reference_matches_edge_kind(
+            dst_node, ref_file, ref_line, ref_char, ref_end_char, adapter, source_inspector
+        ):
+            continue
+        return True
+    return False
+
+
+def _outbound_definition_edge_still_exists(
+    src_node: Node,
+    dst_node: Node,
+    definitions_cache: dict[str, list[list[dict]]],
+    engine_client: "LSPClient",
+    source_inspector: SourceInspector,
+) -> bool:
+    definition_results = definitions_cache.get(src_node.fully_qualified_name)
+    if definition_results is None:
+        file_path = Path(src_node.file_path)
+        call_sites = [
+            (file_path, line, char)
+            for line, char in source_inspector.find_call_sites(file_path)
+            if _position_inside_node(src_node, line, char)
+        ]
+        if not call_sites:
+            definition_results = []
+        else:
+            try:
+                definition_results, _ = engine_client.send_definition_batch(call_sites)
+            except Exception:
+                logger.debug(
+                    "Failed to validate outbound definitions for %s", src_node.fully_qualified_name, exc_info=True
+                )
+                definition_results = []
+        definitions_cache[src_node.fully_qualified_name] = definition_results
+
+    for definitions in definition_results:
+        for definition in definitions:
+            if _definition_points_to_node(definition, dst_node):
+                return True
+    return False
+
+
+def _definition_points_to_node(definition: dict, dst_node: Node) -> bool:
+    uri = definition.get("targetUri", definition.get("uri", ""))
+    file_path = uri_to_path(uri)
+    if file_path is None or str(file_path) != dst_node.file_path:
+        return False
+    selection_range = definition.get("targetSelectionRange", definition.get("targetRange", definition.get("range", {})))
+    start = selection_range.get("start", {})
+    line = start.get("line", -1)
+    character = start.get("character", -1)
+    return _position_inside_node(dst_node, line, character)
+
+
+def _position_inside_node(node: Node, zero_based_line: int, character: int) -> bool:
+    line = zero_based_line + 1
+    if line < node.line_start or line > node.line_end:
+        return False
+    if line == node.line_start and character < node.col_start:
+        return False
+    return True
+
+
+def _reference_matches_edge_kind(
+    dst_node: Node,
+    ref_file: Path,
+    ref_line: int,
+    ref_char: int,
+    ref_end_char: int,
+    adapter: "LanguageAdapter",
+    source_inspector: SourceInspector,
+) -> bool:
+    if adapter.is_class_like(dst_node.type) and not source_inspector.is_invocation(ref_file, ref_line, ref_end_char):
+        return False
+    if dst_node.type == NodeType.CONSTANT and not source_inspector.is_invocation(ref_file, ref_line, ref_end_char):
+        return False
+    if dst_node.type == NodeType.VARIABLE and not source_inspector.is_callable_usage(
+        ref_file, ref_line, ref_char, ref_end_char
+    ):
+        return False
+    return True
 
 
 def _validate_no_dangling_references(analysis_result: dict[str, Any]) -> None:

--- a/static_analyzer/analysis_cache.py
+++ b/static_analyzer/analysis_cache.py
@@ -29,9 +29,6 @@ from typing import TYPE_CHECKING, Any
 
 from filelock import FileLock
 
-from static_analyzer.constants import NodeType
-from static_analyzer.engine.source_inspector import SourceInspector
-from static_analyzer.engine.utils import uri_to_path
 from static_analyzer.graph import CallGraph, Edge
 from static_analyzer.lsp_client.diagnostics import FileDiagnosticsMap
 from static_analyzer.node import Node
@@ -39,8 +36,6 @@ from utils import to_absolute_path, to_relative_path
 
 if TYPE_CHECKING:
     from static_analyzer.analysis_result import StaticAnalysisResults
-    from static_analyzer.engine.language_adapter import LanguageAdapter
-    from static_analyzer.engine.lsp_client import LSPClient
 
 logger = logging.getLogger(__name__)
 
@@ -353,9 +348,11 @@ def invalidate_files(analysis_result: dict[str, Any], changed_files: set[Path]) 
     changed_file_strs = {str(path) for path in changed_files}
 
     call_graph: CallGraph = analysis_result["call_graph"]
-    dropped_edges: list[Edge] = []
-    filtered_cg = call_graph.filter(lambda node: node.file_path not in changed_file_strs, dropped_edges=dropped_edges)
-    invalidated_edges = _cross_boundary_edges(dropped_edges, changed_file_strs)
+    invalidated_edges: list[InvalidatedEdge] = []
+    filtered_cg = call_graph.filter(
+        lambda node: node.file_path not in changed_file_strs,
+        on_dropped_edge=lambda edge: _append_cross_boundary_edge(edge, changed_file_strs, invalidated_edges),
+    )
 
     updated_result: dict[str, Any] = {
         "call_graph": filtered_cg,
@@ -408,18 +405,13 @@ def invalidate_files(analysis_result: dict[str, Any], changed_files: set[Path]) 
 def merge_results(
     cached_result: dict[str, Any],
     new_result: dict[str, Any],
-    *,
-    adapter: "LanguageAdapter | None" = None,
-    engine_client: "LSPClient | None" = None,
 ) -> dict[str, Any]:
     """Union ``cached_result`` (post-invalidation) with ``new_result`` (fresh re-LSP).
 
     For overlapping keys (same file appearing in both), the new result wins
     for class hierarchies, packages, references, and diagnostics. Call-graph
-    nodes from both sides merge; edges from either side that reference nodes
-    present in the merged graph are kept. Cross-boundary edges removed during
-    invalidation are validated through LSP and restored only when they still
-    exist.
+    nodes from both sides merge; edges from either side that reference
+    nodes present in the merged graph are kept.
     """
     merged_result: dict[str, Any] = {
         "call_graph": cached_result["call_graph"].union(new_result["call_graph"]),
@@ -457,188 +449,18 @@ def merge_results(
     if merged_diagnostics:
         merged_result["diagnostics"] = merged_diagnostics
 
-    invalidated_edges: list[InvalidatedEdge] = cached_result.get(_INVALIDATED_CROSS_BOUNDARY_EDGES, [])
-    invalidated_files: set[str] = cached_result.get(_INVALIDATED_FILES, set())
-    if invalidated_edges and adapter is not None and engine_client is not None:
-        _restore_persisted_cross_boundary_edges(
-            merged_result,
-            invalidated_edges,
-            invalidated_files,
-            adapter,
-            engine_client,
-        )
-
     return merged_result
 
 
-def _cross_boundary_edges(dropped_edges: list[Edge], changed_file_strs: set[str]) -> list[InvalidatedEdge]:
-    edges: list[InvalidatedEdge] = []
-    for edge in dropped_edges:
-        src_node = edge.src_node
-        dst_node = edge.dst_node
-        src_changed = src_node.file_path in changed_file_strs
-        dst_changed = dst_node.file_path in changed_file_strs
-        if src_changed != dst_changed:
-            edges.append((edge.get_source(), edge.get_destination(), src_node, dst_node))
-    return edges
-
-
-def _restore_persisted_cross_boundary_edges(
-    merged_analysis: dict[str, Any],
-    candidate_edges: list[InvalidatedEdge],
-    changed_file_strs: set[str],
-    adapter: "LanguageAdapter",
-    engine_client: "LSPClient",
+def _append_cross_boundary_edge(
+    edge: Edge, changed_file_strs: set[str], invalidated_edges: list[InvalidatedEdge]
 ) -> None:
-    call_graph: CallGraph = merged_analysis["call_graph"]
-    source_inspector = SourceInspector()
-    restored = 0
-    checked = 0
-    references_cache: dict[str, list[dict]] = {}
-    definitions_cache: dict[str, list[list[dict]]] = {}
-
-    for src_name, dst_name, _old_src_node, _old_dst_node in candidate_edges:
-        if not call_graph.has_node(src_name) or not call_graph.has_node(dst_name):
-            continue
-
-        src_node = call_graph.nodes.get(src_name)
-        dst_node = call_graph.nodes.get(dst_name)
-        if src_node is None or dst_node is None:
-            continue
-
-        checked += 1
-        refs = references_cache.get(dst_name)
-        if refs is None:
-            try:
-                engine_client.did_open(Path(dst_node.file_path), adapter.language_id)
-                refs = engine_client.references(Path(dst_node.file_path), dst_node.line_start - 1, dst_node.col_start)
-            except Exception:
-                logger.debug("Failed to validate references for %s", dst_name, exc_info=True)
-                refs = []
-            references_cache[dst_name] = refs
-
-        edge_exists = _edge_reference_still_exists(src_node, dst_node, refs, adapter, source_inspector)
-        if not edge_exists and src_node.file_path in changed_file_strs:
-            edge_exists = _outbound_definition_edge_still_exists(
-                src_node, dst_node, definitions_cache, engine_client, source_inspector
-            )
-
-        if edge_exists:
-            try:
-                call_graph.add_edge(src_name, dst_name)
-                restored += 1
-            except ValueError:
-                logger.debug("Failed to restore edge %s -> %s", src_name, dst_name, exc_info=True)
-
-    logger.info(
-        "Validated %d cross-boundary cached edge(s), restored %d/%d",
-        len(candidate_edges),
-        restored,
-        checked,
-    )
-
-
-def _edge_reference_still_exists(
-    src_node: Node,
-    dst_node: Node,
-    refs: list[dict],
-    adapter: "LanguageAdapter",
-    source_inspector: SourceInspector,
-) -> bool:
-    for ref in refs:
-        ref_file = uri_to_path(ref.get("uri", ""))
-        if ref_file is None or str(ref_file) != src_node.file_path:
-            continue
-
-        ref_range = ref.get("range", {})
-        ref_start = ref_range.get("start", {})
-        ref_end = ref_range.get("end", {})
-        ref_line = ref_start.get("line", -1)
-        ref_char = ref_start.get("character", -1)
-        ref_end_char = ref_end.get("character", -1)
-        if not _position_inside_node(src_node, ref_line, ref_char):
-            continue
-        if not _reference_matches_edge_kind(
-            dst_node, ref_file, ref_line, ref_char, ref_end_char, adapter, source_inspector
-        ):
-            continue
-        return True
-    return False
-
-
-def _outbound_definition_edge_still_exists(
-    src_node: Node,
-    dst_node: Node,
-    definitions_cache: dict[str, list[list[dict]]],
-    engine_client: "LSPClient",
-    source_inspector: SourceInspector,
-) -> bool:
-    definition_results = definitions_cache.get(src_node.fully_qualified_name)
-    if definition_results is None:
-        file_path = Path(src_node.file_path)
-        call_sites = [
-            (file_path, line, char)
-            for line, char in source_inspector.find_call_sites(file_path)
-            if _position_inside_node(src_node, line, char)
-        ]
-        if not call_sites:
-            definition_results = []
-        else:
-            try:
-                definition_results, _ = engine_client.send_definition_batch(call_sites)
-            except Exception:
-                logger.debug(
-                    "Failed to validate outbound definitions for %s", src_node.fully_qualified_name, exc_info=True
-                )
-                definition_results = []
-        definitions_cache[src_node.fully_qualified_name] = definition_results
-
-    for definitions in definition_results:
-        for definition in definitions:
-            if _definition_points_to_node(definition, dst_node):
-                return True
-    return False
-
-
-def _definition_points_to_node(definition: dict, dst_node: Node) -> bool:
-    uri = definition.get("targetUri", definition.get("uri", ""))
-    file_path = uri_to_path(uri)
-    if file_path is None or str(file_path) != dst_node.file_path:
-        return False
-    selection_range = definition.get("targetSelectionRange", definition.get("targetRange", definition.get("range", {})))
-    start = selection_range.get("start", {})
-    line = start.get("line", -1)
-    character = start.get("character", -1)
-    return _position_inside_node(dst_node, line, character)
-
-
-def _position_inside_node(node: Node, zero_based_line: int, character: int) -> bool:
-    line = zero_based_line + 1
-    if line < node.line_start or line > node.line_end:
-        return False
-    if line == node.line_start and character < node.col_start:
-        return False
-    return True
-
-
-def _reference_matches_edge_kind(
-    dst_node: Node,
-    ref_file: Path,
-    ref_line: int,
-    ref_char: int,
-    ref_end_char: int,
-    adapter: "LanguageAdapter",
-    source_inspector: SourceInspector,
-) -> bool:
-    if adapter.is_class_like(dst_node.type) and not source_inspector.is_invocation(ref_file, ref_line, ref_end_char):
-        return False
-    if dst_node.type == NodeType.CONSTANT and not source_inspector.is_invocation(ref_file, ref_line, ref_end_char):
-        return False
-    if dst_node.type == NodeType.VARIABLE and not source_inspector.is_callable_usage(
-        ref_file, ref_line, ref_char, ref_end_char
-    ):
-        return False
-    return True
+    src_node = edge.src_node
+    dst_node = edge.dst_node
+    src_changed = src_node.file_path in changed_file_strs
+    dst_changed = dst_node.file_path in changed_file_strs
+    if src_changed != dst_changed:
+        invalidated_edges.append((edge.get_source(), edge.get_destination(), src_node, dst_node))
 
 
 def _validate_no_dangling_references(analysis_result: dict[str, Any]) -> None:

--- a/static_analyzer/analysis_cache.py
+++ b/static_analyzer/analysis_cache.py
@@ -32,7 +32,7 @@ from filelock import FileLock
 from static_analyzer.constants import NodeType
 from static_analyzer.engine.source_inspector import SourceInspector
 from static_analyzer.engine.utils import uri_to_path
-from static_analyzer.graph import CallGraph
+from static_analyzer.graph import CallGraph, Edge
 from static_analyzer.lsp_client.diagnostics import FileDiagnosticsMap
 from static_analyzer.node import Node
 from utils import to_absolute_path, to_relative_path
@@ -353,8 +353,9 @@ def invalidate_files(analysis_result: dict[str, Any], changed_files: set[Path]) 
     changed_file_strs = {str(path) for path in changed_files}
 
     call_graph: CallGraph = analysis_result["call_graph"]
-    invalidated_edges = _collect_cross_boundary_edges(call_graph, changed_file_strs)
-    filtered_cg = call_graph.filter(lambda node: node.file_path not in changed_file_strs)
+    dropped_edges: list[Edge] = []
+    filtered_cg = call_graph.filter(lambda node: node.file_path not in changed_file_strs, dropped_edges=dropped_edges)
+    invalidated_edges = _cross_boundary_edges(dropped_edges, changed_file_strs)
 
     updated_result: dict[str, Any] = {
         "call_graph": filtered_cg,
@@ -470,9 +471,9 @@ def merge_results(
     return merged_result
 
 
-def _collect_cross_boundary_edges(call_graph: CallGraph, changed_file_strs: set[str]) -> list[InvalidatedEdge]:
+def _cross_boundary_edges(dropped_edges: list[Edge], changed_file_strs: set[str]) -> list[InvalidatedEdge]:
     edges: list[InvalidatedEdge] = []
-    for edge in call_graph.edges:
+    for edge in dropped_edges:
         src_node = edge.src_node
         dst_node = edge.dst_node
         src_changed = src_node.file_path in changed_file_strs

--- a/static_analyzer/analysis_cache.py
+++ b/static_analyzer/analysis_cache.py
@@ -29,6 +29,7 @@ from typing import TYPE_CHECKING, Any
 
 from filelock import FileLock
 
+from static_analyzer.analysis_result import AnalysisData, InvalidatedAnalysis, InvalidatedEdge
 from static_analyzer.graph import CallGraph, Edge
 from static_analyzer.lsp_client.diagnostics import FileDiagnosticsMap
 from static_analyzer.node import Node
@@ -54,9 +55,6 @@ _LEGACY_CACHE_SUBDIR = "cache"
 # v2: StaticAnalysisResults switched from dict-of-dicts to LanguageResults
 # dataclass storage. v1 pickles will be treated as cache misses and re-run.
 _TAG_VERSION = "v2"
-_INVALIDATED_CROSS_BOUNDARY_EDGES = "_invalidated_cross_boundary_edges"
-_INVALIDATED_FILES = "_invalidated_files"
-InvalidatedEdge = tuple[str, str, Node, Node]
 
 
 class StaticAnalysisCache:
@@ -335,7 +333,7 @@ def _atomic_copy(src: Path, dest: Path) -> None:
         raise
 
 
-def invalidate_files(analysis_result: dict[str, Any], changed_files: set[Path]) -> dict[str, Any]:
+def invalidate_files(analysis_result: dict[str, Any], changed_files: set[Path]) -> InvalidatedAnalysis:
     """Return a copy of *analysis_result* with every entry from *changed_files* removed.
 
     Drops nodes whose ``file_path`` is in the change set, cascades edges that
@@ -351,28 +349,26 @@ def invalidate_files(analysis_result: dict[str, Any], changed_files: set[Path]) 
     invalidated_edges: list[InvalidatedEdge] = []
     filtered_cg = call_graph.filter(
         lambda node: node.file_path not in changed_file_strs,
-        on_dropped_edge=lambda edge: _append_cross_boundary_edge(edge, changed_file_strs, invalidated_edges),
+        on_dropped_edge=lambda edge: _collect_invalidated_edge(edge, changed_file_strs, invalidated_edges),
     )
 
-    updated_result: dict[str, Any] = {
-        "call_graph": filtered_cg,
-        "class_hierarchies": {},
-        "package_relations": {},
-        "references": [],
-        "source_files": [],
-        _INVALIDATED_CROSS_BOUNDARY_EDGES: invalidated_edges,
-        _INVALIDATED_FILES: changed_file_strs,
-    }
+    updated_result = AnalysisData(
+        call_graph=filtered_cg,
+        class_hierarchies={},
+        package_relations={},
+        references=[],
+        source_files=[],
+    )
 
     if "diagnostics" in analysis_result:
-        updated_result["diagnostics"] = {
+        updated_result.diagnostics = {
             fp: diags for fp, diags in analysis_result["diagnostics"].items() if fp not in changed_file_strs
         }
 
     class_hierarchies: dict[str, Any] = analysis_result["class_hierarchies"]
     for class_name, class_info in class_hierarchies.items():
         if class_info.get("file_path", "") not in changed_file_strs:
-            updated_result["class_hierarchies"][class_name] = class_info.copy()
+            updated_result.class_hierarchies[class_name] = class_info.copy()
 
     package_relations: dict[str, Any] = analysis_result["package_relations"]
     for package_name, package_info in package_relations.items():
@@ -381,31 +377,31 @@ def invalidate_files(analysis_result: dict[str, Any], changed_files: set[Path]) 
         if remaining:
             updated_package_info = package_info.copy()
             updated_package_info["files"] = remaining
-            updated_result["package_relations"][package_name] = updated_package_info
+            updated_result.package_relations[package_name] = updated_package_info
 
     references: list[Node] = analysis_result["references"]
     for ref in references:
         if ref.file_path not in changed_file_strs:
-            updated_result["references"].append(ref)
+            updated_result.references.append(ref)
 
     source_files: list[Path] = analysis_result["source_files"]
     for file_path in source_files:
         if str(file_path) not in changed_file_strs:
-            updated_result["source_files"].append(file_path)
+            updated_result.source_files.append(file_path)
 
     _validate_no_dangling_references(updated_result)
 
     logger.info(
         f"Invalidated {len(changed_files)} files: kept {len(filtered_cg.nodes)} nodes, "
-        f"{len(filtered_cg.edges)} edges, {len(updated_result['references'])} references"
+        f"{len(filtered_cg.edges)} edges, {len(updated_result.references)} references"
     )
-    return updated_result
+    return InvalidatedAnalysis(updated_result, invalidated_edges, changed_file_strs)
 
 
 def merge_results(
-    cached_result: dict[str, Any],
+    cached_result: AnalysisData,
     new_result: dict[str, Any],
-) -> dict[str, Any]:
+) -> AnalysisData:
     """Union ``cached_result`` (post-invalidation) with ``new_result`` (fresh re-LSP).
 
     For overlapping keys (same file appearing in both), the new result wins
@@ -413,46 +409,46 @@ def merge_results(
     nodes from both sides merge; edges from either side that reference
     nodes present in the merged graph are kept.
     """
-    merged_result: dict[str, Any] = {
-        "call_graph": cached_result["call_graph"].union(new_result["call_graph"]),
-        "class_hierarchies": {},
-        "package_relations": {},
-        "references": [],
-        "source_files": [],
-    }
+    new = AnalysisData.from_dict(new_result)
+    merged = AnalysisData(
+        call_graph=cached_result.call_graph.union(new.call_graph),
+        class_hierarchies={},
+        package_relations={},
+        references=[],
+        source_files=[],
+    )
 
-    merged_result["class_hierarchies"].update(cached_result["class_hierarchies"])
-    merged_result["class_hierarchies"].update(new_result["class_hierarchies"])
+    merged.class_hierarchies.update(cached_result.class_hierarchies)
+    merged.class_hierarchies.update(new.class_hierarchies)
 
-    merged_result["package_relations"].update(cached_result["package_relations"])
-    merged_result["package_relations"].update(new_result["package_relations"])
+    merged.package_relations.update(cached_result.package_relations)
+    merged.package_relations.update(new.package_relations)
 
-    new_source_files: list[Path] = new_result.get("source_files", [])
-    new_file_paths = {str(path) for path in new_source_files}
+    new_file_paths = {str(path) for path in new.source_files}
 
-    for ref in cached_result["references"]:
+    for ref in cached_result.references:
         if ref.file_path not in new_file_paths:
-            merged_result["references"].append(ref)
-    merged_result["references"].extend(new_result["references"])
+            merged.references.append(ref)
+    merged.references.extend(new.references)
 
-    for file_path in cached_result["source_files"]:
+    for file_path in cached_result.source_files:
         if str(file_path) not in new_file_paths:
-            merged_result["source_files"].append(file_path)
-    merged_result["source_files"].extend(new_source_files)
+            merged.source_files.append(file_path)
+    merged.source_files.extend(new.source_files)
 
-    cached_diagnostics: FileDiagnosticsMap = cached_result.get("diagnostics", {})
-    new_diagnostics: FileDiagnosticsMap = new_result.get("diagnostics", {})
+    cached_diagnostics = cached_result.diagnostics or {}
+    new_diagnostics = new.diagnostics or {}
     merged_diagnostics: FileDiagnosticsMap = {
         fp: diags for fp, diags in cached_diagnostics.items() if fp not in new_file_paths
     }
     merged_diagnostics.update(new_diagnostics)
     if merged_diagnostics:
-        merged_result["diagnostics"] = merged_diagnostics
+        merged.diagnostics = merged_diagnostics
 
-    return merged_result
+    return merged
 
 
-def _append_cross_boundary_edge(
+def _collect_invalidated_edge(
     edge: Edge, changed_file_strs: set[str], invalidated_edges: list[InvalidatedEdge]
 ) -> None:
     src_node = edge.src_node
@@ -463,12 +459,12 @@ def _append_cross_boundary_edge(
         invalidated_edges.append((edge.get_source(), edge.get_destination(), src_node, dst_node))
 
 
-def _validate_no_dangling_references(analysis_result: dict[str, Any]) -> None:
+def _validate_no_dangling_references(analysis_result: AnalysisData) -> None:
     """Sanity-check: every edge reaches existing nodes, every reference / class /
     package points at a file in ``source_files``. Raises on violations."""
-    call_graph: CallGraph = analysis_result["call_graph"]
+    call_graph = analysis_result.call_graph
     existing_nodes = set(call_graph.nodes.keys())
-    source_file_strs = {str(path) for path in analysis_result["source_files"]}
+    source_file_strs = {str(path) for path in analysis_result.source_files}
     errors: list[str] = []
 
     for edge in call_graph.edges:
@@ -479,16 +475,16 @@ def _validate_no_dangling_references(analysis_result: dict[str, Any]) -> None:
         if dst_name not in existing_nodes:
             errors.append(f"Edge destination '{dst_name}' references non-existent node")
 
-    for ref in analysis_result["references"]:
+    for ref in analysis_result.references:
         if ref.file_path not in source_file_strs:
             errors.append(f"Reference '{ref.fully_qualified_name}' from '{ref.file_path}' references non-existent file")
 
-    for class_name, class_info in analysis_result["class_hierarchies"].items():
+    for class_name, class_info in analysis_result.class_hierarchies.items():
         class_file_path = class_info.get("file_path", "")
         if class_file_path and class_file_path not in source_file_strs:
             errors.append(f"Class hierarchy '{class_name}' references non-existent file '{class_file_path}'")
 
-    for package_name, package_info in analysis_result["package_relations"].items():
+    for package_name, package_info in analysis_result.package_relations.items():
         for package_file in package_info.get("files", []):
             if package_file not in source_file_strs:
                 errors.append(f"Package '{package_name}' references non-existent file '{package_file}'")

--- a/static_analyzer/analysis_cache.py
+++ b/static_analyzer/analysis_cache.py
@@ -410,41 +410,23 @@ def merge_results(
     nodes present in the merged graph are kept.
     """
     new = AnalysisData.from_dict(new_result)
-    merged = AnalysisData(
-        call_graph=cached_result.call_graph.union(new.call_graph),
-        class_hierarchies={},
-        package_relations={},
-        references=[],
-        source_files=[],
-    )
-
-    merged.class_hierarchies.update(cached_result.class_hierarchies)
-    merged.class_hierarchies.update(new.class_hierarchies)
-
-    merged.package_relations.update(cached_result.package_relations)
-    merged.package_relations.update(new.package_relations)
-
     new_file_paths = {str(path) for path in new.source_files}
-
-    for ref in cached_result.references:
-        if ref.file_path not in new_file_paths:
-            merged.references.append(ref)
-    merged.references.extend(new.references)
-
-    for file_path in cached_result.source_files:
-        if str(file_path) not in new_file_paths:
-            merged.source_files.append(file_path)
-    merged.source_files.extend(new.source_files)
-
     cached_diagnostics = cached_result.diagnostics or {}
     new_diagnostics = new.diagnostics or {}
     merged_diagnostics: FileDiagnosticsMap = {
         fp: diags for fp, diags in cached_diagnostics.items() if fp not in new_file_paths
     }
     merged_diagnostics.update(new_diagnostics)
-    if merged_diagnostics:
-        merged.diagnostics = merged_diagnostics
 
+    merged = AnalysisData(
+        call_graph=cached_result.call_graph.union(new.call_graph),
+        class_hierarchies={**cached_result.class_hierarchies, **new.class_hierarchies},
+        package_relations={**cached_result.package_relations, **new.package_relations},
+        references=[ref for ref in cached_result.references if ref.file_path not in new_file_paths] + new.references,
+        source_files=[path for path in cached_result.source_files if str(path) not in new_file_paths]
+        + new.source_files,
+        diagnostics=merged_diagnostics or None,
+    )
     return merged
 
 

--- a/static_analyzer/analysis_cache.py
+++ b/static_analyzer/analysis_cache.py
@@ -30,7 +30,7 @@ from typing import TYPE_CHECKING, Any
 from filelock import FileLock
 
 from static_analyzer.analysis_result import AnalysisData, InvalidatedAnalysis, InvalidatedEdge
-from static_analyzer.graph import CallGraph, Edge
+from static_analyzer.graph import Edge
 from static_analyzer.lsp_client.diagnostics import FileDiagnosticsMap
 from static_analyzer.node import Node
 from utils import to_absolute_path, to_relative_path
@@ -345,49 +345,41 @@ def invalidate_files(analysis_result: dict[str, Any], changed_files: set[Path]) 
     """
     changed_file_strs = {str(path) for path in changed_files}
 
-    call_graph: CallGraph = analysis_result["call_graph"]
+    cached = AnalysisData.from_dict(analysis_result)
+    call_graph = cached.call_graph
     invalidated_edges: list[InvalidatedEdge] = []
     filtered_cg = call_graph.filter(
         lambda node: node.file_path not in changed_file_strs,
         on_dropped_edge=lambda edge: _collect_invalidated_edge(edge, changed_file_strs, invalidated_edges),
     )
 
+    diagnostics = None
+    if cached.diagnostics is not None:
+        diagnostics = {fp: diags for fp, diags in cached.diagnostics.items() if fp not in changed_file_strs}
+
+    class_hierarchies = {
+        class_name: class_info.copy()
+        for class_name, class_info in cached.class_hierarchies.items()
+        if class_info.get("file_path", "") not in changed_file_strs
+    }
+
+    package_relations: dict[str, Any] = {}
+    for package_name, package_info in cached.package_relations.items():
+        remaining_files = [f for f in package_info.get("files", []) if f not in changed_file_strs]
+        if remaining_files:
+            package_relations[package_name] = {**package_info, "files": remaining_files}
+
+    references = [ref for ref in cached.references if ref.file_path not in changed_file_strs]
+    source_files = [file_path for file_path in cached.source_files if str(file_path) not in changed_file_strs]
+
     updated_result = AnalysisData(
         call_graph=filtered_cg,
-        class_hierarchies={},
-        package_relations={},
-        references=[],
-        source_files=[],
+        class_hierarchies=class_hierarchies,
+        package_relations=package_relations,
+        references=references,
+        source_files=source_files,
+        diagnostics=diagnostics,
     )
-
-    if "diagnostics" in analysis_result:
-        updated_result.diagnostics = {
-            fp: diags for fp, diags in analysis_result["diagnostics"].items() if fp not in changed_file_strs
-        }
-
-    class_hierarchies: dict[str, Any] = analysis_result["class_hierarchies"]
-    for class_name, class_info in class_hierarchies.items():
-        if class_info.get("file_path", "") not in changed_file_strs:
-            updated_result.class_hierarchies[class_name] = class_info.copy()
-
-    package_relations: dict[str, Any] = analysis_result["package_relations"]
-    for package_name, package_info in package_relations.items():
-        original_files = package_info.get("files", [])
-        remaining = [f for f in original_files if f not in changed_file_strs]
-        if remaining:
-            updated_package_info = package_info.copy()
-            updated_package_info["files"] = remaining
-            updated_result.package_relations[package_name] = updated_package_info
-
-    references: list[Node] = analysis_result["references"]
-    for ref in references:
-        if ref.file_path not in changed_file_strs:
-            updated_result.references.append(ref)
-
-    source_files: list[Path] = analysis_result["source_files"]
-    for file_path in source_files:
-        if str(file_path) not in changed_file_strs:
-            updated_result.source_files.append(file_path)
 
     _validate_no_dangling_references(updated_result)
 

--- a/static_analyzer/analysis_result.py
+++ b/static_analyzer/analysis_result.py
@@ -2,6 +2,8 @@ import logging
 import re
 from collections.abc import Iterator
 from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
 
 from static_analyzer.constants import Language
 from static_analyzer.graph import CallGraph
@@ -31,6 +33,48 @@ _WORD_RE = re.compile(r"\b([a-z]+)\b")
 # Matches a standalone single lowercase letter (not preceded or followed by a word char).
 # Used to detect generic type params like T or E in lowercased method signatures.
 _STANDALONE_SINGLE_LETTER_RE = re.compile(r"(?<![a-z])([a-z])(?!\w)")
+
+InvalidatedEdge = tuple[str, str, Node, Node]
+
+
+@dataclass
+class AnalysisData:
+    call_graph: CallGraph
+    class_hierarchies: dict[str, Any]
+    package_relations: dict[str, Any]
+    references: list[Node]
+    source_files: list[Path]
+    diagnostics: FileDiagnosticsMap | None = None
+
+    @classmethod
+    def from_dict(cls, analysis: dict[str, Any]) -> "AnalysisData":
+        return cls(
+            call_graph=analysis["call_graph"],
+            class_hierarchies=analysis["class_hierarchies"],
+            package_relations=analysis["package_relations"],
+            references=analysis["references"],
+            source_files=analysis["source_files"],
+            diagnostics=analysis.get("diagnostics"),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        analysis: dict[str, Any] = {
+            "call_graph": self.call_graph,
+            "class_hierarchies": self.class_hierarchies,
+            "package_relations": self.package_relations,
+            "references": self.references,
+            "source_files": self.source_files,
+        }
+        if self.diagnostics is not None:
+            analysis["diagnostics"] = self.diagnostics
+        return analysis
+
+
+@dataclass
+class InvalidatedAnalysis:
+    analysis: AnalysisData
+    invalidated_edges: list[InvalidatedEdge]
+    invalidated_files: set[str]
 
 
 def _strip_java_generics(name: str) -> str:

--- a/static_analyzer/graph.py
+++ b/static_analyzer/graph.py
@@ -171,13 +171,13 @@ class CallGraph:
 
         self.nodes[src_name].added_method_called_by_me(self.nodes[dst_name])
 
-    def filter(self, keep_node: Callable[[Node], bool]) -> "CallGraph":
+    def filter(self, keep_node: Callable[[Node], bool], dropped_edges: list[Edge] | None = None) -> "CallGraph":
         """Return a new CallGraph keeping only nodes matching ``keep_node`` and connecting edges.
 
         ``_cluster_cache`` is preserved and pruned to the surviving qnames so
         a warm-start invalidation/filter step doesn't silently drop the prior
         clustering. Edges whose endpoints both survive are re-added; edges
-        with a dropped endpoint are cascaded out.
+        with a dropped endpoint are cascaded out and optionally collected.
         """
         out = CallGraph(language=self.language)
         for node in self.nodes.values():
@@ -190,6 +190,8 @@ class CallGraph:
                     out.add_edge(src, dst)
                 except ValueError as e:
                     logger.warning(f"Failed to add edge {src} -> {dst} during filter: {e}")
+            elif dropped_edges is not None:
+                dropped_edges.append(edge)
         out._cluster_cache = self._prune_cluster_cache(out.nodes)
         return out
 

--- a/static_analyzer/graph.py
+++ b/static_analyzer/graph.py
@@ -171,7 +171,11 @@ class CallGraph:
 
         self.nodes[src_name].added_method_called_by_me(self.nodes[dst_name])
 
-    def filter(self, keep_node: Callable[[Node], bool], dropped_edges: list[Edge] | None = None) -> "CallGraph":
+    def filter(
+        self,
+        keep_node: Callable[[Node], bool],
+        on_dropped_edge: Callable[[Edge], None],
+    ) -> "CallGraph":
         """Return a new CallGraph keeping only nodes matching ``keep_node`` and connecting edges.
 
         ``_cluster_cache`` is preserved and pruned to the surviving qnames so
@@ -190,8 +194,8 @@ class CallGraph:
                     out.add_edge(src, dst)
                 except ValueError as e:
                     logger.warning(f"Failed to add edge {src} -> {dst} during filter: {e}")
-            elif dropped_edges is not None:
-                dropped_edges.append(edge)
+            else:
+                on_dropped_edge(edge)
         out._cluster_cache = self._prune_cluster_cache(out.nodes)
         return out
 

--- a/static_analyzer/incremental_orchestrator.py
+++ b/static_analyzer/incremental_orchestrator.py
@@ -13,15 +13,11 @@ from typing import Any
 
 from repo_utils.ignore import RepoIgnoreManager
 from static_analyzer.analysis_cache import invalidate_files, merge_results
-from static_analyzer.constants import NodeType
 from static_analyzer.engine.call_graph_builder import CallGraphBuilder
 from static_analyzer.engine.language_adapter import LanguageAdapter
 from static_analyzer.engine.lsp_client import LSPClient
 from static_analyzer.engine.result_converter import convert_to_codeboarding_format
-from static_analyzer.engine.source_inspector import SourceInspector
-from static_analyzer.engine.utils import uri_to_path
 from static_analyzer.graph import CallGraph
-from static_analyzer.node import Node
 
 logger = logging.getLogger(__name__)
 
@@ -65,7 +61,6 @@ def update_cfg_for_changed_files(
         len(deleted_files),
     )
 
-    cross_boundary_edges = _collect_cross_boundary_edges(cached_analysis["call_graph"], changed_files)
     updated_cache = invalidate_files(cached_analysis, changed_files)
 
     changed_source_files = [
@@ -90,187 +85,8 @@ def update_cfg_for_changed_files(
     if fresh_diagnostics:
         new_analysis["diagnostics"] = fresh_diagnostics
 
-    merged_analysis = merge_results(updated_cache, new_analysis)
-    _restore_persisted_cross_boundary_edges(
-        merged_analysis, cross_boundary_edges, changed_files, adapter, engine_client
-    )
+    merged_analysis = merge_results(updated_cache, new_analysis, adapter=adapter, engine_client=engine_client)
     return _filter_to_live_files(merged_analysis)
-
-
-def _collect_cross_boundary_edges(call_graph: CallGraph, changed_files: set[Path]) -> list[tuple[str, str, Node, Node]]:
-    changed_file_strs = {str(path) for path in changed_files}
-    edges: list[tuple[str, str, Node, Node]] = []
-    for edge in call_graph.edges:
-        src_node = edge.src_node
-        dst_node = edge.dst_node
-        src_changed = src_node.file_path in changed_file_strs
-        dst_changed = dst_node.file_path in changed_file_strs
-        if src_changed != dst_changed:
-            edges.append((edge.get_source(), edge.get_destination(), src_node, dst_node))
-    return edges
-
-
-def _restore_persisted_cross_boundary_edges(
-    merged_analysis: dict[str, Any],
-    candidate_edges: list[tuple[str, str, Node, Node]],
-    changed_files: set[Path],
-    adapter: LanguageAdapter,
-    engine_client: LSPClient,
-) -> None:
-    if not candidate_edges:
-        return
-
-    call_graph: CallGraph = merged_analysis["call_graph"]
-    source_inspector = SourceInspector()
-    restored = 0
-    checked = 0
-    references_cache: dict[str, list[dict]] = {}
-    definitions_cache: dict[str, list[list[dict]]] = {}
-    changed_file_strs = {str(path) for path in changed_files}
-
-    for src_name, dst_name, _old_src_node, _old_dst_node in candidate_edges:
-        if not call_graph.has_node(src_name) or not call_graph.has_node(dst_name):
-            continue
-
-        src_node = call_graph.nodes.get(src_name)
-        dst_node = call_graph.nodes.get(dst_name)
-        if src_node is None or dst_node is None:
-            continue
-
-        checked += 1
-        refs = references_cache.get(dst_name)
-        if refs is None:
-            try:
-                engine_client.did_open(Path(dst_node.file_path), adapter.language_id)
-                refs = engine_client.references(Path(dst_node.file_path), dst_node.line_start - 1, dst_node.col_start)
-            except Exception:
-                logger.debug("Failed to validate references for %s", dst_name, exc_info=True)
-                refs = []
-            references_cache[dst_name] = refs
-
-        edge_exists = _edge_reference_still_exists(src_node, dst_node, refs, adapter, source_inspector)
-        if not edge_exists and src_node.file_path in changed_file_strs:
-            edge_exists = _outbound_definition_edge_still_exists(
-                src_node, dst_node, definitions_cache, engine_client, source_inspector
-            )
-
-        if edge_exists:
-            try:
-                call_graph.add_edge(src_name, dst_name)
-                restored += 1
-            except ValueError:
-                logger.debug("Failed to restore edge %s -> %s", src_name, dst_name, exc_info=True)
-
-    if candidate_edges:
-        logger.info(
-            "Validated %d cross-boundary cached edge(s), restored %d/%d",
-            len(candidate_edges),
-            restored,
-            checked,
-        )
-
-
-def _edge_reference_still_exists(
-    src_node: Node,
-    dst_node: Node,
-    refs: list[dict],
-    adapter: LanguageAdapter,
-    source_inspector: SourceInspector,
-) -> bool:
-    for ref in refs:
-        ref_file = uri_to_path(ref.get("uri", ""))
-        if ref_file is None or str(ref_file) != src_node.file_path:
-            continue
-
-        ref_range = ref.get("range", {})
-        ref_start = ref_range.get("start", {})
-        ref_end = ref_range.get("end", {})
-        ref_line = ref_start.get("line", -1)
-        ref_char = ref_start.get("character", -1)
-        ref_end_char = ref_end.get("character", -1)
-        if not _position_inside_node(src_node, ref_line, ref_char):
-            continue
-        if not _reference_matches_edge_kind(
-            dst_node, ref_file, ref_line, ref_char, ref_end_char, adapter, source_inspector
-        ):
-            continue
-        return True
-    return False
-
-
-def _outbound_definition_edge_still_exists(
-    src_node: Node,
-    dst_node: Node,
-    definitions_cache: dict[str, list[list[dict]]],
-    engine_client: LSPClient,
-    source_inspector: SourceInspector,
-) -> bool:
-    definition_results = definitions_cache.get(src_node.fully_qualified_name)
-    if definition_results is None:
-        file_path = Path(src_node.file_path)
-        call_sites = [
-            (file_path, line, char)
-            for line, char in source_inspector.find_call_sites(file_path)
-            if _position_inside_node(src_node, line, char)
-        ]
-        if not call_sites:
-            definition_results = []
-        else:
-            try:
-                definition_results, _ = engine_client.send_definition_batch(call_sites)
-            except Exception:
-                logger.debug(
-                    "Failed to validate outbound definitions for %s", src_node.fully_qualified_name, exc_info=True
-                )
-                definition_results = []
-        definitions_cache[src_node.fully_qualified_name] = definition_results
-
-    for definitions in definition_results:
-        for definition in definitions:
-            if _definition_points_to_node(definition, dst_node):
-                return True
-    return False
-
-
-def _definition_points_to_node(definition: dict, dst_node: Node) -> bool:
-    uri = definition.get("targetUri", definition.get("uri", ""))
-    file_path = uri_to_path(uri)
-    if file_path is None or str(file_path) != dst_node.file_path:
-        return False
-    selection_range = definition.get("targetSelectionRange", definition.get("targetRange", definition.get("range", {})))
-    start = selection_range.get("start", {})
-    line = start.get("line", -1)
-    character = start.get("character", -1)
-    return _position_inside_node(dst_node, line, character)
-
-
-def _position_inside_node(node: Node, zero_based_line: int, character: int) -> bool:
-    line = zero_based_line + 1
-    if line < node.line_start or line > node.line_end:
-        return False
-    if line == node.line_start and character < node.col_start:
-        return False
-    return True
-
-
-def _reference_matches_edge_kind(
-    dst_node: Node,
-    ref_file: Path,
-    ref_line: int,
-    ref_char: int,
-    ref_end_char: int,
-    adapter: LanguageAdapter,
-    source_inspector: SourceInspector,
-) -> bool:
-    if adapter.is_class_like(dst_node.type) and not source_inspector.is_invocation(ref_file, ref_line, ref_end_char):
-        return False
-    if dst_node.type == NodeType.CONSTANT and not source_inspector.is_invocation(ref_file, ref_line, ref_end_char):
-        return False
-    if dst_node.type == NodeType.VARIABLE and not source_inspector.is_callable_usage(
-        ref_file, ref_line, ref_char, ref_end_char
-    ):
-        return False
-    return True
 
 
 def _filter_to_live_files(merged_analysis: dict[str, Any]) -> dict[str, Any]:

--- a/static_analyzer/incremental_orchestrator.py
+++ b/static_analyzer/incremental_orchestrator.py
@@ -12,12 +12,22 @@ from pathlib import Path
 from typing import Any
 
 from repo_utils.ignore import RepoIgnoreManager
-from static_analyzer.analysis_cache import invalidate_files, merge_results
+from static_analyzer.analysis_cache import (
+    _INVALIDATED_CROSS_BOUNDARY_EDGES,
+    _INVALIDATED_FILES,
+    InvalidatedEdge,
+    invalidate_files,
+    merge_results,
+)
+from static_analyzer.constants import NodeType
 from static_analyzer.engine.call_graph_builder import CallGraphBuilder
 from static_analyzer.engine.language_adapter import LanguageAdapter
 from static_analyzer.engine.lsp_client import LSPClient
 from static_analyzer.engine.result_converter import convert_to_codeboarding_format
+from static_analyzer.engine.source_inspector import SourceInspector
+from static_analyzer.engine.utils import uri_to_path
 from static_analyzer.graph import CallGraph
+from static_analyzer.node import Node
 
 logger = logging.getLogger(__name__)
 
@@ -85,8 +95,176 @@ def update_cfg_for_changed_files(
     if fresh_diagnostics:
         new_analysis["diagnostics"] = fresh_diagnostics
 
-    merged_analysis = merge_results(updated_cache, new_analysis, adapter=adapter, engine_client=engine_client)
+    merged_analysis = merge_results(updated_cache, new_analysis)
+    _restore_persisted_cross_boundary_edges(
+        merged_analysis,
+        updated_cache.get(_INVALIDATED_CROSS_BOUNDARY_EDGES, []),
+        updated_cache.get(_INVALIDATED_FILES, set()),
+        adapter,
+        engine_client,
+    )
     return _filter_to_live_files(merged_analysis)
+
+
+def _restore_persisted_cross_boundary_edges(
+    merged_analysis: dict[str, Any],
+    candidate_edges: list[InvalidatedEdge],
+    changed_file_strs: set[str],
+    adapter: LanguageAdapter,
+    engine_client: LSPClient,
+) -> None:
+    if not candidate_edges:
+        return
+
+    call_graph: CallGraph = merged_analysis["call_graph"]
+    source_inspector = SourceInspector()
+    restored = 0
+    checked = 0
+    references_cache: dict[str, list[dict]] = {}
+    definitions_cache: dict[str, list[list[dict]]] = {}
+
+    for src_name, dst_name, _old_src_node, _old_dst_node in candidate_edges:
+        if not call_graph.has_node(src_name) or not call_graph.has_node(dst_name):
+            continue
+
+        src_node = call_graph.nodes.get(src_name)
+        dst_node = call_graph.nodes.get(dst_name)
+        if src_node is None or dst_node is None:
+            continue
+
+        checked += 1
+        refs = references_cache.get(dst_name)
+        if refs is None:
+            try:
+                engine_client.did_open(Path(dst_node.file_path), adapter.language_id)
+                refs = engine_client.references(Path(dst_node.file_path), dst_node.line_start - 1, dst_node.col_start)
+            except Exception:
+                logger.debug("Failed to validate references for %s", dst_name, exc_info=True)
+                refs = []
+            references_cache[dst_name] = refs
+
+        edge_exists = _edge_reference_still_exists(src_node, dst_node, refs, adapter, source_inspector)
+        if not edge_exists and src_node.file_path in changed_file_strs:
+            edge_exists = _outbound_definition_edge_still_exists(
+                src_node, dst_node, definitions_cache, engine_client, source_inspector
+            )
+
+        if edge_exists:
+            try:
+                call_graph.add_edge(src_name, dst_name)
+                restored += 1
+            except ValueError:
+                logger.debug("Failed to restore edge %s -> %s", src_name, dst_name, exc_info=True)
+
+    logger.info(
+        "Validated %d cross-boundary cached edge(s), restored %d/%d",
+        len(candidate_edges),
+        restored,
+        checked,
+    )
+
+
+def _edge_reference_still_exists(
+    src_node: Node,
+    dst_node: Node,
+    refs: list[dict],
+    adapter: LanguageAdapter,
+    source_inspector: SourceInspector,
+) -> bool:
+    for ref in refs:
+        ref_file = uri_to_path(ref.get("uri", ""))
+        if ref_file is None or str(ref_file) != src_node.file_path:
+            continue
+
+        ref_range = ref.get("range", {})
+        ref_start = ref_range.get("start", {})
+        ref_end = ref_range.get("end", {})
+        ref_line = ref_start.get("line", -1)
+        ref_char = ref_start.get("character", -1)
+        ref_end_char = ref_end.get("character", -1)
+        if not _position_inside_node(src_node, ref_line, ref_char):
+            continue
+        if not _reference_matches_edge_kind(
+            dst_node, ref_file, ref_line, ref_char, ref_end_char, adapter, source_inspector
+        ):
+            continue
+        return True
+    return False
+
+
+def _outbound_definition_edge_still_exists(
+    src_node: Node,
+    dst_node: Node,
+    definitions_cache: dict[str, list[list[dict]]],
+    engine_client: LSPClient,
+    source_inspector: SourceInspector,
+) -> bool:
+    definition_results = definitions_cache.get(src_node.fully_qualified_name)
+    if definition_results is None:
+        file_path = Path(src_node.file_path)
+        call_sites = [
+            (file_path, line, char)
+            for line, char in source_inspector.find_call_sites(file_path)
+            if _position_inside_node(src_node, line, char)
+        ]
+        if not call_sites:
+            definition_results = []
+        else:
+            try:
+                definition_results, _ = engine_client.send_definition_batch(call_sites)
+            except Exception:
+                logger.debug(
+                    "Failed to validate outbound definitions for %s", src_node.fully_qualified_name, exc_info=True
+                )
+                definition_results = []
+        definitions_cache[src_node.fully_qualified_name] = definition_results
+
+    for definitions in definition_results:
+        for definition in definitions:
+            if _definition_points_to_node(definition, dst_node):
+                return True
+    return False
+
+
+def _definition_points_to_node(definition: dict, dst_node: Node) -> bool:
+    uri = definition.get("targetUri", definition.get("uri", ""))
+    file_path = uri_to_path(uri)
+    if file_path is None or str(file_path) != dst_node.file_path:
+        return False
+    selection_range = definition.get("targetSelectionRange", definition.get("targetRange", definition.get("range", {})))
+    start = selection_range.get("start", {})
+    line = start.get("line", -1)
+    character = start.get("character", -1)
+    return _position_inside_node(dst_node, line, character)
+
+
+def _position_inside_node(node: Node, zero_based_line: int, character: int) -> bool:
+    line = zero_based_line + 1
+    if line < node.line_start or line > node.line_end:
+        return False
+    if line == node.line_start and character < node.col_start:
+        return False
+    return True
+
+
+def _reference_matches_edge_kind(
+    dst_node: Node,
+    ref_file: Path,
+    ref_line: int,
+    ref_char: int,
+    ref_end_char: int,
+    adapter: LanguageAdapter,
+    source_inspector: SourceInspector,
+) -> bool:
+    if adapter.is_class_like(dst_node.type) and not source_inspector.is_invocation(ref_file, ref_line, ref_end_char):
+        return False
+    if dst_node.type == NodeType.CONSTANT and not source_inspector.is_invocation(ref_file, ref_line, ref_end_char):
+        return False
+    if dst_node.type == NodeType.VARIABLE and not source_inspector.is_callable_usage(
+        ref_file, ref_line, ref_char, ref_end_char
+    ):
+        return False
+    return True
 
 
 def _filter_to_live_files(merged_analysis: dict[str, Any]) -> dict[str, Any]:
@@ -107,7 +285,10 @@ def _filter_to_live_files(merged_analysis: dict[str, Any]) -> dict[str, Any]:
     ]
 
     merged_cg = merged_analysis.get("call_graph", CallGraph())
-    merged_analysis["call_graph"] = merged_cg.filter(lambda node: node.file_path in existing_file_strs)
+    merged_analysis["call_graph"] = merged_cg.filter(
+        lambda node: node.file_path in existing_file_strs,
+        on_dropped_edge=lambda _edge: None,
+    )
 
     merged_analysis["class_hierarchies"] = {
         name: info

--- a/static_analyzer/incremental_orchestrator.py
+++ b/static_analyzer/incremental_orchestrator.py
@@ -12,10 +12,8 @@ from pathlib import Path
 from typing import Any
 
 from repo_utils.ignore import RepoIgnoreManager
+from static_analyzer.analysis_result import AnalysisData, InvalidatedEdge
 from static_analyzer.analysis_cache import (
-    _INVALIDATED_CROSS_BOUNDARY_EDGES,
-    _INVALIDATED_FILES,
-    InvalidatedEdge,
     invalidate_files,
     merge_results,
 )
@@ -95,19 +93,19 @@ def update_cfg_for_changed_files(
     if fresh_diagnostics:
         new_analysis["diagnostics"] = fresh_diagnostics
 
-    merged_analysis = merge_results(updated_cache, new_analysis)
+    merged_analysis = merge_results(updated_cache.analysis, new_analysis)
     _restore_persisted_cross_boundary_edges(
         merged_analysis,
-        updated_cache.get(_INVALIDATED_CROSS_BOUNDARY_EDGES, []),
-        updated_cache.get(_INVALIDATED_FILES, set()),
+        updated_cache.invalidated_edges,
+        updated_cache.invalidated_files,
         adapter,
         engine_client,
     )
-    return _filter_to_live_files(merged_analysis)
+    return _filter_to_live_files(merged_analysis).to_dict()
 
 
 def _restore_persisted_cross_boundary_edges(
-    merged_analysis: dict[str, Any],
+    merged_analysis: AnalysisData,
     candidate_edges: list[InvalidatedEdge],
     changed_file_strs: set[str],
     adapter: LanguageAdapter,
@@ -116,7 +114,7 @@ def _restore_persisted_cross_boundary_edges(
     if not candidate_edges:
         return
 
-    call_graph: CallGraph = merged_analysis["call_graph"]
+    call_graph = merged_analysis.call_graph
     source_inspector = SourceInspector()
     restored = 0
     checked = 0
@@ -267,7 +265,7 @@ def _reference_matches_edge_kind(
     return True
 
 
-def _filter_to_live_files(merged_analysis: dict[str, Any]) -> dict[str, Any]:
+def _filter_to_live_files(merged_analysis: AnalysisData) -> AnalysisData:
     """Drop entries whose file no longer exists on disk.
 
     A file in ``source_files`` may have been re-LSPed earlier in the run and
@@ -276,31 +274,28 @@ def _filter_to_live_files(merged_analysis: dict[str, Any]) -> dict[str, Any]:
     """
     # Normalize: ``merge_results`` may contain a mix of Path (from the cached
     # side) and str (from the LSP-rebuilt new side); coerce before ``.exists()``.
-    all_existing = {Path(f) for f in merged_analysis.get("source_files", []) if Path(f).exists()}
+    all_existing = {Path(f) for f in merged_analysis.source_files if Path(f).exists()}
     existing_file_strs = {str(f) for f in all_existing}
 
-    merged_analysis["source_files"] = list(all_existing)
-    merged_analysis["references"] = [
-        ref for ref in merged_analysis.get("references", []) if ref.file_path in existing_file_strs
-    ]
+    merged_analysis.source_files = list(all_existing)
+    merged_analysis.references = [ref for ref in merged_analysis.references if ref.file_path in existing_file_strs]
 
-    merged_cg = merged_analysis.get("call_graph", CallGraph())
-    merged_analysis["call_graph"] = merged_cg.filter(
+    merged_analysis.call_graph = merged_analysis.call_graph.filter(
         lambda node: node.file_path in existing_file_strs,
         on_dropped_edge=lambda _edge: None,
     )
 
-    merged_analysis["class_hierarchies"] = {
+    merged_analysis.class_hierarchies = {
         name: info
-        for name, info in merged_analysis.get("class_hierarchies", {}).items()
+        for name, info in merged_analysis.class_hierarchies.items()
         if info.get("file_path") in existing_file_strs
     }
 
     filtered_packages: dict[str, Any] = {}
-    for pkg_name, pkg_info in merged_analysis.get("package_relations", {}).items():
+    for pkg_name, pkg_info in merged_analysis.package_relations.items():
         existing_pkg_files = [f for f in pkg_info.get("files", []) if f in existing_file_strs]
         if existing_pkg_files:
             filtered_packages[pkg_name] = {**pkg_info, "files": existing_pkg_files}
-    merged_analysis["package_relations"] = filtered_packages
+    merged_analysis.package_relations = filtered_packages
 
     return merged_analysis

--- a/static_analyzer/incremental_orchestrator.py
+++ b/static_analyzer/incremental_orchestrator.py
@@ -1,12 +1,11 @@
 """Pkl warm-start updater: bring cached per-language analysis up to date.
 
-The warm path keeps unchanged files from the pkl and re-LSPs only changed
-files. After merging fresh changed-file data into the cached graph, it rebuilds
-the changed-file edge frontier: inbound cached edges are kept only if LSP
-references still prove ``unchanged -> changed``, and outbound edges are resolved
-from changed-file call sites via LSP definitions. Unchanged-only edges stay
-cached. No JSON or disk writes happen here; ``StaticAnalyzer`` persists the
-updated pkl after this returns.
+Warm-start flow:
+1. Keep unchanged files from the pkl and invalidate changed/deleted files.
+2. Re-LSP existing changed files and merge their fresh nodes/references back in.
+3. Rebuild inbound edges: keep ``unchanged -> changed`` only when references still prove it.
+4. Rebuild outbound edges: resolve changed-file call sites with definitions.
+5. Keep unchanged-only edges cached and let ``StaticAnalyzer`` persist the new pkl.
 """
 
 import logging

--- a/static_analyzer/incremental_orchestrator.py
+++ b/static_analyzer/incremental_orchestrator.py
@@ -101,6 +101,7 @@ def update_cfg_for_changed_files(
         adapter,
         engine_client,
     )
+    _add_new_outbound_edges_from_changed_files(merged_analysis, changed_source_files, engine_client)
     return _filter_to_live_files(merged_analysis).to_dict()
 
 
@@ -225,6 +226,70 @@ def _outbound_definition_edge_still_exists(
             if _definition_points_to_node(definition, dst_node):
                 return True
     return False
+
+
+def _add_new_outbound_edges_from_changed_files(
+    merged_analysis: AnalysisData,
+    changed_source_files: list[Path],
+    engine_client: LSPClient,
+) -> None:
+    if not changed_source_files:
+        return
+
+    call_graph = merged_analysis.call_graph
+    source_inspector = SourceInspector()
+    added = 0
+
+    for file_path in changed_source_files:
+        call_sites = source_inspector.find_call_sites(file_path)
+        if not call_sites:
+            continue
+        queries = [(file_path, line, char) for line, char in call_sites]
+        try:
+            definition_results, _ = engine_client.send_definition_batch(queries)
+        except Exception:
+            logger.debug("Failed to resolve outbound definitions for %s", file_path, exc_info=True)
+            continue
+
+        for (line, char), definitions in zip(call_sites, definition_results):
+            src_node = _find_containing_callable_node(call_graph, file_path, line, char)
+            if src_node is None:
+                continue
+            for definition in definitions:
+                dst_node = _find_definition_node(call_graph, definition)
+                if dst_node is None or dst_node.fully_qualified_name == src_node.fully_qualified_name:
+                    continue
+                try:
+                    call_graph.add_edge(src_node.fully_qualified_name, dst_node.fully_qualified_name)
+                    added += 1
+                except ValueError:
+                    logger.debug(
+                        "Failed to add outbound edge %s -> %s",
+                        src_node.fully_qualified_name,
+                        dst_node.fully_qualified_name,
+                        exc_info=True,
+                    )
+
+    if added:
+        logger.info("Added %d new outbound edge(s) from changed files", added)
+
+
+def _find_containing_callable_node(call_graph: CallGraph, file_path: Path, line: int, char: int) -> Node | None:
+    containing = [
+        node
+        for node in call_graph.nodes.values()
+        if node.is_callable() and node.file_path == str(file_path) and _position_inside_node(node, line, char)
+    ]
+    if not containing:
+        return None
+    return max(containing, key=lambda node: (node.line_start, node.col_start, len(node.fully_qualified_name)))
+
+
+def _find_definition_node(call_graph: CallGraph, definition: dict) -> Node | None:
+    for node in call_graph.nodes.values():
+        if _definition_points_to_node(definition, node):
+            return node
+    return None
 
 
 def _definition_points_to_node(definition: dict, dst_node: Node) -> bool:

--- a/static_analyzer/incremental_orchestrator.py
+++ b/static_analyzer/incremental_orchestrator.py
@@ -1,10 +1,12 @@
-"""Pkl warm-start updater: bring a cached per-language analysis up to date in-memory.
+"""Pkl warm-start updater: bring cached per-language analysis up to date.
 
-Given a cached analysis dict (loaded from the SHA-tagged pkl) and the file
-list git reports as changed since the pkl's tag SHA, rerun the LSP for those
-files only and merge the result with the kept-from-cache state. No JSON, no
-disk writes — the only persistence is the pkl save that ``StaticAnalyzer``
-performs after this returns.
+The warm path keeps unchanged files from the pkl and re-LSPs only changed
+files. After merging fresh changed-file data into the cached graph, it rebuilds
+the changed-file edge frontier: inbound cached edges are kept only if LSP
+references still prove ``unchanged -> changed``, and outbound edges are resolved
+from changed-file call sites via LSP definitions. Unchanged-only edges stay
+cached. No JSON or disk writes happen here; ``StaticAnalyzer`` persists the
+updated pkl after this returns.
 """
 
 import logging

--- a/static_analyzer/incremental_orchestrator.py
+++ b/static_analyzer/incremental_orchestrator.py
@@ -13,11 +13,15 @@ from typing import Any
 
 from repo_utils.ignore import RepoIgnoreManager
 from static_analyzer.analysis_cache import invalidate_files, merge_results
+from static_analyzer.constants import NodeType
 from static_analyzer.engine.call_graph_builder import CallGraphBuilder
 from static_analyzer.engine.language_adapter import LanguageAdapter
 from static_analyzer.engine.lsp_client import LSPClient
 from static_analyzer.engine.result_converter import convert_to_codeboarding_format
+from static_analyzer.engine.source_inspector import SourceInspector
+from static_analyzer.engine.utils import uri_to_path
 from static_analyzer.graph import CallGraph
+from static_analyzer.node import Node
 
 logger = logging.getLogger(__name__)
 
@@ -61,6 +65,7 @@ def update_cfg_for_changed_files(
         len(deleted_files),
     )
 
+    cross_boundary_edges = _collect_cross_boundary_edges(cached_analysis["call_graph"], changed_files)
     updated_cache = invalidate_files(cached_analysis, changed_files)
 
     changed_source_files = [
@@ -86,7 +91,186 @@ def update_cfg_for_changed_files(
         new_analysis["diagnostics"] = fresh_diagnostics
 
     merged_analysis = merge_results(updated_cache, new_analysis)
+    _restore_persisted_cross_boundary_edges(
+        merged_analysis, cross_boundary_edges, changed_files, adapter, engine_client
+    )
     return _filter_to_live_files(merged_analysis)
+
+
+def _collect_cross_boundary_edges(call_graph: CallGraph, changed_files: set[Path]) -> list[tuple[str, str, Node, Node]]:
+    changed_file_strs = {str(path) for path in changed_files}
+    edges: list[tuple[str, str, Node, Node]] = []
+    for edge in call_graph.edges:
+        src_node = edge.src_node
+        dst_node = edge.dst_node
+        src_changed = src_node.file_path in changed_file_strs
+        dst_changed = dst_node.file_path in changed_file_strs
+        if src_changed != dst_changed:
+            edges.append((edge.get_source(), edge.get_destination(), src_node, dst_node))
+    return edges
+
+
+def _restore_persisted_cross_boundary_edges(
+    merged_analysis: dict[str, Any],
+    candidate_edges: list[tuple[str, str, Node, Node]],
+    changed_files: set[Path],
+    adapter: LanguageAdapter,
+    engine_client: LSPClient,
+) -> None:
+    if not candidate_edges:
+        return
+
+    call_graph: CallGraph = merged_analysis["call_graph"]
+    source_inspector = SourceInspector()
+    restored = 0
+    checked = 0
+    references_cache: dict[str, list[dict]] = {}
+    definitions_cache: dict[str, list[list[dict]]] = {}
+    changed_file_strs = {str(path) for path in changed_files}
+
+    for src_name, dst_name, _old_src_node, _old_dst_node in candidate_edges:
+        if not call_graph.has_node(src_name) or not call_graph.has_node(dst_name):
+            continue
+
+        src_node = call_graph.nodes.get(src_name)
+        dst_node = call_graph.nodes.get(dst_name)
+        if src_node is None or dst_node is None:
+            continue
+
+        checked += 1
+        refs = references_cache.get(dst_name)
+        if refs is None:
+            try:
+                engine_client.did_open(Path(dst_node.file_path), adapter.language_id)
+                refs = engine_client.references(Path(dst_node.file_path), dst_node.line_start - 1, dst_node.col_start)
+            except Exception:
+                logger.debug("Failed to validate references for %s", dst_name, exc_info=True)
+                refs = []
+            references_cache[dst_name] = refs
+
+        edge_exists = _edge_reference_still_exists(src_node, dst_node, refs, adapter, source_inspector)
+        if not edge_exists and src_node.file_path in changed_file_strs:
+            edge_exists = _outbound_definition_edge_still_exists(
+                src_node, dst_node, definitions_cache, engine_client, source_inspector
+            )
+
+        if edge_exists:
+            try:
+                call_graph.add_edge(src_name, dst_name)
+                restored += 1
+            except ValueError:
+                logger.debug("Failed to restore edge %s -> %s", src_name, dst_name, exc_info=True)
+
+    if candidate_edges:
+        logger.info(
+            "Validated %d cross-boundary cached edge(s), restored %d/%d",
+            len(candidate_edges),
+            restored,
+            checked,
+        )
+
+
+def _edge_reference_still_exists(
+    src_node: Node,
+    dst_node: Node,
+    refs: list[dict],
+    adapter: LanguageAdapter,
+    source_inspector: SourceInspector,
+) -> bool:
+    for ref in refs:
+        ref_file = uri_to_path(ref.get("uri", ""))
+        if ref_file is None or str(ref_file) != src_node.file_path:
+            continue
+
+        ref_range = ref.get("range", {})
+        ref_start = ref_range.get("start", {})
+        ref_end = ref_range.get("end", {})
+        ref_line = ref_start.get("line", -1)
+        ref_char = ref_start.get("character", -1)
+        ref_end_char = ref_end.get("character", -1)
+        if not _position_inside_node(src_node, ref_line, ref_char):
+            continue
+        if not _reference_matches_edge_kind(
+            dst_node, ref_file, ref_line, ref_char, ref_end_char, adapter, source_inspector
+        ):
+            continue
+        return True
+    return False
+
+
+def _outbound_definition_edge_still_exists(
+    src_node: Node,
+    dst_node: Node,
+    definitions_cache: dict[str, list[list[dict]]],
+    engine_client: LSPClient,
+    source_inspector: SourceInspector,
+) -> bool:
+    definition_results = definitions_cache.get(src_node.fully_qualified_name)
+    if definition_results is None:
+        file_path = Path(src_node.file_path)
+        call_sites = [
+            (file_path, line, char)
+            for line, char in source_inspector.find_call_sites(file_path)
+            if _position_inside_node(src_node, line, char)
+        ]
+        if not call_sites:
+            definition_results = []
+        else:
+            try:
+                definition_results, _ = engine_client.send_definition_batch(call_sites)
+            except Exception:
+                logger.debug(
+                    "Failed to validate outbound definitions for %s", src_node.fully_qualified_name, exc_info=True
+                )
+                definition_results = []
+        definitions_cache[src_node.fully_qualified_name] = definition_results
+
+    for definitions in definition_results:
+        for definition in definitions:
+            if _definition_points_to_node(definition, dst_node):
+                return True
+    return False
+
+
+def _definition_points_to_node(definition: dict, dst_node: Node) -> bool:
+    uri = definition.get("targetUri", definition.get("uri", ""))
+    file_path = uri_to_path(uri)
+    if file_path is None or str(file_path) != dst_node.file_path:
+        return False
+    selection_range = definition.get("targetSelectionRange", definition.get("targetRange", definition.get("range", {})))
+    start = selection_range.get("start", {})
+    line = start.get("line", -1)
+    character = start.get("character", -1)
+    return _position_inside_node(dst_node, line, character)
+
+
+def _position_inside_node(node: Node, zero_based_line: int, character: int) -> bool:
+    line = zero_based_line + 1
+    if line < node.line_start or line > node.line_end:
+        return False
+    if line == node.line_start and character < node.col_start:
+        return False
+    return True
+
+
+def _reference_matches_edge_kind(
+    dst_node: Node,
+    ref_file: Path,
+    ref_line: int,
+    ref_char: int,
+    ref_end_char: int,
+    adapter: LanguageAdapter,
+    source_inspector: SourceInspector,
+) -> bool:
+    if adapter.is_class_like(dst_node.type) and not source_inspector.is_invocation(ref_file, ref_line, ref_end_char):
+        return False
+    if dst_node.type == NodeType.CONSTANT and not source_inspector.is_invocation(ref_file, ref_line, ref_end_char):
+        return False
+    if dst_node.type == NodeType.VARIABLE and not source_inspector.is_callable_usage(
+        ref_file, ref_line, ref_char, ref_end_char
+    ):
+        return False
+    return True
 
 
 def _filter_to_live_files(merged_analysis: dict[str, Any]) -> dict[str, Any]:

--- a/static_analyzer/incremental_orchestrator.py
+++ b/static_analyzer/incremental_orchestrator.py
@@ -94,42 +94,54 @@ def update_cfg_for_changed_files(
         new_analysis["diagnostics"] = fresh_diagnostics
 
     merged_analysis = merge_results(updated_cache.analysis, new_analysis)
-    _restore_persisted_cross_boundary_edges(
+    _rebuild_changed_file_edges(
         merged_analysis,
         updated_cache.invalidated_edges,
         updated_cache.invalidated_files,
+        changed_source_files,
         adapter,
         engine_client,
     )
-    _add_new_outbound_edges_from_changed_files(merged_analysis, changed_source_files, engine_client)
     return _filter_to_live_files(merged_analysis).to_dict()
 
 
-def _restore_persisted_cross_boundary_edges(
+def _rebuild_changed_file_edges(
     merged_analysis: AnalysisData,
-    candidate_edges: list[InvalidatedEdge],
+    invalidated_edges: list[InvalidatedEdge],
     changed_file_strs: set[str],
+    changed_source_files: list[Path],
     adapter: LanguageAdapter,
     engine_client: LSPClient,
 ) -> None:
-    if not candidate_edges:
+    _restore_inbound_edges(
+        merged_analysis.call_graph, invalidated_edges, changed_file_strs, adapter, engine_client, SourceInspector()
+    )
+    _add_outbound_edges_from_changed_files(merged_analysis.call_graph, changed_source_files, engine_client)
+
+
+def _restore_inbound_edges(
+    call_graph: CallGraph,
+    invalidated_edges: list[InvalidatedEdge],
+    changed_file_strs: set[str],
+    adapter: LanguageAdapter,
+    engine_client: LSPClient,
+    source_inspector: SourceInspector,
+) -> None:
+    if not invalidated_edges:
         return
 
-    call_graph = merged_analysis.call_graph
-    source_inspector = SourceInspector()
     restored = 0
     checked = 0
     references_cache: dict[str, list[dict]] = {}
-    definitions_cache: dict[str, list[list[dict]]] = {}
 
-    for src_name, dst_name, _old_src_node, _old_dst_node in candidate_edges:
+    for src_name, dst_name, old_src_node, old_dst_node in invalidated_edges:
+        if old_src_node.file_path in changed_file_strs or old_dst_node.file_path not in changed_file_strs:
+            continue
         if not call_graph.has_node(src_name) or not call_graph.has_node(dst_name):
             continue
 
-        src_node = call_graph.nodes.get(src_name)
-        dst_node = call_graph.nodes.get(dst_name)
-        if src_node is None or dst_node is None:
-            continue
+        src_node = call_graph.nodes[src_name]
+        dst_node = call_graph.nodes[dst_name]
 
         checked += 1
         refs = references_cache.get(dst_name)
@@ -142,16 +154,8 @@ def _restore_persisted_cross_boundary_edges(
                 refs = []
             references_cache[dst_name] = refs
 
-        # Inbound: unchanged B -> changed A is restored by asking "who references A?"
-        # and checking whether one reference still lands inside B.
-        edge_exists = _edge_reference_still_exists(src_node, dst_node, refs, adapter, source_inspector)
-        if not edge_exists and src_node.file_path in changed_file_strs:
-            # Outbound: changed A -> unchanged C falls back to definitions from A's call sites.
-            edge_exists = _outbound_definition_edge_still_exists(
-                src_node, dst_node, definitions_cache, engine_client, source_inspector
-            )
-
-        if edge_exists:
+        # Inbound: unchanged B -> changed A is kept only if references(A) still lands inside B.
+        if _edge_reference_still_exists(src_node, dst_node, refs, adapter, source_inspector):
             try:
                 call_graph.add_edge(src_name, dst_name)
                 restored += 1
@@ -159,8 +163,8 @@ def _restore_persisted_cross_boundary_edges(
                 logger.debug("Failed to restore edge %s -> %s", src_name, dst_name, exc_info=True)
 
     logger.info(
-        "Validated %d cross-boundary cached edge(s), restored %d/%d",
-        len(candidate_edges),
+        "Validated %d inbound cached edge(s), restored %d/%d",
+        len(invalidated_edges),
         restored,
         checked,
     )
@@ -194,49 +198,14 @@ def _edge_reference_still_exists(
     return False
 
 
-def _outbound_definition_edge_still_exists(
-    src_node: Node,
-    dst_node: Node,
-    definitions_cache: dict[str, list[list[dict]]],
-    engine_client: LSPClient,
-    source_inspector: SourceInspector,
-) -> bool:
-    definition_results = definitions_cache.get(src_node.fully_qualified_name)
-    if definition_results is None:
-        file_path = Path(src_node.file_path)
-        call_sites = [
-            (file_path, line, char)
-            for line, char in source_inspector.find_call_sites(file_path)
-            if _position_inside_node(src_node, line, char)
-        ]
-        if not call_sites:
-            definition_results = []
-        else:
-            try:
-                definition_results, _ = engine_client.send_definition_batch(call_sites)
-            except Exception:
-                logger.debug(
-                    "Failed to validate outbound definitions for %s", src_node.fully_qualified_name, exc_info=True
-                )
-                definition_results = []
-        definitions_cache[src_node.fully_qualified_name] = definition_results
-
-    for definitions in definition_results:
-        for definition in definitions:
-            if _definition_points_to_node(definition, dst_node):
-                return True
-    return False
-
-
-def _add_new_outbound_edges_from_changed_files(
-    merged_analysis: AnalysisData,
+def _add_outbound_edges_from_changed_files(
+    call_graph: CallGraph,
     changed_source_files: list[Path],
     engine_client: LSPClient,
 ) -> None:
     if not changed_source_files:
         return
 
-    call_graph = merged_analysis.call_graph
     source_inspector = SourceInspector()
     added = 0
 
@@ -252,44 +221,43 @@ def _add_new_outbound_edges_from_changed_files(
             continue
 
         for (line, char), definitions in zip(call_sites, definition_results):
-            src_node = _find_containing_callable_node(call_graph, file_path, line, char)
-            if src_node is None:
+            containing_nodes = _containing_callable_nodes(call_graph, file_path, line, char)
+            if not containing_nodes:
                 continue
+            src_node = max(
+                containing_nodes, key=lambda node: (node.line_start, node.col_start, len(node.fully_qualified_name))
+            )
             for definition in definitions:
-                dst_node = _find_definition_node(call_graph, definition)
-                if dst_node is None or dst_node.fully_qualified_name == src_node.fully_qualified_name:
-                    continue
-                try:
-                    call_graph.add_edge(src_node.fully_qualified_name, dst_node.fully_qualified_name)
-                    added += 1
-                except ValueError:
-                    logger.debug(
-                        "Failed to add outbound edge %s -> %s",
-                        src_node.fully_qualified_name,
-                        dst_node.fully_qualified_name,
-                        exc_info=True,
-                    )
+                for dst_node in _definition_nodes(call_graph, definition):
+                    if dst_node.fully_qualified_name == src_node.fully_qualified_name:
+                        continue
+                    try:
+                        before = len(call_graph.edges)
+                        call_graph.add_edge(src_node.fully_qualified_name, dst_node.fully_qualified_name)
+                        if len(call_graph.edges) > before:
+                            added += 1
+                    except ValueError:
+                        logger.debug(
+                            "Failed to add outbound edge %s -> %s",
+                            src_node.fully_qualified_name,
+                            dst_node.fully_qualified_name,
+                            exc_info=True,
+                        )
 
     if added:
         logger.info("Added %d new outbound edge(s) from changed files", added)
 
 
-def _find_containing_callable_node(call_graph: CallGraph, file_path: Path, line: int, char: int) -> Node | None:
-    containing = [
+def _containing_callable_nodes(call_graph: CallGraph, file_path: Path, line: int, char: int) -> list[Node]:
+    return [
         node
         for node in call_graph.nodes.values()
         if node.is_callable() and node.file_path == str(file_path) and _position_inside_node(node, line, char)
     ]
-    if not containing:
-        return None
-    return max(containing, key=lambda node: (node.line_start, node.col_start, len(node.fully_qualified_name)))
 
 
-def _find_definition_node(call_graph: CallGraph, definition: dict) -> Node | None:
-    for node in call_graph.nodes.values():
-        if _definition_points_to_node(definition, node):
-            return node
-    return None
+def _definition_nodes(call_graph: CallGraph, definition: dict) -> list[Node]:
+    return [node for node in call_graph.nodes.values() if _definition_points_to_node(definition, node)]
 
 
 def _definition_points_to_node(definition: dict, dst_node: Node) -> bool:

--- a/static_analyzer/incremental_orchestrator.py
+++ b/static_analyzer/incremental_orchestrator.py
@@ -141,8 +141,11 @@ def _restore_persisted_cross_boundary_edges(
                 refs = []
             references_cache[dst_name] = refs
 
+        # Inbound: unchanged B -> changed A is restored by asking "who references A?"
+        # and checking whether one reference still lands inside B.
         edge_exists = _edge_reference_still_exists(src_node, dst_node, refs, adapter, source_inspector)
         if not edge_exists and src_node.file_path in changed_file_strs:
+            # Outbound: changed A -> unchanged C falls back to definitions from A's call sites.
             edge_exists = _outbound_definition_edge_still_exists(
                 src_node, dst_node, definitions_cache, engine_client, source_inspector
             )

--- a/tests/integration/test_static_analysis_warm_start_delta.py
+++ b/tests/integration/test_static_analysis_warm_start_delta.py
@@ -138,17 +138,29 @@ def _edge_set(result: StaticAnalysisResults, repo_path: Path) -> set[tuple[str, 
     return edges
 
 
-def _assert_new_outbound_edge_added(
+def _boundary_edges(edges: set[tuple[str, str, str, str]], changed_files: set[str]) -> set[tuple[str, str, str, str]]:
+    return {edge for edge in edges if edge[2] in changed_files or edge[3] in changed_files}
+
+
+def _assert_boundary_edges_match_full(
     warm_static_analysis: StaticAnalysisResults,
     full_static_analysis: StaticAnalysisResults,
     repo_path: Path,
+    changed_files: set[str],
 ) -> None:
-    expected_edge = ("pkg.new_worker.run_new", "pkg.util.helper", "pkg/new_worker.py", "pkg/util.py")
+    expected_edges = {
+        ("pkg.app.main", "pkg.service.service", "pkg/app.py", "pkg/service.py"),
+        ("pkg.service.service", "pkg.util.helper", "pkg/service.py", "pkg/util.py"),
+        ("pkg.new_worker.run_new", "pkg.util.helper", "pkg/new_worker.py", "pkg/util.py"),
+    }
     warm_edges = _edge_set(warm_static_analysis, repo_path)
     full_edges = _edge_set(full_static_analysis, repo_path)
+    warm_boundary = _boundary_edges(warm_edges, changed_files)
+    full_boundary = _boundary_edges(full_edges, changed_files)
 
-    assert expected_edge in full_edges
-    assert expected_edge in warm_edges
+    assert expected_edges <= full_boundary
+    assert expected_edges <= warm_boundary
+    assert warm_boundary == full_boundary
 
 
 def _removed_cross_boundary_edges(
@@ -315,7 +327,7 @@ def run_new():
 
     full_static_analysis = get_static_analysis(repo_path, fresh_dir, skip_cache=True, source_sha="after-two-changes")
 
-    _assert_new_outbound_edge_added(new_static_analysis, full_static_analysis, repo_path)
+    _assert_boundary_edges_match_full(new_static_analysis, full_static_analysis, repo_path, changed_files)
 
     _assert_graph_changes(
         old_static_analysis,

--- a/tests/integration/test_static_analysis_warm_start_delta.py
+++ b/tests/integration/test_static_analysis_warm_start_delta.py
@@ -1,0 +1,298 @@
+"""Warm-start static analysis should only change analysis for edited files."""
+
+from pathlib import Path
+import subprocess
+
+import pytest
+
+import static_analyzer as static_analyzer_module
+from static_analyzer import StaticAnalyzer
+from static_analyzer.analysis_result import StaticAnalysisResults
+
+
+def _git(args: list[str], cwd: Path | None = None) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    return result.stdout.strip()
+
+
+def _init_git_repo(repo_path: Path) -> str:
+    _git(["init"], cwd=repo_path)
+    _git(["config", "user.email", "test@example.com"], cwd=repo_path)
+    _git(["config", "user.name", "Test User"], cwd=repo_path)
+    _git(["add", "."], cwd=repo_path)
+    _git(["commit", "-m", "base"], cwd=repo_path)
+    return _git(["rev-parse", "HEAD"], cwd=repo_path)
+
+
+def _apply_changes(repo_path: Path, change_name: str, files: dict[str, str]) -> set[str]:
+    changed_files: set[str] = set()
+    for relative_path, content in files.items():
+        path = repo_path / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+        changed_files.add(relative_path)
+    assert changed_files, f"{change_name} must touch at least one file"
+    return changed_files
+
+
+def _rel(path: str, repo_path: Path) -> str:
+    return Path(path).resolve().relative_to(repo_path.resolve()).as_posix()
+
+
+def _node_tuple(node, repo_path: Path) -> tuple:
+    return (
+        node.fully_qualified_name,
+        _rel(node.file_path, repo_path),
+        node.line_start,
+        node.line_end,
+        node.col_start,
+        int(node.type),
+    )
+
+
+def _static_analysis_by_file(result: StaticAnalysisResults, repo_path: Path) -> dict[str, frozenset[tuple]]:
+    by_file: dict[str, set[tuple]] = {}
+
+    def add(file_path: str, value: tuple) -> None:
+        by_file.setdefault(_rel(file_path, repo_path), set()).add(value)
+
+    for language in result.get_languages():
+        for source_file in result.get_source_files(language):
+            add(source_file, ("source", language.value))
+
+        try:
+            cfg = result.get_cfg(language)
+        except ValueError:
+            continue
+        for node in cfg.nodes.values():
+            add(node.file_path, ("node", *_node_tuple(node, repo_path)))
+        for edge in cfg.edges:
+            add(
+                edge.src_node.file_path,
+                (
+                    "edge",
+                    language.value,
+                    edge.get_source(),
+                    edge.get_destination(),
+                    _rel(edge.dst_node.file_path, repo_path),
+                ),
+            )
+
+        for ref in result.iter_reference_nodes(language):
+            add(ref.file_path, ("reference", *_node_tuple(ref, repo_path)))
+
+        try:
+            hierarchy = result.get_hierarchy(language)
+        except ValueError:
+            hierarchy = {}
+        for class_name, info in hierarchy.items():
+            file_path = info.get("file_path")
+            if file_path:
+                add(
+                    file_path,
+                    (
+                        "class",
+                        class_name,
+                        tuple(sorted(info.get("superclasses", []))),
+                        tuple(sorted(info.get("subclasses", []))),
+                    ),
+                )
+
+    return {file_path: frozenset(items) for file_path, items in by_file.items()}
+
+
+def _changed_analysis_files(
+    old_result: StaticAnalysisResults, new_result: StaticAnalysisResults, repo_path: Path
+) -> set[str]:
+    old_by_file = _static_analysis_by_file(old_result, repo_path)
+    new_by_file = _static_analysis_by_file(new_result, repo_path)
+    return {
+        file_path
+        for file_path in set(old_by_file) | set(new_by_file)
+        if old_by_file.get(file_path) != new_by_file.get(file_path)
+    }
+
+
+def _edge_set(result: StaticAnalysisResults, repo_path: Path) -> set[tuple[str, str, str, str]]:
+    edges: set[tuple[str, str, str, str]] = set()
+    for language in result.get_languages():
+        try:
+            cfg = result.get_cfg(language)
+        except ValueError:
+            continue
+        for edge in cfg.edges:
+            edges.add(
+                (
+                    edge.get_source(),
+                    edge.get_destination(),
+                    _rel(edge.src_node.file_path, repo_path),
+                    _rel(edge.dst_node.file_path, repo_path),
+                )
+            )
+    return edges
+
+
+def _removed_cross_boundary_edges(
+    old_result: StaticAnalysisResults,
+    new_result: StaticAnalysisResults,
+    repo_path: Path,
+    changed_files: set[str],
+) -> tuple[set[tuple[str, str, str, str]], set[tuple[str, str, str, str]]]:
+    removed_edges = _edge_set(old_result, repo_path) - _edge_set(new_result, repo_path)
+    inbound = {edge for edge in removed_edges if edge[2] not in changed_files and edge[3] in changed_files}
+    outbound = {edge for edge in removed_edges if edge[2] in changed_files and edge[3] not in changed_files}
+    return inbound, outbound
+
+
+def _assert_only_expected_analysis_files_changed(
+    changed_analysis_files: set[str], expected_changed_files: set[str]
+) -> None:
+    unexpected = changed_analysis_files - expected_changed_files
+    if unexpected:
+        pytest.fail(
+            "warm-start static analysis changed files outside the edited files\n"
+            f"expected_only={sorted(expected_changed_files)!r}\n"
+            f"actual_changed_static_analysis_files={sorted(changed_analysis_files)!r}\n"
+            f"unexpected={sorted(unexpected)!r}"
+        )
+
+
+def _assert_no_persisted_cross_boundary_edges_were_dropped(
+    inbound: set[tuple[str, str, str, str]],
+    outbound: set[tuple[str, str, str, str]],
+    full_static_analysis: StaticAnalysisResults,
+    repo_path: Path,
+) -> None:
+    full_edges = _edge_set(full_static_analysis, repo_path)
+    persisted_inbound = inbound & full_edges
+    persisted_outbound = outbound & full_edges
+    if persisted_inbound or persisted_outbound:
+        pytest.fail(
+            "warm-start static analysis dropped cross-boundary edges that still exist in a full analysis\n"
+            f"persisted_inbound_unchanged_to_changed={len(persisted_inbound)} "
+            f"sample={sorted(persisted_inbound)[:10]!r}\n"
+            f"persisted_outbound_changed_to_unchanged={len(persisted_outbound)} "
+            f"sample={sorted(persisted_outbound)[:10]!r}\n"
+            f"stale_removed_inbound={len(inbound - full_edges)}\n"
+            f"stale_removed_outbound={len(outbound - full_edges)}"
+        )
+
+
+def _write_boundary_project(repo_path: Path) -> None:
+    (repo_path / "pkg").mkdir(parents=True)
+    (repo_path / "pkg" / "__init__.py").write_text("", encoding="utf-8")
+    (repo_path / "pkg" / "util.py").write_text(
+        """def helper():
+    return "ok"
+
+
+def normalize(value):
+    return value.strip()
+""",
+        encoding="utf-8",
+    )
+    (repo_path / "pkg" / "service.py").write_text(
+        """from pkg.util import helper
+
+
+def service():
+    return helper()
+""",
+        encoding="utf-8",
+    )
+    (repo_path / "pkg" / "workflow.py").write_text(
+        """from pkg.util import normalize
+
+
+def workflow(value):
+    return normalize(value)
+""",
+        encoding="utf-8",
+    )
+    (repo_path / "pkg" / "app.py").write_text(
+        """from pkg.service import service
+from pkg.workflow import workflow
+
+
+def main(value):
+    first = service()
+    return workflow(first + value)
+""",
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.python_lang
+def test_static_analysis_warm_start_preserves_boundary_edges_in_small_project(tmp_path: Path, monkeypatch) -> None:
+    repo_path = tmp_path / "boundary_project"
+    repo_path.mkdir()
+    _write_boundary_project(repo_path)
+    base_sha = _init_git_repo(repo_path)
+    artifact_dir = tmp_path / "warm_cache"
+    fresh_dir = tmp_path / "fresh_cache"
+
+    with StaticAnalyzer(repo_path) as analyzer:
+        old_static_analysis = analyzer.analyze(cache_dir=artifact_dir, skip_cache=True, source_sha=base_sha)
+
+    change_1_files = _apply_changes(
+        repo_path,
+        "change_1_service_keeps_inbound_and_outbound_edges",
+        {
+            "pkg/service.py": """from pkg.util import helper
+
+
+def service():
+    value = helper()
+    return value
+"""
+        },
+    )
+    change_2_files = _apply_changes(
+        repo_path,
+        "change_2_workflow_keeps_inbound_and_outbound_edges",
+        {
+            "pkg/workflow.py": """from pkg.util import normalize
+
+
+def workflow(value):
+    cleaned = normalize(value)
+    return cleaned
+"""
+        },
+    )
+    changed_files = change_1_files | change_2_files
+
+    warm_start_scopes: list[set[str]] = []
+    real_update = static_analyzer_module.update_cfg_for_changed_files
+
+    def record_update(cached_analysis, changed_paths, adapter, project_path, engine_client, ignore_manager):
+        warm_start_scopes.append({_rel(str(path), repo_path) for path in changed_paths})
+        return real_update(cached_analysis, changed_paths, adapter, project_path, engine_client, ignore_manager)
+
+    monkeypatch.setattr(static_analyzer_module, "update_cfg_for_changed_files", record_update)
+
+    with StaticAnalyzer(repo_path) as analyzer:
+        new_static_analysis = analyzer.analyze(cache_dir=artifact_dir, skip_cache=False, source_sha="after-two-changes")
+
+    with StaticAnalyzer(repo_path) as analyzer:
+        full_static_analysis = analyzer.analyze(cache_dir=fresh_dir, skip_cache=True, source_sha="after-two-changes")
+
+    changed_analysis_files = _changed_analysis_files(old_static_analysis, new_static_analysis, repo_path)
+    removed_inbound, removed_outbound = _removed_cross_boundary_edges(
+        old_static_analysis, new_static_analysis, repo_path, changed_files
+    )
+
+    assert warm_start_scopes, "expected the second run to load and update the base static_analysis.pkl"
+    assert set().union(*warm_start_scopes) == changed_files
+    _assert_no_persisted_cross_boundary_edges_were_dropped(
+        removed_inbound, removed_outbound, full_static_analysis, repo_path
+    )
+    _assert_only_expected_analysis_files_changed(changed_analysis_files, changed_files)

--- a/tests/integration/test_static_analysis_warm_start_delta.py
+++ b/tests/integration/test_static_analysis_warm_start_delta.py
@@ -5,8 +5,7 @@ import subprocess
 
 import pytest
 
-import static_analyzer as static_analyzer_module
-from static_analyzer import StaticAnalyzer
+from static_analyzer import get_static_analysis
 from static_analyzer.analysis_result import StaticAnalysisResults
 
 
@@ -185,6 +184,24 @@ def _assert_no_persisted_cross_boundary_edges_were_dropped(
         )
 
 
+def _assert_graph_changes(
+    old_static_analysis: StaticAnalysisResults,
+    new_static_analysis: StaticAnalysisResults,
+    full_static_analysis: StaticAnalysisResults,
+    repo_path: Path,
+    changed_files: set[str],
+) -> None:
+    changed_analysis_files = _changed_analysis_files(old_static_analysis, new_static_analysis, repo_path)
+    removed_inbound, removed_outbound = _removed_cross_boundary_edges(
+        old_static_analysis, new_static_analysis, repo_path, changed_files
+    )
+
+    _assert_no_persisted_cross_boundary_edges_were_dropped(
+        removed_inbound, removed_outbound, full_static_analysis, repo_path
+    )
+    _assert_only_expected_analysis_files_changed(changed_analysis_files, changed_files)
+
+
 def _write_boundary_project(repo_path: Path) -> None:
     (repo_path / "pkg").mkdir(parents=True)
     (repo_path / "pkg" / "__init__.py").write_text("", encoding="utf-8")
@@ -231,7 +248,7 @@ def main(value):
 
 @pytest.mark.integration
 @pytest.mark.python_lang
-def test_static_analysis_warm_start_preserves_boundary_edges_in_small_project(tmp_path: Path, monkeypatch) -> None:
+def test_static_analysis_updates_cross_edges(tmp_path: Path) -> None:
     repo_path = tmp_path / "boundary_project"
     repo_path.mkdir()
     _write_boundary_project(repo_path)
@@ -239,8 +256,7 @@ def test_static_analysis_warm_start_preserves_boundary_edges_in_small_project(tm
     artifact_dir = tmp_path / "warm_cache"
     fresh_dir = tmp_path / "fresh_cache"
 
-    with StaticAnalyzer(repo_path) as analyzer:
-        old_static_analysis = analyzer.analyze(cache_dir=artifact_dir, skip_cache=True, source_sha=base_sha)
+    old_static_analysis = get_static_analysis(repo_path, artifact_dir, skip_cache=True, source_sha=base_sha)
 
     change_1_files = _apply_changes(
         repo_path,
@@ -270,29 +286,14 @@ def workflow(value):
     )
     changed_files = change_1_files | change_2_files
 
-    warm_start_scopes: list[set[str]] = []
-    real_update = static_analyzer_module.update_cfg_for_changed_files
+    new_static_analysis = get_static_analysis(repo_path, artifact_dir, skip_cache=False, source_sha="after-two-changes")
 
-    def record_update(cached_analysis, changed_paths, adapter, project_path, engine_client, ignore_manager):
-        warm_start_scopes.append({_rel(str(path), repo_path) for path in changed_paths})
-        return real_update(cached_analysis, changed_paths, adapter, project_path, engine_client, ignore_manager)
+    full_static_analysis = get_static_analysis(repo_path, fresh_dir, skip_cache=True, source_sha="after-two-changes")
 
-    monkeypatch.setattr(static_analyzer_module, "update_cfg_for_changed_files", record_update)
-
-    with StaticAnalyzer(repo_path) as analyzer:
-        new_static_analysis = analyzer.analyze(cache_dir=artifact_dir, skip_cache=False, source_sha="after-two-changes")
-
-    with StaticAnalyzer(repo_path) as analyzer:
-        full_static_analysis = analyzer.analyze(cache_dir=fresh_dir, skip_cache=True, source_sha="after-two-changes")
-
-    changed_analysis_files = _changed_analysis_files(old_static_analysis, new_static_analysis, repo_path)
-    removed_inbound, removed_outbound = _removed_cross_boundary_edges(
-        old_static_analysis, new_static_analysis, repo_path, changed_files
+    _assert_graph_changes(
+        old_static_analysis,
+        new_static_analysis,
+        full_static_analysis,
+        repo_path,
+        changed_files,
     )
-
-    assert warm_start_scopes, "expected the second run to load and update the base static_analysis.pkl"
-    assert set().union(*warm_start_scopes) == changed_files
-    _assert_no_persisted_cross_boundary_edges_were_dropped(
-        removed_inbound, removed_outbound, full_static_analysis, repo_path
-    )
-    _assert_only_expected_analysis_files_changed(changed_analysis_files, changed_files)

--- a/tests/integration/test_static_analysis_warm_start_delta.py
+++ b/tests/integration/test_static_analysis_warm_start_delta.py
@@ -138,6 +138,19 @@ def _edge_set(result: StaticAnalysisResults, repo_path: Path) -> set[tuple[str, 
     return edges
 
 
+def _assert_new_outbound_edge_added(
+    warm_static_analysis: StaticAnalysisResults,
+    full_static_analysis: StaticAnalysisResults,
+    repo_path: Path,
+) -> None:
+    expected_edge = ("pkg.new_worker.run_new", "pkg.util.helper", "pkg/new_worker.py", "pkg/util.py")
+    warm_edges = _edge_set(warm_static_analysis, repo_path)
+    full_edges = _edge_set(full_static_analysis, repo_path)
+
+    assert expected_edge in full_edges
+    assert expected_edge in warm_edges
+
+
 def _removed_cross_boundary_edges(
     old_result: StaticAnalysisResults,
     new_result: StaticAnalysisResults,
@@ -284,11 +297,25 @@ def workflow(value):
 """
         },
     )
-    changed_files = change_1_files | change_2_files
+    change_3_files = _apply_changes(
+        repo_path,
+        "change_3_new_file_adds_outbound_edge_to_existing_method",
+        {
+            "pkg/new_worker.py": """from pkg.util import helper
+
+
+def run_new():
+    return helper()
+"""
+        },
+    )
+    changed_files = change_1_files | change_2_files | change_3_files
 
     new_static_analysis = get_static_analysis(repo_path, artifact_dir, skip_cache=False, source_sha="after-two-changes")
 
     full_static_analysis = get_static_analysis(repo_path, fresh_dir, skip_cache=True, source_sha="after-two-changes")
+
+    _assert_new_outbound_edge_added(new_static_analysis, full_static_analysis, repo_path)
 
     _assert_graph_changes(
         old_static_analysis,

--- a/tests/static_analyzer/test_analysis_cache_inmem.py
+++ b/tests/static_analyzer/test_analysis_cache_inmem.py
@@ -10,12 +10,8 @@ import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock
 
-from static_analyzer.analysis_cache import (
-    _INVALIDATED_CROSS_BOUNDARY_EDGES,
-    _INVALIDATED_FILES,
-    invalidate_files,
-    merge_results,
-)
+from static_analyzer.analysis_cache import invalidate_files, merge_results
+from static_analyzer.analysis_result import AnalysisData
 from static_analyzer.constants import NodeType
 from static_analyzer.graph import CallGraph, ClusterResult, Edge
 from static_analyzer.node import Node
@@ -48,6 +44,10 @@ def _result(
     }
 
 
+def _analysis_data(result: dict) -> AnalysisData:
+    return AnalysisData.from_dict(result)
+
+
 class TestInvalidateFiles(unittest.TestCase):
     def test_drops_nodes_from_changed_files(self) -> None:
         cg = CallGraph(language="python")
@@ -55,11 +55,11 @@ class TestInvalidateFiles(unittest.TestCase):
         cg.add_node(_node("b.bar", "b.py"))
         cached = _result(cg, source_files=["a.py", "b.py"])
 
-        updated = invalidate_files(cached, {Path("a.py")})
+        updated = invalidate_files(cached, {Path("a.py")}).analysis
 
-        self.assertNotIn("a.foo", updated["call_graph"].nodes)
-        self.assertIn("b.bar", updated["call_graph"].nodes)
-        self.assertEqual([str(p) for p in updated["source_files"]], ["b.py"])
+        self.assertNotIn("a.foo", updated.call_graph.nodes)
+        self.assertIn("b.bar", updated.call_graph.nodes)
+        self.assertEqual([str(p) for p in updated.source_files], ["b.py"])
 
     def test_cascades_edges_when_endpoint_dropped(self) -> None:
         # Edge a.foo -> b.bar must be dropped when a.foo is removed; the
@@ -70,9 +70,9 @@ class TestInvalidateFiles(unittest.TestCase):
         cg.add_edge("a.foo", "b.bar")
         cached = _result(cg, source_files=["a.py", "b.py"])
 
-        updated = invalidate_files(cached, {Path("a.py")})
+        updated = invalidate_files(cached, {Path("a.py")}).analysis
 
-        self.assertEqual(len(updated["call_graph"].edges), 0)
+        self.assertEqual(len(updated.call_graph.edges), 0)
 
     def test_tracks_invalidated_cross_boundary_edges_for_merge(self) -> None:
         cg = CallGraph(language="python")
@@ -83,9 +83,9 @@ class TestInvalidateFiles(unittest.TestCase):
 
         updated = invalidate_files(cached, {Path("a.py")})
 
-        self.assertEqual(updated[_INVALIDATED_FILES], {"a.py"})
+        self.assertEqual(updated.invalidated_files, {"a.py"})
         self.assertEqual(
-            [(src, dst) for src, dst, _src_node, _dst_node in updated[_INVALIDATED_CROSS_BOUNDARY_EDGES]],
+            [(src, dst) for src, dst, _src_node, _dst_node in updated.invalidated_edges],
             [("a.foo", "b.bar")],
         )
 
@@ -103,11 +103,11 @@ class TestInvalidateFiles(unittest.TestCase):
             package_relations={"pkg": {"files": ["a.py", "b.py"]}},
         )
 
-        updated = invalidate_files(cached, {Path("a.py")})
+        updated = invalidate_files(cached, {Path("a.py")}).analysis
 
-        self.assertEqual([r.fully_qualified_name for r in updated["references"]], ["b.bar"])
-        self.assertEqual(set(updated["class_hierarchies"].keys()), {"B"})
-        self.assertEqual(updated["package_relations"]["pkg"]["files"], ["b.py"])
+        self.assertEqual([r.fully_qualified_name for r in updated.references], ["b.bar"])
+        self.assertEqual(set(updated.class_hierarchies.keys()), {"B"})
+        self.assertEqual(updated.package_relations["pkg"]["files"], ["b.py"])
 
     def test_diagnostics_preserved_for_unchanged_files(self) -> None:
         cg = CallGraph(language="python")
@@ -116,9 +116,9 @@ class TestInvalidateFiles(unittest.TestCase):
         cached = _result(cg, source_files=["a.py", "b.py"])
         cached["diagnostics"] = {"a.py": ["d1"], "b.py": ["d2"]}
 
-        updated = invalidate_files(cached, {Path("a.py")})
+        updated = invalidate_files(cached, {Path("a.py")}).analysis
 
-        self.assertEqual(updated["diagnostics"], {"b.py": ["d2"]})
+        self.assertEqual(updated.diagnostics, {"b.py": ["d2"]})
 
 
 class TestMergeResults(unittest.TestCase):
@@ -128,9 +128,11 @@ class TestMergeResults(unittest.TestCase):
         new_cg = CallGraph(language="python")
         new_cg.add_node(_node("b.bar", "b.py"))
 
-        merged = merge_results(_result(cached_cg, source_files=["a.py"]), _result(new_cg, source_files=["b.py"]))
+        merged = merge_results(
+            _analysis_data(_result(cached_cg, source_files=["a.py"])), _result(new_cg, source_files=["b.py"])
+        )
 
-        self.assertEqual(set(merged["call_graph"].nodes), {"a.foo", "b.bar"})
+        self.assertEqual(set(merged.call_graph.nodes), {"a.foo", "b.bar"})
 
     def test_new_overrides_cached_for_same_file_references(self) -> None:
         # ``b.bar`` lives in b.py in both halves; the new half wins.
@@ -145,9 +147,9 @@ class TestMergeResults(unittest.TestCase):
             source_files=["b.py"],
         )
 
-        merged = merge_results(cached, new)
+        merged = merge_results(_analysis_data(cached), new)
 
-        self.assertEqual([(r.fully_qualified_name, r.line_start) for r in merged["references"]], [("b.bar", 20)])
+        self.assertEqual([(r.fully_qualified_name, r.line_start) for r in merged.references], [("b.bar", 20)])
 
     def test_cached_references_for_files_not_in_new_are_kept(self) -> None:
         cached = _result(
@@ -161,9 +163,9 @@ class TestMergeResults(unittest.TestCase):
             source_files=["b.py"],
         )
 
-        merged = merge_results(cached, new)
+        merged = merge_results(_analysis_data(cached), new)
 
-        names = sorted((r.fully_qualified_name, r.line_start) for r in merged["references"])
+        names = sorted((r.fully_qualified_name, r.line_start) for r in merged.references)
         self.assertEqual(names, [("a.foo", 1), ("b.bar", 99)])
 
     def test_diagnostics_merge_with_new_winning(self) -> None:
@@ -172,9 +174,9 @@ class TestMergeResults(unittest.TestCase):
         new = _result(CallGraph(language="python"), source_files=["b.py"])
         new["diagnostics"] = {"b.py": ["new-b"]}
 
-        merged = merge_results(cached, new)
+        merged = merge_results(_analysis_data(cached), new)
 
-        self.assertEqual(merged["diagnostics"], {"a.py": ["old-a"], "b.py": ["new-b"]})
+        self.assertEqual(merged.diagnostics, {"a.py": ["old-a"], "b.py": ["new-b"]})
 
 
 class TestClusterCachePreservation(unittest.TestCase):
@@ -200,10 +202,10 @@ class TestClusterCachePreservation(unittest.TestCase):
     def test_invalidate_files_preserves_cluster_cache_for_kept_files(self) -> None:
         cached = _result(self._cg_with_cluster_cache(), source_files=["a.py", "b.py"])
 
-        updated = invalidate_files(cached, {Path("a.py")})
+        updated = invalidate_files(cached, {Path("a.py")}).analysis
 
-        cc = updated["call_graph"]._cluster_cache
-        self.assertIsNotNone(cc)
+        cc = updated.call_graph._cluster_cache
+        assert cc is not None
         # Cluster 1 had only a.py members -> dropped entirely.
         # Cluster 2 keeps b.qux from b.py.
         self.assertNotIn(1, cc.clusters)
@@ -216,9 +218,10 @@ class TestClusterCachePreservation(unittest.TestCase):
         cached = _result(self._cg_with_cluster_cache(), source_files=["a.py", "b.py"])
         # Only invalidate b.py; cluster 1 (members in a.py) survives whole;
         # cluster 2 (b.qux only) drops.
-        updated = invalidate_files(cached, {Path("b.py")})
+        updated = invalidate_files(cached, {Path("b.py")}).analysis
 
-        cc = updated["call_graph"]._cluster_cache
+        cc = updated.call_graph._cluster_cache
+        assert cc is not None
         self.assertEqual(cc.clusters[1], {"a.foo", "a.bar"})
         self.assertNotIn(2, cc.clusters)
 
@@ -228,9 +231,10 @@ class TestClusterCachePreservation(unittest.TestCase):
         new_cg.add_node(_node("c.new", "c.py"))
         new = _result(new_cg, source_files=["c.py"])
 
-        merged = merge_results(cached, new)
+        merged = merge_results(_analysis_data(cached), new)
 
-        cc = merged["call_graph"]._cluster_cache
+        cc = merged.call_graph._cluster_cache
+        assert cc is not None
         # Cached clusters survive; new node 'c.new' is unclustered (intentional —
         # cluster_delta will pick it up as drift on the next run).
         self.assertEqual(cc.clusters[1], {"a.foo", "a.bar"})

--- a/tests/static_analyzer/test_analysis_cache_inmem.py
+++ b/tests/static_analyzer/test_analysis_cache_inmem.py
@@ -10,7 +10,12 @@ import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock
 
-from static_analyzer.analysis_cache import invalidate_files, merge_results
+from static_analyzer.analysis_cache import (
+    _INVALIDATED_CROSS_BOUNDARY_EDGES,
+    _INVALIDATED_FILES,
+    invalidate_files,
+    merge_results,
+)
 from static_analyzer.constants import NodeType
 from static_analyzer.graph import CallGraph, ClusterResult
 from static_analyzer.node import Node
@@ -68,6 +73,21 @@ class TestInvalidateFiles(unittest.TestCase):
         updated = invalidate_files(cached, {Path("a.py")})
 
         self.assertEqual(len(updated["call_graph"].edges), 0)
+
+    def test_tracks_invalidated_cross_boundary_edges_for_merge(self) -> None:
+        cg = CallGraph(language="python")
+        cg.add_node(_node("a.foo", "a.py"))
+        cg.add_node(_node("b.bar", "b.py"))
+        cg.add_edge("a.foo", "b.bar")
+        cached = _result(cg, source_files=["a.py", "b.py"])
+
+        updated = invalidate_files(cached, {Path("a.py")})
+
+        self.assertEqual(updated[_INVALIDATED_FILES], {"a.py"})
+        self.assertEqual(
+            [(src, dst) for src, dst, _src_node, _dst_node in updated[_INVALIDATED_CROSS_BOUNDARY_EDGES]],
+            [("a.foo", "b.bar")],
+        )
 
     def test_drops_references_class_hierarchies_and_packages(self) -> None:
         cg = CallGraph(language="python")

--- a/tests/static_analyzer/test_analysis_cache_inmem.py
+++ b/tests/static_analyzer/test_analysis_cache_inmem.py
@@ -243,7 +243,7 @@ class TestClusterCachePreservation(unittest.TestCase):
         assert cg._cluster_cache is not None
         original_cluster_ids = set(cg._cluster_cache.clusters.keys())
 
-        cg.filter(lambda n: n.file_path != "a.py")
+        cg.filter(lambda n: n.file_path != "a.py", on_dropped_edge=lambda _edge: None)
 
         self.assertEqual(len(cg.nodes), original_node_count)
         assert cg._cluster_cache is not None
@@ -256,7 +256,7 @@ class TestClusterCachePreservation(unittest.TestCase):
         cg.add_edge("a.foo", "b.bar")
         dropped_edges: list[Edge] = []
 
-        filtered = cg.filter(lambda n: n.file_path != "a.py", dropped_edges=dropped_edges)
+        filtered = cg.filter(lambda n: n.file_path != "a.py", on_dropped_edge=dropped_edges.append)
 
         self.assertEqual(len(filtered.edges), 0)
         self.assertNotIn("a.foo", filtered.nodes)

--- a/tests/static_analyzer/test_analysis_cache_inmem.py
+++ b/tests/static_analyzer/test_analysis_cache_inmem.py
@@ -17,7 +17,7 @@ from static_analyzer.analysis_cache import (
     merge_results,
 )
 from static_analyzer.constants import NodeType
-from static_analyzer.graph import CallGraph, ClusterResult
+from static_analyzer.graph import CallGraph, ClusterResult, Edge
 from static_analyzer.node import Node
 from static_analyzer.incremental_orchestrator import update_cfg_for_changed_files
 
@@ -254,12 +254,14 @@ class TestClusterCachePreservation(unittest.TestCase):
         cg.add_node(_node("a.foo", "a.py"))
         cg.add_node(_node("b.bar", "b.py"))
         cg.add_edge("a.foo", "b.bar")
+        dropped_edges: list[Edge] = []
 
-        filtered = cg.filter(lambda n: n.file_path != "a.py")
+        filtered = cg.filter(lambda n: n.file_path != "a.py", dropped_edges=dropped_edges)
 
         self.assertEqual(len(filtered.edges), 0)
         self.assertNotIn("a.foo", filtered.nodes)
         self.assertIn("b.bar", filtered.nodes)
+        self.assertEqual([(edge.get_source(), edge.get_destination()) for edge in dropped_edges], [("a.foo", "b.bar")])
 
     def test_union_preserves_cached_side_cluster_cache(self) -> None:
         cached = self._cg_with_cluster_cache()


### PR DESCRIPTION
When we have cached static analysis there is a bug of skipping over edges.
Flow:
1. load existing analysis
2. invalidate fails which haev modification -> remove every related edge incoming to the file and outgoing
3. rerun static analysis for those modified files in isolation
(BUG: when rerunin the anlaysis in isolation the result is that incoming and outgoing edges won't be resolved properly)

Solution colelct the discarded edges and then promote them back to avoid indexing of all dependent files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Warm-start analysis now maintains cross-file call-graph integrity during incremental updates, validating edges and restoring connections across file boundaries.

* **Tests**
  * Added validation test ensuring warm-start incremental results remain consistent with full reanalysis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->