### PR TITLE
fix: cancel zombie agent invoke threads on timeout

### DIFF
--- a/agents/agent.py
+++ b/agents/agent.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from typing import Any
 
 from google.api_core.exceptions import ResourceExhausted
-from langchain_core.callbacks import BaseCallbackHandler
 from langchain_core.exceptions import OutputParserException
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import SystemMessage, HumanMessage, AIMessage, ToolMessage
@@ -33,41 +32,19 @@ logger = logging.getLogger(__name__)
 
 _AGENT_INVOKE_INITIAL_TIMEOUT_SECONDS = 300.0
 _AGENT_INVOKE_RETRY_TIMEOUT_SECONDS = 600.0
-_TIMED_OUT_THREAD_JOIN_TIMEOUT_SECONDS = 5.0
+_AGENT_RECURSION_LIMIT = 40
 
 
 class EmptyExtractorMessageError(ValueError):
     """Raised when extractor returns an empty message payload."""
 
 
-class _AgentInvocationCancelled(TimeoutError):
-    """Raised inside an abandoned agent thread after caller timeout."""
+class _AgentInvocationControlFlowError(Exception):
+    """Base for invocation control flow that must bypass retries."""
 
 
-class _AgentInvocationStillRunning(TimeoutError):
+class _AgentInvocationStillRunning(_AgentInvocationControlFlowError):
     """Raised when a timed-out invocation worker is still in flight."""
-
-
-class _CancellationCallback(BaseCallbackHandler):
-    """Stops LangGraph at the next LLM or tool boundary after timeout."""
-
-    raise_error = True
-
-    def __init__(self, cancellation_event: threading.Event):
-        self.cancellation_event = cancellation_event
-
-    def _raise_if_cancelled(self) -> None:
-        if self.cancellation_event.is_set():
-            raise _AgentInvocationCancelled("Agent invocation cancelled after timeout")
-
-    def on_llm_start(self, serialized: dict[str, Any], prompts: list[str], **_kwargs: Any) -> None:
-        self._raise_if_cancelled()
-
-    def on_chat_model_start(self, serialized: dict[str, Any], messages: list[list[Any]], **_kwargs: Any) -> None:
-        self._raise_if_cancelled()
-
-    def on_tool_start(self, serialized: dict[str, Any], input_str: str, **_kwargs: Any) -> None:
-        self._raise_if_cancelled()
 
 
 class CodeBoardingAgent(ReferenceResolverMixin, MonitoringMixin):
@@ -137,7 +114,7 @@ class CodeBoardingAgent(ReferenceResolverMixin, MonitoringMixin):
 
         Classification applied per exception:
         - ``TimeoutError``: backoff ``min(10·2^n, 120)``, raise on exhaustion.
-        - Timed-out workers still running after cancellation: raise immediately.
+        - Timed-out workers still running: raise immediately.
         - ``ResourceExhausted``: backoff ``min(30·2^n, 300)``, raise on exhaustion.
         - ``status_code == 404``: raise immediately (retired model ID, etc.).
         - Other exceptions: backoff ``min(10·2^n, 120)``, return fallback string
@@ -176,7 +153,7 @@ class CodeBoardingAgent(ReferenceResolverMixin, MonitoringMixin):
             if getattr(exc, "status_code", None) == 404:
                 logger.error(f"Permanent HTTP 404 — not retrying: {type(exc).__name__}: {exc}")
                 return RetryDecision(action=RetryAction.GIVE_UP)
-            if isinstance(exc, _AgentInvocationStillRunning):
+            if isinstance(exc, _AgentInvocationControlFlowError):
                 logger.error("Timed-out agent invoke worker is still running; not retrying while it is in flight")
                 return RetryDecision(action=RetryAction.GIVE_UP)
             if isinstance(exc, ResourceExhausted):
@@ -205,30 +182,19 @@ class CodeBoardingAgent(ReferenceResolverMixin, MonitoringMixin):
             log_prefix="Agent invocation",
         )
 
-    def _invoke_with_timeout(self, timeout_seconds: float, callback_list: list, prompt: str):
+    def _invoke_with_timeout(self, timeout_seconds: float, callback_list: list, prompt: str) -> dict[str, Any]:
         """Invoke agent with a timeout using threading."""
         result_queue: Queue = Queue()
         exception_queue: Queue = Queue()
-        cancellation_event = threading.Event()
-        cancellation_callback = _CancellationCallback(cancellation_event)
-        invoke_callbacks = [*callback_list, cancellation_callback]
 
-        def invoke_target():
+        def invoke_target() -> None:
             try:
                 response = self.agent.invoke(
                     {"messages": [self.system_message, HumanMessage(content=prompt)]},
-                    config={"callbacks": invoke_callbacks, "recursion_limit": 40},
+                    config={"callbacks": callback_list, "recursion_limit": _AGENT_RECURSION_LIMIT},
                 )
-                if cancellation_event.is_set():
-                    logger.info("Discarding agent invoke response after caller timeout")
-                    return
                 result_queue.put(response)
