### PR TITLE
v0.12.4 chore: prepare core release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "codeboarding"
-version = "0.12.2"
+version = "0.12.4"
 description = "Interactive Diagrams for Code"
 readme = "PYPI.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -336,7 +336,7 @@ wheels = [
 
 [[package]]
 name = "codeboarding"
-version = "0.12.2"
+version = "0.12.4"
 source = { editable = "." }
 dependencies = [
     { name = "docker" },


### PR DESCRIPTION
## Summary
- Bumps the `codeboarding` package metadata from `0.12.2` to `0.12.4`.
- Updates the editable package entry in `uv.lock` to match.
- This fixes the release metadata mismatch where tag `v0.12.3` still built package metadata as `0.12.2`.

## Verification
- `python` metadata check: `pyproject.toml` and editable `uv.lock` entry both report `0.12.4`.
- `uv run python -m build --wheel --outdir /tmp/codeboarding-release-check` succeeded.
- Inspected built wheel metadata: `Version: 0.12.4`.
- Spot-checked source files in the wheel, including `agents/tools/read_source.py`, `static_analyzer/engine/source_inspector.py`, and `codeboarding_cli/commands/incremental_analysis.py`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 0.12.4

<!-- end of auto-generated comment: release notes by coderabbit.ai -->