### PR TITLE
Handle inaccessible Java during version checks

### DIFF
--- a/static_analyzer/java_utils.py
+++ b/static_analyzer/java_utils.py
@@ -29,7 +29,7 @@ def get_java_version(java_cmd: str = "java") -> int:
 
         return 0
 
-    except (FileNotFoundError, subprocess.TimeoutExpired) as e:
+    except (OSError, subprocess.TimeoutExpired) as e:
         logger.debug(f"Failed to get Java version: {e}")
         return 0
 

--- a/tests/static_analyzer/test_java_utils.py
+++ b/tests/static_analyzer/test_java_utils.py
@@ -67,6 +67,13 @@ class TestGetJavaVersion(unittest.TestCase):
         self.assertEqual(version, 0)
 
     @patch("subprocess.run")
+    def test_get_java_version_permission_denied(self, mock_run):
+        mock_run.side_effect = PermissionError("java permission denied")
+
+        version = get_java_version("java")
+        self.assertEqual(version, 0)
+
+    @patch("subprocess.run")
     def test_get_java_version_timeout(self, mock_run):
         """Test when Java command times out."""
         mock_run.side_effect = subprocess.TimeoutExpired("java", 5)


### PR DESCRIPTION
## Summary
- Treat OS-level Java launch failures, including permission denied, as Java unavailable
- Add regression coverage for permission-denied Java version probes

## Test
- uv run pytest tests/static_analyzer/test_java_utils.py::TestGetJavaVersion -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Java version detection to handle additional startup errors gracefully and return a safe default when Java cannot be executed.
* **Tests**
  * Added coverage for permission-denied scenarios to confirm the fallback behavior works as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->