### PR TITLE
feat(cli): print webview view-instructions after local analysis

### DIFF
--- a/codeboarding_cli/commands/full_analysis.py
+++ b/codeboarding_cli/commands/full_analysis.py
@@ -6,6 +6,7 @@ from tqdm import tqdm
 
 from agents.llm_config import LLMConfigError
 from codeboarding_cli.bootstrap import bootstrap_environment, resolve_local_run_paths
+from codeboarding_cli.view_instructions import print_view_instructions
 from codeboarding_workflows.analysis import run_full
 from codeboarding_workflows.orchestration import run_analysis_pipeline
 from codeboarding_workflows.rendering import render_docs
@@ -16,7 +17,7 @@ from monitoring.paths import get_monitoring_run_dir
 from repo_utils import get_branch, store_token
 from repo_utils.git_ops import get_current_commit
 from repo_utils.ignore import initialize_codeboardingignore
-from utils import CODEBOARDING_DIR_NAME, copy_files, monitoring_enabled
+from utils import ANALYSIS_FILENAME, CODEBOARDING_DIR_NAME, copy_files, monitoring_enabled
 
 logger = logging.getLogger(__name__)
 
@@ -111,6 +112,8 @@ def _run_local(args: argparse.Namespace) -> None:
         scope=scope,
     )
     logger.info(f"Documentation generated successfully in {run_paths.output_dir}")
+
+    print_view_instructions(run_paths.output_dir / ANALYSIS_FILENAME)
 
 
 def _run_remote(args: argparse.Namespace) -> None:

--- a/codeboarding_cli/commands/incremental_analysis.py
+++ b/codeboarding_cli/commands/incremental_analysis.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from agents.llm_config import LLMConfigError
 from codeboarding_cli.bootstrap import bootstrap_environment, resolve_local_run_paths
+from codeboarding_cli.view_instructions import print_view_instructions
 from codeboarding_workflows.analysis import BaselineUnavailableError, run_incremental
 from diagram_analysis import RunContext
 from diagram_analysis.io_utils import load_analysis_commit_hash
@@ -119,6 +120,8 @@ def run_from_args(args: argparse.Namespace, parser: argparse.ArgumentParser) -> 
                 "analysis_path": str(analysis_path),
             }
         )
+        # Human-facing hint (logs to stderr, so the stdout JSON contract stays clean).
+        print_view_instructions(analysis_path)
     finally:
         run_context.finalize()
 

--- a/codeboarding_cli/commands/partial_analysis.py
+++ b/codeboarding_cli/commands/partial_analysis.py
@@ -3,11 +3,13 @@ import logging
 
 from agents.llm_config import LLMConfigError
 from codeboarding_cli.bootstrap import bootstrap_environment, resolve_local_run_paths
+from codeboarding_cli.view_instructions import print_view_instructions
 from codeboarding_workflows.analysis import run_partial
 from codeboarding_workflows.orchestration import run_analysis_pipeline
 from codeboarding_workflows.sources import SourceContext, local_source
 from diagram_analysis import RunContext
 from repo_utils.ignore import initialize_codeboardingignore
+from utils import ANALYSIS_FILENAME
 
 logger = logging.getLogger(__name__)
 
@@ -66,3 +68,5 @@ def run_from_args(args: argparse.Namespace, parser: argparse.ArgumentParser) -> 
         reuse_latest_run_id=True,
     )
     logger.info(f"Component '{args.component_id}' updated in {run_paths.output_dir}")
+
+    print_view_instructions(run_paths.output_dir / ANALYSIS_FILENAME)

