### PR TITLE
Respect ignored files during language detection

### DIFF
--- a/diagram_analysis/diagram_generator.py
+++ b/diagram_analysis/diagram_generator.py
@@ -330,7 +330,7 @@ class DiagramGenerator:
 
         # --- Capture Static Analysis Stats ---
         static_stats: dict[str, Any] = {"repo_name": self.repo_name, "languages": {}}
-        scanner = ProjectScanner(self.repo_location)
+        scanner = ProjectScanner(self.repo_location, RepoIgnoreManager(self.repo_location))
         loc_by_language = {pl.language: pl.size for pl in scanner.scan()}
         for language in static_analysis.get_languages():
             files = static_analysis.get_source_files(language)

--- a/static_analyzer/__init__.py
+++ b/static_analyzer/__init__.py
@@ -172,7 +172,7 @@ class StaticAnalyzer:
     def __init__(self, repository_path: Path):
         self.repository_path = repository_path.resolve()
         self.ignore_manager = RepoIgnoreManager(self.repository_path)
-        self.programming_langs = ProjectScanner(self.repository_path).scan()
+        self.programming_langs = ProjectScanner(self.repository_path, self.ignore_manager).scan()
         self._engine_configs = _create_engine_configs(self.programming_langs, self.repository_path, self.ignore_manager)
         self._engine_clients: list[tuple[EngineConfig, LSPClient]] = []
         self.collected_diagnostics: dict[Language, FileDiagnosticsMap] = {}

--- a/static_analyzer/dotnet_sdk.py
+++ b/static_analyzer/dotnet_sdk.py
@@ -65,14 +65,30 @@ def private_dotnet_path(install_dir: Path | None = None) -> Path:
     return (install_dir or dotnet_install_dir()) / f"dotnet{exe_suffix()}"
 
 
-def find_global_json(project_root: Path) -> Path | None:
-    """Return the nearest ancestor ``global.json`` that .NET would consider."""
+def find_global_json(project_root: Path, search_root: Path) -> Path | None:
+    """Return the nearest ``global.json`` within the repository boundary."""
     current = project_root.resolve()
+    boundary = search_root.resolve()
     for directory in (current, *current.parents):
+        try:
+            directory.relative_to(boundary)
+        except ValueError:
+            break
         candidate = directory / "global.json"
         if candidate.is_file():
             return candidate
+        if directory == boundary:
+            break
     return None
+
+
+def _global_json_search_root(project_root: Path) -> Path:
+    for directory in (project_root, *project_root.parents):
+        if directory.name == "snapshot-worktree" and directory.parent.name == ".codeboarding":
+            return directory
+        if (directory / ".git").exists():
+            return directory
+    return project_root
 
 
 def read_global_sdk_version(global_json: Path) -> str | None:
@@ -87,7 +103,7 @@ def read_global_sdk_version(global_json: Path) -> str | None:
 def resolve_dotnet_sdk(project_root: Path) -> DotnetSdkResolution:
     """Resolve or install the .NET SDK set needed for a C# project."""
     project_root = project_root.resolve()
-    global_json = find_global_json(project_root)
+    global_json = find_global_json(project_root, _global_json_search_root(project_root))
     requested_version = read_global_sdk_version(global_json) if global_json else None
 
     install_dir = dotnet_install_dir()

--- a/static_analyzer/scanner.py
+++ b/static_analyzer/scanner.py
@@ -5,6 +5,7 @@ import shlex
 import subprocess
 from pathlib import Path
 
+from repo_utils.ignore import RepoIgnoreManager
 from static_analyzer.programming_language import ProgrammingLanguage, ProgrammingLanguageBuilder
 from telemetry.events import track_tech_stack
 from tool_registry.paths import is_wsl
