### PR TITLE
fix: clearer WSL/Windows-aware diagnostics when tokei scan fails

### DIFF
--- a/static_analyzer/scanner.py
+++ b/static_analyzer/scanner.py
@@ -1,14 +1,64 @@
 import json
 import logging
+import platform
+import shlex
 import subprocess
 from pathlib import Path
-from typing import Set
 
 from static_analyzer.programming_language import ProgrammingLanguage, ProgrammingLanguageBuilder
 from telemetry.events import track_tech_stack
+from tool_registry.paths import is_wsl
 from utils import get_config
 
 logger = logging.getLogger(__name__)
+
+
+def _format_command(command: object) -> str:
+    if isinstance(command, str):
+        return command
+    if isinstance(command, (list, tuple)):
+        return shlex.join([str(part) for part in command])
+    return str(command)
+
+
+def _format_stderr(stderr: object) -> str:
+    if stderr is None:
+        return "no stderr output"
+    if isinstance(stderr, bytes):
+        stderr = stderr.decode(errors="replace")
+    stderr_text = str(stderr).strip()
+    return stderr_text or "no stderr output"
+
+
+def _tokei_failure_message(
+    repo_location: Path,
+    command: object,
+    reason: str,
+    stderr: object,
+    install_hint: bool,
+) -> str:
+    wsl_detected = is_wsl()
+    if wsl_detected:
+        guidance = (
+            "WSL detected: if a Windows tokei binary is being invoked from WSL, "
+            "install and run a Linux tokei binary inside WSL."
+        )
+    elif install_hint:
+        guidance = (
+            "Install tokei and ensure it is available on PATH, then verify that "
+            "'tokei -o json' works in your terminal."
+        )
+    else:
+        guidance = "Verify that 'tokei -o json' works in your terminal."
+
+    return (
+        f"{reason} for repository '{repo_location}'. "
+        f"Platform: {platform.platform()}. "
+        f"WSL detected: {'yes' if wsl_detected else 'no'}. "
+        f"Command: {_format_command(command)}. "
+        f"stderr: {_format_stderr(stderr)}. "
+        f"{guidance}"
+    )
 
 
 class ProjectScanner:
@@ -27,15 +77,38 @@ class ProjectScanner:
         """
 
         commands = get_config("tools")["tokei"]["command"]
-        result = subprocess.run(commands, cwd=self.repo_location, capture_output=True, text=True, check=True)
+        try:
+            result = subprocess.run(commands, cwd=self.repo_location, capture_output=True, text=True, check=True)
+        except FileNotFoundError as exc:
+            raise RuntimeError(
+                _tokei_failure_message(
+                    self.repo_location,
+                    commands,
+                    f"Tokei executable not found ({exc})",
+                    None,
+                    install_hint=True,
+                )
+            ) from exc
+        except subprocess.CalledProcessError as exc:
+            raise RuntimeError(
+                _tokei_failure_message(
+                    self.repo_location,
+                    commands,
+                    f"Tokei command failed with exit code {exc.returncode}",
+                    exc.stderr,
+                    install_hint=False,
+                )
+            ) from exc
 
         if not result.stdout:
-            stderr_msg = result.stderr.strip() if result.stderr else "no stderr output"
             raise RuntimeError(
-                f"Tokei produced no output for repository '{self.repo_location}'. "
-                f"stderr: {stderr_msg}. "
-                f"This may indicate a tokei installation issue (e.g. Windows binary invoked inside WSL). "
-                f"Verify that 'tokei -o json' works in your terminal."
+                _tokei_failure_message(
+                    self.repo_location,
+                    commands,
+                    "Tokei produced no output",
+                    result.stderr,
+                    install_hint=False,
+                )
             )
 
         server_config = get_config("lsp_servers")
@@ -88,7 +161,7 @@ class ProjectScanner:
         return programming_languages
 
     @staticmethod
-    def _extract_suffixes(files: list[str]) -> Set[str]:
+    def _extract_suffixes(files: list[str]) -> set[str]:
         """
         Extract unique file suffixes from a list of files.
 