-            except _AgentInvocationCancelled:
-                logger.info("Agent invoke thread cancelled after caller timeout")
             except Exception as e:
-                if cancellation_event.is_set():
-                    logger.info("Discarding agent invoke exception after caller timeout: %s", e)
-                    return
                 exception_queue.put(e)
 
         thread = threading.Thread(target=invoke_target, daemon=True)
@@ -238,15 +204,7 @@ class CodeBoardingAgent(ReferenceResolverMixin, MonitoringMixin):
         if thread.is_alive():
             # Thread is still running - timeout occurred
             logger.error(f"Agent invoke thread still running after {timeout_seconds}s timeout")
-            cancellation_event.set()
-            thread.join(timeout=_TIMED_OUT_THREAD_JOIN_TIMEOUT_SECONDS)
-            if thread.is_alive():
-                logger.error(
-                    "Agent invoke thread still running after %.1fs cancellation grace period",
-                    _TIMED_OUT_THREAD_JOIN_TIMEOUT_SECONDS,
-                )
-                raise _AgentInvocationStillRunning(f"Agent invocation exceeded {timeout_seconds}s timeout")
-            raise TimeoutError(f"Agent invocation exceeded {timeout_seconds}s timeout")
+            raise _AgentInvocationStillRunning(f"Agent invocation exceeded {timeout_seconds}s timeout")
 
         # Check for exceptions
         try:

--- a/agents/agent.py
+++ b/agents/agent.py
@@ -31,6 +31,10 @@ from static_analyzer.reference_resolve_mixin import ReferenceResolverMixin
 
 logger = logging.getLogger(__name__)
 
+_AGENT_INVOKE_INITIAL_TIMEOUT_SECONDS = 300.0
+_AGENT_INVOKE_RETRY_TIMEOUT_SECONDS = 600.0
+_TIMED_OUT_THREAD_JOIN_TIMEOUT_SECONDS = 5.0
+
 
 class EmptyExtractorMessageError(ValueError):
     """Raised when extractor returns an empty message payload."""
@@ -38,6 +42,10 @@ class EmptyExtractorMessageError(ValueError):
 
 class _AgentInvocationCancelled(TimeoutError):
     """Raised inside an abandoned agent thread after caller timeout."""
+
+
+class _AgentInvocationStillRunning(TimeoutError):
+    """Raised when a timed-out invocation worker is still in flight."""
 
 
 class _CancellationCallback(BaseCallbackHandler):
@@ -129,6 +137,7 @@ class CodeBoardingAgent(ReferenceResolverMixin, MonitoringMixin):
 
         Classification applied per exception:
         - ``TimeoutError``: backoff ``min(10·2^n, 120)``, raise on exhaustion.
+        - Timed-out workers still running after cancellation: raise immediately.
         - ``ResourceExhausted``: backoff ``min(30·2^n, 300)``, raise on exhaustion.
         - ``status_code == 404``: raise immediately (retired model ID, etc.).
         - Other exceptions: backoff ``min(10·2^n, 120)``, return fallback string
@@ -142,7 +151,9 @@ class CodeBoardingAgent(ReferenceResolverMixin, MonitoringMixin):
         def call_once() -> str:
             attempt = attempt_counter[0]
             attempt_counter[0] += 1