@@ -62,8 +63,9 @@ def _tokei_failure_message(
 
 
 class ProjectScanner:
-    def __init__(self, repo_location: Path):
+    def __init__(self, repo_location: Path, ignore_manager: RepoIgnoreManager):
         self.repo_location = repo_location
+        self.ignore_manager = ignore_manager
         self.all_text_files: list[str] = []
 
     def scan(self) -> list[ProgrammingLanguage]:
@@ -117,32 +119,41 @@ class ProjectScanner:
         # Parse Tokei JSON output
         tokei_data = json.loads(result.stdout)
 
-        # Compute total code count
-        total_code = tokei_data.get("Total", {}).get("code", 0)
-        if not total_code:
-            logger.warning("No total code count found in Tokei output")
-            return []
-
         programming_languages: list[ProgrammingLanguage] = []
         all_files: list[str] = []
+        language_stats: list[tuple[str, int, list[dict]]] = []
         for technology, stats in tokei_data.items():
             if technology == "Total":
                 continue
 
+            reports = [report for report in stats.get("reports", []) if not self._should_ignore_report(report)]
+            if not reports:
+                continue
+
             # Collect ALL text file paths from Tokei for file coverage,
             # including languages with code_count == 0 (e.g. Markdown is 100% comments)
-            for report in stats.get("reports", []):
+            for report in reports:
                 all_files.append(report["name"])
 
-            code_count = stats.get("code", 0)
+            code_count = self._code_count(stats, reports)
             if code_count == 0:
                 continue
+
+            language_stats.append((technology, code_count, reports))
+
+        total_code = sum(code_count for _, code_count, _ in language_stats)
+        if not total_code:
+            logger.warning("No non-ignored code count found in Tokei output")
+            self.all_text_files = all_files
+            return []
+
+        for technology, code_count, reports in language_stats:
 
             percentage = code_count / total_code * 100
 
             # Extract suffixes from reports
             suffixes = set()
-            for report in stats.get("reports", []):
+            for report in reports:
                 suffixes |= self._extract_suffixes([report["name"]])
 
             pl = builder.build(
@@ -159,6 +170,23 @@ class ProjectScanner:
         self.all_text_files = all_files
         track_tech_stack(self.repo_location, total_code, programming_languages)
         return programming_languages
+
+    def _should_ignore_report(self, report: dict) -> bool:
+        name = report.get("name")
+        return not isinstance(name, str) or self.ignore_manager.should_ignore(Path(name))
+
+    @staticmethod
+    def _code_count(stats: dict, reports: list[dict]) -> int:
+        report_counts: list[int] = []
+        for report in reports:
+            report_stats = report.get("stats", {})
+            code = report_stats.get("code") if isinstance(report_stats, dict) else report.get("code")
+            if isinstance(code, int):
+                report_counts.append(code)
+        if report_counts:
+            return sum(report_counts)
+        code_count = stats.get("code", 0)
+        return code_count if isinstance(code_count, int) else 0
 
     @staticmethod
     def _extract_suffixes(files: list[str]) -> set[str]:

--- a/tests/static_analyzer/test_dotnet_sdk.py
+++ b/tests/static_analyzer/test_dotnet_sdk.py
@@ -9,13 +9,32 @@ def _proc(returncode: int = 0, stdout: str = "", stderr: str = "") -> subprocess
 
 
 def test_find_global_json_uses_nearest_ancestor(tmp_path):
+    (tmp_path / ".git").mkdir()
     (tmp_path / "global.json").write_text('{"sdk": {"version": "10.0.100"}}')
     nested = tmp_path / "src" / "App"
     nested.mkdir(parents=True)
     (tmp_path / "src" / "global.json").write_text('{"sdk": {"version": "10.0.301"}}')
 
-    assert dotnet_sdk.find_global_json(nested) == tmp_path / "src" / "global.json"
+    assert dotnet_sdk.find_global_json(nested, tmp_path) == tmp_path / "src" / "global.json"
     assert dotnet_sdk.read_global_sdk_version(tmp_path / "src" / "global.json") == "10.0.301"
+
+
+def test_find_global_json_ignores_parent_outside_repository(tmp_path):
+    repo = tmp_path / "repo"
+    nested = repo / "src" / "App"
+    nested.mkdir(parents=True)
+    (tmp_path / "global.json").write_text('{"sdk": {"version": "10.0.100"}}')
+
+    assert dotnet_sdk.find_global_json(nested, repo) is None
+
+
+def test_find_global_json_uses_snapshot_worktree_boundary(tmp_path):
+    snapshot = tmp_path / ".codeboarding" / "snapshot-worktree"
+    project = snapshot / "src" / "App"
+    project.mkdir(parents=True)
+    (tmp_path / "global.json").write_text('{"sdk": {"version": "10.0.100"}}')
+
+    assert dotnet_sdk.find_global_json(project, snapshot) is None
 
 
 def test_resolve_uses_satisfying_system_dotnet(tmp_path, monkeypatch):

--- a/tests/static_analyzer/test_project_scanner.py
+++ b/tests/static_analyzer/test_project_scanner.py
@@ -1,14 +1,17 @@
 import subprocess
+import tempfile
 import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+from repo_utils.ignore import RepoIgnoreManager
 from static_analyzer.scanner import ProjectScanner
 
 
 class TestProjectScanner(unittest.TestCase):
     def setUp(self):
-        self.scanner = ProjectScanner(Path("/fake/repo"))
+        repo = Path("/fake/repo")
+        self.scanner = ProjectScanner(repo, RepoIgnoreManager(repo))
 
     @patch("static_analyzer.scanner.platform.platform", return_value="Linux-6.8.0")
     @patch("static_analyzer.scanner.is_wsl", return_value=False)
@@ -105,6 +108,41 @@ class TestProjectScanner(unittest.TestCase):
         self.assertEqual(result[0].size, 100)
         self.assertEqual(result[0].suffixes, [".py"])
         self.assertEqual(self.scanner.all_text_files, ["main.py"])
+
+    @patch("static_analyzer.scanner.track_tech_stack")
+    @patch("static_analyzer.scanner.get_config")
+    @patch("static_analyzer.scanner.subprocess.run")
+    def test_scan_ignores_languages_with_only_ignored_files(self, mock_run, mock_get_config, mock_track):
+        temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(temp_dir.cleanup)
+        repo = Path(temp_dir.name)
+        (repo / ".codeboarding").mkdir()
+        (repo / ".codeboarding" / ".codeboardingignore").write_text("tests/\n")
+
+        scanner = ProjectScanner(repo, RepoIgnoreManager(repo))
+        mock_get_config.side_effect = [
+            {"tokei": {"command": ["tokei", "-o", "json"]}},
+            {
+                "python": {"command": ["pyright-langserver", "--stdio"], "file_extensions": [".py"]},
+                "csharp": {"command": ["csharp-ls"], "file_extensions": [".cs"]},
+            },
+        ]
+        mock_run.return_value = MagicMock(
+            stdout=(
+                '{"Python": {"code": 12, "reports": [{"name": "main.py", "stats": {"code": 12}}]}, '
+                '"C#": {"code": 7, "reports": [{"name": "tests/Ignored.cs", "stats": {"code": 7}}]}, '
+                '"Total": {"code": 19}}'
+            )
+        )
+
+        result = scanner.scan()
+
+        self.assertEqual([lang.language for lang in result], ["Python"])
+        self.assertEqual(result[0].size, 12)
+        self.assertEqual(result[0].percentage, 100)
+        self.assertEqual(scanner.all_text_files, ["main.py"])
+        mock_track.assert_called_once()
+        self.assertEqual(mock_track.call_args.args[1], 12)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- filter Tokei reports through RepoIgnoreManager before computing detected languages
- prevent ignored-only languages from creating analyzer engine configs / LSP setup
- keep C# project discovery ignore-aware and bound .NET global.json lookup to the analyzed repo/snapshot

## Verification
- uv run pytest tests/static_analyzer/test_project_scanner.py tests/static_analyzer/test_csharp_config_scanner.py tests/static_analyzer/test_dotnet_sdk.py
- checked demo snapshot language detection returns only Python

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Repository ignore rules are now honored during scanning, so ignored files are excluded from language detection, file lists, code totals, and percentages.
  * .NET `global.json` discovery is now constrained to the repository/snapshot boundary to avoid unrelated configurations.
  * Projects with only ignored files now return empty results cleanly.

* **Tests**
  * Added unit tests for repository-boundary `global.json` discovery behavior.
  * Added test coverage ensuring scans exclude languages backed only by ignored files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->