### PR TITLE
chore: set analysis depth_level to 4

### DIFF
--- a/.github/workflows/codeboarding-sync.yml
+++ b/.github/workflows/codeboarding-sync.yml
@@ -38,6 +38,12 @@ jobs:
         with:
           mode: sync
           force_full: ${{ inputs.force_full || false }}
+          # Desired analysis depth for this repo. Sync is the baseline writer, so
+          # setting it here re-seeds .codeboarding/analysis.json at depth 4 on the
+          # next sync; review then inherits depth 4 from the committed baseline.
+          # Requires the licensed tier (license_key/llm_api_key) — the free tier
+          # caps depth at 3.
+          depth_level: 4
           # Free tier needs no secret — these fall through to the hosted OIDC tier when
           # unset. Add either repo secret (Settings → Secrets and variables → Actions)
           # for more/unmetered usage; no YAML edit required.

--- a/.github/workflows/codeboarding.yml
+++ b/.github/workflows/codeboarding.yml
@@ -31,6 +31,11 @@ jobs:
     steps:
       - uses: CodeBoarding/CodeBoarding-action@v1
         with:
+          # Desired analysis depth. Review inherits the committed baseline's depth
+          # once sync has re-seeded it at 4; this is set explicitly too so a review
+          # that runs before the first depth-4 sync still analyzes at depth 4.
+          # Requires the licensed tier (the free tier caps depth at 3).
+          depth_level: 4
           # Free tier needs no secret — these fall through to the hosted OIDC tier when
           # unset. Add either repo secret (Settings → Secrets and variables → Actions)
           # for more/unmetered usage; no YAML edit required.


### PR DESCRIPTION
Set depth_level: 4 on both the sync and review CodeBoarding workflows. 
Notice, this should be merged only after we release the GHA changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configurations to explicitly set code analysis depth levels, ensuring consistent analysis quality across all pull request reviews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->