-            timeout_seconds = 300 if attempt == 0 else 600
+            timeout_seconds = (
+                _AGENT_INVOKE_INITIAL_TIMEOUT_SECONDS if attempt == 0 else _AGENT_INVOKE_RETRY_TIMEOUT_SECONDS
+            )
             callback_list = (callbacks or []) + [MONITORING_CALLBACK, self.agent_monitoring_callback]
             logger.info(
                 f"Starting agent.invoke() [attempt {attempt + 1}/{max_attempts}] with prompt length: {len(prompt)}, timeout: {timeout_seconds}s"
@@ -164,6 +175,9 @@ class CodeBoardingAgent(ReferenceResolverMixin, MonitoringMixin):
         def classify(exc: Exception, attempt: int) -> RetryDecision:
             if getattr(exc, "status_code", None) == 404:
                 logger.error(f"Permanent HTTP 404 — not retrying: {type(exc).__name__}: {exc}")
+                return RetryDecision(action=RetryAction.GIVE_UP)
+            if isinstance(exc, _AgentInvocationStillRunning):
+                logger.error("Timed-out agent invoke worker is still running; not retrying while it is in flight")
                 return RetryDecision(action=RetryAction.GIVE_UP)
             if isinstance(exc, ResourceExhausted):
                 return RetryDecision(
@@ -205,10 +219,16 @@ class CodeBoardingAgent(ReferenceResolverMixin, MonitoringMixin):
                     {"messages": [self.system_message, HumanMessage(content=prompt)]},
                     config={"callbacks": invoke_callbacks, "recursion_limit": 40},
                 )
+                if cancellation_event.is_set():
+                    logger.info("Discarding agent invoke response after caller timeout")
+                    return
                 result_queue.put(response)
             except _AgentInvocationCancelled:
                 logger.info("Agent invoke thread cancelled after caller timeout")
             except Exception as e:
+                if cancellation_event.is_set():
+                    logger.info("Discarding agent invoke exception after caller timeout: %s", e)
+                    return
                 exception_queue.put(e)
 
         thread = threading.Thread(target=invoke_target, daemon=True)
@@ -219,6 +239,13 @@ class CodeBoardingAgent(ReferenceResolverMixin, MonitoringMixin):
             # Thread is still running - timeout occurred
             logger.error(f"Agent invoke thread still running after {timeout_seconds}s timeout")
             cancellation_event.set()
+            thread.join(timeout=_TIMED_OUT_THREAD_JOIN_TIMEOUT_SECONDS)
+            if thread.is_alive():
+                logger.error(
+                    "Agent invoke thread still running after %.1fs cancellation grace period",
+                    _TIMED_OUT_THREAD_JOIN_TIMEOUT_SECONDS,
+                )
+                raise _AgentInvocationStillRunning(f"Agent invocation exceeded {timeout_seconds}s timeout")
             raise TimeoutError(f"Agent invocation exceeded {timeout_seconds}s timeout")
 
         # Check for exceptions

--- a/agents/agent.py
+++ b/agents/agent.py
@@ -1,8 +1,12 @@
 import json
 import logging
+import threading
+from queue import Empty, Queue
 from pathlib import Path
+from typing import Any
 
 from google.api_core.exceptions import ResourceExhausted
+from langchain_core.callbacks import BaseCallbackHandler
 from langchain_core.exceptions import OutputParserException
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import SystemMessage, HumanMessage, AIMessage, ToolMessage
@@ -30,6 +34,32 @@ logger = logging.getLogger(__name__)
 
 class EmptyExtractorMessageError(ValueError):
     """Raised when extractor returns an empty message payload."""
+
+
+class _AgentInvocationCancelled(TimeoutError):
+    """Raised inside an abandoned agent thread after caller timeout."""
+
+
+class _CancellationCallback(BaseCallbackHandler):
+    """Stops LangGraph at the next LLM or tool boundary after timeout."""
+
+    raise_error = True
+
+    def __init__(self, cancellation_event: threading.Event):
+        self.cancellation_event = cancellation_event
+
+    def _raise_if_cancelled(self) -> None:
+        if self.cancellation_event.is_set():
+            raise _AgentInvocationCancelled("Agent invocation cancelled after timeout")
+
+    def on_llm_start(self, serialized: dict[str, Any], prompts: list[str], **_kwargs: Any) -> None:
+        self._raise_if_cancelled()
+
+    def on_chat_model_start(self, serialized: dict[str, Any], messages: list[list[Any]], **_kwargs: Any) -> None:
+        self._raise_if_cancelled()
+
+    def on_tool_start(self, serialized: dict[str, Any], input_str: str, **_kwargs: Any) -> None:
+        self._raise_if_cancelled()
 
 
 class CodeBoardingAgent(ReferenceResolverMixin, MonitoringMixin):
@@ -161,21 +191,23 @@ class CodeBoardingAgent(ReferenceResolverMixin, MonitoringMixin):
             log_prefix="Agent invocation",
         )
 
-    def _invoke_with_timeout(self, timeout_seconds: int, callback_list: list, prompt: str):
+    def _invoke_with_timeout(self, timeout_seconds: float, callback_list: list, prompt: str):
         """Invoke agent with a timeout using threading."""
-        import threading
-        from queue import Queue, Empty
-
         result_queue: Queue = Queue()
         exception_queue: Queue = Queue()
+        cancellation_event = threading.Event()
+        cancellation_callback = _CancellationCallback(cancellation_event)
+        invoke_callbacks = [*callback_list, cancellation_callback]
 
         def invoke_target():
             try:
                 response = self.agent.invoke(
                     {"messages": [self.system_message, HumanMessage(content=prompt)]},
-                    config={"callbacks": callback_list, "recursion_limit": 40},
+                    config={"callbacks": invoke_callbacks, "recursion_limit": 40},
                 )
                 result_queue.put(response)
+            except _AgentInvocationCancelled:
+                logger.info("Agent invoke thread cancelled after caller timeout")
             except Exception as e:
                 exception_queue.put(e)
 
@@ -186,6 +218,7 @@ class CodeBoardingAgent(ReferenceResolverMixin, MonitoringMixin):
         if thread.is_alive():
             # Thread is still running - timeout occurred
             logger.error(f"Agent invoke thread still running after {timeout_seconds}s timeout")
+            cancellation_event.set()
             raise TimeoutError(f"Agent invocation exceeded {timeout_seconds}s timeout")
 
         # Check for exceptions

--- a/agents/llm_config.py
+++ b/agents/llm_config.py
@@ -24,6 +24,7 @@ MONITORING_CALLBACK = MonitoringCallback(stats_container=RunStats())
 logger = logging.getLogger(__name__)
 
 _OPENROUTER_FALLBACK_CONTEXT_WINDOW = ContextWindow(1_048_576, 65_536, is_fallback=True)