--- a/codeboarding_cli/view_instructions.py
+++ b/codeboarding_cli/view_instructions.py
@@ -1,0 +1,41 @@
+"""Tell the user how to view a generated analysis in the CodeBoarding webview.
+
+A local ``codeboarding`` run writes ``analysis.json`` to disk but never uploads it,
+so there is no URL the hosted webview can fetch. We therefore don't try to auto-open
+anything; we just print how to load the file manually: open the webview and use its
+"Load a file" picker. This works in every browser and needs no local server.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+WEBVIEW_BASE_URL = os.environ.get("CODEBOARDING_WEBVIEW_URL", "https://app.codeboarding.org").rstrip("/")
+
+
+def print_view_instructions(analysis_path: Path) -> None:
+    """Print how to view ``analysis_path`` in the webview (best-effort, never raises)."""
+    try:
+        analysis_path = Path(analysis_path).resolve()
+        if not analysis_path.is_file():
+            logger.warning("Analysis file not found at %s; nothing to view yet.", analysis_path)
+            return
+        logger.info(
+            "\n".join(
+                [
+                    "",
+                    "Analysis ready. View your architecture diagram:",
+                    "",
+                    f"  1. Open the webview:   {WEBVIEW_BASE_URL}",
+                    "  2. Click 'Load a file' and pick:",
+                    f"       {analysis_path}",
+                    "",
+                ]
+            )
+        )
+    except Exception as exc:  # never break a successful run over this
+        logger.warning("Could not print webview instructions: %s", exc)

--- a/tests/test_view_instructions.py
+++ b/tests/test_view_instructions.py
@@ -1,0 +1,32 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from codeboarding_cli.view_instructions import print_view_instructions
+
+
+class TestPrintViewInstructions(unittest.TestCase):
+    def test_prints_webview_url_and_file_path(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            analysis = Path(temp_dir) / "analysis.json"
+            analysis.write_text("{}")
+
+            with self.assertLogs("codeboarding_cli.view_instructions", level="INFO") as cm:
+                print_view_instructions(analysis)
+
+        msg = "\n".join(cm.output)
+        self.assertIn("app.codeboarding.org", msg)
+        self.assertIn("Load a file", msg)
+        self.assertIn(str(analysis.resolve()), msg)
+
+    def test_missing_file_warns_and_does_not_print_instructions(self):
+        with self.assertLogs("codeboarding_cli.view_instructions", level="WARNING") as cm:
+            print_view_instructions(Path("/does/not/exist/analysis.json"))
+
+        msg = "\n".join(cm.output)
+        self.assertIn("not found", msg)
+        self.assertNotIn("Load a file", msg)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

After a local **full**, **partial**, or **incremental** analysis finishes, the CLI now prints clear instructions for viewing the generated `analysis.json` in the hosted webview — open `app.codeboarding.org` and use **"Load a file"** to pick the file.

No upload, no local server, works in every browser.

## Why

We explored auto-opening the result (a short-lived loopback server serving the file to `app.codeboarding.org/?src=...`), but dropped it: the JSON is too large for a URL, the hosted webview that renders `?src=` isn't deployed yet, and current Chrome/Edge **Local Network Access** restrictions make a public-site → `127.0.0.1` fetch unreliable. Manual "Load a file" is the route that works today, everywhere, with zero infrastructure.

## Details

- New `codeboarding_cli/view_instructions.py` with a single `print_view_instructions(analysis_path)` (logs the webview URL + the file path; warns and no-ops if the file is missing; never raises).
- Wired into the end of `full`, `partial`, and `incremental`.
- For `incremental`, the instructions log to **stderr** (via the logger), so the **stdout JSON wire contract** consumed by the VS Code wrapper stays clean — verified.

## Testing

- `uv run pytest --ignore=tests/integration` → **1656 passed, 28 skipped**.
- `uv run mypy .` clean on changed files; `black` clean (pre-commit passing).
- **Manually tested** — this is what's printed at the end of a local analysis run:

```
Analysis ready. View your architecture diagram:

  1. Open the webview:   https://app.codeboarding.org
  2. Click 'Load a file' and pick:
       /Users/path...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added user-facing instructions after analysis runs to help you open and view generated results in the web interface.
  * Local analysis output now includes a clear path and viewing guidance.

* **Bug Fixes**
  * Improved handling when the generated analysis file is missing, with a helpful warning instead of failing silently.
  * Kept result output available while adding the new viewing message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->