### PR TITLE
fix: update JDTLS setup archive

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -45,15 +45,17 @@ on:
 jobs:
   # Emit the matrix.include list, event-driven:
   #   schedule / workflow_dispatch → full 7 langs x 3 OSes minus skipped pairs.
-  #   push / pull_request         → Windows all langs + java on Linux/mac.
+  #   push / pull_request         → Windows all langs (except java) + java on
+  #                                 Linux/mac (java's dev platforms).
   # workflow_dispatch honors the optional ``language`` input to narrow
   # the full matrix to a single language.
   #
   # Skipped pairs:
   #   mac/go    — free macos-latest is 3 vCPU / 7 GB RAM; gopls indexing
   #               prometheus blows past 25 min under that memory pressure.
-  #   win/java is included temporarily on this PR to verify the JDTLS setup fix
-  #   across all three CI operating systems.
+  #   win/java  — JDTLS races its own readiness signals on Windows (observed
+  #               85 vs 142 edges on the same commit across runs). Stable on
+  #               Linux/macOS; revisit after the LSP sync path is reworked.
   setup-matrix:
     runs-on: ubuntu-latest
     outputs:
@@ -74,7 +76,7 @@ jobs:
 
           all_langs = ["python", "java", "go", "typescript", "php", "javascript", "rust", "csharp"]
           all_os = ["ubuntu-latest", "macos-latest", "windows-latest"]
-          skip = {("macos-latest", "go")}  # see job-level note
+          skip = {("macos-latest", "go"), ("windows-latest", "java")}  # see job-level note
 
           if event in ("schedule", "workflow_dispatch"):
               langs = [dispatch_lang] if dispatch_lang else all_langs

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -45,17 +45,15 @@ on:
 jobs:
   # Emit the matrix.include list, event-driven:
   #   schedule / workflow_dispatch → full 7 langs x 3 OSes minus skipped pairs.
-  #   push / pull_request         → Windows all langs (except java) + java on
-  #                                 Linux/mac (java's dev platforms).
+  #   push / pull_request         → Windows all langs + java on Linux/mac.
   # workflow_dispatch honors the optional ``language`` input to narrow
   # the full matrix to a single language.
   #
   # Skipped pairs:
   #   mac/go    — free macos-latest is 3 vCPU / 7 GB RAM; gopls indexing
   #               prometheus blows past 25 min under that memory pressure.
-  #   win/java  — JDTLS races its own readiness signals on Windows (observed
-  #               85 vs 142 edges on the same commit across runs). Stable on
-  #               Linux/macOS; revisit after the LSP sync path is reworked.
+  #   win/java is included temporarily on this PR to verify the JDTLS setup fix
+  #   across all three CI operating systems.
   setup-matrix:
     runs-on: ubuntu-latest
     outputs:
@@ -76,7 +74,7 @@ jobs:
 
           all_langs = ["python", "java", "go", "typescript", "php", "javascript", "rust", "csharp"]
           all_os = ["ubuntu-latest", "macos-latest", "windows-latest"]
-          skip = {("macos-latest", "go"), ("windows-latest", "java")}  # see job-level note
+          skip = {("macos-latest", "go")}  # see job-level note
 
           if event in ("schedule", "workflow_dispatch"):
               langs = [dispatch_lang] if dispatch_lang else all_langs

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -821,14 +821,14 @@ class TestToolSource(unittest.TestCase):
 
     def test_asset_url_direct_upstream(self):
         source = UpstreamToolSource(
-            tag="1.44.0",
-            url_template="https://download.eclipse.org/jdtls/milestones/{version}/jdt-language-server-{version}-{build}.tar.gz",
-            build="202501221502",
+            tag="1.59.0",
+            url_template="https://download.eclipse.org/jdtls/snapshots/jdt-language-server-{version}-{build}.tar.gz",
+            build="202605111959",
         )
         url = asset_url(source, "ignored")
         self.assertEqual(
             url,
-            "https://download.eclipse.org/jdtls/milestones/1.44.0/jdt-language-server-1.44.0-202501221502.tar.gz",
+            "https://download.eclipse.org/jdtls/snapshots/jdt-language-server-1.59.0-202605111959.tar.gz",
         )
 
     @patch("tool_registry.installers.requests.get")

--- a/tool_registry/registry.py
+++ b/tool_registry/registry.py
@@ -26,11 +26,9 @@ ProgressCallback = Callable[[str, int, int], None]
 TOOLS_REPO = "CodeBoarding/tools"
 TOOLS_TAG = "tools-2026.04.05"
 
-JDTLS_VERSION = "1.44.0"
-JDTLS_BUILD = "202501221502"
-JDTLS_URL_TEMPLATE = (
-    "https://download.eclipse.org/jdtls/milestones/{version}/jdt-language-server-{version}-{build}.tar.gz"
-)
+JDTLS_VERSION = "1.59.0"
+JDTLS_BUILD = "202605111959"
+JDTLS_URL_TEMPLATE = "https://download.eclipse.org/jdtls/snapshots/jdt-language-server-{version}-{build}.tar.gz"
 
 # rust-analyzer is pulled directly from upstream (weekly releases, ~17MB
 # per platform) rather than mirrored. Bumping the tag triggers a reinstall


### PR DESCRIPTION
## Summary

- update the JDTLS setup pin from the removed 1.44.0 milestone archive to the available 1.59.0 snapshot archive
- update the registry URL-construction test to match the new upstream URL shape

## Why

PR #391's Java integration jobs fail during setup because the pinned JDTLS 1.44.0 milestone URL now returns 404, leaving CodeBoarding Setup
========================================
Step: npm check started
Step: npm check finished: success (version 10.8.2)
Step: Node.js servers installation started
Step: TypeScript Language Server installation finished: success
Step: Pyright Language Server installation finished: success
Step: Intelephense installation finished: success
Step: Binary download started
Step: Binary download finished
Step: JDTLS download started
Step: JDTLS download finished
Step: Package-manager tool installation started
  csharp-ls: installed
Step: Package-manager tool installation finished
Step: pre-commit hooks installation started
Step: pre-commit hooks installation finished: success
Step: Language support summary
  - go: yes
  - python: yes
  - typescript: yes
  - javascript: yes
  - php: yes
  - csharp: yes
  - java: yes
  - rust: yes

========================================
Setup complete!
Configure your LLM provider key in ~/.codeboarding/config.toml, then run:
  codeboarding full --local /path/to/repo without a JDTLS install for the Java adapter.

## Validation

- ...                                                                      [100%]
3 passed in 0.01s
- HTTP/2 200 
server: nginx
date: Fri, 26 Jun 2026 07:48:34 GMT
content-type: application/x-gzip
content-length: 51543088
last-modified: Mon, 11 May 2026 20:04:49 GMT
etag: "3127c30-65190424913b6"
content-security-policy: frame-ancestors 'self'
x-frame-options: SAMEORIGIN
x-content-type-options: nosniff
strict-transport-security: max-age=63072000; includeSubDomains; preload
cache-control: private, max-age=8m, no-transform
x-content-type-options: nosniff
x-xss-protection: 1; mode=block
x-proxy-cache: HIT
accept-ranges: bytes
 returns HTTP 200


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Java language server (jdtls) to the latest upstream snapshot for improved download availability and faster recovery when assets change.
  * Corrected the Java tooling download details (version/build and URL format) so the app consistently fetches the right Java LSP package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->