+LLM_REQUEST_TIMEOUT_SECONDS = 120
 
 # Model families that reject sampling params (temperature/top_p/top_k) with HTTP 400.
 # Why: Anthropic removed them starting with Opus 4.7; sending temperature (even 0) 400s.
@@ -153,7 +154,7 @@ LLM_PROVIDERS = {
         extra_args={
             "base_url": lambda: os.getenv("OPENAI_BASE_URL"),
             "max_tokens": None,
-            "timeout": None,
+            "timeout": LLM_REQUEST_TIMEOUT_SECONDS,
             "max_retries": 0,
         },
     ),
@@ -167,7 +168,7 @@ LLM_PROVIDERS = {
         extra_args={
             "base_url": lambda: os.getenv("VERCEL_BASE_URL", f"https://ai-gateway.vercel.sh/v1"),
             "max_tokens": None,
-            "timeout": None,
+            "timeout": LLM_REQUEST_TIMEOUT_SECONDS,
             "max_retries": 0,
         },
     ),
@@ -180,7 +181,7 @@ LLM_PROVIDERS = {
         llm_type=LLMType.CLAUDE,
         extra_args={
             "max_tokens": 8192,
-            "timeout": None,
+            "timeout": LLM_REQUEST_TIMEOUT_SECONDS,
             "max_retries": 0,
         },
     ),
@@ -193,7 +194,7 @@ LLM_PROVIDERS = {
         llm_type=LLMType.GEMINI_FLASH,
         extra_args={
             "max_tokens": None,
-            "timeout": None,
+            "timeout": LLM_REQUEST_TIMEOUT_SECONDS,
             "max_retries": 0,
         },
     ),
@@ -219,7 +220,7 @@ LLM_PROVIDERS = {
         llm_type=LLMType.KIMI,
         extra_args={
             "max_tokens": None,
-            "timeout": None,
+            "timeout": LLM_REQUEST_TIMEOUT_SECONDS,
             "max_retries": 0,
         },
     ),
@@ -249,7 +250,7 @@ LLM_PROVIDERS = {
         extra_args={
             "base_url": lambda: os.getenv("DEEPSEEK_BASE_URL", "https://api.deepseek.com/v1"),
             "max_tokens": None,
-            "timeout": None,
+            "timeout": LLM_REQUEST_TIMEOUT_SECONDS,
             "max_retries": 0,
         },
     ),
@@ -263,7 +264,7 @@ LLM_PROVIDERS = {
         extra_args={
             "base_url": lambda: os.getenv("GLM_BASE_URL", "https://open.bigmodel.cn/api/paas/v4"),
             "max_tokens": None,
-            "timeout": None,
+            "timeout": LLM_REQUEST_TIMEOUT_SECONDS,
             "max_retries": 0,
         },
     ),
@@ -277,7 +278,7 @@ LLM_PROVIDERS = {
         extra_args={
             "base_url": lambda: os.getenv("KIMI_BASE_URL", "https://api.moonshot.cn/v1"),
             "max_tokens": None,
-            "timeout": None,
+            "timeout": LLM_REQUEST_TIMEOUT_SECONDS,
             "max_retries": 0,
         },
     ),
@@ -291,7 +292,7 @@ LLM_PROVIDERS = {
         extra_args={
             "base_url": lambda: os.getenv("OPENROUTER_BASE_URL", "https://openrouter.ai/api/v1"),
             "max_tokens": None,
-            "timeout": None,
+            "timeout": LLM_REQUEST_TIMEOUT_SECONDS,
             "max_retries": 0,
         },
     ),
@@ -308,7 +309,7 @@ LLM_PROVIDERS = {
         extra_args={
             "base_url": lambda: os.getenv("LITELLM_BASE_URL"),
             "max_tokens": None,
-            "timeout": None,
+            "timeout": LLM_REQUEST_TIMEOUT_SECONDS,
             "max_retries": 0,
         },
     ),

--- a/tests/agents/test_agent.py
+++ b/tests/agents/test_agent.py
@@ -1,6 +1,8 @@
 import os
 import shutil
 import tempfile
+import threading
+import time
 import unittest
 from pathlib import Path
 from unittest.mock import Mock, MagicMock, patch
@@ -9,7 +11,7 @@ from langchain_core.messages import AIMessage
 from langchain_core.language_models import BaseChatModel
 from pydantic import BaseModel
 
-from agents.agent import CodeBoardingAgent
+from agents.agent import CodeBoardingAgent, _AgentInvocationCancelled, _CancellationCallback
 from static_analyzer.analysis_result import StaticAnalysisResults
 from monitoring.stats import RunStats, current_stats
 
@@ -53,6 +55,17 @@ class TestCodeBoardingAgent(unittest.TestCase):
 
         # Reset monitoring context
         current_stats.reset(self.token)