@@ -96,7 +169,7 @@ class ProjectScanner:
             files (list[str]): list of file paths
 
         Returns:
-            Set[str]: Unique file extensions/suffixes
+            set[str]: Unique file extensions/suffixes
         """
         suffixes = set()
         for file_path in files:

--- a/tests/static_analyzer/test_project_scanner.py
+++ b/tests/static_analyzer/test_project_scanner.py
@@ -1,6 +1,7 @@
+import subprocess
 import unittest
 from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 from static_analyzer.scanner import ProjectScanner
 
@@ -9,35 +10,89 @@ class TestProjectScanner(unittest.TestCase):
     def setUp(self):
         self.scanner = ProjectScanner(Path("/fake/repo"))
 
+    @patch("static_analyzer.scanner.platform.platform", return_value="Linux-6.8.0")
+    @patch("static_analyzer.scanner.is_wsl", return_value=False)
     @patch("static_analyzer.scanner.get_config")
     @patch("static_analyzer.scanner.subprocess.run")
-    def test_scan_raises_on_empty_stdout(self, mock_run, mock_get_config):
+    def test_scan_raises_on_empty_stdout(self, mock_run, mock_get_config, mock_is_wsl, mock_platform):
         mock_get_config.return_value = {"tokei": {"command": ["tokei", "-o", "json"]}}
         mock_run.return_value = MagicMock(stdout="", stderr="some warning")
 
         with self.assertRaises(RuntimeError) as ctx:
             self.scanner.scan()
 
-        self.assertIn("Tokei produced no output", str(ctx.exception))
-        self.assertIn("some warning", str(ctx.exception))
+        message = str(ctx.exception)
+        self.assertIn("Tokei produced no output", message)
+        self.assertIn("Platform: Linux-6.8.0", message)
+        self.assertIn("WSL detected: no", message)
+        self.assertIn("Command: tokei -o json", message)
+        self.assertIn("some warning", message)
+        self.assertIn("Verify that 'tokei -o json' works in your terminal", message)
+        self.assertNotIn("Windows tokei binary", message)
 
+    @patch("static_analyzer.scanner.platform.platform", return_value="Linux-5.15.0-microsoft")
+    @patch("static_analyzer.scanner.is_wsl", return_value=True)
     @patch("static_analyzer.scanner.get_config")
     @patch("static_analyzer.scanner.subprocess.run")
-    def test_scan_raises_on_none_stdout(self, mock_run, mock_get_config):
+    def test_scan_raises_on_none_stdout(self, mock_run, mock_get_config, mock_is_wsl, mock_platform):
         mock_get_config.return_value = {"tokei": {"command": ["tokei", "-o", "json"]}}
         mock_run.return_value = MagicMock(stdout=None, stderr="")
 
         with self.assertRaises(RuntimeError) as ctx:
             self.scanner.scan()
 
-        self.assertIn("Tokei produced no output", str(ctx.exception))
+        message = str(ctx.exception)
+        self.assertIn("Tokei produced no output", message)
+        self.assertIn("Platform: Linux-5.15.0-microsoft", message)
+        self.assertIn("WSL detected: yes", message)
+        self.assertIn("Windows tokei binary", message)
+
+    @patch("static_analyzer.scanner.platform.platform", return_value="Windows-10")
+    @patch("static_analyzer.scanner.is_wsl", return_value=False)
+    @patch("static_analyzer.scanner.get_config")
+    @patch("static_analyzer.scanner.subprocess.run")
+    def test_scan_wraps_nonzero_tokei_exit(self, mock_run, mock_get_config, mock_is_wsl, mock_platform):
+        mock_get_config.return_value = {"tokei": {"command": ["tokei", "-o", "json"]}}
+        mock_run.side_effect = subprocess.CalledProcessError(
+            returncode=2,
+            cmd=["tokei", "-o", "json"],
+            stderr="failed to read repository",
+        )
+
+        with self.assertRaises(RuntimeError) as ctx:
+            self.scanner.scan()
+
+        message = str(ctx.exception)
+        self.assertIn("Tokei command failed with exit code 2", message)
+        self.assertIn("Platform: Windows-10", message)
+        self.assertIn("WSL detected: no", message)
+        self.assertIn("Command: tokei -o json", message)
+        self.assertIn("failed to read repository", message)
+
+    @patch("static_analyzer.scanner.platform.platform", return_value="Darwin-25.0.0")
+    @patch("static_analyzer.scanner.is_wsl", return_value=False)
+    @patch("static_analyzer.scanner.get_config")
+    @patch("static_analyzer.scanner.subprocess.run")
+    def test_scan_wraps_missing_tokei_binary(self, mock_run, mock_get_config, mock_is_wsl, mock_platform):
+        mock_get_config.return_value = {"tokei": {"command": ["tokei", "-o", "json"]}}
+        mock_run.side_effect = FileNotFoundError("No such file or directory: 'tokei'")
+
+        with self.assertRaises(RuntimeError) as ctx:
+            self.scanner.scan()
+
+        message = str(ctx.exception)
+        self.assertIn("Tokei executable not found", message)
+        self.assertIn("Platform: Darwin-25.0.0", message)
+        self.assertIn("Command: tokei -o json", message)
+        self.assertIn("stderr: no stderr output", message)
+        self.assertIn("Install tokei and ensure it is available on PATH", message)
 
     @patch("static_analyzer.scanner.get_config")
     @patch("static_analyzer.scanner.subprocess.run")
     def test_scan_succeeds_with_valid_output(self, mock_run, mock_get_config):
         mock_get_config.side_effect = [
             {"tokei": {"command": ["tokei", "-o", "json"]}},
-            {"python": {"command": ["pyright-langserver", "--stdio"]}},
+            {"python": {"command": ["pyright-langserver", "--stdio"], "file_extensions": [".py"]}},
         ]
         mock_run.return_value = MagicMock(
             stdout='{"Python": {"code": 100, "reports": [{"name": "main.py"}]}, "Total": {"code": 100}}'
@@ -45,7 +100,11 @@ class TestProjectScanner(unittest.TestCase):
 
         result = self.scanner.scan()
 
-        self.assertIsInstance(result, list)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].language, "Python")
+        self.assertEqual(result[0].size, 100)
+        self.assertEqual(result[0].suffixes, [".py"])
+        self.assertEqual(self.scanner.all_text_files, ["main.py"])
 
 
 if __name__ == "__main__":

--- a/tests/test_windows_compatibility.py
+++ b/tests/test_windows_compatibility.py
@@ -4,8 +4,10 @@ import platform
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 from static_analyzer.engine.utils import uri_to_path
+from tool_registry.paths import is_wsl
 
 IS_WINDOWS = platform.system() == "Windows"
 
@@ -22,6 +24,34 @@ class TestFileURIParsing(unittest.TestCase):
 
     def test_non_file_scheme(self):
         self.assertIsNone(uri_to_path("http://example.com/foo"))
+
+
+class TestWSLDetection(unittest.TestCase):
+    @patch("tool_registry.paths.Path.read_text", return_value="Linux version 5.15.0 Microsoft")
+    @patch("tool_registry.paths.platform.release", return_value="5.15.0-generic")
+    @patch("tool_registry.paths.platform.system", return_value="Linux")
+    def test_detects_proc_version_microsoft_marker(self, mock_system, mock_release, mock_read_text):
+        self.assertTrue(is_wsl())
+
+    @patch("tool_registry.paths.Path.read_text", side_effect=OSError("missing /proc/version"))
+    @patch("tool_registry.paths.platform.release", return_value="5.15.90.1-microsoft-standard-WSL2")
+    @patch("tool_registry.paths.platform.system", return_value="Linux")
+    def test_detects_release_wsl_marker(self, mock_system, mock_release, mock_read_text):
+        self.assertTrue(is_wsl())
+        mock_read_text.assert_not_called()
+
+    @patch("tool_registry.paths.Path.read_text", return_value="Linux version 6.8.0 generic")
+    @patch("tool_registry.paths.platform.release", return_value="6.8.0-generic")
+    @patch("tool_registry.paths.platform.system", return_value="Linux")
+    def test_native_linux_is_not_wsl(self, mock_system, mock_release, mock_read_text):
+        self.assertFalse(is_wsl())
+
+    @patch("tool_registry.paths.Path.read_text")
+    @patch("tool_registry.paths.platform.release", return_value="23.0.0")
+    @patch("tool_registry.paths.platform.system", return_value="Darwin")
+    def test_non_linux_is_not_wsl(self, mock_system, mock_release, mock_read_text):
+        self.assertFalse(is_wsl())
+        mock_read_text.assert_not_called()
 
 
 @unittest.skipUnless(IS_WINDOWS, "drive-letter stripping is Windows-only behavior")

--- a/tool_registry/paths.py
+++ b/tool_registry/paths.py
@@ -31,6 +31,23 @@ def exe_suffix() -> str:
     return ".exe" if platform.system() == "Windows" else ""
 
 
+def is_wsl() -> bool:
+    """Return True when running inside Windows Subsystem for Linux."""
+    if platform.system() != "Linux":
+        return False
+
+    release = platform.release().lower()
+    if "microsoft" in release or "wsl" in release:
+        return True
+
+    try:
+        proc_version = Path("/proc/version").read_text(encoding="utf-8").lower()
+    except OSError:
+        return False
+
+    return "microsoft" in proc_version or "wsl" in proc_version
+
+
 def platform_bin_dir(base: Path) -> Path:
     """Return the platform-specific binary directory under base (e.g. base/bin/macos)."""
     system = platform.system().lower()


### PR DESCRIPTION
## Summary
When `tokei` fails during a scan — a missing binary, or a Windows `tokei.exe` invoked from inside WSL — CodeBoarding raised an opaque `FileNotFoundError` / `CalledProcessError` with no context. This wraps the tokei subprocess so a failure raises an actionable diagnostic instead.

## Why this matters
#389 reports tokei scan failures on Windows/WSL that surface as bare subprocess errors, leaving the user with nothing to act on. The new message includes the platform, whether WSL was detected, the exact command, and stderr, plus WSL-specific guidance (install and run a Linux `tokei` inside WSL rather than invoking the Windows binary). This turns a dead-end stack trace into a fix-it hint.

## Changes
- `tool_registry/paths.py`: add `is_wsl()` (checks `platform.release()` and `/proc/version` for microsoft/wsl markers).
- `static_analyzer/scanner.py`: catch `FileNotFoundError` and `CalledProcessError` around the tokei call and raise a `RuntimeError` carrying platform / WSL / command / stderr context and an install-or-WSL hint.

## Testing
Added `tests/static_analyzer/test_project_scanner.py` (failure-path diagnostics) and `tests/test_windows_compatibility.py` (`is_wsl` detection). `is_wsl()` verified locally (returns `False` on macOS, helper formatters asserted); the full pytest suite needs the project's pinned Python 3.12 + LLM deps, which CI exercises.

Fixes #389

AI was used for assistance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved scan error messages with clearer details about platform, WSL status, command used, and stderr output.
  * Added detection for Windows Subsystem for Linux to better handle environment-specific behavior.

* **Bug Fixes**
  * Tokei failures are now reported consistently for missing binaries, non-zero exits, and empty output.
  * Scan results now more reliably capture discovered file types and related metadata.

* **Tests**
  * Expanded coverage for scan success and failure cases, including Windows/WSL scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->