### PR TITLE
fix: use baseline lineage for recursive scope snapshots

### DIFF
--- a/diagram_analysis/diagram_generator.py
+++ b/diagram_analysis/diagram_generator.py
@@ -883,7 +883,10 @@ def _build_scope_incremental_inputs(
     changes: ChangeSet | None,
     repo_dir: Path,
 ) -> tuple[dict[str, ClusterResult], StructuralClusterDiff]:
-    old_snapshot = scoped_snapshot_for_component(component, scope_id, incremental_agent)
+    old_static_analysis = (
+        incremental_agent.static_analysis.incremental_base_results or incremental_agent.static_analysis
+    )
+    old_snapshot = scoped_snapshot_for_component(component, scope_id, old_static_analysis)
     if not old_snapshot.all_cluster_ids():
         return {}, StructuralClusterDiff()
 
@@ -910,14 +913,14 @@ def _build_scope_incremental_inputs(
 def scoped_snapshot_for_component(
     component: Component,
     scope_id: str,
-    incremental_agent: IncrementalAgent,
+    static_analysis: StaticAnalysisResults,
 ) -> ClusterSnapshot:
     assigned_qnames = {
         method.qualified_name for group in component.file_methods for method in group.methods if method.qualified_name
     }
     by_language = {}
-    for language in incremental_agent.static_analysis.get_languages():
-        cfg = incremental_agent.static_analysis.get_cfg(language)
+    for language in static_analysis.get_languages():
+        cfg = static_analysis.get_cfg(language)
         sub_cfg = cfg.filter_by_nodes(assigned_qnames)
         if sub_cfg.nodes:
             by_language[str(language)] = scoped_snapshot_from_lineage(sub_cfg, scope_id)

--- a/static_analyzer/graph.py
+++ b/static_analyzer/graph.py
@@ -87,6 +87,11 @@ class Edge:
         for site in call_sites:
             self.add_call_site(site)
 
+    def __setstate__(self, state: dict) -> None:
+        self.__dict__.update(state)
+        self._call_sites = [self._normalize_call_site(site) for site in getattr(self, "_call_sites", [])]
+        self._call_site_keys = {tuple(sorted(site.items())) for site in self._call_sites}
+
     @property
     def call_sites(self) -> list[dict[str, Hashable]]:
         return [dict(site) for site in self._call_sites]

--- a/tests/diagram_analysis/test_diagram_analysis.py
+++ b/tests/diagram_analysis/test_diagram_analysis.py
@@ -35,7 +35,12 @@ from diagram_analysis.analysis_json import (
     parse_unified_analysis,
 )
 from diagram_analysis.cluster_delta import ClusterMemberDelta, ClusterRef, LanguageStructuralDiff, StructuralClusterDiff
-from diagram_analysis.diagram_generator import DiagramGenerator, _component_depth, _component_expansion_seeds
+from diagram_analysis.diagram_generator import (
+    DiagramGenerator,
+    _build_scope_incremental_inputs,
+    _component_depth,
+    _component_expansion_seeds,
+)
 from diagram_analysis.exceptions import IncrementalCacheMissingError
 from diagram_analysis.version import Version
 from repo_utils.change_detector import ChangeSet
@@ -1370,6 +1375,71 @@ class TestDiagramGenerator(unittest.TestCase):
 
         mock_prune.assert_not_called()
         self.assertEqual(sub_analyses["1.1"].components[0].name, "Stable Leaf")
+
+    @patch("diagram_analysis.diagram_generator.structural_diff_from_delta")
+    def test_recursive_scope_old_snapshot_uses_incremental_base_lineage(self, mock_structural_diff):
+        baseline_cfg = CallGraph(language="python")
+        target_cfg = CallGraph(language="python")
+        for cfg in [baseline_cfg, target_cfg]:
+            cfg.add_node(
+                Node(
+                    fully_qualified_name="pkg.stable_a",
+                    node_type=NodeType.FUNCTION,
+                    file_path="pkg/module.py",
+                    line_start=1,
+                    line_end=5,
+                )
+            )
+            cfg.add_node(
+                Node(
+                    fully_qualified_name="pkg.stable_b",
+                    node_type=NodeType.FUNCTION,
+                    file_path="pkg/module.py",
+                    line_start=7,
+                    line_end=11,
+                )
+            )
+        baseline_cfg.record_cluster_paths(
+            ClusterResult(clusters={1: {"pkg.stable_a"}, 2: {"pkg.stable_b"}}),
+            scope_id="2",
+        )
+        target_cfg.record_cluster_paths(
+            ClusterResult(clusters={19: {"pkg.stable_a", "pkg.stable_b"}}),
+            scope_id="2",
+        )
+
+        baseline_static_analysis = StaticAnalysisResults()
+        baseline_static_analysis.add_cfg(Language.PYTHON, baseline_cfg)
+        target_static_analysis = StaticAnalysisResults()
+        target_static_analysis.add_cfg(Language.PYTHON, target_cfg)
+        target_static_analysis.incremental_base_results = baseline_static_analysis
+
+        incremental_agent = Mock()
+        incremental_agent.static_analysis = target_static_analysis
+        target_cluster_results = {"python": ClusterResult(clusters={19: {"pkg.stable_a", "pkg.stable_b"}})}
+        incremental_agent._create_strict_component_subgraph.return_value = ("", target_cluster_results, {})
+        mock_structural_diff.return_value = StructuralClusterDiff()
+        component = Component(
+            name="Registry",
+            description="",
+            component_id="2",
+            key_entities=[],
+            file_methods=[
+                FileMethodGroup(
+                    file_path="pkg/module.py",
+                    methods=[
+                        MethodEntry(qualified_name="pkg.stable_a", start_line=1, end_line=5, node_type="FUNCTION"),
+                        MethodEntry(qualified_name="pkg.stable_b", start_line=7, end_line=11, node_type="FUNCTION"),
+                    ],
+                )
+            ],
+        )
+
+        _build_scope_incremental_inputs(component, "2", incremental_agent, changes=None, repo_dir=self.repo_location)
+
+        old_snapshot = mock_structural_diff.call_args.args[0]
+        self.assertEqual(old_snapshot.all_cluster_ids(), {1, 2})
+        self.assertNotIn(19, old_snapshot.all_cluster_ids())
 
     def test_persist_static_analysis_artifact_saves_cluster_cache_without_injected_analyzer(self):
         gen = DiagramGenerator(

--- a/tests/static_analyzer/test_graph.py
+++ b/tests/static_analyzer/test_graph.py
@@ -121,6 +121,17 @@ class TestEdge(unittest.TestCase):
         self.assertIn("module.dst", repr_str)
         self.assertIn("->", repr_str)
 
+    def test_edge_unpickle_legacy_state_without_call_sites(self):
+        src = Node("module.src", 12, "/file.py", 1, 10)
+        dst = Node("module.dst", 12, "/file.py", 20, 30)
+        edge = Edge.__new__(Edge)
+
+        edge.__setstate__({"src_node": src, "dst_node": dst})
+
+        self.assertEqual(edge.call_sites, [])
+        edge.add_call_site({"file_path": "/file.py", "line": 5})
+        self.assertEqual(edge.call_sites, [{"file": "/file.py", "line": 5}])
+
 
 class TestCallGraph(unittest.TestCase):
     def test_callgraph_creation_empty(self):


### PR DESCRIPTION
## Summary
- Fix recursive incremental scope diffs so the old scoped snapshot is built from `static_analysis.incremental_base_results` when available.
- Keep target static analysis for the new scoped cluster results, preserving the intended old-vs-new split.
- Add a regression test where unchanged methods have stable baseline lineage but shuffled target lineage, verifying the old snapshot uses the baseline cluster IDs.

## Test plan
- [x] `uv run pytest tests/diagram_analysis/test_diagram_analysis.py -k "recursive_scope_old_snapshot_uses_incremental_base_lineage or incremental_refresh_updates_existing_parent_scope or incremental_refresh_skips_child_scope_when_local_diff_is_empty"`
- [x] `uv run pytest tests/diagram_analysis/test_diagram_analysis.py`

## Notes
- The working tree had pre-existing `.codeboarding/` changes before this branch was created. They were not staged or included in this PR.