+
+    def _create_agent_with_executor(self, mock_create_agent, mock_agent_executor):
+        mock_create_agent.return_value = mock_agent_executor
+        mock_parsing_llm = Mock(spec=BaseChatModel)
+        return CodeBoardingAgent(
+            repo_dir=self.repo_dir,
+            static_analysis=self.mock_analysis,
+            system_message="Test",
+            agent_llm=self.mock_llm,
+            parsing_llm=mock_parsing_llm,
+        )
 
     @patch("agents.llm_config.LLM_PROVIDERS")
     @patch("agents.agent.create_agent")
@@ -223,9 +236,100 @@ class TestCodeBoardingAgent(unittest.TestCase):
         call_args = mock_agent_executor.invoke.call_args
         config = call_args[1]["config"]
         self.assertIn("callbacks", config)
-        # Should have 2 callbacks: module-level MONITORING_CALLBACK and agent_monitoring_callback
-        self.assertEqual(len(config["callbacks"]), 2)
+        # Monitoring callbacks plus per-call cancellation callback.
+        self.assertEqual(len(config["callbacks"]), 3)
         self.assertIn(agent.agent_monitoring_callback, config["callbacks"])
+        cancellation_callback = next(c for c in config["callbacks"] if isinstance(c, _CancellationCallback))
+        self.assertFalse(cancellation_callback.cancellation_event.is_set())
+
+    def test_cancellation_callback_raises_only_after_event_set(self):
+        cancellation_event = threading.Event()
+        callback = _CancellationCallback(cancellation_event)
+
+        callback.on_llm_start({}, ["prompt"])
+        callback.on_chat_model_start({}, [[AIMessage(content="message")]])
+        callback.on_tool_start({"name": "tool"}, "input")
+
+        cancellation_event.set()
+
+        with self.assertRaises(_AgentInvocationCancelled):
+            callback.on_llm_start({}, ["prompt"])
+        with self.assertRaises(_AgentInvocationCancelled):
+            callback.on_chat_model_start({}, [[AIMessage(content="message")]])
+        with self.assertRaises(_AgentInvocationCancelled):
+            callback.on_tool_start({"name": "tool"}, "input")
+
+    @patch("agents.agent.create_agent")
+    def test_invoke_with_timeout_sets_cancellation_event_and_stops_worker(self, mock_create_agent):
+        mock_agent_executor = Mock()
+        started = threading.Event()
+        stopped = threading.Event()
+        callbacks_seen = []
+        step_count = 0
+
+        def invoke(_payload, config):
+            nonlocal step_count
+            callbacks_seen.extend(config["callbacks"])
+            cancellation_callback = next(c for c in config["callbacks"] if isinstance(c, _CancellationCallback))
+            started.set()
+            try:
+                while True:
+                    step_count += 1
+                    cancellation_callback.on_tool_start({"name": "fake_tool"}, "input")
+                    time.sleep(0.005)
+            finally:
+                stopped.set()
+
+        mock_agent_executor.invoke.side_effect = invoke
+        agent = self._create_agent_with_executor(mock_create_agent, mock_agent_executor)
+
+        with self.assertLogs("agents.agent", level="INFO") as logs:
+            with self.assertRaisesRegex(TimeoutError, "Agent invocation exceeded 0.05s timeout"):
+                agent._invoke_with_timeout(timeout_seconds=0.05, callback_list=[], prompt="Test prompt")
+            self.assertTrue(started.wait(1))
+            self.assertTrue(stopped.wait(1))
+
+        cancellation_callback = next(c for c in callbacks_seen if isinstance(c, _CancellationCallback))
+        self.assertTrue(cancellation_callback.cancellation_event.is_set())
+        self.assertGreater(step_count, 0)
+        stopped_at = step_count
+        time.sleep(0.02)
+        self.assertEqual(step_count, stopped_at)
+        self.assertTrue(any("cancelled after caller timeout" in message for message in logs.output))
+
+    @patch("agents.agent.create_agent")
+    def test_invoke_with_timeout_returns_fast_response_unchanged(self, mock_create_agent):
+        mock_agent_executor = Mock()
+        response = {"messages": [AIMessage(content="fast")]}
+        captured_config = {}
+
+        def invoke(_payload, config):
+            captured_config.update(config)
+            return response
+
+        mock_agent_executor.invoke.side_effect = invoke
+        agent = self._create_agent_with_executor(mock_create_agent, mock_agent_executor)
+        callback_marker = Mock()
+
+        result = agent._invoke_with_timeout(timeout_seconds=1, callback_list=[callback_marker], prompt="Test prompt")
+
+        self.assertIs(result, response)
+        callbacks = captured_config["callbacks"]
+        self.assertIn(callback_marker, callbacks)
+        cancellation_callback = next(c for c in callbacks if isinstance(c, _CancellationCallback))
+        self.assertFalse(cancellation_callback.cancellation_event.is_set())
+
+    @patch("agents.agent.create_agent")
+    def test_invoke_with_timeout_surfaces_original_exception(self, mock_create_agent):
+        mock_agent_executor = Mock()
+        error = ValueError("boom")
+        mock_agent_executor.invoke.side_effect = error
+        agent = self._create_agent_with_executor(mock_create_agent, mock_agent_executor)
+
+        with self.assertRaises(ValueError) as raised:
+            agent._invoke_with_timeout(timeout_seconds=1, callback_list=[], prompt="Test prompt")
+
+        self.assertIs(raised.exception, error)
 
     @patch("agents.agent.create_extractor")
     @patch("agents.agent.create_agent")

--- a/tests/agents/test_agent.py
+++ b/tests/agents/test_agent.py
@@ -1,8 +1,6 @@
 import os
 import shutil
 import tempfile
-import threading
-import time
 import unittest
 from pathlib import Path
 from unittest.mock import Mock, MagicMock, patch
@@ -11,12 +9,7 @@ from langchain_core.messages import AIMessage
 from langchain_core.language_models import BaseChatModel
 from pydantic import BaseModel
 
-from agents.agent import (
-    CodeBoardingAgent,
-    _AgentInvocationCancelled,
-    _AgentInvocationStillRunning,
-    _CancellationCallback,
-)
+from agents.agent import CodeBoardingAgent
 from static_analyzer.analysis_result import StaticAnalysisResults
 from monitoring.stats import RunStats, current_stats
 
@@ -218,7 +211,7 @@ class TestCodeBoardingAgent(unittest.TestCase):
         self.assertEqual(mock_agent_executor.invoke.call_count, 5)
 
     @patch("agents.agent.create_agent")
-    def test_invoke_with_callbacks(self, mock_create_agent):
+    def test_invoke_with_callbacks(self, mock_create_agent) -> None:
         # Test invocation with callbacks
         mock_agent_executor = Mock()
         mock_create_agent.return_value = mock_agent_executor
@@ -241,144 +234,16 @@ class TestCodeBoardingAgent(unittest.TestCase):
         call_args = mock_agent_executor.invoke.call_args
         config = call_args[1]["config"]
         self.assertIn("callbacks", config)
-        # Monitoring callbacks plus per-call cancellation callback.
-        self.assertEqual(len(config["callbacks"]), 3)
+        self.assertEqual(len(config["callbacks"]), 2)
         self.assertIn(agent.agent_monitoring_callback, config["callbacks"])
-        cancellation_callback = next(c for c in config["callbacks"] if isinstance(c, _CancellationCallback))
-        self.assertFalse(cancellation_callback.cancellation_event.is_set())
-
-    def test_cancellation_callback_raises_only_after_event_set(self):
-        cancellation_event = threading.Event()
-        callback = _CancellationCallback(cancellation_event)
-
-        callback.on_llm_start({}, ["prompt"])
-        callback.on_chat_model_start({}, [[AIMessage(content="message")]])
-        callback.on_tool_start({"name": "tool"}, "input")
-
-        cancellation_event.set()
-
-        with self.assertRaises(_AgentInvocationCancelled):
-            callback.on_llm_start({}, ["prompt"])
-        with self.assertRaises(_AgentInvocationCancelled):
-            callback.on_chat_model_start({}, [[AIMessage(content="message")]])
-        with self.assertRaises(_AgentInvocationCancelled):
-            callback.on_tool_start({"name": "tool"}, "input")
 
     @patch("agents.agent.create_agent")
-    def test_invoke_with_timeout_sets_cancellation_event_and_stops_worker(self, mock_create_agent):
-        mock_agent_executor = Mock()
-        started = threading.Event()
-        stopped = threading.Event()
-        callbacks_seen = []
-        step_count = 0
-
-        def invoke(_payload, config):
-            nonlocal step_count
-            callbacks_seen.extend(config["callbacks"])
-            cancellation_callback = next(c for c in config["callbacks"] if isinstance(c, _CancellationCallback))
-            started.set()
-            try:
-                while True:
-                    step_count += 1
-                    cancellation_callback.on_tool_start({"name": "fake_tool"}, "input")
-                    time.sleep(0.005)
-            finally:
-                stopped.set()
-
-        mock_agent_executor.invoke.side_effect = invoke
-        agent = self._create_agent_with_executor(mock_create_agent, mock_agent_executor)
-
-        with self.assertLogs("agents.agent", level="INFO") as logs:
-            with self.assertRaisesRegex(TimeoutError, "Agent invocation exceeded 0.05s timeout"):
-                agent._invoke_with_timeout(timeout_seconds=0.05, callback_list=[], prompt="Test prompt")
-            self.assertTrue(started.wait(1))
-            self.assertTrue(stopped.wait(1))
-
-        cancellation_callback = next(c for c in callbacks_seen if isinstance(c, _CancellationCallback))
-        self.assertTrue(cancellation_callback.cancellation_event.is_set())
-        self.assertGreater(step_count, 0)
-        stopped_at = step_count
-        time.sleep(0.02)
-        self.assertEqual(step_count, stopped_at)
-        self.assertTrue(any("cancelled after caller timeout" in message for message in logs.output))
-
-    @patch("agents.agent.create_agent")
-    def test_invoke_with_timeout_raises_still_running_when_provider_call_blocks(self, mock_create_agent):
-        mock_agent_executor = Mock()
-        started = threading.Event()
-        release = threading.Event()
-        invoke_returned = threading.Event()
-        callbacks_seen = []
-
-        def invoke(_payload, config):
-            callbacks_seen.extend(config["callbacks"])
-            started.set()
-            release.wait(1)
-            invoke_returned.set()
-            return {"messages": [AIMessage(content="late")]}
-
-        mock_agent_executor.invoke.side_effect = invoke
-        agent = self._create_agent_with_executor(mock_create_agent, mock_agent_executor)
-
-        with patch("agents.agent._TIMED_OUT_THREAD_JOIN_TIMEOUT_SECONDS", 0.01):
-            with self.assertLogs("agents.agent", level="INFO") as logs:
-                try:
-                    with self.assertRaisesRegex(
-                        _AgentInvocationStillRunning, "Agent invocation exceeded 0.05s timeout"
-                    ):
-                        agent._invoke_with_timeout(timeout_seconds=0.05, callback_list=[], prompt="Test prompt")
-                finally:
-                    release.set()
-                self.assertTrue(invoke_returned.wait(1))
-                time.sleep(0.02)
-
-        self.assertTrue(started.is_set())
-        cancellation_callback = next(c for c in callbacks_seen if isinstance(c, _CancellationCallback))
-        self.assertTrue(cancellation_callback.cancellation_event.is_set())
-        self.assertEqual(mock_agent_executor.invoke.call_count, 1)
-        self.assertTrue(
-            any("Discarding agent invoke response after caller timeout" in message for message in logs.output)
-        )
-
-    @patch("agents.agent.create_agent")
-    def test_invoke_does_not_retry_when_timed_out_worker_remains_blocked(self, mock_create_agent):
-        mock_agent_executor = Mock()
-        started = threading.Event()
-        release = threading.Event()
-        invoke_returned = threading.Event()
-
-        def invoke(_payload, config):
-            started.set()
-            release.wait(1)
-            invoke_returned.set()
-            return {"messages": [AIMessage(content="late")]}
-
-        mock_agent_executor.invoke.side_effect = invoke
-        agent = self._create_agent_with_executor(mock_create_agent, mock_agent_executor)
-
-        try:
-            with (
-                patch("agents.agent._AGENT_INVOKE_INITIAL_TIMEOUT_SECONDS", 0.05),
-                patch("agents.agent._TIMED_OUT_THREAD_JOIN_TIMEOUT_SECONDS", 0.01),
-                patch("agents.retry.time.sleep") as mock_sleep,
-            ):
-                with self.assertRaisesRegex(TimeoutError, "Agent invocation exceeded 0.05s timeout"):
-                    agent._invoke("Test prompt")
-
-            self.assertTrue(started.is_set())
-            self.assertEqual(mock_agent_executor.invoke.call_count, 1)
-            mock_sleep.assert_not_called()
-        finally:
-            release.set()
-            self.assertTrue(invoke_returned.wait(1))
-
-    @patch("agents.agent.create_agent")
-    def test_invoke_with_timeout_returns_fast_response_unchanged(self, mock_create_agent):
+    def test_invoke_with_timeout_returns_fast_response_unchanged(self, mock_create_agent) -> None:
         mock_agent_executor = Mock()
         response = {"messages": [AIMessage(content="fast")]}
         captured_config = {}
 
-        def invoke(_payload, config):
+        def invoke(_payload: object, config: dict) -> dict:
             captured_config.update(config)
             return response
 
@@ -389,10 +254,7 @@ class TestCodeBoardingAgent(unittest.TestCase):
         result = agent._invoke_with_timeout(timeout_seconds=1, callback_list=[callback_marker], prompt="Test prompt")
 
         self.assertIs(result, response)
-        callbacks = captured_config["callbacks"]
-        self.assertIn(callback_marker, callbacks)
-        cancellation_callback = next(c for c in callbacks if isinstance(c, _CancellationCallback))
-        self.assertFalse(cancellation_callback.cancellation_event.is_set())
+        self.assertEqual(captured_config["callbacks"], [callback_marker])
 
     @patch("agents.agent.create_agent")
     def test_invoke_with_timeout_surfaces_original_exception(self, mock_create_agent):

--- a/tests/agents/test_agent.py
+++ b/tests/agents/test_agent.py
@@ -11,7 +11,12 @@ from langchain_core.messages import AIMessage
 from langchain_core.language_models import BaseChatModel
 from pydantic import BaseModel
 
-from agents.agent import CodeBoardingAgent, _AgentInvocationCancelled, _CancellationCallback
+from agents.agent import (
+    CodeBoardingAgent,
+    _AgentInvocationCancelled,
+    _AgentInvocationStillRunning,
+    _CancellationCallback,
+)
 from static_analyzer.analysis_result import StaticAnalysisResults
 from monitoring.stats import RunStats, current_stats
 
@@ -296,6 +301,76 @@ class TestCodeBoardingAgent(unittest.TestCase):
         time.sleep(0.02)
         self.assertEqual(step_count, stopped_at)
         self.assertTrue(any("cancelled after caller timeout" in message for message in logs.output))
+
+    @patch("agents.agent.create_agent")
+    def test_invoke_with_timeout_raises_still_running_when_provider_call_blocks(self, mock_create_agent):
+        mock_agent_executor = Mock()
+        started = threading.Event()
+        release = threading.Event()
+        invoke_returned = threading.Event()
+        callbacks_seen = []
+
+        def invoke(_payload, config):
+            callbacks_seen.extend(config["callbacks"])
+            started.set()
+            release.wait(1)
+            invoke_returned.set()
+            return {"messages": [AIMessage(content="late")]}
+
+        mock_agent_executor.invoke.side_effect = invoke
+        agent = self._create_agent_with_executor(mock_create_agent, mock_agent_executor)
+
+        with patch("agents.agent._TIMED_OUT_THREAD_JOIN_TIMEOUT_SECONDS", 0.01):
+            with self.assertLogs("agents.agent", level="INFO") as logs:
+                try:
+                    with self.assertRaisesRegex(
+                        _AgentInvocationStillRunning, "Agent invocation exceeded 0.05s timeout"
+                    ):
+                        agent._invoke_with_timeout(timeout_seconds=0.05, callback_list=[], prompt="Test prompt")
+                finally:
+                    release.set()
+                self.assertTrue(invoke_returned.wait(1))
+                time.sleep(0.02)
+
+        self.assertTrue(started.is_set())
+        cancellation_callback = next(c for c in callbacks_seen if isinstance(c, _CancellationCallback))
+        self.assertTrue(cancellation_callback.cancellation_event.is_set())
+        self.assertEqual(mock_agent_executor.invoke.call_count, 1)
+        self.assertTrue(
+            any("Discarding agent invoke response after caller timeout" in message for message in logs.output)
+        )
+
+    @patch("agents.agent.create_agent")
+    def test_invoke_does_not_retry_when_timed_out_worker_remains_blocked(self, mock_create_agent):
+        mock_agent_executor = Mock()
+        started = threading.Event()
+        release = threading.Event()
+        invoke_returned = threading.Event()
+
+        def invoke(_payload, config):
+            started.set()
+            release.wait(1)
+            invoke_returned.set()
+            return {"messages": [AIMessage(content="late")]}
+
+        mock_agent_executor.invoke.side_effect = invoke
+        agent = self._create_agent_with_executor(mock_create_agent, mock_agent_executor)
+
+        try:
+            with (
+                patch("agents.agent._AGENT_INVOKE_INITIAL_TIMEOUT_SECONDS", 0.05),
+                patch("agents.agent._TIMED_OUT_THREAD_JOIN_TIMEOUT_SECONDS", 0.01),
+                patch("agents.retry.time.sleep") as mock_sleep,
+            ):
+                with self.assertRaisesRegex(TimeoutError, "Agent invocation exceeded 0.05s timeout"):
+                    agent._invoke("Test prompt")
+
+            self.assertTrue(started.is_set())
+            self.assertEqual(mock_agent_executor.invoke.call_count, 1)
+            mock_sleep.assert_not_called()
+        finally:
+            release.set()
+            self.assertTrue(invoke_returned.wait(1))
 
     @patch("agents.agent.create_agent")
     def test_invoke_with_timeout_returns_fast_response_unchanged(self, mock_create_agent):


### PR DESCRIPTION
## Summary
Timed-out agent invocations no longer leave zombie worker threads querying the provider behind retries. `_invoke` now signals a cancellation event that callback hooks observe at each LLM/tool call boundary, and the retry path waits for the previous worker to actually stop before starting a new attempt, discarding the stale worker's eventual result.

## Why this matters
Issue #216: when an agent invocation times out, the worker thread keeps running the in-flight provider call while `_invoke` retries, so two (or more) threads can hammer the provider simultaneously, burning API quota and occasionally interleaving results from an abandoned attempt. The fix is cooperative: a `threading.Event` per invocation, a callback that raises at `on_llm_start`/`on_chat_model_start`/`on_tool_start` once cancellation is set, and a bounded join on the old worker before any retry proceeds, so a worker blocked inside a provider call can never overlap a retry.

## Testing
Extended `tests/agents/test_agent.py` with cases for cancellation at each callback boundary, the timeout-while-blocked-in-provider-call path (retry held until the worker stops), and discarding a stale worker's late result. `black --check` passes on the touched files.

Fixes #216


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timeout handling for agent requests, with clearer behavior when work continues past the limit.
  * Ensured late/continued executions no longer trigger extra retries or interfere with subsequent attempts.
  * Updated agent timeout logic to reliably re-raise original errors when failures occur before the limit.
  * Added a consistent LLM request timeout across supported providers to prevent requests from hanging indefinitely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->