### PR TITLE
Align incremental analysis with the extended relation pipeline

### DIFF
--- a/agents/abstraction_agent.py
+++ b/agents/abstraction_agent.py
@@ -22,6 +22,7 @@ from agents.prompts import (
     get_api_surfaces_message,
     get_relation_analysis_message,
     get_system_message,
+    format_project_system_message,
 )
 from agents.relation_edges import index_relation_endpoints
 from agents.repair import ComponentRepairContext, repair_component_group_names, repair_key_entities
@@ -53,13 +54,7 @@ class AbstractionAgent(ClusterMethodsMixin, CodeBoardingAgent):
         agent_llm: BaseChatModel,
         parsing_llm: BaseChatModel,
     ):
-        meta_context_str = meta_context.llm_str() if meta_context else "No project context available."
-        project_type = meta_context.project_type if meta_context else "unknown"
-        system_message = get_system_message().format(
-            project_name=project_name,
-            project_type=project_type,
-            meta_context=meta_context_str,
-        )
+        system_message = format_project_system_message(get_system_message(), project_name, meta_context)
         super().__init__(repo_dir, static_analysis, system_message, agent_llm, parsing_llm)
 
         self.project_name = project_name
@@ -68,11 +63,11 @@ class AbstractionAgent(ClusterMethodsMixin, CodeBoardingAgent):
         self.prompts = {
             "group_clusters": PromptTemplate(
                 template=get_cluster_grouping_message(),
-                input_variables=["project_name", "cfg_clusters", "meta_context", "project_type"],
+                input_variables=["cfg_clusters"],
             ),
             "final_analysis": PromptTemplate(
                 template=get_final_analysis_message(),
-                input_variables=["project_name", "cluster_analysis", "meta_context", "project_type"],
+                input_variables=["cluster_analysis"],
             ),
             "api_surfaces": PromptTemplate(
                 template=get_api_surfaces_message(),
@@ -95,9 +90,6 @@ class AbstractionAgent(ClusterMethodsMixin, CodeBoardingAgent):
     def step_clusters_grouping(self, cluster_results: dict[str, ClusterResult]) -> ClusterAnalysis:
         logger.info(f"[AbstractionAgent] Grouping CFG clusters for: {self.project_name}")
 
-        meta_context_str = self.meta_context.llm_str() if self.meta_context else "No project context available."
-        project_type = self.meta_context.project_type if self.meta_context else "unknown"
-
         programming_langs = self.static_analysis.get_languages()
 
         # Measure everything that wraps cfg_clusters (system message + rendered
@@ -105,10 +97,7 @@ class AbstractionAgent(ClusterMethodsMixin, CodeBoardingAgent):
         # the input window before budgeting the cluster string.
         overhead_chars = len(str(self.system_message.content)) + len(
             self.prompts["group_clusters"].format(
-                project_name=self.project_name,
                 cfg_clusters="",
-                meta_context=meta_context_str,
-                project_type=project_type,
             )
         )
         cluster_str = self._build_cluster_string(
@@ -116,18 +105,13 @@ class AbstractionAgent(ClusterMethodsMixin, CodeBoardingAgent):
         )
 
         prompt = self.prompts["group_clusters"].format(
-            project_name=self.project_name,
             cfg_clusters=cluster_str,
-            meta_context=meta_context_str,
-            project_type=project_type,
         )
 
-        cluster_analysis = self._invoke_repair_validate(
+        cluster_analysis = self._invoke_validate(
             prompt,
             ClusterAnalysis,
-            repairs=[],
             validators=[validate_cluster_coverage],
-            repair_context=None,
             validation_context=ValidationContext(
                 cluster_results=cluster_results,
                 expected_cluster_ids=get_all_cluster_ids(cluster_results),
@@ -142,18 +126,12 @@ class AbstractionAgent(ClusterMethodsMixin, CodeBoardingAgent):
     ) -> AnalysisInsights:
         logger.info(f"[AbstractionAgent] Generating final component analysis for: {self.project_name}")
 
-        meta_context_str = self.meta_context.llm_str() if self.meta_context else "No project context available."
-        project_type = self.meta_context.project_type if self.meta_context else "unknown"
-
         cluster_str = llm_cluster_analysis.llm_str() if llm_cluster_analysis else "No cluster analysis available."
 
         group_names = [cc.name for cc in llm_cluster_analysis.cluster_components] if llm_cluster_analysis else []
 
         prompt = self.prompts["final_analysis"].format(
-            project_name=self.project_name,
             cluster_analysis=cluster_str,
-            meta_context=meta_context_str,
-            project_type=project_type,
         )
 
         if group_names:
@@ -198,15 +176,7 @@ class AbstractionAgent(ClusterMethodsMixin, CodeBoardingAgent):
             component_summaries=analysis.llm_str(),
             static_call_evidence=static_call_evidence,
         )
-        return self._invoke_repair_validate(
-            prompt,
-            ComponentApiSurfaces,
-            repairs=[],
-            validators=[],
-            repair_context=None,
-            validation_context=None,
-            max_validation_attempts=1,
-        )
+        return self._parse_invoke(prompt, ComponentApiSurfaces)
 
     @trace
     def step_relation_analysis(
@@ -227,12 +197,10 @@ class AbstractionAgent(ClusterMethodsMixin, CodeBoardingAgent):
             api_surfaces=api_surfaces.llm_str(),
             static_call_evidence=static_call_evidence,
         )
-        relation_result = self._invoke_repair_validate(
+        relation_result = self._invoke_validate(
             prompt,
             ComponentRelations,
-            repairs=[],
             validators=[validate_relations],
-            repair_context=None,
             validation_context=ValidationContext(
                 cluster_results=cluster_results,
                 cfg_graphs=cfg_graphs,

--- a/agents/abstraction_agent.py
+++ b/agents/abstraction_agent.py
@@ -23,6 +23,8 @@ from agents.prompts import (
     get_relation_analysis_message,
     get_system_message,
 )
+from agents.relation_edges import index_relation_endpoints
+from agents.repair import ComponentRepairContext, repair_component_group_names, repair_key_entities
 from agents.validation import (
     ValidationContext,
     validate_cluster_coverage,
@@ -51,7 +53,14 @@ class AbstractionAgent(ClusterMethodsMixin, CodeBoardingAgent):
         agent_llm: BaseChatModel,
         parsing_llm: BaseChatModel,
     ):
-        super().__init__(repo_dir, static_analysis, get_system_message(), agent_llm, parsing_llm)
+        meta_context_str = meta_context.llm_str() if meta_context else "No project context available."
+        project_type = meta_context.project_type if meta_context else "unknown"
+        system_message = get_system_message().format(
+            project_name=project_name,
+            project_type=project_type,
+            meta_context=meta_context_str,
+        )
+        super().__init__(repo_dir, static_analysis, system_message, agent_llm, parsing_llm)
 
         self.project_name = project_name
         self.meta_context = meta_context
@@ -68,22 +77,16 @@ class AbstractionAgent(ClusterMethodsMixin, CodeBoardingAgent):
             "api_surfaces": PromptTemplate(
                 template=get_api_surfaces_message(),
                 input_variables=[
-                    "project_name",
                     "component_summaries",
                     "static_call_evidence",
-                    "meta_context",
-                    "project_type",
                 ],
             ),
             "relation_analysis": PromptTemplate(
                 template=get_relation_analysis_message(),
                 input_variables=[
-                    "project_name",
                     "component_summaries",
                     "api_surfaces",
                     "static_call_evidence",
-                    "meta_context",
-                    "project_type",
                 ],
             ),
         }
@@ -119,11 +122,13 @@ class AbstractionAgent(ClusterMethodsMixin, CodeBoardingAgent):
             project_type=project_type,
         )
 
-        cluster_analysis = self._validation_invoke(
+        cluster_analysis = self._invoke_repair_validate(
             prompt,
             ClusterAnalysis,
+            repairs=[],
             validators=[validate_cluster_coverage],
-            context=ValidationContext(
+            repair_context=None,
+            validation_context=ValidationContext(
                 cluster_results=cluster_results,
                 expected_cluster_ids=get_all_cluster_ids(cluster_results),
             ),
@@ -163,14 +168,20 @@ class AbstractionAgent(ClusterMethodsMixin, CodeBoardingAgent):
             llm_cluster_analysis=llm_cluster_analysis,
         )
 
-        architecture = self._validation_invoke(
+        architecture = self._invoke_repair_validate(
             prompt,
             ComponentArchitecture,
+            repairs=[repair_component_group_names, repair_key_entities],
             validators=[
                 validate_group_name_coverage,
                 validate_key_entities,
             ],
-            context=context,
+            repair_context=ComponentRepairContext(
+                reference_resolver=self.reference_resolver,
+                cluster_results=cluster_results,
+                llm_cluster_analysis=llm_cluster_analysis,
+            ),
+            validation_context=context,
             max_validation_attempts=3,
         )
         return AnalysisInsights(
@@ -182,21 +193,18 @@ class AbstractionAgent(ClusterMethodsMixin, CodeBoardingAgent):
     @trace
     def step_api_surfaces(self, analysis: AnalysisInsights) -> ComponentApiSurfaces:
         logger.info(f"[AbstractionAgent] Analyzing component API surfaces for: {self.project_name}")
-        meta_context_str = self.meta_context.llm_str() if self.meta_context else "No project context available."
-        project_type = self.meta_context.project_type if self.meta_context else "unknown"
         static_call_evidence = self.build_scope_cfg_string(analysis)
         prompt = self.prompts["api_surfaces"].format(
-            project_name=self.project_name,
             component_summaries=analysis.llm_str(),
             static_call_evidence=static_call_evidence,
-            meta_context=meta_context_str,
-            project_type=project_type,
         )
-        return self._validation_invoke(
+        return self._invoke_repair_validate(
             prompt,
             ComponentApiSurfaces,
+            repairs=[],
             validators=[],
-            context=None,
+            repair_context=None,
+            validation_context=None,
             max_validation_attempts=1,
         )
 
@@ -209,26 +217,23 @@ class AbstractionAgent(ClusterMethodsMixin, CodeBoardingAgent):
         cluster_results: dict[str, ClusterResult],
     ) -> None:
         logger.info(f"[AbstractionAgent] Discovering component relations for: {self.project_name}")
-        meta_context_str = self.meta_context.llm_str() if self.meta_context else "No project context available."
-        project_type = self.meta_context.project_type if self.meta_context else "unknown"
         static_call_evidence = self.build_scope_cfg_string(analysis)
         cfg_graphs = self.static_analysis.available_cfgs()
         self.toolkit.context.cluster_analysis = cluster_analysis
         self.toolkit.context.cluster_results = cluster_results
         self.toolkit.context.cfg_graphs = cfg_graphs
         prompt = self.prompts["relation_analysis"].format(
-            project_name=self.project_name,
             component_summaries=analysis.llm_str(),
             api_surfaces=api_surfaces.llm_str(),
             static_call_evidence=static_call_evidence,
-            meta_context=meta_context_str,
-            project_type=project_type,
         )
-        relation_result = self._validation_invoke(
+        relation_result = self._invoke_repair_validate(
             prompt,
             ComponentRelations,
+            repairs=[],
             validators=[validate_relations],
-            context=ValidationContext(
+            repair_context=None,
+            validation_context=ValidationContext(
                 cluster_results=cluster_results,
                 cfg_graphs=cfg_graphs,
                 repo_dir=str(self.repo_dir),
@@ -266,7 +271,9 @@ class AbstractionAgent(ClusterMethodsMixin, CodeBoardingAgent):
 
         # Step 8: Fix source code reference lines (resolves reference_file paths for key_entities and key_edges)
         analysis = self.reference_resolver.fix_source_code_reference_lines(analysis)
-        # Step 9: Ensure unique key entities across components
+        # Step 9: Index relation endpoints after reference resolution
+        index_relation_endpoints(analysis, self.repo_dir)
+        # Step 10: Ensure unique key entities across components
         self._ensure_unique_key_entities(analysis)
 
         return analysis, cluster_results

--- a/agents/agent.py
+++ b/agents/agent.py
@@ -227,7 +227,13 @@ class CodeBoardingAgent(MonitoringMixin):
         assert isinstance(response, str), f"Expected a string as response type got {response}"
         return self._parse_response(prompt, response, type, include_hidden=include_hidden)
 
-    def _score_result(self, result, validators: list, context) -> tuple[float, list[tuple[float, str]]]:
+    def _repair_result(self, result, repairs: list, repair_context) -> None:
+        """Apply deterministic repairs to one parsed candidate."""
+        for repair in repairs:
+            logger.info("[Repair] Applying %s", repair.__name__)
+            repair(result, repair_context)
+
+    def _score_result(self, result, validators: list, validation_context) -> tuple[float, list[tuple[float, str]]]:
         """Run all validators on a result and return (score, prioritized_feedback).
 
         The score is computed using weighted validators where coverage-related
@@ -241,7 +247,7 @@ class CodeBoardingAgent(MonitoringMixin):
         validator_results: list[tuple] = []
         weighted_feedback: list[tuple[float, str]] = []
         for validator in validators:
-            validator_result: ValidationResult = validator(result, context)
+            validator_result: ValidationResult = validator(result, validation_context)
             validator_results.append((validator, validator_result))
             if not validator_result.is_valid:
                 weight = VALIDATOR_WEIGHTS.get(validator.__name__, DEFAULT_VALIDATOR_WEIGHT)
@@ -254,44 +260,25 @@ class CodeBoardingAgent(MonitoringMixin):
         score = score_validation_results(validator_results)
         return score, weighted_feedback
 
-    def _validation_invoke(
+    def _invoke_repair_validate(
         self,
         prompt: str,
         return_type: type,
+        repairs: list,
         validators: list,
-        context,
+        repair_context,
+        validation_context,
         max_validation_attempts: int = 1,
         include_hidden: bool = False,
     ):
-        """
-        Invoke LLM with validation, feedback loop, and best-of-N selection.
-
-        Each attempt (initial + retries) is scored using weighted validators.
-        Coverage validators (validate_cluster_coverage, validate_group_name_coverage)
-        are weighted ~2x higher than other validators, so the selection strongly
-        favours results with complete coverage.
-
-        If any attempt scores perfectly (all validators pass), it is returned
-        immediately. Otherwise the highest-scoring result across all attempts is
-        returned.
-
-        Args:
-            prompt: The original prompt
-            return_type: Pydantic type to parse into
-            validators: List of validation functions to run
-            context: ValidationContext with data needed for validation
-            max_validation_attempts: Maximum validation attempts (initial attempt included).
-                Retries occur only when this value is greater than 1. (default: 1)
-
-        Returns:
-            The highest-scoring result of return_type across all attempts
-        """
+        """Parse, repair, and validate each candidate before best-of-N selection."""
         # Compute the maximum possible score so we can detect a perfect result
         max_possible_score = sum(VALIDATOR_WEIGHTS.get(v.__name__, DEFAULT_VALIDATOR_WEIGHT) for v in validators)
 
         result = self._parse_invoke(prompt, return_type, include_hidden=include_hidden)
+        self._repair_result(result, repairs, repair_context)
         logger.info(
-            "[Validation] Parsed %s: %s",
+            "[Validation] Parsed and repaired %s: %s",
             return_type.__name__,
             result.llm_str()[:500],
         )
@@ -304,7 +291,7 @@ class CodeBoardingAgent(MonitoringMixin):
         critical_threshold = 10.0
 
         for attempt in range(1, max_validation_attempts + 1):
-            score, weighted_feedback = self._score_result(result, validators, context)
+            score, weighted_feedback = self._score_result(result, validators, validation_context)
 
             logger.info(
                 f"[Validation] Attempt {attempt}/{max_validation_attempts} "
@@ -348,6 +335,7 @@ class CodeBoardingAgent(MonitoringMixin):
                 f"with {len(weighted_feedback)} feedback items"
             )
             result = self._parse_invoke(feedback_prompt, return_type, include_hidden=include_hidden)
+            self._repair_result(result, repairs, repair_context)
 
         return best_result
 

--- a/agents/agent.py
+++ b/agents/agent.py
@@ -297,14 +297,41 @@ class CodeBoardingAgent(MonitoringMixin):
         max_validation_attempts: int = 1,
         include_hidden: bool = False,
     ) -> ResultT:
-        """Parse, repair, and validate each candidate before best-of-N selection."""
+        """Bind deterministic repairs to every candidate before validation."""
+
+        def repair_candidate(result: ResultT) -> None:
+            self._repair_result(result, repairs, repair_context)
+
+        return self._invoke_validate(
+            prompt,
+            return_type,
+            validators,
+            validation_context,
+            max_validation_attempts=max_validation_attempts,
+            include_hidden=include_hidden,
+            candidate_repair=repair_candidate,
+        )
+
+    def _invoke_validate(
+        self,
+        prompt: str,
+        return_type: type[ResultT],
+        validators: list[Callable[[ResultT, ValidationContextT], ValidationResult]],
+        validation_context: ValidationContextT,
+        max_validation_attempts: int = 1,
+        include_hidden: bool = False,
+        candidate_repair: Callable[[ResultT], None] | None = None,
+    ) -> ResultT:
+        """Validate parsed candidates and return the best-scoring result."""
         # Compute the maximum possible score so we can detect a perfect result
         max_possible_score = sum(VALIDATOR_WEIGHTS.get(v.__name__, DEFAULT_VALIDATOR_WEIGHT) for v in validators)
 
         result = self._parse_invoke(prompt, return_type, include_hidden=include_hidden)
-        self._repair_result(result, repairs, repair_context)
+        if candidate_repair is not None:
+            candidate_repair(result)
         logger.info(
-            "[Validation] Parsed and repaired %s: %s",
+            "[Validation] Parsed%s %s: %s",
+            " and repaired" if candidate_repair is not None else "",
             return_type.__name__,
             result.llm_str()[:500],
         )
@@ -361,7 +388,8 @@ class CodeBoardingAgent(MonitoringMixin):
                 f"with {len(weighted_feedback)} feedback items"
             )
             result = self._parse_invoke(feedback_prompt, return_type, include_hidden=include_hidden)
-            self._repair_result(result, repairs, repair_context)
+            if candidate_repair is not None:
+                candidate_repair(result)
 
         return best_result
 

--- a/agents/agent.py
+++ b/agents/agent.py
@@ -1,6 +1,8 @@
 import json
 import logging
+from collections.abc import Callable
 from pathlib import Path
+from typing import Protocol, TypeVar
 
 from google.api_core.exceptions import ResourceExhausted
 from langchain_core.exceptions import OutputParserException
@@ -27,6 +29,15 @@ from static_analyzer.analysis_result import StaticAnalysisResults
 from static_analyzer.reference_resolver import StaticReferenceResolver
 
 logger = logging.getLogger(__name__)
+
+ParseResultT = TypeVar("ParseResultT")
+ResultT = TypeVar("ResultT", bound="RepairValidationResult")
+RepairContextT = TypeVar("RepairContextT")
+ValidationContextT = TypeVar("ValidationContextT")
+
+
+class RepairValidationResult(Protocol):
+    def llm_str(self) -> str: ...
 
 
 class EmptyExtractorMessageError(ValueError):
@@ -222,18 +233,33 @@ class CodeBoardingAgent(MonitoringMixin):
         except Empty:
             raise RuntimeError("Agent invocation completed but no result was returned")
 
-    def _parse_invoke(self, prompt: str, type: type, include_hidden: bool = False):
+    def _parse_invoke(
+        self,
+        prompt: str,
+        return_type: type[ParseResultT],
+        include_hidden: bool = False,
+    ) -> ParseResultT:
         response = self._invoke(prompt)
         assert isinstance(response, str), f"Expected a string as response type got {response}"
-        return self._parse_response(prompt, response, type, include_hidden=include_hidden)
+        return self._parse_response(prompt, response, return_type, include_hidden=include_hidden)
 
-    def _repair_result(self, result, repairs: list, repair_context) -> None:
+    def _repair_result(
+        self,
+        result: ResultT,
+        repairs: list[Callable[[ResultT, RepairContextT], None]],
+        repair_context: RepairContextT,
+    ) -> None:
         """Apply deterministic repairs to one parsed candidate."""
         for repair in repairs:
             logger.info("[Repair] Applying %s", repair.__name__)
             repair(result, repair_context)
 
-    def _score_result(self, result, validators: list, validation_context) -> tuple[float, list[tuple[float, str]]]:
+    def _score_result(
+        self,
+        result: ResultT,
+        validators: list[Callable[[ResultT, ValidationContextT], ValidationResult]],
+        validation_context: ValidationContextT,
+    ) -> tuple[float, list[tuple[float, str]]]:
         """Run all validators on a result and return (score, prioritized_feedback).
 
         The score is computed using weighted validators where coverage-related
@@ -244,7 +270,7 @@ class CodeBoardingAgent(MonitoringMixin):
         weight descending, so that the LLM focuses on the most critical issues
         (cluster/group coverage) before lower-priority ones (key entities).
         """
-        validator_results: list[tuple] = []
+        validator_results: list[tuple[Callable[[ResultT, ValidationContextT], ValidationResult], ValidationResult]] = []
         weighted_feedback: list[tuple[float, str]] = []
         for validator in validators:
             validator_result: ValidationResult = validator(result, validation_context)
@@ -263,14 +289,14 @@ class CodeBoardingAgent(MonitoringMixin):
     def _invoke_repair_validate(
         self,
         prompt: str,
-        return_type: type,
-        repairs: list,
-        validators: list,
-        repair_context,
-        validation_context,
+        return_type: type[ResultT],
+        repairs: list[Callable[[ResultT, RepairContextT], None]],
+        validators: list[Callable[[ResultT, ValidationContextT], ValidationResult]],
+        repair_context: RepairContextT,
+        validation_context: ValidationContextT,
         max_validation_attempts: int = 1,
         include_hidden: bool = False,
-    ):
+    ) -> ResultT:
         """Parse, repair, and validate each candidate before best-of-N selection."""
         # Compute the maximum possible score so we can detect a perfect result
         max_possible_score = sum(VALIDATOR_WEIGHTS.get(v.__name__, DEFAULT_VALIDATOR_WEIGHT) for v in validators)

--- a/agents/agent_responses.py
+++ b/agents/agent_responses.py
@@ -840,6 +840,13 @@ class ScopeOperation(LLMBaseModel):
     )
     name: str | None = Field(default=None, description="Component name for create/update operations.")
     description: str | None = Field(default=None, description="Component description for create/update operations.")
+    key_entities: list[SourceCodeReference] = Field(
+        default_factory=list,
+        description=(
+            "Important existing source symbols for a created component or a semantically refreshed component. "
+            "Leave empty on updates that preserve the current key entities."
+        ),
+    )
     recurse: bool = Field(
         default=False, description="Whether this component should be considered for child-scope update."
     )
@@ -848,7 +855,11 @@ class ScopeOperation(LLMBaseModel):
     def llm_str(self):
         refs = ", ".join(ref.llm_str() for ref in self.cluster_refs) or "no clusters"
         target = self.component_id or self.name or "new component"
-        return f"{self.action}: {refs} -> {target}; recurse={self.recurse}; {self.rationale}"
+        key_entities = ", ".join(entity.qualified_name for entity in self.key_entities) or "unchanged"
+        return (
+            f"{self.action}: {refs} -> {target}; key_entities=[{key_entities}]; "
+            f"recurse={self.recurse}; {self.rationale}"
+        )
 
 
 class ScopeUpdateDecision(LLMBaseModel):

--- a/agents/agent_responses.py
+++ b/agents/agent_responses.py
@@ -821,7 +821,6 @@ class ScopeOperationAction(StrEnum):
     UPDATE_COMPONENT = "update_component"
     DELETE_COMPONENT = "delete_component"
     NOOP = "noop"
-    REGENERATE_SCOPE = "regenerate_scope"
 
 
 class ScopedClusterRef(LLMBaseModel):

--- a/agents/agent_responses.py
+++ b/agents/agent_responses.py
@@ -202,25 +202,10 @@ class RelationEdge(LLMBaseModel):
         target_key = edge.get("target")
         if not isinstance(source_key, str) or not isinstance(target_key, str):
             raise ValueError("Relation edge endpoints must be method-index keys")
-        source = methods_index.get(source_key)
-        target = methods_index.get(target_key)
-        if source is None or target is None:
-            missing = source_key if source is None else target_key
-            raise ValueError(f"Relation edge endpoint is missing from methods_index: {missing}")
         call_sites = edge.get("call_sites") or []
         return cls(
-            source=SourceCodeReference(
-                qualified_name=source.qualified_name,
-                reference_file=source.file_path,
-                reference_start_line=source.start_line,
-                reference_end_line=source.end_line,
-            ),
-            target=SourceCodeReference(
-                qualified_name=target.qualified_name,
-                reference_file=target.file_path,
-                reference_start_line=target.start_line,
-                reference_end_line=target.end_line,
-            ),
+            source=_relation_endpoint_from_key(source_key, methods_index),
+            target=_relation_endpoint_from_key(target_key, methods_index),
             description=edge.get("description", ""),
             call_sites=[RelationCallSite.model_validate(site) for site in call_sites],
         )
@@ -258,6 +243,28 @@ class RelationEdge(LLMBaseModel):
             self.target.reference_end_line,
             tuple(sorted((site.line, site.column) for site in self.call_sites)),
         )
+
+
+def _relation_endpoint_from_key(
+    key: str,
+    methods_index: dict[str, MethodIndexEntry],
+) -> SourceCodeReference:
+    indexed = methods_index.get(key)
+    if indexed is not None:
+        return SourceCodeReference(
+            qualified_name=indexed.qualified_name,
+            reference_file=indexed.file_path or None,
+            reference_start_line=indexed.start_line,
+            reference_end_line=indexed.end_line,
+        )
+
+    file_path, separator, qualified_name = key.partition("|")
+    if not separator or not qualified_name:
+        raise ValueError(f"Malformed relation edge endpoint key: {key!r}")
+    return SourceCodeReference(
+        qualified_name=qualified_name,
+        reference_file=file_path or None,
+    )
 
 
 class Relation(LLMBaseModel):

--- a/agents/cluster_ids.py
+++ b/agents/cluster_ids.py
@@ -1,3 +1,6 @@
+from agents.scope_ids import ROOT_SCOPE_ID
+
+
 type GraphClusterId = int
 type CodeBoardingClusterId = str
 
@@ -9,6 +12,10 @@ class GraphClusterIds:
 
 
 class CodeBoardingClusterIds:
+    @classmethod
+    def prefix_for_scope(cls, scope_id: str) -> CodeBoardingClusterId:
+        return "" if scope_id == ROOT_SCOPE_ID else scope_id
+
     @classmethod
     def sort(cls, cluster_ids: set[CodeBoardingClusterId]) -> list[CodeBoardingClusterId]:
         # Sort by depth first, then naturally within a level: ["1", "2", "10", "2.1", "3.4"].

--- a/agents/cluster_methods_mixin.py
+++ b/agents/cluster_methods_mixin.py
@@ -11,14 +11,11 @@ from agents.agent_responses import (
     ClusterAnalysis,
     Component,
 )
-from agents.file_index_models import FileEntry, FileMethodGroup, MethodEntry
+from agents.file_index_models import FileMethodGroup, MethodEntry
 from agents.cluster_budget import ClusterPromptBudget
 from agents.content_hash import (
-    MethodRef,
-    MethodSpan,
     SourceCache,
     hash_method_body,
-    hash_whole_file,
     read_source_lines,
 )
 from agents.cluster_ids import CodeBoardingClusterId, CodeBoardingClusterIds, GraphClusterId
@@ -27,6 +24,7 @@ from agents.model_capabilities import ContextWindow
 from constants import MIN_CLUSTERS_THRESHOLD
 from diagram_analysis.cluster_delta import _delta_for_language
 from diagram_analysis.cluster_snapshot import ClusterSnapshotEntry
+from diagram_analysis.file_index import build_files_index
 from repo_utils.path_utils import normalize_repo_path
 from static_analyzer.analysis_result import StaticAnalysisResults
 from static_analyzer.cfg_skip_planner import ContextBudgetExceededError, plan_skip_set
@@ -804,77 +802,6 @@ class ClusterMethodsMixin:
         pct = (assigned_nodes / total_nodes * 100) if total_nodes else 0
         logger.info(f"Node coverage: {assigned_nodes}/{total_nodes} ({pct:.1f}%) nodes assigned to components")
 
-    def build_files_index(
-        self, analysis: AnalysisInsights, source_cache: SourceCache | None = None
-    ) -> dict[str, FileEntry]:
-        """Assemble the file -> ``FileEntry`` index, hashing each method's span
-        from live source. Each ``MethodEntry`` is hashed at the span it carries,
-        so callers whose spans may be stale (the incremental carry-forward path)
-        must run :meth:`refresh_method_spans_from_cfg` first. Pass ``source_cache``
-        to reuse the reads from an earlier ``_build_file_methods_from_nodes`` pass.
-        """
-        file_cache = source_cache if source_cache is not None else {}
-        files: dict[str, FileEntry] = {}
-        for component in analysis.components:
-            for fmg in component.file_methods:
-                entry = files.get(fmg.file_path)
-                if entry is None:
-                    entry = FileEntry(
-                        methods=[],
-                        content_hash=hash_whole_file(read_source_lines(self.repo_dir, fmg.file_path, file_cache)),
-                    )
-                    files[fmg.file_path] = entry
-
-                methods_by_qname = {m.qualified_name: m for m in entry.methods}
-                for method in fmg.methods:
-                    if method.qualified_name not in methods_by_qname:
-                        copied = method.model_copy(deep=True)
-                        copied.content_hash = hash_method_body(
-                            read_source_lines(self.repo_dir, fmg.file_path, file_cache),
-                            method.start_line,
-                            method.end_line,
-                        )
-                        methods_by_qname[method.qualified_name] = copied
-
-                entry.methods = sorted(
-                    methods_by_qname.values(),
-                    key=lambda m: (m.start_line, m.end_line, m.qualified_name),
-                )
-        return files
-
-    def refresh_method_spans_from_cfg(self, analysis: AnalysisInsights) -> None:
-        """Update every carried-forward ``MethodEntry`` span from the live CFG.
-
-        The incremental flow reuses component/method assignments from disk while
-        the CFG has been re-analyzed, so an untouched component's spans can point
-        at unrelated code (an edit above the method) and its stored hash can mask
-        a body-only edit. This propagates the current CFG span onto each entry so
-        :meth:`build_files_index` hashes the real body. A method absent from the
-        live CFG gets an out-of-range span, which hashes to '' (unavailable).
-        """
-        spans = self._cfg_method_spans()
-        for component in analysis.components:
-            for fmg in component.file_methods:
-                for method in fmg.methods:
-                    span = spans.get(MethodRef(fmg.file_path, method.qualified_name))
-                    if span is not None:
-                        method.start_line, method.end_line = span
-                    else:
-                        method.start_line, method.end_line = 0, 0
-
-    def _cfg_method_spans(self) -> dict[MethodRef, MethodSpan]:
-        """Live-CFG line span per method, keyed by (repo-relative file, qname)."""
-        spans: dict[MethodRef, MethodSpan] = {}
-        for language in self.static_analysis.get_languages():
-            try:
-                cfg = self.static_analysis.get_cfg(language)
-            except (KeyError, ValueError):
-                continue
-            for qname, node in cfg.nodes.items():
-                rel_path = normalize_repo_path(node.file_path, self.repo_dir)
-                spans.setdefault(MethodRef(rel_path, qname), MethodSpan(node.line_start, node.line_end))
-        return spans
-
     def populate_file_methods(
         self,
         analysis: AnalysisInsights,
@@ -925,7 +852,7 @@ class ClusterMethodsMixin:
                 component_nodes.get(comp.component_id, []), source_cache
             )
 
-        analysis.files = self.build_files_index(analysis, source_cache)
+        analysis.files = build_files_index(analysis, self.repo_dir, source_cache)
 
         self._log_node_coverage(analysis, len(all_nodes))
 

--- a/agents/details_agent.py
+++ b/agents/details_agent.py
@@ -22,6 +22,7 @@ from agents.prompts import (
     get_details_message,
     get_api_surfaces_message,
     get_relation_analysis_message,
+    format_project_system_message,
 )
 from agents.relation_edges import index_relation_endpoints
 from agents.repair import ComponentRepairContext, repair_component_group_names, repair_key_entities
@@ -57,13 +58,7 @@ class DetailsAgent(ClusterMethodsMixin, CodeBoardingAgent):
         parsing_llm: BaseChatModel,
         run_id: str,
     ):
-        meta_context_str = meta_context.llm_str() if meta_context else "No project context available."
-        project_type = meta_context.project_type if meta_context else "unknown"
-        system_message = get_system_details_message().format(
-            project_name=project_name,
-            project_type=project_type,
-            meta_context=meta_context_str,
-        )
+        system_message = format_project_system_message(get_system_details_message(), project_name, meta_context)
         super().__init__(repo_dir, static_analysis, system_message, agent_llm, parsing_llm)
         self.project_name = project_name
         self.meta_context = meta_context
@@ -75,11 +70,11 @@ class DetailsAgent(ClusterMethodsMixin, CodeBoardingAgent):
         self.prompts = {
             "group_clusters": PromptTemplate(
                 template=get_cfg_details_message(),
-                input_variables=["project_name", "cfg_clusters", "component", "meta_context", "project_type"],
+                input_variables=["cfg_clusters", "component"],
             ),
             "final_analysis": PromptTemplate(
                 template=get_details_message(),
-                input_variables=["project_name", "cluster_analysis", "component", "meta_context", "project_type"],
+                input_variables=["cluster_analysis", "component"],
             ),
             "api_surfaces": PromptTemplate(
                 template=get_api_surfaces_message(),
@@ -113,18 +108,12 @@ class DetailsAgent(ClusterMethodsMixin, CodeBoardingAgent):
             ClusterAnalysis with grouped clusters for this component
         """
         logger.info(f"[DetailsAgent] Grouping clusters for component: {component.name}")
-        meta_context_str = self.meta_context.llm_str() if self.meta_context else "No project context available."
-        project_type = self.meta_context.project_type if self.meta_context else "unknown"
-
         programming_langs = self.static_analysis.get_languages()
 
         overhead_chars = len(str(self.system_message.content)) + len(
             self.prompts["group_clusters"].format(
-                project_name=self.project_name,
                 cfg_clusters="",
                 component=component.llm_str(),
-                meta_context=meta_context_str,
-                project_type=project_type,
             )
         )
         cluster_str = self._build_cluster_string(
@@ -132,11 +121,8 @@ class DetailsAgent(ClusterMethodsMixin, CodeBoardingAgent):
         )
 
         prompt = self.prompts["group_clusters"].format(
-            project_name=self.project_name,
             cfg_clusters=cluster_str,
             component=component.llm_str(),
-            meta_context=meta_context_str,
-            project_type=project_type,
         )
 
         context = ValidationContext(
@@ -148,12 +134,10 @@ class DetailsAgent(ClusterMethodsMixin, CodeBoardingAgent):
 
         if (cached := self._cluster_cache.load(cache_key)) is not None:
             return cached
-        cluster_analysis = self._invoke_repair_validate(
+        cluster_analysis = self._invoke_validate(
             prompt,
             ClusterAnalysis,
-            repairs=[],
             validators=[validate_cluster_coverage],
-            repair_context=None,
             validation_context=context,
             max_validation_attempts=3,
         )
@@ -184,19 +168,13 @@ class DetailsAgent(ClusterMethodsMixin, CodeBoardingAgent):
             AnalysisInsights with detailed component information
         """
         logger.info(f"[DetailsAgent] Generating final detailed analysis for: {component.name}")
-        meta_context_str = self.meta_context.llm_str() if self.meta_context else "No project context available."
-        project_type = self.meta_context.project_type if self.meta_context else "unknown"
-
         cluster_str = cluster_analysis.llm_str() if cluster_analysis else "No cluster analysis available."
 
         group_names = [cc.name for cc in cluster_analysis.cluster_components] if cluster_analysis else []
 
         prompt = self.prompts["final_analysis"].format(
-            project_name=self.project_name,
             cluster_analysis=cluster_str,
             component=component.llm_str(),
-            meta_context=meta_context_str,
-            project_type=project_type,
         )
 
         if group_names:
@@ -255,15 +233,7 @@ class DetailsAgent(ClusterMethodsMixin, CodeBoardingAgent):
             component_summaries=analysis.llm_str(),
             static_call_evidence=static_call_evidence,
         )
-        return self._invoke_repair_validate(
-            prompt,
-            ComponentApiSurfaces,
-            repairs=[],
-            validators=[],
-            repair_context=None,
-            validation_context=None,
-            max_validation_attempts=1,
-        )
+        return self._parse_invoke(prompt, ComponentApiSurfaces)
 
     @trace
     def step_relation_analysis(
@@ -285,12 +255,10 @@ class DetailsAgent(ClusterMethodsMixin, CodeBoardingAgent):
             api_surfaces=api_surfaces.llm_str(),
             static_call_evidence=static_call_evidence,
         )
-        relation_result = self._invoke_repair_validate(
+        relation_result = self._invoke_validate(
             prompt,
             ComponentRelations,
-            repairs=[],
             validators=[validate_relations],
-            repair_context=None,
             validation_context=ValidationContext(
                 cluster_results=cluster_results,
                 cfg_graphs=cfg_graphs,

--- a/agents/details_agent.py
+++ b/agents/details_agent.py
@@ -23,6 +23,8 @@ from agents.prompts import (
     get_api_surfaces_message,
     get_relation_analysis_message,
 )
+from agents.relation_edges import index_relation_endpoints
+from agents.repair import ComponentRepairContext, repair_component_group_names, repair_key_entities
 from agents.cluster_methods_mixin import ClusterMethodsMixin
 from caching.cache import ModelSettings
 from caching.details_cache import (
@@ -55,7 +57,14 @@ class DetailsAgent(ClusterMethodsMixin, CodeBoardingAgent):
         parsing_llm: BaseChatModel,
         run_id: str,
     ):
-        super().__init__(repo_dir, static_analysis, get_system_details_message(), agent_llm, parsing_llm)
+        meta_context_str = meta_context.llm_str() if meta_context else "No project context available."
+        project_type = meta_context.project_type if meta_context else "unknown"
+        system_message = get_system_details_message().format(
+            project_name=project_name,
+            project_type=project_type,
+            meta_context=meta_context_str,
+        )
+        super().__init__(repo_dir, static_analysis, system_message, agent_llm, parsing_llm)
         self.project_name = project_name
         self.meta_context = meta_context
         self.run_id = run_id
@@ -75,22 +84,16 @@ class DetailsAgent(ClusterMethodsMixin, CodeBoardingAgent):
             "api_surfaces": PromptTemplate(
                 template=get_api_surfaces_message(),
                 input_variables=[
-                    "project_name",
                     "component_summaries",
                     "static_call_evidence",
-                    "meta_context",
-                    "project_type",
                 ],
             ),
             "relation_analysis": PromptTemplate(
                 template=get_relation_analysis_message(),
                 input_variables=[
-                    "project_name",
                     "component_summaries",
                     "api_surfaces",
                     "static_call_evidence",
-                    "meta_context",
-                    "project_type",
                 ],
             ),
         }
@@ -145,8 +148,14 @@ class DetailsAgent(ClusterMethodsMixin, CodeBoardingAgent):
 
         if (cached := self._cluster_cache.load(cache_key)) is not None:
             return cached
-        cluster_analysis = self._validation_invoke(
-            prompt, ClusterAnalysis, validators=[validate_cluster_coverage], context=context, max_validation_attempts=3
+        cluster_analysis = self._invoke_repair_validate(
+            prompt,
+            ClusterAnalysis,
+            repairs=[],
+            validators=[validate_cluster_coverage],
+            repair_context=None,
+            validation_context=context,
+            max_validation_attempts=3,
         )
         self._cluster_cache.store(
             cache_key,
@@ -210,14 +219,20 @@ class DetailsAgent(ClusterMethodsMixin, CodeBoardingAgent):
 
         if (cached := self._analysis_cache.load(cache_key)) is not None:
             return cached
-        architecture = self._validation_invoke(
+        architecture = self._invoke_repair_validate(
             prompt,
             ComponentArchitecture,
+            repairs=[repair_component_group_names, repair_key_entities],
             validators=[
                 validate_group_name_coverage,
                 validate_key_entities,
             ],
-            context=context,
+            repair_context=ComponentRepairContext(
+                reference_resolver=self.reference_resolver,
+                cluster_results=subgraph_cluster_results,
+                llm_cluster_analysis=cluster_analysis,
+            ),
+            validation_context=context,
             max_validation_attempts=3,
         )
         result = AnalysisInsights(
@@ -235,21 +250,18 @@ class DetailsAgent(ClusterMethodsMixin, CodeBoardingAgent):
     @trace
     def step_api_surfaces(self, analysis: AnalysisInsights) -> ComponentApiSurfaces:
         logger.info(f"[DetailsAgent] Analyzing component API surfaces for: {self.project_name}")
-        meta_context_str = self.meta_context.llm_str() if self.meta_context else "No project context available."
-        project_type = self.meta_context.project_type if self.meta_context else "unknown"
         static_call_evidence = self.build_scope_cfg_string(analysis)
         prompt = self.prompts["api_surfaces"].format(
-            project_name=self.project_name,
             component_summaries=analysis.llm_str(),
             static_call_evidence=static_call_evidence,
-            meta_context=meta_context_str,
-            project_type=project_type,
         )
-        return self._validation_invoke(
+        return self._invoke_repair_validate(
             prompt,
             ComponentApiSurfaces,
+            repairs=[],
             validators=[],
-            context=None,
+            repair_context=None,
+            validation_context=None,
             max_validation_attempts=1,
         )
 
@@ -264,25 +276,22 @@ class DetailsAgent(ClusterMethodsMixin, CodeBoardingAgent):
         source_cluster_id_prefix: str,
     ) -> None:
         logger.info(f"[DetailsAgent] Discovering component relations for: {self.project_name}")
-        meta_context_str = self.meta_context.llm_str() if self.meta_context else "No project context available."
-        project_type = self.meta_context.project_type if self.meta_context else "unknown"
         static_call_evidence = self.build_scope_cfg_string(analysis)
         self.toolkit.context.cluster_analysis = cluster_analysis
         self.toolkit.context.cluster_results = cluster_results
         self.toolkit.context.cfg_graphs = cfg_graphs
         prompt = self.prompts["relation_analysis"].format(
-            project_name=self.project_name,
             component_summaries=analysis.llm_str(),
             api_surfaces=api_surfaces.llm_str(),
             static_call_evidence=static_call_evidence,
-            meta_context=meta_context_str,
-            project_type=project_type,
         )
-        relation_result = self._validation_invoke(
+        relation_result = self._invoke_repair_validate(
             prompt,
             ComponentRelations,
+            repairs=[],
             validators=[validate_relations],
-            context=ValidationContext(
+            repair_context=None,
+            validation_context=ValidationContext(
                 cluster_results=cluster_results,
                 cfg_graphs=cfg_graphs,
                 repo_dir=str(self.repo_dir),
@@ -357,7 +366,10 @@ class DetailsAgent(ClusterMethodsMixin, CodeBoardingAgent):
         # Step 9: Fix source code reference lines (resolves reference_file paths)
         analysis = self.reference_resolver.fix_source_code_reference_lines(analysis)
 
-        # Step 10: Ensure unique key entities across components
+        # Step 10: Index relation endpoints after reference resolution
+        index_relation_endpoints(analysis, self.repo_dir)
+
+        # Step 11: Ensure unique key entities across components
         self._ensure_unique_key_entities(analysis)
 
         return analysis, subgraph_cluster_results

--- a/agents/file_index_models.py
+++ b/agents/file_index_models.py
@@ -63,3 +63,42 @@ class FileEntry(BaseModel):
         default="",
         description="Truncated SHA-256 of the entire file's bytes; '' when source was unavailable.",
     )
+
+    def merge_from(self, other: FileEntry) -> FileEntry:
+        """Merge another entry while retaining independent, canonical method metadata."""
+        if not self.content_hash:
+            self.content_hash = other.content_hash
+
+        methods_by_qname: dict[str, MethodEntry] = {}
+        for method in [*self.methods, *other.methods]:
+            candidate = method.model_copy(deep=True)
+            indexed = methods_by_qname.get(candidate.qualified_name)
+            if indexed is None:
+                methods_by_qname[candidate.qualified_name] = candidate
+                continue
+
+            if bool(indexed.content_hash) != bool(candidate.content_hash) and candidate.content_hash:
+                preferred, fallback = candidate, indexed
+            else:
+                preferred, fallback = indexed, candidate
+            preferred.start_line = preferred.start_line or fallback.start_line
+            preferred.end_line = preferred.end_line or fallback.end_line
+            preferred.content_hash = preferred.content_hash or fallback.content_hash
+            methods_by_qname[candidate.qualified_name] = preferred
+
+        self.methods = sorted(
+            methods_by_qname.values(),
+            key=lambda method: (method.start_line, method.end_line, method.qualified_name),
+        )
+        return self
+
+    def merge_method_spans(self, spans: dict[str, tuple[int, int]]) -> None:
+        """Fill missing spans for methods already owned by this file entry."""
+        methods_by_qname = {method.qualified_name: method for method in self.methods}
+        for qualified_name, (start_line, end_line) in spans.items():
+            method = methods_by_qname.get(qualified_name)
+            if method is None:
+                continue
+            method.start_line = method.start_line or start_line
+            method.end_line = method.end_line or end_line
+        self.methods.sort(key=lambda method: (method.start_line, method.end_line, method.qualified_name))

--- a/agents/incremental_agent.py
+++ b/agents/incremental_agent.py
@@ -1,6 +1,7 @@
 """Incremental refresh helpers for scoped structural updates."""
 
 import logging
+from dataclasses import dataclass
 from pathlib import Path
 
 from langchain_core.language_models import BaseChatModel
@@ -9,15 +10,20 @@ from langchain_core.prompts import PromptTemplate
 from agents.agent import CodeBoardingAgent
 from agents.agent_responses import (
     AnalysisInsights,
+    ClusterAnalysis,
+    ClustersComponent,
     Component,
+    ComponentApiSurfaces,
+    ComponentArchitecture,
+    ComponentRelations,
     SourceCodeReference,
     MetaAnalysisInsights,
     Relation,
     ScopeOperation,
     ScopeOperationAction,
-    ScopeRelations,
     ScopeUpdateDecision,
     assign_component_ids,
+    assign_relation_ids,
     iter_components,
 )
 from agents.file_index_models import FileMethodGroup, MethodEntry
@@ -25,17 +31,23 @@ from agents.cluster_methods_mixin import ClusterMethodsMixin
 from agents.content_hash import SourceCache
 from agents.cluster_ids import CodeBoardingClusterIds
 from agents.incremental_results import ScopeUpdateResult
-from agents.prompts import get_scope_relations_message, get_system_message
+from agents.prompts import get_api_surfaces_message, get_relation_analysis_message, get_system_message
 from agents.scope_ids import ROOT_SCOPE_ID
-from agents.validation import ValidationContext, validate_scope_relation_names
+from agents.validation import ValidationContext, validate_relations
+from diagram_analysis.exceptions import IncrementalScopeContextMissingError, IncrementalScopeRegenerationRequiredError
 from monitoring import trace
 from repo_utils.change_detector import ChangeSet
 from static_analyzer.analysis_result import StaticAnalysisResults
-from static_analyzer.cluster_relations import ClusterRelation, merge_relations
 from static_analyzer.constants import Language
 from static_analyzer.graph import CallGraph, ClusterResult
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class _ScopeRelationContext:
+    cluster_results: dict[str, ClusterResult]
+    cfg_graphs: dict[str, CallGraph]
 
 
 class IncrementalAgent(ClusterMethodsMixin, CodeBoardingAgent):
@@ -56,6 +68,30 @@ class IncrementalAgent(ClusterMethodsMixin, CodeBoardingAgent):
             self.toolkit.context.changes = changes
         self.project_name = project_name
         self.meta_context = meta_context
+        self._scope_relation_contexts: dict[str, _ScopeRelationContext] = {}
+        self.prompts = {
+            "api_surfaces": PromptTemplate(
+                template=get_api_surfaces_message(),
+                input_variables=[
+                    "project_name",
+                    "component_summaries",
+                    "static_call_evidence",
+                    "meta_context",
+                    "project_type",
+                ],
+            ),
+            "relation_analysis": PromptTemplate(
+                template=get_relation_analysis_message(),
+                input_variables=[
+                    "project_name",
+                    "component_summaries",
+                    "api_surfaces",
+                    "static_call_evidence",
+                    "meta_context",
+                    "project_type",
+                ],
+            ),
+        }
 
     @trace
     def update_scope(
@@ -74,8 +110,7 @@ class IncrementalAgent(ClusterMethodsMixin, CodeBoardingAgent):
 
         for operation in decision.operations:
             if operation.action == ScopeOperationAction.REGENERATE_SCOPE:
-                result.regenerate_scope = True
-                continue
+                raise IncrementalScopeRegenerationRequiredError(scope_id, operation.rationale)
             if operation.action == ScopeOperationAction.CREATE_COMPONENT:
                 self._create_component_from_operation(scope_id, scope, operation, components_by_id, result)
                 continue
@@ -90,6 +125,13 @@ class IncrementalAgent(ClusterMethodsMixin, CodeBoardingAgent):
                     result.removed_ids.add(operation.component_id)
                 continue
             if operation.action == ScopeOperationAction.NOOP:
+                component = components_by_id.get(operation.component_id or "")
+                if component is not None:
+                    component.source_cluster_ids = CodeBoardingClusterIds.sort(
+                        set(component.source_cluster_ids) | set(_operation_source_cluster_ids(scope_id, operation))
+                    )
+                    if component.component_id:
+                        result.refresh_ids.add(component.component_id)
                 continue
 
             component = components_by_id.get(operation.component_id or "")
@@ -109,8 +151,13 @@ class IncrementalAgent(ClusterMethodsMixin, CodeBoardingAgent):
         if touched_ids:
             cfg_graphs = _cfg_graphs_for_cluster_results(self.static_analysis, cluster_results)
             self._patch_scope_file_methods(scope, cluster_results, cfg_graphs, touched_ids, scope_id)
-            self.build_static_relations(scope, _cfg_graphs_for_scope_methods(self.static_analysis, scope))
             self._refresh_key_entities(scope, touched_ids)
+
+        if touched_ids or result.removed_ids:
+            self._scope_contexts()[scope_id] = _ScopeRelationContext(
+                cluster_results=cluster_results,
+                cfg_graphs=_cfg_graphs_for_scope_methods(self.static_analysis, scope),
+            )
 
         _log_duplicate_cluster_ownership(scope_id, scope.components)
 
@@ -136,7 +183,7 @@ class IncrementalAgent(ClusterMethodsMixin, CodeBoardingAgent):
         component = Component(
             name=operation.name or "New Component",
             description=operation.description or "",
-            key_entities=[],
+            key_entities=operation.key_entities,
             source_group_names=[operation.name or "New Component"],
             source_cluster_ids=source_cluster_ids,
         )
@@ -157,6 +204,8 @@ class IncrementalAgent(ClusterMethodsMixin, CodeBoardingAgent):
             component.name = operation.name
         if operation.description:
             component.description = operation.description
+        if operation.key_entities:
+            component.key_entities = operation.key_entities
         merged_cluster_ids = set(component.source_cluster_ids) | set(_operation_source_cluster_ids(scope_id, operation))
         component.source_cluster_ids = CodeBoardingClusterIds.sort(merged_cluster_ids)
 
@@ -164,7 +213,17 @@ class IncrementalAgent(ClusterMethodsMixin, CodeBoardingAgent):
         for component in scope.components:
             if component.component_id not in component_ids:
                 continue
-            component.key_entities = _key_entities_from_file_methods(component)
+            owned_qnames = {
+                method.qualified_name
+                for group in component.file_methods
+                for method in group.methods
+                if method.qualified_name
+            }
+            component.key_entities = [
+                entity for entity in component.key_entities if entity.qualified_name in owned_qnames
+            ][:5]
+            if not component.key_entities:
+                component.key_entities = _key_entities_from_file_methods(component)
 
     def _patch_scope_file_methods(
         self,
@@ -198,58 +257,106 @@ class IncrementalAgent(ClusterMethodsMixin, CodeBoardingAgent):
         scope.files = self.build_files_index(scope, source_cache)
 
     @trace
-    def generate_scope_relations(self, scope: AnalysisInsights, scope_name: str) -> list[Relation]:
-        """Generate LLM relations for a single scope and merge with static relations."""
-        if len(scope.components) < 2:
-            return []
-
+    def step_api_surfaces(self, scope: AnalysisInsights, scope_name: str) -> ComponentApiSurfaces:
+        """Analyze API surfaces for one updated scope."""
+        logger.info("[IncrementalAgent] Analyzing API surfaces for scope: %s", scope_name)
         meta_context_str = self.meta_context.llm_str() if self.meta_context else "No project context available."
         project_type = self.meta_context.project_type if self.meta_context else "unknown"
-        component_summaries = "\n".join(c.llm_str() for c in scope.components)
-        cross_calls = self.build_scope_cfg_string(scope)
-
-        prompt_template = PromptTemplate(
-            template=get_scope_relations_message(),
-            input_variables=[
-                "scope_name",
-                "project_name",
-                "meta_context",
-                "project_type",
-                "component_summaries",
-                "cross_component_calls",
-            ],
-        )
-        prompt = prompt_template.format(
-            scope_name=scope_name,
+        prompt = self.prompts["api_surfaces"].format(
             project_name=self.project_name,
+            component_summaries=ComponentArchitecture(
+                description=scope.description, components=scope.components
+            ).llm_str(),
+            static_call_evidence=self.build_scope_cfg_string(scope),
             meta_context=meta_context_str,
             project_type=project_type,
-            component_summaries=component_summaries,
-            cross_component_calls=cross_calls,
+        )
+        return self._validation_invoke(
+            prompt,
+            ComponentApiSurfaces,
+            validators=[],
+            context=None,
+            max_validation_attempts=1,
         )
 
-        valid_names = {c.name for c in scope.components}
-        result: ScopeRelations = self._validation_invoke(
+    @trace
+    def step_relation_analysis(
+        self,
+        scope: AnalysisInsights,
+        scope_name: str,
+        api_surfaces: ComponentApiSurfaces,
+        cluster_analysis: ClusterAnalysis,
+        cluster_results: dict[str, ClusterResult],
+        cfg_graphs: dict[str, CallGraph],
+    ) -> list[Relation]:
+        """Discover evidence-backed relations and attach deterministic CFG edges."""
+        logger.info("[IncrementalAgent] Discovering component relations for scope: %s", scope_name)
+        meta_context_str = self.meta_context.llm_str() if self.meta_context else "No project context available."
+        project_type = self.meta_context.project_type if self.meta_context else "unknown"
+        self.toolkit.context.cluster_analysis = cluster_analysis
+        self.toolkit.context.cluster_results = cluster_results
+        self.toolkit.context.cfg_graphs = cfg_graphs
+        prompt = self.prompts["relation_analysis"].format(
+            project_name=self.project_name,
+            component_summaries=ComponentArchitecture(
+                description=scope.description, components=scope.components
+            ).llm_str(),
+            api_surfaces=api_surfaces.llm_str(),
+            static_call_evidence=self.build_scope_cfg_string(scope),
+            meta_context=meta_context_str,
+            project_type=project_type,
+        )
+        relation_result: ComponentRelations = self._validation_invoke(
             prompt,
-            ScopeRelations,
-            validators=[validate_scope_relation_names],
-            context=ValidationContext(valid_component_names=valid_names),
+            ComponentRelations,
+            validators=[validate_relations],
+            context=ValidationContext(
+                cluster_results=cluster_results,
+                cfg_graphs=cfg_graphs,
+                repo_dir=str(self.repo_dir),
+                static_analysis=self.static_analysis,
+                llm_cluster_analysis=cluster_analysis,
+                components=scope.components,
+            ),
             max_validation_attempts=3,
         )
+        scope.components_relations = relation_result.components_relations
+        assign_relation_ids(scope)
+        self.build_static_relations(scope, cfg_graphs)
+        self.reference_resolver.fix_source_code_reference_lines(scope)
+        return relation_result.components_relations
 
-        existing_static = [r for r in scope.components_relations if r.is_static]
-        static_relations = [
-            ClusterRelation(
-                src_cluster_id=relation.src_id,
-                dst_cluster_id=relation.dst_id,
-                all_edges=relation.all_edges,
-            )
-            for relation in existing_static
-        ]
-        merged = merge_relations(result.components_relations, static_relations, scope)
+    @trace
+    def generate_scope_relations(
+        self,
+        scope: AnalysisInsights,
+        scope_name: str,
+        cluster_results: dict[str, ClusterResult] | None = None,
+        cfg_graphs: dict[str, CallGraph] | None = None,
+    ) -> list[Relation]:
+        """Run the API-surface and relation stages for one updated scope."""
+        if len(scope.components) < 2:
+            scope.components_relations = []
+            self.reference_resolver.fix_source_code_reference_lines(scope)
+            return []
 
-        scope.components_relations = merged
-        return result.components_relations
+        if cluster_results is None or cfg_graphs is None:
+            context = self._scope_contexts().get(scope_name)
+            if context is None:
+                raise IncrementalScopeContextMissingError(scope_name)
+            cluster_results = context.cluster_results
+            cfg_graphs = context.cfg_graphs
+
+        cluster_analysis = _cluster_analysis_for_scope(scope, scope_name, cluster_results)
+        api_surfaces = self.step_api_surfaces(scope, scope_name)
+        return self.step_relation_analysis(
+            scope,
+            scope_name,
+            api_surfaces,
+            cluster_analysis,
+            cluster_results,
+            cfg_graphs,
+        )
 
     @trace
     def generate_all_scope_relations(
@@ -260,11 +367,11 @@ class IncrementalAgent(ClusterMethodsMixin, CodeBoardingAgent):
     ) -> None:
         """Generate LLM relations for every touched scope with at least two components."""
         all_llm_rels: list[tuple[str, list[Relation]]] = []
-        if "" in touched_scopes:
-            rels = self.generate_scope_relations(root_analysis, "root")
+        if ROOT_SCOPE_ID in touched_scopes:
+            rels = self.generate_scope_relations(root_analysis, ROOT_SCOPE_ID)
             if rels:
-                all_llm_rels.append(("root", rels))
-        for scope_id in sorted(touched_scopes - {""}):
+                all_llm_rels.append((ROOT_SCOPE_ID, rels))
+        for scope_id in sorted(touched_scopes - {ROOT_SCOPE_ID}):
             sub = sub_analyses.get(scope_id)
             if sub is not None:
                 rels = self.generate_scope_relations(sub, scope_id)
@@ -273,6 +380,57 @@ class IncrementalAgent(ClusterMethodsMixin, CodeBoardingAgent):
 
         if all_llm_rels:
             _log_scope_relations_summary(all_llm_rels)
+
+    def _scope_contexts(self) -> dict[str, _ScopeRelationContext]:
+        contexts = getattr(self, "_scope_relation_contexts", None)
+        if contexts is None:
+            contexts = {}
+            self._scope_relation_contexts = contexts
+        return contexts
+
+
+def _cluster_analysis_for_scope(
+    scope: AnalysisInsights,
+    scope_id: str,
+    cluster_results: dict[str, ClusterResult],
+) -> ClusterAnalysis:
+    """Reconstruct grouped-cluster context for a persisted incremental scope."""
+    valid_cluster_ids = {
+        cluster_id for cluster_result in cluster_results.values() for cluster_id in cluster_result.clusters
+    }
+    groups: list[ClustersComponent] = []
+    for component in scope.components:
+        cluster_ids = _local_graph_cluster_ids(component.source_cluster_ids, scope_id, valid_cluster_ids)
+        if not component.source_group_names:
+            component.source_group_names = [component.name]
+        for group_name in component.source_group_names:
+            groups.append(
+                ClustersComponent(
+                    name=group_name,
+                    cluster_ids=cluster_ids,
+                    description=component.description,
+                )
+            )
+    return ClusterAnalysis(cluster_components=groups)
+
+
+def _local_graph_cluster_ids(
+    source_cluster_ids: list[str],
+    scope_id: str,
+    valid_cluster_ids: set[int],
+) -> list[int]:
+    prefix = "" if scope_id == ROOT_SCOPE_ID else f"{scope_id}."
+    local_ids: set[int] = set()
+    for source_cluster_id in source_cluster_ids:
+        if prefix:
+            if not source_cluster_id.startswith(prefix):
+                continue
+            local_id = source_cluster_id.removeprefix(prefix)
+        else:
+            local_id = source_cluster_id
+        if local_id.isdigit() and int(local_id) in valid_cluster_ids:
+            local_ids.add(int(local_id))
+    return sorted(local_ids)
 
 
 def _log_scope_relations_summary(all_rels: list[tuple[str, list[Relation]]]) -> None:

--- a/agents/incremental_agent.py
+++ b/agents/incremental_agent.py
@@ -1,7 +1,6 @@
 """Incremental refresh helpers for scoped structural updates."""
 
 import logging
-from dataclasses import dataclass
 from pathlib import Path
 
 from langchain_core.language_models import BaseChatModel
@@ -29,12 +28,16 @@ from agents.file_index_models import FileMethodGroup, MethodEntry
 from agents.cluster_methods_mixin import ClusterMethodsMixin
 from agents.content_hash import SourceCache
 from agents.cluster_ids import CodeBoardingClusterIds
-from agents.incremental_results import ScopeUpdateResult
-from agents.prompts import get_api_surfaces_message, get_relation_analysis_message, get_system_message
+from agents.incremental_results import ScopeRelationContext, ScopeUpdateResult
+from agents.prompts import (
+    format_project_system_message,
+    get_api_surfaces_message,
+    get_relation_analysis_message,
+    get_system_message,
+)
 from agents.relation_edges import index_relation_endpoints
 from agents.scope_ids import ROOT_SCOPE_ID
 from agents.validation import ValidationContext, validate_relations
-from diagram_analysis.exceptions import IncrementalScopeContextMissingError
 from diagram_analysis.file_index import build_files_index
 from monitoring import trace
 from repo_utils.change_detector import ChangeSet
@@ -43,12 +46,6 @@ from static_analyzer.constants import Language
 from static_analyzer.graph import CallGraph, ClusterResult
 
 logger = logging.getLogger(__name__)
-
-
-@dataclass(frozen=True)
-class _ScopeRelationContext:
-    cluster_results: dict[str, ClusterResult]
-    cfg_graphs: dict[str, CallGraph]
 
 
 class IncrementalAgent(ClusterMethodsMixin, CodeBoardingAgent):
@@ -64,19 +61,12 @@ class IncrementalAgent(ClusterMethodsMixin, CodeBoardingAgent):
         parsing_llm: BaseChatModel,
         changes: ChangeSet | None = None,
     ):
-        meta_context_str = meta_context.llm_str() if meta_context else "No project context available."
-        project_type = meta_context.project_type if meta_context else "unknown"
-        system_message = get_system_message().format(
-            project_name=project_name,
-            project_type=project_type,
-            meta_context=meta_context_str,
-        )
+        system_message = format_project_system_message(get_system_message(), project_name, meta_context)
         super().__init__(repo_dir, static_analysis, system_message, agent_llm, parsing_llm)
         if changes is not None:
             self.toolkit.context.changes = changes
         self.project_name = project_name
         self.meta_context = meta_context
-        self._scope_relation_contexts: dict[str, _ScopeRelationContext] = {}
         self.prompts = {
             "api_surfaces": PromptTemplate(
                 template=get_api_surfaces_message(),
@@ -104,15 +94,28 @@ class IncrementalAgent(ClusterMethodsMixin, CodeBoardingAgent):
         cluster_results: dict[str, ClusterResult],
     ) -> ScopeUpdateResult:
         """Apply a planning decision to one scope and refresh its derived fields."""
-        result = ScopeUpdateResult()
         components_by_id = {
             component.component_id: component for component in scope.components if component.component_id
         }
-        result.refresh_ids.update(_remove_reassigned_clusters(scope_id, scope.components, components_by_id, decision))
+        refresh_ids = _remove_reassigned_clusters(
+            scope_id,
+            scope.components,
+            components_by_id,
+            decision,
+        )
+        new_component_ids: set[str] = set()
+        removed_ids: set[str] = set()
 
         for operation in decision.operations:
             if operation.action == ScopeOperationAction.CREATE_COMPONENT:
-                self._create_component_from_operation(scope_id, scope, operation, components_by_id, result)
+                self._create_component_from_operation(
+                    scope_id,
+                    scope,
+                    operation,
+                    components_by_id,
+                    refresh_ids,
+                    new_component_ids,
+                )
                 continue
             if operation.action == ScopeOperationAction.DELETE_COMPONENT:
                 if operation.component_id:
@@ -120,9 +123,9 @@ class IncrementalAgent(ClusterMethodsMixin, CodeBoardingAgent):
                     if component is not None and _component_has_live_cfg_methods(
                         component, _live_cfg_qnames(self.static_analysis)
                     ):
-                        result.refresh_ids.add(operation.component_id)
+                        refresh_ids.add(operation.component_id)
                         continue
-                    result.removed_ids.add(operation.component_id)
+                    removed_ids.add(operation.component_id)
                 continue
             if operation.action == ScopeOperationAction.NOOP:
                 component = components_by_id.get(operation.component_id or "")
@@ -131,7 +134,7 @@ class IncrementalAgent(ClusterMethodsMixin, CodeBoardingAgent):
                         set(component.source_cluster_ids) | set(_operation_source_cluster_ids(scope_id, operation))
                     )
                     if component.component_id:
-                        result.refresh_ids.add(component.component_id)
+                        refresh_ids.add(component.component_id)
                 continue
 
             component = components_by_id.get(operation.component_id or "")
@@ -139,29 +142,31 @@ class IncrementalAgent(ClusterMethodsMixin, CodeBoardingAgent):
                 continue
             self._update_component_from_operation(scope_id, component, operation)
             if component.component_id:
-                result.refresh_ids.add(component.component_id)
+                refresh_ids.add(component.component_id)
 
-        if result.removed_ids:
+        if removed_ids:
             scope.components = [
-                component for component in scope.components if component.component_id not in result.removed_ids
+                component for component in scope.components if component.component_id not in removed_ids
             ]
-            _strip_relations(scope, result.removed_ids)
+            _strip_relations(scope, removed_ids)
 
-        touched_ids = result.refresh_ids | result.new_component_ids
+        touched_ids = refresh_ids | new_component_ids
         if touched_ids:
             cfg_graphs = _cfg_graphs_for_cluster_results(self.static_analysis, cluster_results)
             self._patch_scope_file_methods(scope, cluster_results, cfg_graphs, touched_ids, scope_id)
-            self.reference_resolver.fix_key_entities_refs(scope, touched_ids, force_resolve=True)
-
-        if touched_ids or result.removed_ids:
-            self._scope_relation_contexts[scope_id] = _ScopeRelationContext(
-                cluster_results=cluster_results,
-                cfg_graphs=_cfg_graphs_for_scope_methods(self.static_analysis, scope),
-            )
+            self.reference_resolver.fix_key_entities_refs(scope, touched_ids)
 
         _log_duplicate_cluster_ownership(scope_id, scope.components)
 
-        return result
+        return ScopeUpdateResult(
+            relation_context=ScopeRelationContext(
+                cluster_results=cluster_results,
+                cfg_graphs=_cfg_graphs_for_scope_methods(self.static_analysis, scope),
+            ),
+            refresh_ids=refresh_ids,
+            new_component_ids=new_component_ids,
+            removed_ids=removed_ids,
+        )
 
     def _create_component_from_operation(
         self,
@@ -169,7 +174,8 @@ class IncrementalAgent(ClusterMethodsMixin, CodeBoardingAgent):
         scope: AnalysisInsights,
         operation: ScopeOperation,
         components_by_id: dict[str, Component],
-        result: ScopeUpdateResult,
+        refresh_ids: set[str],
+        new_component_ids: set[str],
     ) -> None:
         source_cluster_ids = _operation_source_cluster_ids(scope_id, operation)
         if not source_cluster_ids:
@@ -190,8 +196,8 @@ class IncrementalAgent(ClusterMethodsMixin, CodeBoardingAgent):
         scope.components.append(component)
         assign_component_ids(scope, parent_id=_component_id_parent(scope_id), only_new=True)
         if component.component_id:
-            result.refresh_ids.add(component.component_id)
-            result.new_component_ids.add(component.component_id)
+            refresh_ids.add(component.component_id)
+            new_component_ids.add(component.component_id)
             components_by_id[component.component_id] = component
 
     def _update_component_from_operation(
@@ -250,15 +256,7 @@ class IncrementalAgent(ClusterMethodsMixin, CodeBoardingAgent):
             ).llm_str(),
             static_call_evidence=self.build_scope_cfg_string(scope),
         )
-        return self._invoke_repair_validate(
-            prompt,
-            ComponentApiSurfaces,
-            repairs=[],
-            validators=[],
-            repair_context=None,
-            validation_context=None,
-            max_validation_attempts=1,
-        )
+        return self._parse_invoke(prompt, ComponentApiSurfaces)
 
     @trace
     def step_relation_analysis(
@@ -282,12 +280,10 @@ class IncrementalAgent(ClusterMethodsMixin, CodeBoardingAgent):
             api_surfaces=api_surfaces.llm_str(),
             static_call_evidence=self.build_scope_cfg_string(scope),
         )
-        relation_result: ComponentRelations = self._invoke_repair_validate(
+        relation_result: ComponentRelations = self._invoke_validate(
             prompt,
             ComponentRelations,
-            repairs=[],
             validators=[validate_relations],
-            repair_context=None,
             validation_context=ValidationContext(
                 cluster_results=cluster_results,
                 cfg_graphs=cfg_graphs,
@@ -310,8 +306,7 @@ class IncrementalAgent(ClusterMethodsMixin, CodeBoardingAgent):
         self,
         scope: AnalysisInsights,
         scope_name: str,
-        cluster_results: dict[str, ClusterResult] | None = None,
-        cfg_graphs: dict[str, CallGraph] | None = None,
+        context: ScopeRelationContext,
     ) -> list[Relation]:
         """Run the API-surface and relation stages for one updated scope."""
         if len(scope.components) < 2:
@@ -319,22 +314,15 @@ class IncrementalAgent(ClusterMethodsMixin, CodeBoardingAgent):
             self.reference_resolver.fix_source_code_reference_lines(scope)
             return []
 
-        if cluster_results is None or cfg_graphs is None:
-            context = self._scope_relation_contexts.get(scope_name)
-            if context is None:
-                raise IncrementalScopeContextMissingError(scope_name)
-            cluster_results = context.cluster_results
-            cfg_graphs = context.cfg_graphs
-
-        cluster_analysis = _cluster_analysis_for_scope(scope, scope_name, cluster_results)
+        cluster_analysis = _cluster_analysis_for_scope(scope, scope_name, context.cluster_results)
         api_surfaces = self.step_api_surfaces(scope, scope_name)
         return self.step_relation_analysis(
             scope,
             scope_name,
             api_surfaces,
             cluster_analysis,
-            cluster_results,
-            cfg_graphs,
+            context.cluster_results,
+            context.cfg_graphs,
         )
 
     @trace
@@ -342,18 +330,19 @@ class IncrementalAgent(ClusterMethodsMixin, CodeBoardingAgent):
         self,
         root_analysis: AnalysisInsights,
         sub_analyses: dict[str, AnalysisInsights],
-        touched_scopes: set[str],
+        relation_contexts: dict[str, ScopeRelationContext],
     ) -> None:
         """Generate LLM relations for every touched scope with at least two components."""
         all_llm_rels: list[tuple[str, list[Relation]]] = []
-        if ROOT_SCOPE_ID in touched_scopes:
-            rels = self.generate_scope_relations(root_analysis, ROOT_SCOPE_ID)
+        root_context = relation_contexts.get(ROOT_SCOPE_ID)
+        if root_context is not None:
+            rels = self.generate_scope_relations(root_analysis, ROOT_SCOPE_ID, root_context)
             if rels:
                 all_llm_rels.append((ROOT_SCOPE_ID, rels))
-        for scope_id in sorted(touched_scopes - {ROOT_SCOPE_ID}):
+        for scope_id in sorted(relation_contexts.keys() - {ROOT_SCOPE_ID}):
             sub = sub_analyses.get(scope_id)
             if sub is not None:
-                rels = self.generate_scope_relations(sub, scope_id)
+                rels = self.generate_scope_relations(sub, scope_id, relation_contexts[scope_id])
                 if rels:
                     all_llm_rels.append((scope_id, rels))
 

--- a/agents/incremental_agent.py
+++ b/agents/incremental_agent.py
@@ -151,6 +151,7 @@ class IncrementalAgent(ClusterMethodsMixin, CodeBoardingAgent):
         if touched_ids:
             cfg_graphs = _cfg_graphs_for_cluster_results(self.static_analysis, cluster_results)
             self._patch_scope_file_methods(scope, cluster_results, cfg_graphs, touched_ids, scope_id)
+            self.reference_resolver.fix_key_entities_refs(scope, touched_ids)
             self._refresh_key_entities(scope, touched_ids)
 
         if touched_ids or result.removed_ids:

--- a/agents/incremental_agent.py
+++ b/agents/incremental_agent.py
@@ -16,7 +16,6 @@ from agents.agent_responses import (
     ComponentApiSurfaces,
     ComponentArchitecture,
     ComponentRelations,
-    SourceCodeReference,
     MetaAnalysisInsights,
     Relation,
     ScopeOperation,
@@ -32,9 +31,11 @@ from agents.content_hash import SourceCache
 from agents.cluster_ids import CodeBoardingClusterIds
 from agents.incremental_results import ScopeUpdateResult
 from agents.prompts import get_api_surfaces_message, get_relation_analysis_message, get_system_message
+from agents.relation_edges import index_relation_endpoints
 from agents.scope_ids import ROOT_SCOPE_ID
 from agents.validation import ValidationContext, validate_relations
-from diagram_analysis.exceptions import IncrementalScopeContextMissingError, IncrementalScopeRegenerationRequiredError
+from diagram_analysis.exceptions import IncrementalScopeContextMissingError
+from diagram_analysis.file_index import build_files_index
 from monitoring import trace
 from repo_utils.change_detector import ChangeSet
 from static_analyzer.analysis_result import StaticAnalysisResults
@@ -63,7 +64,14 @@ class IncrementalAgent(ClusterMethodsMixin, CodeBoardingAgent):
         parsing_llm: BaseChatModel,
         changes: ChangeSet | None = None,
     ):
-        super().__init__(repo_dir, static_analysis, get_system_message(), agent_llm, parsing_llm)
+        meta_context_str = meta_context.llm_str() if meta_context else "No project context available."
+        project_type = meta_context.project_type if meta_context else "unknown"
+        system_message = get_system_message().format(
+            project_name=project_name,
+            project_type=project_type,
+            meta_context=meta_context_str,
+        )
+        super().__init__(repo_dir, static_analysis, system_message, agent_llm, parsing_llm)
         if changes is not None:
             self.toolkit.context.changes = changes
         self.project_name = project_name
@@ -73,22 +81,16 @@ class IncrementalAgent(ClusterMethodsMixin, CodeBoardingAgent):
             "api_surfaces": PromptTemplate(
                 template=get_api_surfaces_message(),
                 input_variables=[
-                    "project_name",
                     "component_summaries",
                     "static_call_evidence",
-                    "meta_context",
-                    "project_type",
                 ],
             ),
             "relation_analysis": PromptTemplate(
                 template=get_relation_analysis_message(),
                 input_variables=[
-                    "project_name",
                     "component_summaries",
                     "api_surfaces",
                     "static_call_evidence",
-                    "meta_context",
-                    "project_type",
                 ],
             ),
         }
@@ -109,8 +111,6 @@ class IncrementalAgent(ClusterMethodsMixin, CodeBoardingAgent):
         result.refresh_ids.update(_remove_reassigned_clusters(scope_id, scope.components, components_by_id, decision))
 
         for operation in decision.operations:
-            if operation.action == ScopeOperationAction.REGENERATE_SCOPE:
-                raise IncrementalScopeRegenerationRequiredError(scope_id, operation.rationale)
             if operation.action == ScopeOperationAction.CREATE_COMPONENT:
                 self._create_component_from_operation(scope_id, scope, operation, components_by_id, result)
                 continue
@@ -151,8 +151,7 @@ class IncrementalAgent(ClusterMethodsMixin, CodeBoardingAgent):
         if touched_ids:
             cfg_graphs = _cfg_graphs_for_cluster_results(self.static_analysis, cluster_results)
             self._patch_scope_file_methods(scope, cluster_results, cfg_graphs, touched_ids, scope_id)
-            self.reference_resolver.fix_key_entities_refs(scope, touched_ids)
-            self._refresh_key_entities(scope, touched_ids)
+            self.reference_resolver.fix_key_entities_refs(scope, touched_ids, force_resolve=True)
 
         if touched_ids or result.removed_ids:
             self._scope_contexts()[scope_id] = _ScopeRelationContext(
@@ -210,22 +209,6 @@ class IncrementalAgent(ClusterMethodsMixin, CodeBoardingAgent):
         merged_cluster_ids = set(component.source_cluster_ids) | set(_operation_source_cluster_ids(scope_id, operation))
         component.source_cluster_ids = CodeBoardingClusterIds.sort(merged_cluster_ids)
 
-    def _refresh_key_entities(self, scope: AnalysisInsights, component_ids: set[str]) -> None:
-        for component in scope.components:
-            if component.component_id not in component_ids:
-                continue
-            owned_qnames = {
-                method.qualified_name
-                for group in component.file_methods
-                for method in group.methods
-                if method.qualified_name
-            }
-            component.key_entities = [
-                entity for entity in component.key_entities if entity.qualified_name in owned_qnames
-            ][:5]
-            if not component.key_entities:
-                component.key_entities = _key_entities_from_file_methods(component)
-
     def _patch_scope_file_methods(
         self,
         scope: AnalysisInsights,
@@ -236,7 +219,7 @@ class IncrementalAgent(ClusterMethodsMixin, CodeBoardingAgent):
     ) -> None:
         all_nodes = self._collect_all_cfg_nodes(cluster_results, cfg_graphs)
         cluster_to_component = self._build_cluster_to_component_map(scope)
-        cluster_id_prefix = _cluster_id_prefix(scope_id)
+        cluster_id_prefix = CodeBoardingClusterIds.prefix_for_scope(scope_id)
         node_to_cluster, all_cluster_ids = self._build_node_to_cluster_map(cluster_results, cluster_id_prefix)
         self._validate_cluster_coverage(cluster_to_component, all_cluster_ids)
 
@@ -255,28 +238,25 @@ class IncrementalAgent(ClusterMethodsMixin, CodeBoardingAgent):
             for component_id, nodes in component_nodes.items()
         }
         _patch_file_methods(scope, patched_groups, touched_ids, _live_cfg_qnames(self.static_analysis))
-        scope.files = self.build_files_index(scope, source_cache)
+        scope.files = build_files_index(scope, self.repo_dir, source_cache)
 
     @trace
     def step_api_surfaces(self, scope: AnalysisInsights, scope_name: str) -> ComponentApiSurfaces:
         """Analyze API surfaces for one updated scope."""
         logger.info("[IncrementalAgent] Analyzing API surfaces for scope: %s", scope_name)
-        meta_context_str = self.meta_context.llm_str() if self.meta_context else "No project context available."
-        project_type = self.meta_context.project_type if self.meta_context else "unknown"
         prompt = self.prompts["api_surfaces"].format(
-            project_name=self.project_name,
             component_summaries=ComponentArchitecture(
                 description=scope.description, components=scope.components
             ).llm_str(),
             static_call_evidence=self.build_scope_cfg_string(scope),
-            meta_context=meta_context_str,
-            project_type=project_type,
         )
-        return self._validation_invoke(
+        return self._invoke_repair_validate(
             prompt,
             ComponentApiSurfaces,
+            repairs=[],
             validators=[],
-            context=None,
+            repair_context=None,
+            validation_context=None,
             max_validation_attempts=1,
         )
 
@@ -292,26 +272,23 @@ class IncrementalAgent(ClusterMethodsMixin, CodeBoardingAgent):
     ) -> list[Relation]:
         """Discover evidence-backed relations and attach deterministic CFG edges."""
         logger.info("[IncrementalAgent] Discovering component relations for scope: %s", scope_name)
-        meta_context_str = self.meta_context.llm_str() if self.meta_context else "No project context available."
-        project_type = self.meta_context.project_type if self.meta_context else "unknown"
         self.toolkit.context.cluster_analysis = cluster_analysis
         self.toolkit.context.cluster_results = cluster_results
         self.toolkit.context.cfg_graphs = cfg_graphs
         prompt = self.prompts["relation_analysis"].format(
-            project_name=self.project_name,
             component_summaries=ComponentArchitecture(
                 description=scope.description, components=scope.components
             ).llm_str(),
             api_surfaces=api_surfaces.llm_str(),
             static_call_evidence=self.build_scope_cfg_string(scope),
-            meta_context=meta_context_str,
-            project_type=project_type,
         )
-        relation_result: ComponentRelations = self._validation_invoke(
+        relation_result: ComponentRelations = self._invoke_repair_validate(
             prompt,
             ComponentRelations,
+            repairs=[],
             validators=[validate_relations],
-            context=ValidationContext(
+            repair_context=None,
+            validation_context=ValidationContext(
                 cluster_results=cluster_results,
                 cfg_graphs=cfg_graphs,
                 repo_dir=str(self.repo_dir),
@@ -325,6 +302,7 @@ class IncrementalAgent(ClusterMethodsMixin, CodeBoardingAgent):
         assign_relation_ids(scope)
         self.build_static_relations(scope, cfg_graphs)
         self.reference_resolver.fix_source_code_reference_lines(scope)
+        index_relation_endpoints(scope, self.repo_dir)
         return relation_result.components_relations
 
     @trace
@@ -420,7 +398,8 @@ def _local_graph_cluster_ids(
     scope_id: str,
     valid_cluster_ids: set[int],
 ) -> list[int]:
-    prefix = "" if scope_id == ROOT_SCOPE_ID else f"{scope_id}."
+    scope_prefix = CodeBoardingClusterIds.prefix_for_scope(scope_id)
+    prefix = f"{scope_prefix}." if scope_prefix else ""
     local_ids: set[int] = set()
     for source_cluster_id in source_cluster_ids:
         if prefix:
@@ -446,7 +425,7 @@ def _operation_source_cluster_ids(scope_id: str, operation: ScopeOperation) -> l
     local_ids = {ref.cluster_id for ref in operation.cluster_refs if ref.scope_id == scope_id}
     return CodeBoardingClusterIds.qualify_local_ids(
         CodeBoardingClusterIds.from_graph_ids(local_ids),
-        _cluster_id_prefix(scope_id),
+        CodeBoardingClusterIds.prefix_for_scope(scope_id),
     )
 
 
@@ -494,29 +473,8 @@ def _log_duplicate_cluster_ownership(scope_id: str, components: list[Component])
         )
 
 
-def _cluster_id_prefix(scope_id: str) -> str:
-    return "" if scope_id == ROOT_SCOPE_ID else scope_id
-
-
 def _component_id_parent(scope_id: str) -> str:
     return "" if scope_id == ROOT_SCOPE_ID else scope_id
-
-
-def _key_entities_from_file_methods(component: Component) -> list[SourceCodeReference]:
-    refs: list[SourceCodeReference] = []
-    for group in sorted(component.file_methods, key=lambda file_group: file_group.file_path):
-        for method in sorted(group.methods, key=lambda item: (item.start_line, item.end_line, item.qualified_name)):
-            refs.append(
-                SourceCodeReference(
-                    qualified_name=method.qualified_name,
-                    reference_file=group.file_path,
-                    reference_start_line=method.start_line,
-                    reference_end_line=method.end_line,
-                )
-            )
-            if len(refs) == 5:
-                return refs
-    return refs
 
 
 def _patch_file_methods(

--- a/agents/incremental_agent.py
+++ b/agents/incremental_agent.py
@@ -154,7 +154,7 @@ class IncrementalAgent(ClusterMethodsMixin, CodeBoardingAgent):
             self.reference_resolver.fix_key_entities_refs(scope, touched_ids, force_resolve=True)
 
         if touched_ids or result.removed_ids:
-            self._scope_contexts()[scope_id] = _ScopeRelationContext(
+            self._scope_relation_contexts[scope_id] = _ScopeRelationContext(
                 cluster_results=cluster_results,
                 cfg_graphs=_cfg_graphs_for_scope_methods(self.static_analysis, scope),
             )
@@ -320,7 +320,7 @@ class IncrementalAgent(ClusterMethodsMixin, CodeBoardingAgent):
             return []
 
         if cluster_results is None or cfg_graphs is None:
-            context = self._scope_contexts().get(scope_name)
+            context = self._scope_relation_contexts.get(scope_name)
             if context is None:
                 raise IncrementalScopeContextMissingError(scope_name)
             cluster_results = context.cluster_results
@@ -359,13 +359,6 @@ class IncrementalAgent(ClusterMethodsMixin, CodeBoardingAgent):
 
         if all_llm_rels:
             _log_scope_relations_summary(all_llm_rels)
-
-    def _scope_contexts(self) -> dict[str, _ScopeRelationContext]:
-        contexts = getattr(self, "_scope_relation_contexts", None)
-        if contexts is None:
-            contexts = {}
-            self._scope_relation_contexts = contexts
-        return contexts
 
 
 def _cluster_analysis_for_scope(

--- a/agents/incremental_planning_agent.py
+++ b/agents/incremental_planning_agent.py
@@ -16,7 +16,7 @@ from agents.agent_responses import (
     ScopeUpdateDecision,
 )
 from agents.cluster_ids import CodeBoardingClusterIds
-from agents.prompts import get_planning_message, get_system_message
+from agents.prompts import format_project_system_message, get_planning_message, get_system_message
 from agents.repair import (
     ScopeOperationRepairContext,
     repair_unambiguous_routing_and_optional_key_entity_metadata,
@@ -54,13 +54,7 @@ class IncrementalPlanningAgent(CodeBoardingAgent):
         parsing_llm: BaseChatModel,
         changes: ChangeSet | None = None,
     ):
-        meta_context_str = meta_context.llm_str() if meta_context else "No project context available."
-        project_type = meta_context.project_type if meta_context else "unknown"
-        system_message = get_system_message().format(
-            project_name=project_name,
-            project_type=project_type,
-            meta_context=meta_context_str,
-        )
+        system_message = format_project_system_message(get_system_message(), project_name, meta_context)
         super().__init__(repo_dir, static_analysis, system_message, agent_llm, parsing_llm)
         if changes is not None:
             self.toolkit.context.changes = changes

--- a/agents/incremental_planning_agent.py
+++ b/agents/incremental_planning_agent.py
@@ -14,7 +14,7 @@ from agents.agent_responses import (
     AnalysisInsights,
     Component,
     MetaAnalysisInsights,
-    SourceCodeReference,
+    ScopeOperation,
     ScopeOperationAction,
     ScopeUpdateDecision,
     ScopedClusterRef,
@@ -33,10 +33,26 @@ from diagram_analysis.cluster_delta import (
 from diagram_analysis.exceptions import InvalidIncrementalPlanError, IncrementalScopeRegenerationRequiredError
 from repo_utils.change_detector import ChangeSet
 from static_analyzer.analysis_result import StaticAnalysisResults
+from static_analyzer.reference_resolver import StaticReferenceResolver
 from telemetry.service import telemetry
 
 
 logger = logging.getLogger(__name__)
+
+
+_EXISTING_COMPONENT_ACTIONS = frozenset(
+    {
+        ScopeOperationAction.UPDATE_COMPONENT,
+        ScopeOperationAction.DELETE_COMPONENT,
+        ScopeOperationAction.NOOP,
+    }
+)
+_KEY_ENTITY_METADATA_ACTIONS = frozenset(
+    {
+        ScopeOperationAction.CREATE_COMPONENT,
+        ScopeOperationAction.UPDATE_COMPONENT,
+    }
+)
 
 
 _ARCHITECTURE_OUTPUT_CONTRACT = """
@@ -52,9 +68,9 @@ _ARCHITECTURE_OUTPUT_CONTRACT = """
 
 @dataclass
 class ScopeOperationValidationContext:
+    reference_resolver: StaticReferenceResolver
     expected_cluster_refs: set[ClusterRef] = field(default_factory=set)
     existing_component_ids: set[str] = field(default_factory=set)
-    known_qnames: set[str] = field(default_factory=set)
     component_ids_by_cluster_ref: dict[ClusterRef, str] = field(default_factory=dict)
     component_ids_by_name: dict[str, str] = field(default_factory=dict)
     scope_id: str = ROOT_SCOPE_ID
@@ -114,9 +130,9 @@ class IncrementalPlanningAgent(CodeBoardingAgent):
         )
         prompt += _ARCHITECTURE_OUTPUT_CONTRACT
         context = ScopeOperationValidationContext(
+            reference_resolver=self.reference_resolver,
             expected_cluster_refs=_actionable_new_cluster_refs(structural_diff),
             existing_component_ids={component.component_id for component in scope.components if component.component_id},
-            known_qnames=_known_qnames(self.static_analysis),
             component_ids_by_cluster_ref=_component_ids_by_cluster_ref(scope_id, scope.components, structural_diff),
             component_ids_by_name=_component_ids_by_name(scope.components),
             scope_id=scope_id,
@@ -159,17 +175,13 @@ def validate_scope_update_decision(
     decision: ScopeUpdateDecision,
     context: ScopeOperationValidationContext,
 ) -> ValidationResult:
-    _normalize_scope_update_decision(decision, context)
+    _repair_unambiguous_routing_and_optional_key_entity_metadata(decision, context)
     errors: list[str] = []
     seen_refs: list[ClusterRef] = []
     for operation in decision.operations:
         refs = [_cluster_ref_from_scoped_ref(ref) for ref in operation.cluster_refs]
         seen_refs.extend(refs)
-        if operation.action in {
-            ScopeOperationAction.UPDATE_COMPONENT,
-            ScopeOperationAction.DELETE_COMPONENT,
-            ScopeOperationAction.NOOP,
-        }:
+        if operation.action in _EXISTING_COMPONENT_ACTIONS:
             if operation.component_id not in context.existing_component_ids:
                 errors.append(
                     f"Operation {operation.action} references unknown component_id={operation.component_id!r}."
@@ -187,9 +199,6 @@ def validate_scope_update_decision(
         duplicate_qnames = {qname for qname in entity_qnames if entity_qnames.count(qname) > 1}
         if duplicate_qnames:
             errors.append(f"Operation {operation.action} repeats key entities: {sorted(duplicate_qnames)}.")
-        unknown_qnames = set(entity_qnames) - context.known_qnames
-        if context.known_qnames and unknown_qnames:
-            errors.append(f"Operation {operation.action} references unknown key entities: {sorted(unknown_qnames)}.")
 
     seen_set = set(seen_refs)
     missing = context.expected_cluster_refs - seen_set
@@ -204,63 +213,70 @@ def validate_scope_update_decision(
     return ValidationResult(is_valid=not errors, feedback_messages=errors)
 
 
-def _normalize_scope_update_decision(
+def _repair_unambiguous_routing_and_optional_key_entity_metadata(
     decision: ScopeUpdateDecision,
     context: ScopeOperationValidationContext,
 ) -> None:
-    """Repair unambiguous routing and optional key-entity metadata."""
-    qname_aliases = _unique_qname_aliases(context.known_qnames)
-    routed_operations = 0
-    canonicalized_qnames = 0
-    dropped_qnames: set[str] = set()
-    for operation in decision.operations:
-        refs = {_cluster_ref_from_scoped_ref(ref) for ref in operation.cluster_refs}
-        if operation.component_id is None and operation.action in {
-            ScopeOperationAction.UPDATE_COMPONENT,
-            ScopeOperationAction.DELETE_COMPONENT,
-            ScopeOperationAction.NOOP,
-        }:
-            owner_ids = {
-                context.component_ids_by_cluster_ref[ref] for ref in refs if ref in context.component_ids_by_cluster_ref
-            }
-            if len(owner_ids) == 1:
-                operation.component_id = next(iter(owner_ids))
-            elif not owner_ids and operation.name:
-                operation.component_id = context.component_ids_by_name.get(_normalize_component_name(operation.name))
-            if operation.component_id is not None:
-                routed_operations += 1
-
-        if operation.action not in {ScopeOperationAction.CREATE_COMPONENT, ScopeOperationAction.UPDATE_COMPONENT}:
-            continue
-
-        normalized_entities: list[SourceCodeReference] = []
-        seen_qnames: set[str] = set()
-        for entity in operation.key_entities:
-            qname = entity.qualified_name
-            canonical_qname = qname if qname in context.known_qnames else qname_aliases.get(_qname_alias(qname))
-            if context.known_qnames and canonical_qname is None:
-                dropped_qnames.add(qname)
-                continue
-            canonical_qname = canonical_qname or qname
-            if canonical_qname in seen_qnames:
-                continue
-            if canonical_qname != qname:
-                canonicalized_qnames += 1
-            entity.qualified_name = canonical_qname
-            normalized_entities.append(entity)
-            seen_qnames.add(canonical_qname)
-            if len(normalized_entities) == 5:
-                break
-        operation.key_entities = normalized_entities
+    routed_operations = _repair_unambiguous_operation_routing(decision, context)
+    canonicalized_qnames, dropped_qnames = _repair_optional_key_entity_metadata(
+        decision,
+        context.reference_resolver,
+    )
 
     if routed_operations or canonicalized_qnames:
         logger.info(
-            "Normalized incremental plan: routed %d operation(s), canonicalized %d key-entity qname(s)",
+            "Repaired incremental plan: routed %d operation(s), canonicalized %d key-entity qname(s)",
             routed_operations,
             canonicalized_qnames,
         )
     if dropped_qnames:
         logger.warning("Dropped unresolved optional key entities: %s", sorted(dropped_qnames))
+
+
+def _repair_unambiguous_operation_routing(
+    decision: ScopeUpdateDecision,
+    context: ScopeOperationValidationContext,
+) -> int:
+    routed_operations = 0
+    for operation in decision.operations:
+        if operation.component_id is None and operation.action in _EXISTING_COMPONENT_ACTIONS:
+            component_id = _resolve_unambiguous_component_id(operation, context)
+            if component_id is not None:
+                operation.component_id = component_id
+                routed_operations += 1
+
+    return routed_operations
+
+
+def _resolve_unambiguous_component_id(
+    operation: ScopeOperation,
+    context: ScopeOperationValidationContext,
+) -> str | None:
+    refs = {_cluster_ref_from_scoped_ref(ref) for ref in operation.cluster_refs}
+    owner_ids = {
+        context.component_ids_by_cluster_ref[ref] for ref in refs if ref in context.component_ids_by_cluster_ref
+    }
+    if len(owner_ids) == 1:
+        return next(iter(owner_ids))
+    if not owner_ids and operation.name:
+        return context.component_ids_by_name.get(_normalize_component_name(operation.name))
+    return None
+
+
+def _repair_optional_key_entity_metadata(
+    decision: ScopeUpdateDecision,
+    reference_resolver: StaticReferenceResolver,
+) -> tuple[int, set[str]]:
+    canonicalized_qnames = 0
+    dropped_qnames: set[str] = set()
+    for operation in decision.operations:
+        if operation.action in _KEY_ENTITY_METADATA_ACTIONS and operation.key_entities:
+            repair = reference_resolver.repair_key_entity_references(operation.key_entities)
+            operation.key_entities = repair.references[:5]
+            canonicalized_qnames += repair.canonicalized_count
+            dropped_qnames.update(repair.unresolved_qnames)
+
+    return canonicalized_qnames, dropped_qnames
 
 
 def _component_ids_by_cluster_ref(
@@ -308,17 +324,6 @@ def _component_ids_by_name(components: list[Component]) -> dict[str, str]:
 
 def _normalize_component_name(name: str) -> str:
     return " ".join(name.casefold().split())
-
-
-def _qname_alias(qname: str) -> str:
-    return qname.replace("-", "_")
-
-
-def _unique_qname_aliases(known_qnames: set[str]) -> dict[str, str]:
-    qnames_by_alias: dict[str, set[str]] = {}
-    for qname in known_qnames:
-        qnames_by_alias.setdefault(_qname_alias(qname), set()).add(qname)
-    return {alias: next(iter(qnames)) for alias, qnames in qnames_by_alias.items() if len(qnames) == 1}
 
 
 def _cluster_ref_from_scoped_ref(ref: ScopedClusterRef) -> ClusterRef:
@@ -433,16 +438,6 @@ def _format_changed_files(changes: ChangeSet | None) -> str:
         else:
             lines.append(f"- {file_change.status_code} {file_change.file_path}")
     return "\n".join(lines)
-
-
-def _known_qnames(static_analysis: StaticAnalysisResults) -> set[str]:
-    qnames: set[str] = set()
-    for language in static_analysis.get_languages():
-        try:
-            qnames.update(static_analysis.get_cfg(language).nodes)
-        except (KeyError, ValueError):
-            continue
-    return qnames
 
 
 def _format_cluster_ref(ref: ClusterRef) -> str:

--- a/agents/incremental_planning_agent.py
+++ b/agents/incremental_planning_agent.py
@@ -29,6 +29,7 @@ from diagram_analysis.cluster_delta import (
     LanguageStructuralDiff,
     StructuralClusterDiff,
 )
+from diagram_analysis.exceptions import InvalidIncrementalPlanError, IncrementalScopeRegenerationRequiredError
 from repo_utils.change_detector import ChangeSet
 from static_analyzer.analysis_result import StaticAnalysisResults
 from telemetry.service import telemetry
@@ -37,10 +38,21 @@ from telemetry.service import telemetry
 logger = logging.getLogger(__name__)
 
 
+_ARCHITECTURE_OUTPUT_CONTRACT = """
+
+## Architecture output contract
+- This step plans component boundaries only. Do not define component relations; API surfaces and relations are generated later.
+- Preserve an existing component's name, description, and key entities unless its architectural responsibility changed.
+- For create_component, provide a clear name and description plus 1-5 key_entities using exact qualified names from the structural diff or source tools.
+- For update_component, include refreshed name, description, or key_entities only when the component's responsibility changed. An empty key_entities list preserves the current selection.
+"""
+
+
 @dataclass
 class ScopeOperationValidationContext:
     expected_cluster_refs: set[ClusterRef] = field(default_factory=set)
     existing_component_ids: set[str] = field(default_factory=set)
+    known_qnames: set[str] = field(default_factory=set)
     scope_id: str = ROOT_SCOPE_ID
 
 
@@ -96,9 +108,11 @@ class IncrementalPlanningAgent(CodeBoardingAgent):
             changed_files=_format_changed_files(self.toolkit.context.changes),
             structural_diff=format_structural_diff(structural_diff),
         )
+        prompt += _ARCHITECTURE_OUTPUT_CONTRACT
         context = ScopeOperationValidationContext(
             expected_cluster_refs=_actionable_new_cluster_refs(structural_diff),
             existing_component_ids={component.component_id for component in scope.components if component.component_id},
+            known_qnames=_known_qnames(self.static_analysis),
             scope_id=scope_id,
         )
         decision = self._validation_invoke(
@@ -111,10 +125,14 @@ class IncrementalPlanningAgent(CodeBoardingAgent):
         validation = validate_scope_update_decision(decision, context)
         if not validation.is_valid:
             logger.error(
-                "Incremental planning decision remained invalid after retries; will still pass it on. Issues: %s",
+                "Incremental planning decision remained invalid after retries: %s",
                 validation.feedback_messages,
             )
             _track_invalid_planning_decision(scope_id, validation.feedback_messages)
+            raise InvalidIncrementalPlanError(scope_id, validation.feedback_messages)
+        for operation in decision.operations:
+            if operation.action == ScopeOperationAction.REGENERATE_SCOPE:
+                raise IncrementalScopeRegenerationRequiredError(scope_id, operation.rationale)
         return decision
 
 
@@ -152,6 +170,21 @@ def validate_scope_update_decision(
         if operation.action == ScopeOperationAction.CREATE_COMPONENT:
             if not operation.name or not operation.description:
                 errors.append("create_component operations must include name and description.")
+            if not operation.key_entities:
+                errors.append("create_component operations must include at least one key entity.")
+        if operation.action == ScopeOperationAction.NOOP and (
+            operation.name or operation.description or operation.key_entities
+        ):
+            errors.append("noop operations must preserve the component name, description, and key entities.")
+        if len(operation.key_entities) > 5:
+            errors.append(f"Operation {operation.action} includes more than five key entities.")
+        entity_qnames = [entity.qualified_name for entity in operation.key_entities]
+        duplicate_qnames = {qname for qname in entity_qnames if entity_qnames.count(qname) > 1}
+        if duplicate_qnames:
+            errors.append(f"Operation {operation.action} repeats key entities: {sorted(duplicate_qnames)}.")
+        unknown_qnames = set(entity_qnames) - context.known_qnames
+        if context.known_qnames and unknown_qnames:
+            errors.append(f"Operation {operation.action} references unknown key entities: {sorted(unknown_qnames)}.")
 
     seen_set = set(seen_refs)
     missing = context.expected_cluster_refs - seen_set
@@ -253,12 +286,15 @@ def _actionable_new_cluster_refs(structural_diff: StructuralClusterDiff) -> set[
 def _format_scope_components(components: list[Component]) -> str:
     if not components:
         return "No existing components in this scope."
-    return "\n".join(
-        f'- {component.component_id or "?"} "{component.name}" '
-        f"clusters=[{_format_component_cluster_ids(component.source_cluster_ids)}] -- "
-        f"{(component.description or '').strip()}"
-        for component in components
-    )
+    lines: list[str] = []
+    for component in components:
+        key_entities = ", ".join(entity.qualified_name for entity in component.key_entities) or "None"
+        lines.append(
+            f'- {component.component_id or "?"} "{component.name}" '
+            f"clusters=[{_format_component_cluster_ids(component.source_cluster_ids)}] -- "
+            f"{(component.description or '').strip()} -- key_entities=[{key_entities}]"
+        )
+    return "\n".join(lines)
 
 
 def _format_component_cluster_ids(cluster_ids: list[str]) -> str:
@@ -275,6 +311,16 @@ def _format_changed_files(changes: ChangeSet | None) -> str:
         else:
             lines.append(f"- {file_change.status_code} {file_change.file_path}")
     return "\n".join(lines)
+
+
+def _known_qnames(static_analysis: StaticAnalysisResults) -> set[str]:
+    qnames: set[str] = set()
+    for language in static_analysis.get_languages():
+        try:
+            qnames.update(static_analysis.get_cfg(language).nodes)
+        except (KeyError, ValueError):
+            continue
+    return qnames
 
 
 def _format_cluster_ref(ref: ClusterRef) -> str:

--- a/agents/incremental_planning_agent.py
+++ b/agents/incremental_planning_agent.py
@@ -14,6 +14,7 @@ from agents.agent_responses import (
     AnalysisInsights,
     Component,
     MetaAnalysisInsights,
+    SourceCodeReference,
     ScopeOperationAction,
     ScopeUpdateDecision,
     ScopedClusterRef,
@@ -43,8 +44,9 @@ _ARCHITECTURE_OUTPUT_CONTRACT = """
 ## Architecture output contract
 - This step plans component boundaries only. Do not define component relations; API surfaces and relations are generated later.
 - Preserve an existing component's name, description, and key entities unless its architectural responsibility changed.
-- For create_component, provide a clear name and description plus 1-5 key_entities using exact qualified names from the structural diff or source tools.
+- For create_component, provide a clear name and description. Add up to 5 key_entities only when their exact qualified names are available; otherwise leave them empty for deterministic selection.
 - For update_component, include refreshed name, description, or key_entities only when the component's responsibility changed. An empty key_entities list preserves the current selection.
+- For update_component, delete_component, and noop, copy the exact component_id from the existing-components list.
 """
 
 
@@ -53,6 +55,8 @@ class ScopeOperationValidationContext:
     expected_cluster_refs: set[ClusterRef] = field(default_factory=set)
     existing_component_ids: set[str] = field(default_factory=set)
     known_qnames: set[str] = field(default_factory=set)
+    component_ids_by_cluster_ref: dict[ClusterRef, str] = field(default_factory=dict)
+    component_ids_by_name: dict[str, str] = field(default_factory=dict)
     scope_id: str = ROOT_SCOPE_ID
 
 
@@ -113,6 +117,8 @@ class IncrementalPlanningAgent(CodeBoardingAgent):
             expected_cluster_refs=_actionable_new_cluster_refs(structural_diff),
             existing_component_ids={component.component_id for component in scope.components if component.component_id},
             known_qnames=_known_qnames(self.static_analysis),
+            component_ids_by_cluster_ref=_component_ids_by_cluster_ref(scope_id, scope.components, structural_diff),
+            component_ids_by_name=_component_ids_by_name(scope.components),
             scope_id=scope_id,
         )
         decision = self._validation_invoke(
@@ -153,6 +159,7 @@ def validate_scope_update_decision(
     decision: ScopeUpdateDecision,
     context: ScopeOperationValidationContext,
 ) -> ValidationResult:
+    _normalize_scope_update_decision(decision, context)
     errors: list[str] = []
     seen_refs: list[ClusterRef] = []
     for operation in decision.operations:
@@ -170,8 +177,6 @@ def validate_scope_update_decision(
         if operation.action == ScopeOperationAction.CREATE_COMPONENT:
             if not operation.name or not operation.description:
                 errors.append("create_component operations must include name and description.")
-            if not operation.key_entities:
-                errors.append("create_component operations must include at least one key entity.")
         if operation.action == ScopeOperationAction.NOOP and (
             operation.name or operation.description or operation.key_entities
         ):
@@ -197,6 +202,123 @@ def validate_scope_update_decision(
     if duplicates:
         errors.append(f"Duplicate cluster_refs: {_format_cluster_ref_list(duplicates)}")
     return ValidationResult(is_valid=not errors, feedback_messages=errors)
+
+
+def _normalize_scope_update_decision(
+    decision: ScopeUpdateDecision,
+    context: ScopeOperationValidationContext,
+) -> None:
+    """Repair unambiguous routing and optional key-entity metadata."""
+    qname_aliases = _unique_qname_aliases(context.known_qnames)
+    routed_operations = 0
+    canonicalized_qnames = 0
+    dropped_qnames: set[str] = set()
+    for operation in decision.operations:
+        refs = {_cluster_ref_from_scoped_ref(ref) for ref in operation.cluster_refs}
+        if operation.component_id is None and operation.action in {
+            ScopeOperationAction.UPDATE_COMPONENT,
+            ScopeOperationAction.DELETE_COMPONENT,
+            ScopeOperationAction.NOOP,
+        }:
+            owner_ids = {
+                context.component_ids_by_cluster_ref[ref] for ref in refs if ref in context.component_ids_by_cluster_ref
+            }
+            if len(owner_ids) == 1:
+                operation.component_id = next(iter(owner_ids))
+            elif not owner_ids and operation.name:
+                operation.component_id = context.component_ids_by_name.get(_normalize_component_name(operation.name))
+            if operation.component_id is not None:
+                routed_operations += 1
+
+        if operation.action not in {ScopeOperationAction.CREATE_COMPONENT, ScopeOperationAction.UPDATE_COMPONENT}:
+            continue
+
+        normalized_entities: list[SourceCodeReference] = []
+        seen_qnames: set[str] = set()
+        for entity in operation.key_entities:
+            qname = entity.qualified_name
+            canonical_qname = qname if qname in context.known_qnames else qname_aliases.get(_qname_alias(qname))
+            if context.known_qnames and canonical_qname is None:
+                dropped_qnames.add(qname)
+                continue
+            canonical_qname = canonical_qname or qname
+            if canonical_qname in seen_qnames:
+                continue
+            if canonical_qname != qname:
+                canonicalized_qnames += 1
+            entity.qualified_name = canonical_qname
+            normalized_entities.append(entity)
+            seen_qnames.add(canonical_qname)
+            if len(normalized_entities) == 5:
+                break
+        operation.key_entities = normalized_entities
+
+    if routed_operations or canonicalized_qnames:
+        logger.info(
+            "Normalized incremental plan: routed %d operation(s), canonicalized %d key-entity qname(s)",
+            routed_operations,
+            canonicalized_qnames,
+        )
+    if dropped_qnames:
+        logger.warning("Dropped unresolved optional key entities: %s", sorted(dropped_qnames))
+
+
+def _component_ids_by_cluster_ref(
+    scope_id: str,
+    components: list[Component],
+    structural_diff: StructuralClusterDiff,
+) -> dict[ClusterRef, str]:
+    """Map new-side cluster refs to a unique existing owner when overlap proves one."""
+    prefix = "" if scope_id == ROOT_SCOPE_ID else f"{scope_id}."
+    owners_by_cluster_id: dict[str, set[str]] = {}
+    for component in components:
+        if not component.component_id:
+            continue
+        for cluster_id in component.source_cluster_ids:
+            owners_by_cluster_id.setdefault(cluster_id, set()).add(component.component_id)
+
+    def owner_for_old_ref(ref: ClusterRef) -> str | None:
+        owners = owners_by_cluster_id.get(f"{prefix}{ref.cluster_id}", set())
+        return next(iter(owners)) if len(owners) == 1 else None
+
+    owners_by_new_ref: dict[ClusterRef, set[str]] = {}
+    for language_diff in structural_diff.by_language.values():
+        for delta in language_diff.modified:
+            owner = owner_for_old_ref(delta.old_cluster)
+            if owner:
+                owners_by_new_ref.setdefault(delta.new_cluster, set()).add(owner)
+        for reshape in language_diff.reshaped:
+            for (old_ref, new_ref), overlap in reshape.overlap_counts.items():
+                if overlap <= 0:
+                    continue
+                owner = owner_for_old_ref(old_ref)
+                if owner:
+                    owners_by_new_ref.setdefault(new_ref, set()).add(owner)
+
+    return {ref: next(iter(owner_ids)) for ref, owner_ids in owners_by_new_ref.items() if len(owner_ids) == 1}
+
+
+def _component_ids_by_name(components: list[Component]) -> dict[str, str]:
+    ids_by_name: dict[str, set[str]] = {}
+    for component in components:
+        if component.component_id:
+            ids_by_name.setdefault(_normalize_component_name(component.name), set()).add(component.component_id)
+    return {name: next(iter(component_ids)) for name, component_ids in ids_by_name.items() if len(component_ids) == 1}
+
+
+def _normalize_component_name(name: str) -> str:
+    return " ".join(name.casefold().split())
+
+
+def _qname_alias(qname: str) -> str:
+    return qname.replace("-", "_")
+
+
+def _unique_qname_aliases(known_qnames: set[str]) -> dict[str, str]:
+    qnames_by_alias: dict[str, set[str]] = {}
+    for qname in known_qnames:
+        qnames_by_alias.setdefault(_qname_alias(qname), set()).add(qname)
+    return {alias: next(iter(qnames)) for alias, qnames in qnames_by_alias.items() if len(qnames) == 1}
 
 
 def _cluster_ref_from_scoped_ref(ref: ScopedClusterRef) -> ClusterRef:

--- a/agents/incremental_planning_agent.py
+++ b/agents/incremental_planning_agent.py
@@ -1,6 +1,5 @@
 """Plan scoped analysis updates from structural cluster diffs."""
 
-from dataclasses import dataclass, field
 from collections.abc import Iterable
 import logging
 from pathlib import Path
@@ -14,15 +13,16 @@ from agents.agent_responses import (
     AnalysisInsights,
     Component,
     MetaAnalysisInsights,
-    ScopeOperation,
-    ScopeOperationAction,
     ScopeUpdateDecision,
-    ScopedClusterRef,
 )
 from agents.cluster_ids import CodeBoardingClusterIds
 from agents.prompts import get_planning_message, get_system_message
+from agents.repair import (
+    ScopeOperationRepairContext,
+    repair_unambiguous_routing_and_optional_key_entity_metadata,
+)
 from agents.scope_ids import ROOT_SCOPE_ID
-from agents.validation import ValidationResult
+from agents.validation import ScopeOperationValidationContext, validate_scope_update_decision
 from diagram_analysis.cluster_delta import (
     ClusterMemberDelta,
     ClusterRef,
@@ -30,50 +30,14 @@ from diagram_analysis.cluster_delta import (
     LanguageStructuralDiff,
     StructuralClusterDiff,
 )
-from diagram_analysis.exceptions import InvalidIncrementalPlanError, IncrementalScopeRegenerationRequiredError
+from diagram_analysis.exceptions import InvalidIncrementalPlanError
 from repo_utils.change_detector import ChangeSet
 from static_analyzer.analysis_result import StaticAnalysisResults
-from static_analyzer.reference_resolver import StaticReferenceResolver
+from static_analyzer.graph import ClusterResult
 from telemetry.service import telemetry
 
 
 logger = logging.getLogger(__name__)
-
-
-_EXISTING_COMPONENT_ACTIONS = frozenset(
-    {
-        ScopeOperationAction.UPDATE_COMPONENT,
-        ScopeOperationAction.DELETE_COMPONENT,
-        ScopeOperationAction.NOOP,
-    }
-)
-_KEY_ENTITY_METADATA_ACTIONS = frozenset(
-    {
-        ScopeOperationAction.CREATE_COMPONENT,
-        ScopeOperationAction.UPDATE_COMPONENT,
-    }
-)
-
-
-_ARCHITECTURE_OUTPUT_CONTRACT = """
-
-## Architecture output contract
-- This step plans component boundaries only. Do not define component relations; API surfaces and relations are generated later.
-- Preserve an existing component's name, description, and key entities unless its architectural responsibility changed.
-- For create_component, provide a clear name and description. Add up to 5 key_entities only when their exact qualified names are available; otherwise leave them empty for deterministic selection.
-- For update_component, include refreshed name, description, or key_entities only when the component's responsibility changed. An empty key_entities list preserves the current selection.
-- For update_component, delete_component, and noop, copy the exact component_id from the existing-components list.
-"""
-
-
-@dataclass
-class ScopeOperationValidationContext:
-    reference_resolver: StaticReferenceResolver
-    expected_cluster_refs: set[ClusterRef] = field(default_factory=set)
-    existing_component_ids: set[str] = field(default_factory=set)
-    component_ids_by_cluster_ref: dict[ClusterRef, str] = field(default_factory=dict)
-    component_ids_by_name: dict[str, str] = field(default_factory=dict)
-    scope_id: str = ROOT_SCOPE_ID
 
 
 class IncrementalPlanningAgent(CodeBoardingAgent):
@@ -89,7 +53,14 @@ class IncrementalPlanningAgent(CodeBoardingAgent):
         parsing_llm: BaseChatModel,
         changes: ChangeSet | None = None,
     ):
-        super().__init__(repo_dir, static_analysis, get_system_message(), agent_llm, parsing_llm)
+        meta_context_str = meta_context.llm_str() if meta_context else "No project context available."
+        project_type = meta_context.project_type if meta_context else "unknown"
+        system_message = get_system_message().format(
+            project_name=project_name,
+            project_type=project_type,
+            meta_context=meta_context_str,
+        )
+        super().__init__(repo_dir, static_analysis, system_message, agent_llm, parsing_llm)
         if changes is not None:
             self.toolkit.context.changes = changes
         self.agent = create_agent(
@@ -101,10 +72,7 @@ class IncrementalPlanningAgent(CodeBoardingAgent):
         self.prompt = PromptTemplate(
             template=get_planning_message(),
             input_variables=[
-                "project_name",
                 "scope_id",
-                "project_type",
-                "meta_context",
                 "existing_components",
                 "changed_files",
                 "structural_diff",
@@ -116,35 +84,34 @@ class IncrementalPlanningAgent(CodeBoardingAgent):
         scope_id: str,
         scope: AnalysisInsights,
         structural_diff: StructuralClusterDiff,
+        cluster_results: dict[str, ClusterResult],
     ) -> ScopeUpdateDecision:
-        meta_context_str = self.meta_context.llm_str() if self.meta_context else "No project context available."
-        project_type = self.meta_context.project_type if self.meta_context else "unknown"
         prompt = self.prompt.format(
-            project_name=self.project_name,
             scope_id=scope_id,
-            project_type=project_type,
-            meta_context=meta_context_str,
             existing_components=_format_scope_components(scope.components),
             changed_files=_format_changed_files(self.toolkit.context.changes),
             structural_diff=format_structural_diff(structural_diff),
         )
-        prompt += _ARCHITECTURE_OUTPUT_CONTRACT
-        context = ScopeOperationValidationContext(
+        repair_context = ScopeOperationRepairContext(
             reference_resolver=self.reference_resolver,
-            expected_cluster_refs=_actionable_new_cluster_refs(structural_diff),
-            existing_component_ids={component.component_id for component in scope.components if component.component_id},
+            allowed_key_entity_qnames=_scope_key_entity_qnames(cluster_results),
             component_ids_by_cluster_ref=_component_ids_by_cluster_ref(scope_id, scope.components, structural_diff),
             component_ids_by_name=_component_ids_by_name(scope.components),
-            scope_id=scope_id,
         )
-        decision = self._validation_invoke(
+        validation_context = ScopeOperationValidationContext(
+            expected_cluster_refs=_actionable_new_cluster_refs(structural_diff),
+            existing_component_ids={component.component_id for component in scope.components if component.component_id},
+        )
+        decision = self._invoke_repair_validate(
             prompt,
             ScopeUpdateDecision,
+            repairs=[repair_unambiguous_routing_and_optional_key_entity_metadata],
             validators=[validate_scope_update_decision],
-            context=context,
+            repair_context=repair_context,
+            validation_context=validation_context,
             max_validation_attempts=3,
         )
-        validation = validate_scope_update_decision(decision, context)
+        validation = validate_scope_update_decision(decision, validation_context)
         if not validation.is_valid:
             logger.error(
                 "Incremental planning decision remained invalid after retries: %s",
@@ -152,9 +119,6 @@ class IncrementalPlanningAgent(CodeBoardingAgent):
             )
             _track_invalid_planning_decision(scope_id, validation.feedback_messages)
             raise InvalidIncrementalPlanError(scope_id, validation.feedback_messages)
-        for operation in decision.operations:
-            if operation.action == ScopeOperationAction.REGENERATE_SCOPE:
-                raise IncrementalScopeRegenerationRequiredError(scope_id, operation.rationale)
         return decision
 
 
@@ -171,112 +135,13 @@ def _track_invalid_planning_decision(scope_id: str, feedback_messages: list[str]
     telemetry.flush()
 
 
-def validate_scope_update_decision(
-    decision: ScopeUpdateDecision,
-    context: ScopeOperationValidationContext,
-) -> ValidationResult:
-    _repair_unambiguous_routing_and_optional_key_entity_metadata(decision, context)
-    errors: list[str] = []
-    seen_refs: list[ClusterRef] = []
-    for operation in decision.operations:
-        refs = [_cluster_ref_from_scoped_ref(ref) for ref in operation.cluster_refs]
-        seen_refs.extend(refs)
-        if operation.action in _EXISTING_COMPONENT_ACTIONS:
-            if operation.component_id not in context.existing_component_ids:
-                errors.append(
-                    f"Operation {operation.action} references unknown component_id={operation.component_id!r}."
-                )
-        if operation.action == ScopeOperationAction.CREATE_COMPONENT:
-            if not operation.name or not operation.description:
-                errors.append("create_component operations must include name and description.")
-        if operation.action == ScopeOperationAction.NOOP and (
-            operation.name or operation.description or operation.key_entities
-        ):
-            errors.append("noop operations must preserve the component name, description, and key entities.")
-        if len(operation.key_entities) > 5:
-            errors.append(f"Operation {operation.action} includes more than five key entities.")
-        entity_qnames = [entity.qualified_name for entity in operation.key_entities]
-        duplicate_qnames = {qname for qname in entity_qnames if entity_qnames.count(qname) > 1}
-        if duplicate_qnames:
-            errors.append(f"Operation {operation.action} repeats key entities: {sorted(duplicate_qnames)}.")
-
-    seen_set = set(seen_refs)
-    missing = context.expected_cluster_refs - seen_set
-    extra = seen_set - context.expected_cluster_refs
-    duplicates = {ref for ref in seen_set if seen_refs.count(ref) > 1}
-    if missing:
-        errors.append(f"Missing cluster_refs: {_format_cluster_ref_list(missing)}")
-    if extra:
-        errors.append(f"Unexpected cluster_refs: {_format_cluster_ref_list(extra)}")
-    if duplicates:
-        errors.append(f"Duplicate cluster_refs: {_format_cluster_ref_list(duplicates)}")
-    return ValidationResult(is_valid=not errors, feedback_messages=errors)
-
-
-def _repair_unambiguous_routing_and_optional_key_entity_metadata(
-    decision: ScopeUpdateDecision,
-    context: ScopeOperationValidationContext,
-) -> None:
-    routed_operations = _repair_unambiguous_operation_routing(decision, context)
-    canonicalized_qnames, dropped_qnames = _repair_optional_key_entity_metadata(
-        decision,
-        context.reference_resolver,
-    )
-
-    if routed_operations or canonicalized_qnames:
-        logger.info(
-            "Repaired incremental plan: routed %d operation(s), canonicalized %d key-entity qname(s)",
-            routed_operations,
-            canonicalized_qnames,
-        )
-    if dropped_qnames:
-        logger.warning("Dropped unresolved optional key entities: %s", sorted(dropped_qnames))
-
-
-def _repair_unambiguous_operation_routing(
-    decision: ScopeUpdateDecision,
-    context: ScopeOperationValidationContext,
-) -> int:
-    routed_operations = 0
-    for operation in decision.operations:
-        if operation.component_id is None and operation.action in _EXISTING_COMPONENT_ACTIONS:
-            component_id = _resolve_unambiguous_component_id(operation, context)
-            if component_id is not None:
-                operation.component_id = component_id
-                routed_operations += 1
-
-    return routed_operations
-
-
-def _resolve_unambiguous_component_id(
-    operation: ScopeOperation,
-    context: ScopeOperationValidationContext,
-) -> str | None:
-    refs = {_cluster_ref_from_scoped_ref(ref) for ref in operation.cluster_refs}
-    owner_ids = {
-        context.component_ids_by_cluster_ref[ref] for ref in refs if ref in context.component_ids_by_cluster_ref
+def _scope_key_entity_qnames(cluster_results: dict[str, ClusterResult]) -> set[str]:
+    return {
+        qualified_name
+        for cluster_result in cluster_results.values()
+        for members in cluster_result.clusters.values()
+        for qualified_name in members
     }
-    if len(owner_ids) == 1:
-        return next(iter(owner_ids))
-    if not owner_ids and operation.name:
-        return context.component_ids_by_name.get(_normalize_component_name(operation.name))
-    return None
-
-
-def _repair_optional_key_entity_metadata(
-    decision: ScopeUpdateDecision,
-    reference_resolver: StaticReferenceResolver,
-) -> tuple[int, set[str]]:
-    canonicalized_qnames = 0
-    dropped_qnames: set[str] = set()
-    for operation in decision.operations:
-        if operation.action in _KEY_ENTITY_METADATA_ACTIONS and operation.key_entities:
-            repair = reference_resolver.repair_key_entity_references(operation.key_entities)
-            operation.key_entities = repair.references[:5]
-            canonicalized_qnames += repair.canonicalized_count
-            dropped_qnames.update(repair.unresolved_qnames)
-
-    return canonicalized_qnames, dropped_qnames
 
 
 def _component_ids_by_cluster_ref(
@@ -285,7 +150,7 @@ def _component_ids_by_cluster_ref(
     structural_diff: StructuralClusterDiff,
 ) -> dict[ClusterRef, str]:
     """Map new-side cluster refs to a unique existing owner when overlap proves one."""
-    prefix = "" if scope_id == ROOT_SCOPE_ID else f"{scope_id}."
+    cluster_id_prefix = CodeBoardingClusterIds.prefix_for_scope(scope_id)
     owners_by_cluster_id: dict[str, set[str]] = {}
     for component in components:
         if not component.component_id:
@@ -294,7 +159,11 @@ def _component_ids_by_cluster_ref(
             owners_by_cluster_id.setdefault(cluster_id, set()).add(component.component_id)
 
     def owner_for_old_ref(ref: ClusterRef) -> str | None:
-        owners = owners_by_cluster_id.get(f"{prefix}{ref.cluster_id}", set())
+        cluster_id = CodeBoardingClusterIds.qualify_local_id(
+            CodeBoardingClusterIds.from_graph_id(ref.cluster_id),
+            cluster_id_prefix,
+        )
+        owners = owners_by_cluster_id.get(cluster_id, set())
         return next(iter(owners)) if len(owners) == 1 else None
 
     owners_by_new_ref: dict[ClusterRef, set[str]] = {}
@@ -324,10 +193,6 @@ def _component_ids_by_name(components: list[Component]) -> dict[str, str]:
 
 def _normalize_component_name(name: str) -> str:
     return " ".join(name.casefold().split())
-
-
-def _cluster_ref_from_scoped_ref(ref: ScopedClusterRef) -> ClusterRef:
-    return ClusterRef(ref.language, ref.cluster_id, ref.scope_id)
 
 
 def format_structural_diff(structural_diff: StructuralClusterDiff) -> str:
@@ -446,9 +311,3 @@ def _format_cluster_ref(ref: ClusterRef) -> str:
 
 def _sort_cluster_refs(refs: Iterable[ClusterRef]) -> list[ClusterRef]:
     return sorted(refs, key=lambda ref: (ref.scope_id, ref.language, ref.cluster_id))
-
-
-def _format_cluster_ref_list(refs: set[ClusterRef]) -> str:
-    if not refs:
-        return "None"
-    return ", ".join(_format_cluster_ref(ref) for ref in _sort_cluster_refs(refs))

--- a/agents/incremental_planning_agent.py
+++ b/agents/incremental_planning_agent.py
@@ -22,6 +22,7 @@ from agents.repair import (
     repair_unambiguous_routing_and_optional_key_entity_metadata,
 )
 from agents.scope_ids import ROOT_SCOPE_ID
+from agents.scope_operations import cluster_member_qnames, normalize_component_name
 from agents.validation import ScopeOperationValidationContext, validate_scope_update_decision
 from diagram_analysis.cluster_delta import (
     ClusterMemberDelta,
@@ -94,7 +95,7 @@ class IncrementalPlanningAgent(CodeBoardingAgent):
         )
         repair_context = ScopeOperationRepairContext(
             reference_resolver=self.reference_resolver,
-            allowed_key_entity_qnames=_scope_key_entity_qnames(cluster_results),
+            allowed_key_entity_qnames=cluster_member_qnames(cluster_results),
             component_ids_by_cluster_ref=_component_ids_by_cluster_ref(scope_id, scope.components, structural_diff),
             component_ids_by_name=_component_ids_by_name(scope.components),
         )
@@ -133,15 +134,6 @@ def _track_invalid_planning_decision(scope_id: str, feedback_messages: list[str]
         },
     )
     telemetry.flush()
-
-
-def _scope_key_entity_qnames(cluster_results: dict[str, ClusterResult]) -> set[str]:
-    return {
-        qualified_name
-        for cluster_result in cluster_results.values()
-        for members in cluster_result.clusters.values()
-        for qualified_name in members
-    }
 
 
 def _component_ids_by_cluster_ref(
@@ -187,12 +179,8 @@ def _component_ids_by_name(components: list[Component]) -> dict[str, str]:
     ids_by_name: dict[str, set[str]] = {}
     for component in components:
         if component.component_id:
-            ids_by_name.setdefault(_normalize_component_name(component.name), set()).add(component.component_id)
+            ids_by_name.setdefault(normalize_component_name(component.name), set()).add(component.component_id)
     return {name: next(iter(component_ids)) for name, component_ids in ids_by_name.items() if len(component_ids) == 1}
-
-
-def _normalize_component_name(name: str) -> str:
-    return " ".join(name.casefold().split())
 
 
 def format_structural_diff(structural_diff: StructuralClusterDiff) -> str:

--- a/agents/incremental_results.py
+++ b/agents/incremental_results.py
@@ -1,17 +1,31 @@
 from dataclasses import dataclass, field
 
+from static_analyzer.graph import CallGraph, ClusterResult
+
+
+@dataclass(frozen=True)
+class ScopeRelationContext:
+    """Static-analysis context required to regenerate one scope's relations."""
+
+    cluster_results: dict[str, ClusterResult]
+    cfg_graphs: dict[str, CallGraph]
+
 
 @dataclass
 class ScopeUpdateResult:
     """Result of applying one incremental plan to one analysis scope."""
 
+    relation_context: ScopeRelationContext
     refresh_ids: set[str] = field(default_factory=set)
     new_component_ids: set[str] = field(default_factory=set)
     removed_ids: set[str] = field(default_factory=set)
 
 
 @dataclass
-class RecursiveScopeUpdateResult(ScopeUpdateResult):
+class RecursiveScopeUpdateResult:
     """Aggregated result from recursively updating expanded scopes."""
 
-    touched_scopes: set[str] = field(default_factory=set)
+    refresh_ids: set[str] = field(default_factory=set)
+    new_component_ids: set[str] = field(default_factory=set)
+    removed_ids: set[str] = field(default_factory=set)
+    relation_contexts: dict[str, ScopeRelationContext] = field(default_factory=dict)

--- a/agents/incremental_results.py
+++ b/agents/incremental_results.py
@@ -8,7 +8,6 @@ class ScopeUpdateResult:
     refresh_ids: set[str] = field(default_factory=set)
     new_component_ids: set[str] = field(default_factory=set)
     removed_ids: set[str] = field(default_factory=set)
-    regenerate_scope: bool = False
 
 
 @dataclass

--- a/agents/prompts/__init__.py
+++ b/agents/prompts/__init__.py
@@ -11,6 +11,7 @@ from .prompt_factory import (
     initialize_global_factory,
     get_global_factory,
     get_prompt,
+    format_project_system_message,
 )
 
 # Import all the convenience functions for backward compatibility
@@ -60,6 +61,7 @@ __all__ = [
     "initialize_global_factory",
     "get_global_factory",
     "get_prompt",
+    "format_project_system_message",
     # Convenience functions
     "get_system_message",
     "get_cluster_grouping_message",

--- a/agents/prompts/abstract_prompt_factory.py
+++ b/agents/prompts/abstract_prompt_factory.py
@@ -77,9 +77,7 @@ class AbstractPromptFactory(ABC):
         return RELATION_ANALYSIS_MESSAGE
 
 
-API_SURFACES_MESSAGE = """Analyze component API surfaces for `{project_name}`.
-
-Project Type: {project_type}
+API_SURFACES_MESSAGE = """Analyze the component API surfaces.
 
 Components:
 {component_summaries}
@@ -95,9 +93,7 @@ Identify each component's API surface. For every component, describe:
 Static call evidence is incomplete. Reason from component APIs, registries, protocols, runtime dispatch, plugin hooks, configuration, and data flow."""
 
 
-RELATION_ANALYSIS_MESSAGE = """Discover architectural communication relations for `{project_name}`.
-
-Project Type: {project_type}
+RELATION_ANALYSIS_MESSAGE = """Discover architectural communication relations between the components.
 
 Components:
 {component_summaries}

--- a/agents/prompts/claude_prompts.py
+++ b/agents/prompts/claude_prompts.py
@@ -15,13 +15,9 @@ Claude Prompt Design Principles:
 
 from .abstract_prompt_factory import AbstractPromptFactory
 
-SCOPE_RELATIONS_MESSAGE = """Generate inter-component relationships for the `{scope_name}` scope of `{project_name}`.
+SCOPE_RELATIONS_MESSAGE = """Generate inter-component relationships for the `{scope_name}` scope.
 
 <context>
-Project context: {meta_context}
-
-Project type: {project_type}
-
 ### Components in this scope
 {component_summaries}
 
@@ -74,12 +70,7 @@ Focus on:
 - Architectural patterns that help new developers understand the system quickly
 </thinking>"""
 
-CLUSTER_GROUPING_MESSAGE = """Analyze and GROUP the Control Flow Graph clusters for `{project_name}`.
-
-Project Context:
-{meta_context}
-
-Project Type: {project_type}
+CLUSTER_GROUPING_MESSAGE = """Analyze and GROUP the Control Flow Graph clusters.
 
 The CFG has been pre-clustered into groups of related methods/functions. Each cluster represents methods that call each other frequently.
 
@@ -104,15 +95,12 @@ Instructions:
      * The most important classes/methods in this group — mention their exact qualified names as shown in the clusters above
 
 Focus on:
-- Creating cohesive, logical groupings that reflect the actual {project_type} architecture
+- Creating cohesive, logical groupings that reflect the actual architecture
 - Semantic meaning based on method names, call patterns, and architectural context
 - Clear justification for why clusters belong together
 - Describing inter-group interactions based on the inter-cluster connections"""
 
-FINAL_ANALYSIS_MESSAGE = """Create final component architecture for `{project_name}` optimized for flow representation.
-
-Project Context:
-{meta_context}
+FINAL_ANALYSIS_MESSAGE = """Create final component architecture optimized for flow representation.
 
 Cluster Analysis:
 {cluster_analysis}
@@ -125,7 +113,7 @@ Instructions:
 5. Do not define relationships yet; relationships are discovered in a later API-surface step
 6. Provide a one-paragraph description of the overall main flow and purpose
 
-Guidelines for {project_type} projects:
+Guidelines:
 - Aim for 5-8 final components
 - Merge related cluster groups that serve a common purpose
 - Each component should have clear boundaries
@@ -290,12 +278,7 @@ Required outputs:
 
 Focus on subsystem-specific functionality. Avoid cross-cutting concerns like logging or error handling."""
 
-CFG_DETAILS_MESSAGE = """Analyze and GROUP the Control Flow Graph clusters for the `{component}` subsystem of `{project_name}`.
-
-Project Context:
-{meta_context}
-
-Project Type: {project_type}
+CFG_DETAILS_MESSAGE = """Analyze and GROUP the Control Flow Graph clusters for the `{component}` subsystem.
 
 The CFG has been pre-clustered into groups of related methods/functions. Each cluster represents methods that call each other frequently.
 
@@ -321,10 +304,7 @@ Instructions:
 
 Focus on core subsystem functionality only. Avoid cross-cutting concerns like logging or error handling."""
 
-DETAILS_MESSAGE = """Create final sub-component architecture for the `{component}` subsystem of `{project_name}` optimized for flow representation.
-
-Project Context:
-{meta_context}
+DETAILS_MESSAGE = """Create final sub-component architecture for the `{component}` subsystem optimized for flow representation.
 
 Cluster Analysis:
 {cluster_analysis}
@@ -337,7 +317,7 @@ Instructions:
 5. Do not define relationships yet; relationships are discovered in a later API-surface step
 6. Provide a one-paragraph description of the subsystem's main flow and purpose
 
-Guidelines for {project_type} projects:
+Guidelines:
 - Aim for 3-8 final sub-components
 - Merge related cluster groups that serve a common purpose
 - Each sub-component should have clear boundaries
@@ -350,13 +330,9 @@ Constraints:
 
 Justify component choices based on fundamental architectural importance."""
 
-INCREMENTAL_GROUPING_MESSAGE = """Update the architecture of `{project_name}` by routing changed and new CFG clusters to the right components.
+INCREMENTAL_GROUPING_MESSAGE = """Update the architecture by routing changed and new CFG clusters to the right components.
 
 <context>
-Project context: {meta_context}
-
-Project Type: {project_type}
-
 The previous analysis established the components below. Most clusters are unchanged and stay where they are; this prompt only shows the structural slice that changed: new clusters, removed clusters, or clusters whose member set changed through added/removed methods. A method body edit by itself is not a cluster-boundary change.
 
 ### Existing components (each line shows `component_id "name"`)
@@ -386,7 +362,7 @@ Boundary rules:
 
 Focus on:
 - Placing clusters where they belong architecturally, guided by method names, call patterns, and the existing component boundaries
-- Creating cohesive groupings that reflect the actual {project_type} architecture
+- Creating cohesive groupings that reflect the actual architecture
 - Accurately judging whether a delta is meaningful or cosmetic for the redetail decision
 - Choosing sensible parents for new components based on scope and responsibility
 </instructions>
@@ -419,15 +395,15 @@ Return operations for this scope only.
 - For modified clusters, preserve the existing owning component shown by its clusters=[...] list; use update_component for that owner instead of moving the cluster to another component.
 - For new clusters, decide from the structural diff whether they extend an existing responsibility or introduce a new component; do not infer this from file/package layout alone.
 - For reshaped groups, follow overlap counts to keep old cluster ownership stable. Only assign a reshaped new cluster to a different component when the diff proves a real responsibility move.
-- Do not reparent existing components. Preserve their current scope; reparenting is not a valid incremental operation.
+- Reparenting existing components is unsupported by the current incremental schema. Preserve their current scope.
 - Every modified/new/reshaped new-side cluster listed below must appear in exactly one operation's cluster_refs.
 
 <architecture_output_contract>
 - This step plans component boundaries only. Do not define component relations; API surfaces and relations are generated later.
-- Preserve an existing component's name, description, and key entities unless its architectural responsibility changed.
-- For create_component, provide a clear name and description. Select up to 5 key_entities only when their exact qualified names are available; otherwise leave them empty. Key entities are not synthesized later.
-- For update_component, include refreshed name, description, or key_entities only when the component's responsibility changed. An empty key_entities list preserves the current selection.
-- For update_component, delete_component, and noop, copy the exact component_id from the existing-components list.
+- Choose exactly one of these mutually exclusive branches for each operation:
+  - For create_component only: leave component_id null; provide a clear name and description. Select up to 5 key_entities only when their exact qualified names are available; otherwise leave them empty. Key entities are not synthesized later.
+  - For update_component only: copy the exact component_id from the existing-components list. Include refreshed name, description, or key_entities only when the component's architectural responsibility changed; otherwise preserve the existing metadata. An empty key_entities list preserves the current selection.
+  - For delete_component or noop only: copy the exact component_id from the existing-components list and leave name, description, and key_entities empty. Use delete_component only when the component has no remaining responsibility; use noop to preserve it unchanged.
 </architecture_output_contract>
 
 </instructions>

--- a/agents/prompts/claude_prompts.py
+++ b/agents/prompts/claude_prompts.py
@@ -396,14 +396,10 @@ For each cluster you're uncertain about, you may read source. Keep each read sma
 </tool_usage_policy>"""
 
 
-PLANNING_MESSAGE = """Update one scope of the `{project_name}` architecture diagram.
+PLANNING_MESSAGE = """Update one scope of the architecture diagram.
 
 <context>
 Scope: `{scope_id}` (`root` means the top-level diagram)
-Project type: {project_type}
-
-Project context:
-{meta_context}
 
 Existing components in this scope:
 {existing_components}
@@ -423,8 +419,16 @@ Return operations for this scope only.
 - For modified clusters, preserve the existing owning component shown by its clusters=[...] list; use update_component for that owner instead of moving the cluster to another component.
 - For new clusters, decide from the structural diff whether they extend an existing responsibility or introduce a new component; do not infer this from file/package layout alone.
 - For reshaped groups, follow overlap counts to keep old cluster ownership stable. Only assign a reshaped new cluster to a different component when the diff proves a real responsibility move.
-- Do not reparent existing components. If reparenting seems required, use regenerate_scope.
+- Do not reparent existing components. Preserve their current scope; reparenting is not a valid incremental operation.
 - Every modified/new/reshaped new-side cluster listed below must appear in exactly one operation's cluster_refs.
+
+<architecture_output_contract>
+- This step plans component boundaries only. Do not define component relations; API surfaces and relations are generated later.
+- Preserve an existing component's name, description, and key entities unless its architectural responsibility changed.
+- For create_component, provide a clear name and description. Select up to 5 key_entities only when their exact qualified names are available; otherwise leave them empty. Key entities are not synthesized later.
+- For update_component, include refreshed name, description, or key_entities only when the component's responsibility changed. An empty key_entities list preserves the current selection.
+- For update_component, delete_component, and noop, copy the exact component_id from the existing-components list.
+</architecture_output_contract>
 
 </instructions>
 

--- a/agents/prompts/deepseek_prompts.py
+++ b/agents/prompts/deepseek_prompts.py
@@ -404,12 +404,10 @@ Every cluster id listed in the "Cluster groups to assign" section must appear in
 
 
 PLANNING_MESSAGE = """# Task
-Update one scope of the `{project_name}` architecture diagram.
+Update one scope of the architecture diagram.
 
 # Context
 - Scope: `{scope_id}` (`root` means the top-level diagram)
-- Project type: {project_type}
-- Meta: {meta_context}
 
 # Existing components in this scope
 {existing_components}
@@ -431,8 +429,15 @@ Return operations for this scope only.
 5. Use listGitChanges only when the structural diff is not enough to judge semantic impact.
 
 # Critical rules
-- Do not reparent existing components. If reparenting seems required, use regenerate_scope.
+- Do not reparent existing components. Preserve their current scope; reparenting is not a valid incremental operation.
 - Every modified/new/reshaped new-side cluster listed below must appear in exactly one operation's cluster_refs.
+
+# Architecture output contract
+- This step plans component boundaries only. Do not define component relations; API surfaces and relations are generated later.
+- Preserve an existing component's name, description, and key entities unless its architectural responsibility changed.
+- For create_component, provide a clear name and description. Select up to 5 key_entities only when their exact qualified names are available; otherwise leave them empty. Key entities are not synthesized later.
+- For update_component, include refreshed name, description, or key_entities only when the component's responsibility changed. An empty key_entities list preserves the current selection.
+- For update_component, delete_component, and noop, copy the exact component_id from the existing-components list.
 """
 
 

--- a/agents/prompts/deepseek_prompts.py
+++ b/agents/prompts/deepseek_prompts.py
@@ -16,12 +16,7 @@ DeepSeek Prompt Design Principles:
 from .abstract_prompt_factory import AbstractPromptFactory
 
 SCOPE_RELATIONS_MESSAGE = """# Task
-Generate inter-component relationships for the `{scope_name}` scope of `{project_name}`.
-
-# Context
-Project Type: {project_type}
-
-{meta_context}
+Generate inter-component relationships for the `{scope_name}` scope.
 
 # Components in this scope
 {component_summaries}
@@ -71,12 +66,7 @@ Analyze Control Flow Graphs (CFG) for `{project_name}` and generate a high-level
 Begin with provided data. Use tools when necessary. Focus on creating analysis suitable for both documentation and visual diagram generation."""
 
 CLUSTER_GROUPING_MESSAGE = """# Task
-Analyze and GROUP the Control Flow Graph clusters for `{project_name}`.
-
-# Context
-Project Type: {project_type}
-
-{meta_context}
+Analyze and GROUP the Control Flow Graph clusters.
 
 The CFG has been pre-clustered into groups of related methods/functions. Each cluster represents methods that call each other frequently.
 
@@ -98,7 +88,7 @@ The CFG has been pre-clustered into groups of related methods/functions. Each cl
      * The most important classes/methods in this group — mention their exact qualified names as shown in the clusters above
 
 # Focus areas
-- Create cohesive, logical groupings that reflect the actual {project_type} architecture
+- Create cohesive, logical groupings that reflect the actual architecture
 - Base decisions on semantic meaning from method names, call patterns, and architectural context
 - Provide clear justification for why clusters belong together
 - Describe inter-group interactions based on the inter-cluster connections
@@ -107,10 +97,7 @@ The CFG has been pre-clustered into groups of related methods/functions. Each cl
 For each component provide a descriptive name, the list of cluster IDs it contains, and a comprehensive description with rationale and inter-group interactions."""
 
 FINAL_ANALYSIS_MESSAGE = """# Task
-Create final component architecture for `{project_name}` optimized for flow representation.
-
-# Context
-{meta_context}
+Create final component architecture optimized for flow representation.
 
 # Cluster Analysis
 {cluster_analysis}
@@ -122,7 +109,7 @@ Create final component architecture for `{project_name}` optimized for flow repr
 4. Add key entities (2-5 most important classes/methods) for each component, referencing the source file where they are defined.
 5. Do not define relationships yet; relationships are discovered in a later API-surface step.
 
-# Guidelines for {project_type} projects
+# Guidelines
 - Aim for 5-8 final components
 - Merge related cluster groups that serve a common purpose
 - Each component must have clear boundaries
@@ -299,12 +286,7 @@ Analyze a subsystem of `{project_name}`.
 Analyze subsystem-specific functionality. Avoid cross-cutting concerns like logging or error handling."""
 
 CFG_DETAILS_MESSAGE = """# Task
-Analyze and GROUP the Control Flow Graph clusters for the `{component}` subsystem of `{project_name}`.
-
-# Context
-Project Type: {project_type}
-
-{meta_context}
+Analyze and GROUP the Control Flow Graph clusters for the `{component}` subsystem.
 
 The CFG has been pre-clustered into groups of related methods/functions. Each cluster represents methods that call each other frequently.
 
@@ -332,10 +314,7 @@ Analyze core subsystem functionality only. Avoid cross-cutting concerns like log
 For each sub-component provide a descriptive name, the list of cluster IDs it contains, and a comprehensive description with rationale and inter-group interactions."""
 
 DETAILS_MESSAGE = """# Task
-Create final sub-component architecture for the `{component}` subsystem of `{project_name}` optimized for flow representation.
-
-# Context
-{meta_context}
+Create final sub-component architecture for the `{component}` subsystem optimized for flow representation.
 
 # Cluster Analysis
 {cluster_analysis}
@@ -347,7 +326,7 @@ Create final sub-component architecture for the `{component}` subsystem of `{pro
 4. Add key entities (2-5 most important classes/methods) for each sub-component, referencing the source file where they are defined.
 5. Do not define relationships yet; relationships are discovered in a later API-surface step.
 
-# Guidelines for {project_type} projects
+# Guidelines
 - Aim for 3-8 final sub-components
 - Merge related cluster groups that serve a common purpose
 - Each sub-component must have clear boundaries
@@ -367,11 +346,6 @@ Base component choices on fundamental architectural importance."""
 
 INCREMENTAL_GROUPING_MESSAGE = """# Task
 Route each changed or new CFG cluster into the correct component — either an existing one or a brand new one.
-
-# Context
-- Project: {project_name}
-- Type: {project_type}
-- Meta: {meta_context}
 
 The previous analysis established the components below. Most clusters are unchanged and stay where they are; this prompt only shows the structural slice that changed: new clusters, removed clusters, or clusters whose member set changed through added/removed methods. A method body edit by itself is not a cluster-boundary change.
 
@@ -429,15 +403,15 @@ Return operations for this scope only.
 5. Use listGitChanges only when the structural diff is not enough to judge semantic impact.
 
 # Critical rules
-- Do not reparent existing components. Preserve their current scope; reparenting is not a valid incremental operation.
+- Reparenting existing components is unsupported by the current incremental schema. Preserve their current scope.
 - Every modified/new/reshaped new-side cluster listed below must appear in exactly one operation's cluster_refs.
 
 # Architecture output contract
 - This step plans component boundaries only. Do not define component relations; API surfaces and relations are generated later.
-- Preserve an existing component's name, description, and key entities unless its architectural responsibility changed.
-- For create_component, provide a clear name and description. Select up to 5 key_entities only when their exact qualified names are available; otherwise leave them empty. Key entities are not synthesized later.
-- For update_component, include refreshed name, description, or key_entities only when the component's responsibility changed. An empty key_entities list preserves the current selection.
-- For update_component, delete_component, and noop, copy the exact component_id from the existing-components list.
+- Choose exactly one of these mutually exclusive branches for each operation:
+  - For create_component only: leave component_id null; provide a clear name and description. Select up to 5 key_entities only when their exact qualified names are available; otherwise leave them empty. Key entities are not synthesized later.
+  - For update_component only: copy the exact component_id from the existing-components list. Include refreshed name, description, or key_entities only when the component's architectural responsibility changed; otherwise preserve the existing metadata. An empty key_entities list preserves the current selection.
+  - For delete_component or noop only: copy the exact component_id from the existing-components list and leave name, description, and key_entities empty. Use delete_component only when the component has no remaining responsibility; use noop to preserve it unchanged.
 """
 
 

--- a/agents/prompts/gemini_flash_prompts.py
+++ b/agents/prompts/gemini_flash_prompts.py
@@ -15,12 +15,7 @@ Gemini Flash Prompt Design Principles:
 
 from .abstract_prompt_factory import AbstractPromptFactory
 
-SCOPE_RELATIONS_MESSAGE = """Generate inter-component relationships for the `{scope_name}` scope of `{project_name}`.
-
-Project Context:
-{meta_context}
-
-Project Type: {project_type}
+SCOPE_RELATIONS_MESSAGE = """Generate inter-component relationships for the `{scope_name}` scope.
 
 Components in this scope:
 {component_summaries}
@@ -57,12 +52,7 @@ Your analysis must include:
 
 Start with the provided data. Use tools when necessary. Focus on creating analysis suitable for both documentation and visual diagram generation."""
 
-CLUSTER_GROUPING_MESSAGE = """Analyze and GROUP the Control Flow Graph clusters for `{project_name}`.
-
-Project Context:
-{meta_context}
-
-Project Type: {project_type}
+CLUSTER_GROUPING_MESSAGE = """Analyze and GROUP the Control Flow Graph clusters.
 
 The CFG has been pre-clustered into groups of related methods/functions. Each cluster represents methods that call each other frequently.
 
@@ -91,15 +81,12 @@ Instructions:
      * The most important classes/methods in this group — mention their exact qualified names as shown in the clusters above
 
 Focus on:
-- Creating cohesive, logical groupings that reflect the actual {project_type} architecture
+- Creating cohesive, logical groupings that reflect the actual architecture
 - Semantic meaning based on method names, call patterns, and architectural context
 - Clear justification for why clusters belong together
 - Describing inter-group interactions based on the inter-cluster connections"""
 
-FINAL_ANALYSIS_MESSAGE = """Create final component architecture for `{project_name}` optimized for flow representation.
-
-Project Context:
-{meta_context}
+FINAL_ANALYSIS_MESSAGE = """Create final component architecture optimized for flow representation.
 
 Cluster Analysis:
 {cluster_analysis}
@@ -111,7 +98,7 @@ Instructions:
 4. Add key entities (2-5 most important classes/methods) for each component, referencing the source file where they are defined
 5. Do not define relationships yet; relationships are discovered in a later API-surface step
 
-Guidelines for {project_type} projects:
+Guidelines:
 - Aim for 5-8 final components
 - Merge related cluster groups that serve a common purpose
 - Each component should have clear boundaries
@@ -265,12 +252,7 @@ Required outputs:
 
 Focus on subsystem-specific functionality. Avoid cross-cutting concerns like logging or error handling."""
 
-CFG_DETAILS_MESSAGE = """Analyze and GROUP the Control Flow Graph clusters for the `{component}` subsystem of `{project_name}`.
-
-Project Context:
-{meta_context}
-
-Project Type: {project_type}
+CFG_DETAILS_MESSAGE = """Analyze and GROUP the Control Flow Graph clusters for the `{component}` subsystem.
 
 The CFG has been pre-clustered into groups of related methods/functions. Each cluster represents methods that call each other frequently.
 
@@ -296,10 +278,7 @@ Instructions:
 
 Focus on core subsystem functionality only. Avoid cross-cutting concerns like logging or error handling."""
 
-DETAILS_MESSAGE = """Create final sub-component architecture for the `{component}` subsystem of `{project_name}` optimized for flow representation.
-
-Project Context:
-{meta_context}
+DETAILS_MESSAGE = """Create final sub-component architecture for the `{component}` subsystem optimized for flow representation.
 
 Cluster Analysis:
 {cluster_analysis}
@@ -311,7 +290,7 @@ Instructions:
 4. Add key entities (2-5 most important classes/methods) for each sub-component, referencing the source file where they are defined
 5. Do not define relationships yet; relationships are discovered in a later API-surface step
 
-Guidelines for {project_type} projects:
+Guidelines:
 - Aim for 3-8 final sub-components
 - Merge related cluster groups that serve a common purpose
 - Each sub-component should have clear boundaries
@@ -327,12 +306,7 @@ Constraints:
 Justify component choices based on fundamental architectural importance."""
 
 
-INCREMENTAL_GROUPING_MESSAGE = """Update the architecture of `{project_name}` by routing changed and new CFG clusters to the right components.
-
-Project Context:
-{meta_context}
-
-Project Type: {project_type}
+INCREMENTAL_GROUPING_MESSAGE = """Update the architecture by routing changed and new CFG clusters to the right components.
 
 The previous analysis established the components below. Most clusters are unchanged and stay where they are; this prompt only shows the structural slice that changed: new clusters, removed clusters, or clusters whose member set changed through added/removed methods. A method body edit by itself is not a cluster-boundary change.
 
@@ -380,15 +354,15 @@ Rules:
 - For new clusters, decide from the structural diff whether they extend an existing responsibility or introduce a new component; do not infer this from file/package layout alone.
 - For reshaped groups, follow overlap counts to keep old cluster ownership stable. Only assign a reshaped new cluster to a different component when the diff proves a real responsibility move.
 - Use listGitChanges only when the structural diff is not enough to judge semantic impact.
-- Do not reparent existing components. Preserve their current scope; reparenting is not a valid incremental operation.
+- Reparenting existing components is unsupported by the current incremental schema. Preserve their current scope.
 - Every modified/new/reshaped new-side cluster listed below must appear in exactly one operation's cluster_refs.
 
 Architecture output contract:
 - This step plans component boundaries only. Do not define component relations; API surfaces and relations are generated later.
-- Preserve an existing component's name, description, and key entities unless its architectural responsibility changed.
-- For create_component, provide a clear name and description. Select up to 5 key_entities only when their exact qualified names are available; otherwise leave them empty. Key entities are not synthesized later.
-- For update_component, include refreshed name, description, or key_entities only when the component's responsibility changed. An empty key_entities list preserves the current selection.
-- For update_component, delete_component, and noop, copy the exact component_id from the existing-components list.
+- Choose exactly one of these mutually exclusive branches for each operation:
+  - For create_component only: leave component_id null; provide a clear name and description. Select up to 5 key_entities only when their exact qualified names are available; otherwise leave them empty. Key entities are not synthesized later.
+  - For update_component only: copy the exact component_id from the existing-components list. Include refreshed name, description, or key_entities only when the component's architectural responsibility changed; otherwise preserve the existing metadata. An empty key_entities list preserves the current selection.
+  - For delete_component or noop only: copy the exact component_id from the existing-components list and leave name, description, and key_entities empty. Use delete_component only when the component has no remaining responsibility; use noop to preserve it unchanged.
 """
 
 

--- a/agents/prompts/gemini_flash_prompts.py
+++ b/agents/prompts/gemini_flash_prompts.py
@@ -358,13 +358,9 @@ Important rules:
 - Every cluster id listed in the "Cluster groups to assign" section must appear in exactly one entry's **cluster_ids**."""
 
 
-PLANNING_MESSAGE = """Update one scope of the `{project_name}` architecture diagram.
+PLANNING_MESSAGE = """Update one scope of the architecture diagram.
 
 Scope: `{scope_id}` (`root` means the top-level diagram)
-Project type: {project_type}
-
-Project context:
-{meta_context}
 
 Existing components in this scope:
 {existing_components}
@@ -384,8 +380,15 @@ Rules:
 - For new clusters, decide from the structural diff whether they extend an existing responsibility or introduce a new component; do not infer this from file/package layout alone.
 - For reshaped groups, follow overlap counts to keep old cluster ownership stable. Only assign a reshaped new cluster to a different component when the diff proves a real responsibility move.
 - Use listGitChanges only when the structural diff is not enough to judge semantic impact.
-- Do not reparent existing components. If reparenting seems required, use regenerate_scope.
+- Do not reparent existing components. Preserve their current scope; reparenting is not a valid incremental operation.
 - Every modified/new/reshaped new-side cluster listed below must appear in exactly one operation's cluster_refs.
+
+Architecture output contract:
+- This step plans component boundaries only. Do not define component relations; API surfaces and relations are generated later.
+- Preserve an existing component's name, description, and key entities unless its architectural responsibility changed.
+- For create_component, provide a clear name and description. Select up to 5 key_entities only when their exact qualified names are available; otherwise leave them empty. Key entities are not synthesized later.
+- For update_component, include refreshed name, description, or key_entities only when the component's responsibility changed. An empty key_entities list preserves the current selection.
+- For update_component, delete_component, and noop, copy the exact component_id from the existing-components list.
 """
 
 

--- a/agents/prompts/glm_prompts.py
+++ b/agents/prompts/glm_prompts.py
@@ -20,12 +20,7 @@ from .abstract_prompt_factory import AbstractPromptFactory
 SCOPE_RELATIONS_MESSAGE = """You are a software architecture relationship analyst. STRICTLY follow these rules:
 
 MANDATORY TASK:
-Generate inter-component relationships for the `{scope_name}` scope of `{project_name}`.
-
-Project Context:
-{meta_context}
-
-Project Type: {project_type}
+Generate inter-component relationships for the `{scope_name}` scope.
 
 Components in this scope:
 {component_summaries}
@@ -77,12 +72,7 @@ Step 3: Create analysis suitable for both documentation and visual diagram gener
 CLUSTER_GROUPING_MESSAGE = """You are a software architecture analyst. STRICTLY follow these rules:
 
 MANDATORY TASK:
-Analyze and GROUP the Control Flow Graph clusters for `{project_name}`.
-
-Project Context:
-Project Type: {project_type}
-
-{meta_context}
+Analyze and GROUP the Control Flow Graph clusters.
 
 Background:
 The CFG has been pre-clustered into groups of related methods/functions. Each cluster represents methods that call each other frequently.
@@ -105,7 +95,7 @@ REQUIRED STEPS (execute in order):
      * The most important classes/methods in this group — mention their exact qualified names as shown in the clusters above
 
 FOCUS AREAS (prioritize):
-- Create cohesive, logical groupings that reflect the actual {project_type} architecture
+- Create cohesive, logical groupings that reflect the actual architecture
 - Base decisions on semantic meaning from method names, call patterns, and architectural context
 - MUST provide clear justification for why clusters belong together
 - MUST describe inter-group interactions based on the inter-cluster connections
@@ -115,10 +105,7 @@ MUST return each component with a descriptive name, its cluster_ids as a list, a
 FINAL_ANALYSIS_MESSAGE = """You are a software architecture designer. STRICTLY follow these rules:
 
 MANDATORY TASK:
-Create final component architecture for `{project_name}` optimized for flow representation.
-
-Project Context:
-{meta_context}
+Create final component architecture optimized for flow representation.
 
 Cluster Analysis:
 {cluster_analysis}
@@ -130,7 +117,7 @@ REQUIRED STEPS (execute in order):
 4. Add key entities (2-5 most important classes/methods) for each component, referencing the source file where they are defined.
 5. Do not define relationships yet; relationships are discovered in a later API-surface step.
 
-GUIDELINES for {project_type} projects (MUST follow):
+GUIDELINES (MUST follow):
 - Aim for 5-8 final components
 - Merge related cluster groups that serve a common purpose
 - Each component MUST have clear boundaries
@@ -322,12 +309,7 @@ MUST analyze subsystem-specific functionality. STRICTLY avoid cross-cutting conc
 CFG_DETAILS_MESSAGE = """You are a CFG cluster grouping analyst. STRICTLY follow these rules:
 
 MANDATORY TASK:
-Analyze and GROUP the Control Flow Graph clusters for the `{component}` subsystem of `{project_name}`.
-
-Project Context:
-Project Type: {project_type}
-
-{meta_context}
+Analyze and GROUP the Control Flow Graph clusters for the `{component}` subsystem.
 
 Background:
 The CFG has been pre-clustered into groups of related methods/functions. Each cluster represents methods that call each other frequently.
@@ -357,10 +339,7 @@ MUST return each component with a descriptive name, its cluster_ids as a list, a
 DETAILS_MESSAGE = """You are a sub-component architecture designer. STRICTLY follow these rules:
 
 MANDATORY TASK:
-Create final sub-component architecture for the `{component}` subsystem of `{project_name}` optimized for flow representation.
-
-Project Context:
-{meta_context}
+Create final sub-component architecture for the `{component}` subsystem optimized for flow representation.
 
 Cluster Analysis:
 {cluster_analysis}
@@ -372,7 +351,7 @@ REQUIRED STEPS (execute in order):
 4. Add key entities (2-5 most important classes/methods) for each sub-component, referencing the source file where they are defined.
 5. Do not define relationships yet; relationships are discovered in a later API-surface step.
 
-GUIDELINES for {project_type} projects (MUST follow):
+GUIDELINES (MUST follow):
 - Aim for 3-8 final sub-components
 - Merge related cluster groups that serve a common purpose
 - Each sub-component MUST have clear boundaries
@@ -398,12 +377,7 @@ MUST base component choices on fundamental architectural importance."""
 INCREMENTAL_GROUPING_MESSAGE = """You are a software architecture analyst. STRICTLY follow these rules.
 
 TASK:
-Update the architecture of `{project_name}` by routing changed and new CFG clusters into the correct components.
-
-CONTEXT:
-- Project: {project_name}
-- Type: {project_type}
-- Meta: {meta_context}
+Update the architecture by routing changed and new CFG clusters into the correct components.
 
 The previous analysis established the components below. Most clusters are unchanged and stay where they are; this prompt only shows the structural slice that changed: new clusters, removed clusters, or clusters whose member set changed through added/removed methods. A method body edit by itself is not a cluster-boundary change.
 
@@ -460,15 +434,15 @@ REQUIRED STEPS:
 6. Use listGitChanges ONLY when the structural diff is not enough to judge semantic impact.
 
 MANDATORY RULES:
-- Do not reparent existing components. Preserve their current scope; reparenting is not a valid incremental operation.
+- Reparenting existing components is unsupported by the current incremental schema. Preserve their current scope.
 - Every modified/new/reshaped new-side cluster listed below MUST appear in exactly one operation's cluster_refs.
 
 ARCHITECTURE OUTPUT CONTRACT:
 - This step plans component boundaries only. Do NOT define component relations; API surfaces and relations are generated later.
-- Preserve an existing component's name, description, and key entities unless its architectural responsibility changed.
-- For create_component, provide a clear name and description. Select up to 5 key_entities only when their exact qualified names are available; otherwise leave them empty. Key entities are not synthesized later.
-- For update_component, include refreshed name, description, or key_entities only when the component's responsibility changed. An empty key_entities list preserves the current selection.
-- For update_component, delete_component, and noop, copy the exact component_id from the existing-components list.
+- Choose exactly one of these mutually exclusive branches for each operation:
+  - For create_component only: leave component_id null; provide a clear name and description. Select up to 5 key_entities only when their exact qualified names are available; otherwise leave them empty. Key entities are not synthesized later.
+  - For update_component only: copy the exact component_id from the existing-components list. Include refreshed name, description, or key_entities only when the component's architectural responsibility changed; otherwise preserve the existing metadata. An empty key_entities list preserves the current selection.
+  - For delete_component or noop only: copy the exact component_id from the existing-components list and leave name, description, and key_entities empty. Use delete_component only when the component has no remaining responsibility; use noop to preserve it unchanged.
 """
 
 

--- a/agents/prompts/glm_prompts.py
+++ b/agents/prompts/glm_prompts.py
@@ -436,12 +436,10 @@ Return one routing decision per cluster group. Each decision MUST clearly indica
 PLANNING_MESSAGE = """You are a software architecture incremental-update analyst. STRICTLY follow these rules.
 
 TASK:
-Update one scope of the `{project_name}` architecture diagram.
+Update one scope of the architecture diagram.
 
 CONTEXT:
 - Scope: `{scope_id}` (`root` means the top-level diagram)
-- Project type: {project_type}
-- Meta: {meta_context}
 
 EXISTING COMPONENTS IN THIS SCOPE:
 {existing_components}
@@ -462,8 +460,15 @@ REQUIRED STEPS:
 6. Use listGitChanges ONLY when the structural diff is not enough to judge semantic impact.
 
 MANDATORY RULES:
-- Do NOT reparent existing components. If reparenting seems required, use regenerate_scope.
+- Do not reparent existing components. Preserve their current scope; reparenting is not a valid incremental operation.
 - Every modified/new/reshaped new-side cluster listed below MUST appear in exactly one operation's cluster_refs.
+
+ARCHITECTURE OUTPUT CONTRACT:
+- This step plans component boundaries only. Do NOT define component relations; API surfaces and relations are generated later.
+- Preserve an existing component's name, description, and key entities unless its architectural responsibility changed.
+- For create_component, provide a clear name and description. Select up to 5 key_entities only when their exact qualified names are available; otherwise leave them empty. Key entities are not synthesized later.
+- For update_component, include refreshed name, description, or key_entities only when the component's responsibility changed. An empty key_entities list preserves the current selection.
+- For update_component, delete_component, and noop, copy the exact component_id from the existing-components list.
 """
 
 

--- a/agents/prompts/gpt_prompts.py
+++ b/agents/prompts/gpt_prompts.py
@@ -437,12 +437,10 @@ For each cluster group above, decide whether it belongs in an existing component
 - **redetail_needed=False** means the component boundary is unchanged; do not use it to absorb new files, new responsibilities, or clusters owned by another component
 - Every cluster id listed in the cluster groups above must appear in exactly one routing entry"""
 
-PLANNING_MESSAGE = """**Task:** Update one scope of the `{project_name}` architecture diagram.
+PLANNING_MESSAGE = """**Task:** Update one scope of the architecture diagram.
 
 **Context:**
 - Scope: `{scope_id}` (`root` means the top-level diagram)
-- Project type: {project_type}
-- Meta: {meta_context}
 
 **Existing components in this scope:**
 {existing_components}
@@ -464,8 +462,15 @@ Return operations for this scope only.
 5. Use listGitChanges only when the structural diff is not enough to judge semantic impact.
 
 **Hard rules:**
-- Do not reparent existing components. If reparenting seems required, use regenerate_scope.
+- Do not reparent existing components. Preserve their current scope; reparenting is not a valid incremental operation.
 - Every modified/new/reshaped new-side cluster listed below must appear in exactly one operation's cluster_refs.
+
+**Architecture output contract:**
+- This step plans component boundaries only. Do not define component relations; API surfaces and relations are generated later.
+- Preserve an existing component's name, description, and key entities unless its architectural responsibility changed.
+- For create_component, provide a clear name and description. Select up to 5 key_entities only when their exact qualified names are available; otherwise leave them empty. Key entities are not synthesized later.
+- For update_component, include refreshed name, description, or key_entities only when the component's responsibility changed. An empty key_entities list preserves the current selection.
+- For update_component, delete_component, and noop, copy the exact component_id from the existing-components list.
 """
 
 SCOPE_RELATIONS_MESSAGE = """Generate inter-component relationships for the `{scope_name}` scope of `{project_name}`.

--- a/agents/prompts/gpt_prompts.py
+++ b/agents/prompts/gpt_prompts.py
@@ -16,7 +16,7 @@ GPT-4 Prompt Design Principles:
 
 from .abstract_prompt_factory import AbstractPromptFactory
 
-SYSTEM_MESSAGE = """You are an expert software architect analyzing {project_name}. Your task is to create comprehensive documentation and interactive diagrams that help new engineers understand the codebase within their first week.
+SYSTEM_MESSAGE = """You are an expert software architect. Your task is to create comprehensive documentation and interactive diagrams that help new engineers understand the codebase within their first week.
 
 **Your Role:**
 - Analyze code structure and generate architectural insights
@@ -32,7 +32,7 @@ Meta: {meta_context}
 **Analysis Approach:**
 1. Start with CFG data to identify structural patterns
 2. Use available tools to fill information gaps
-3. Apply {project_type} architectural best practices
+3. Apply architectural practices appropriate to this project
 4. Design components suitable for visual diagram representation
 5. Include source file references for interactive navigation
 
@@ -42,12 +42,7 @@ Meta: {meta_context}
 - Interactive diagram elements
 - Documentation for quick developer onboarding"""
 
-CLUSTER_GROUPING_MESSAGE = """Analyze and GROUP the Control Flow Graph clusters for `{project_name}`.
-
-Project Context:
-{meta_context}
-
-Project Type: {project_type}
+CLUSTER_GROUPING_MESSAGE = """Analyze and GROUP the Control Flow Graph clusters.
 
 The CFG has been pre-clustered into groups of related methods/functions. Each cluster represents methods that call each other frequently.
 
@@ -72,15 +67,12 @@ Instructions:
      * The most important classes/methods in this group — mention their exact qualified names as shown in the clusters above
 
 Focus on:
-- Creating cohesive, logical groupings that reflect the actual {project_type} architecture
+- Creating cohesive, logical groupings that reflect the actual architecture
 - Semantic meaning based on method names, call patterns, and architectural context
 - Clear justification for why clusters belong together
 - Describing inter-group interactions based on the inter-cluster connections"""
 
-FINAL_ANALYSIS_MESSAGE = """Create final component architecture for `{project_name}` optimized for flow representation.
-
-Project Context:
-{meta_context}
+FINAL_ANALYSIS_MESSAGE = """Create final component architecture optimized for flow representation.
 
 Cluster Analysis:
 {cluster_analysis}
@@ -92,7 +84,7 @@ Instructions:
 4. Add key entities (2-5 most important classes/methods) for each component, referencing the source file where they are defined
 5. Do not define relationships yet; relationships are discovered in a later API-surface step
 
-Guidelines for {project_type} projects:
+Guidelines:
 - Aim for 5-8 final components
 - Merge related cluster groups that serve a common purpose
 - Each component should have clear boundaries
@@ -346,12 +338,7 @@ Required outputs:
 
 Focus on subsystem-specific functionality. Avoid cross-cutting concerns like logging or error handling."""
 
-CFG_DETAILS_MESSAGE = """Analyze and GROUP the Control Flow Graph clusters for the `{component}` subsystem of `{project_name}`.
-
-Project Context:
-{meta_context}
-
-Project Type: {project_type}
+CFG_DETAILS_MESSAGE = """Analyze and GROUP the Control Flow Graph clusters for the `{component}` subsystem.
 
 The CFG has been pre-clustered into groups of related methods/functions. Each cluster represents methods that call each other frequently.
 
@@ -377,10 +364,7 @@ Instructions:
 
 Focus on core subsystem functionality only. Avoid cross-cutting concerns like logging or error handling."""
 
-DETAILS_MESSAGE = """Create final sub-component architecture for the `{component}` subsystem of `{project_name}` optimized for flow representation.
-
-Project Context:
-{meta_context}
+DETAILS_MESSAGE = """Create final sub-component architecture for the `{component}` subsystem optimized for flow representation.
 
 Cluster Analysis:
 {cluster_analysis}
@@ -392,7 +376,7 @@ Instructions:
 4. Add key entities (2-5 most important classes/methods) for each sub-component, referencing the source file where they are defined
 5. Do not define relationships yet; relationships are discovered in a later API-surface step
 
-Guidelines for {project_type} projects:
+Guidelines:
 - Aim for 3-8 final sub-components
 - Merge related cluster groups that serve a common purpose
 - Each sub-component should have clear boundaries
@@ -407,12 +391,7 @@ Constraints:
 
 Justify component choices based on fundamental architectural importance."""
 
-INCREMENTAL_GROUPING_MESSAGE = """**Task:** Update the architecture of {project_name} by routing changed and new CFG clusters into the correct components.
-
-**Context:**
-- Project: {project_name}
-- Type: {project_type}
-- Meta: {meta_context}
+INCREMENTAL_GROUPING_MESSAGE = """**Task:** Update the architecture by routing changed and new CFG clusters into the correct components.
 
 The previous analysis established the components below. Most clusters are unchanged and stay where they are; this prompt only shows the structural slice that changed: new clusters, removed clusters, or clusters whose member set changed through added/removed methods. A method body edit by itself is not a cluster-boundary change.
 
@@ -462,23 +441,18 @@ Return operations for this scope only.
 5. Use listGitChanges only when the structural diff is not enough to judge semantic impact.
 
 **Hard rules:**
-- Do not reparent existing components. Preserve their current scope; reparenting is not a valid incremental operation.
+- Reparenting existing components is unsupported by the current incremental schema. Preserve their current scope.
 - Every modified/new/reshaped new-side cluster listed below must appear in exactly one operation's cluster_refs.
 
 **Architecture output contract:**
 - This step plans component boundaries only. Do not define component relations; API surfaces and relations are generated later.
-- Preserve an existing component's name, description, and key entities unless its architectural responsibility changed.
-- For create_component, provide a clear name and description. Select up to 5 key_entities only when their exact qualified names are available; otherwise leave them empty. Key entities are not synthesized later.
-- For update_component, include refreshed name, description, or key_entities only when the component's responsibility changed. An empty key_entities list preserves the current selection.
-- For update_component, delete_component, and noop, copy the exact component_id from the existing-components list.
+- Choose exactly one of these mutually exclusive branches for each operation:
+  - For create_component only: leave component_id null; provide a clear name and description. Select up to 5 key_entities only when their exact qualified names are available; otherwise leave them empty. Key entities are not synthesized later.
+  - For update_component only: copy the exact component_id from the existing-components list. Include refreshed name, description, or key_entities only when the component's architectural responsibility changed; otherwise preserve the existing metadata. An empty key_entities list preserves the current selection.
+  - For delete_component or noop only: copy the exact component_id from the existing-components list and leave name, description, and key_entities empty. Use delete_component only when the component has no remaining responsibility; use noop to preserve it unchanged.
 """
 
-SCOPE_RELATIONS_MESSAGE = """Generate inter-component relationships for the `{scope_name}` scope of `{project_name}`.
-
-Project Context:
-{meta_context}
-
-Project Type: {project_type}
+SCOPE_RELATIONS_MESSAGE = """Generate inter-component relationships for the `{scope_name}` scope.
 
 **Components in this scope:**
 {component_summaries}

--- a/agents/prompts/kimi_prompts.py
+++ b/agents/prompts/kimi_prompts.py
@@ -18,12 +18,7 @@ from .abstract_prompt_factory import AbstractPromptFactory
 
 SCOPE_RELATIONS_MESSAGE = """You are Kimi, an AI assistant created by Moonshot AI.
 
-Task: Generate inter-component relationships for the `{scope_name}` scope of `{project_name}`.
-
-Project Context:
-{meta_context}
-
-Project Type: {project_type}
+Task: Generate inter-component relationships for the `{scope_name}` scope.
 
 Components in this scope:
 {component_summaries}
@@ -65,12 +60,7 @@ Focus on architectural patterns for {project_type} projects with clear component
 
 CLUSTER_GROUPING_MESSAGE = """You are Kimi, an AI assistant created by Moonshot AI.
 
-Project Context:
-Project Type: {project_type}
-
-{meta_context}
-
-Analyze and GROUP the Control Flow Graph clusters for `{project_name}`.
+Analyze and GROUP the Control Flow Graph clusters.
 
 The CFG has been pre-clustered into groups of related methods/functions. Each cluster represents methods that call each other frequently.
 
@@ -94,19 +84,16 @@ Reason carefully, then execute:
      * How this group interacts with other cluster groups (which groups it calls, receives data from, or depends on)
      * The most important classes/methods in this group — mention their exact qualified names as shown in the clusters above
 
-Focus on creating cohesive, logical groupings that reflect the actual {project_type} architecture based on semantic meaning from method names, call patterns, and architectural context. Describe inter-group interactions based on the inter-cluster connections.
+Focus on creating cohesive, logical groupings that reflect the actual architecture based on semantic meaning from method names, call patterns, and architectural context. Describe inter-group interactions based on the inter-cluster connections.
 
 Return each grouped component with a descriptive name, its cluster_ids list, and a comprehensive description covering rationale and inter-group interactions."""
 
 FINAL_ANALYSIS_MESSAGE = """You are Kimi, an AI assistant created by Moonshot AI.
 
-Project Context:
-{meta_context}
-
 Cluster Analysis:
 {cluster_analysis}
 
-Task: Create final component architecture for `{project_name}` optimized for flow representation.
+Task: Create final component architecture optimized for flow representation.
 
 Reason step-by-step. Decompose this into subtasks:
 
@@ -116,7 +103,7 @@ Reason step-by-step. Decompose this into subtasks:
 4. For each component, list the 2-5 most important classes/methods, referencing their qualified names and source files.
 5. Do not define relationships yet; relationships are discovered in a later API-surface step.
 
-Guidelines for {project_type} projects:
+Guidelines:
 - Aim for 5-8 final components
 - Merge related cluster groups that serve a common purpose
 - Each component should have clear boundaries
@@ -300,12 +287,7 @@ Focus on subsystem-specific functionality. Avoid cross-cutting concerns like log
 
 CFG_DETAILS_MESSAGE = """You are Kimi, an AI assistant created by Moonshot AI.
 
-Project Context:
-Project Type: {project_type}
-
-{meta_context}
-
-Task: Analyze and GROUP the Control Flow Graph clusters for the `{component}` subsystem of `{project_name}`.
+Task: Analyze and GROUP the Control Flow Graph clusters for the `{component}` subsystem.
 
 The CFG has been pre-clustered into groups of related methods/functions. Each cluster represents methods that call each other frequently.
 
@@ -333,13 +315,10 @@ Return each grouped sub-component with a descriptive name, its cluster_ids list,
 
 DETAILS_MESSAGE = """You are Kimi, an AI assistant created by Moonshot AI.
 
-Project Context:
-{meta_context}
-
 Cluster Analysis:
 {cluster_analysis}
 
-Task: Create final sub-component architecture for the `{component}` subsystem of `{project_name}` optimized for flow representation.
+Task: Create final sub-component architecture for the `{component}` subsystem optimized for flow representation.
 
 Think aloud first (reasoning), then synthesize:
 
@@ -349,7 +328,7 @@ Think aloud first (reasoning), then synthesize:
 4. For each sub-component, list the 2-5 most important classes/methods, referencing their qualified names and source files.
 5. Do not define relationships yet; relationships are discovered in a later API-surface step.
 
-Guidelines for {project_type} projects:
+Guidelines:
 - Aim for 3-8 final sub-components
 - Merge related cluster groups that serve a common purpose
 - Each sub-component should have clear boundaries
@@ -366,12 +345,7 @@ Justify component choices based on fundamental architectural importance."""
 
 INCREMENTAL_GROUPING_MESSAGE = """You are Kimi, an AI assistant created by Moonshot AI.
 
-Reason step-by-step about how the architecture of `{project_name}` should change as new and modified CFG clusters arrive. Use tools proactively to verify any cluster placement you're not confident about.
-
-Project context:
-- Project: {project_name}
-- Type: {project_type}
-- Meta: {meta_context}
+Reason step-by-step about how the architecture should change as new and modified CFG clusters arrive. Use tools proactively to verify any cluster placement you're not confident about.
 
 The previous analysis established the components below. Most clusters are unchanged and stay where they are; this prompt only shows the structural slice that changed: new clusters, removed clusters, or clusters whose member set changed through added/removed methods. A method body edit by itself is not a cluster-boundary change.
 
@@ -416,15 +390,15 @@ Rules:
 - For new clusters, decide from the structural diff whether they extend an existing responsibility or introduce a new component; do not infer this from file/package layout alone.
 - For reshaped groups, follow overlap counts to keep old cluster ownership stable. Only assign a reshaped new cluster to a different component when the diff proves a real responsibility move.
 - Use listGitChanges proactively but narrowly when the structural diff is not enough to judge semantic impact.
-- Do not reparent existing components. Preserve their current scope; reparenting is not a valid incremental operation.
+- Reparenting existing components is unsupported by the current incremental schema. Preserve their current scope.
 - Every modified/new/reshaped new-side cluster listed below must appear in exactly one operation's cluster_refs.
 
 Architecture output contract:
 - This step plans component boundaries only. Do not define component relations; API surfaces and relations are generated later.
-- Preserve an existing component's name, description, and key entities unless its architectural responsibility changed.
-- For create_component, provide a clear name and description. Select up to 5 key_entities only when their exact qualified names are available; otherwise leave them empty. Key entities are not synthesized later.
-- For update_component, include refreshed name, description, or key_entities only when the component's responsibility changed. An empty key_entities list preserves the current selection.
-- For update_component, delete_component, and noop, copy the exact component_id from the existing-components list.
+- Choose exactly one of these mutually exclusive branches for each operation:
+  - For create_component only: leave component_id null; provide a clear name and description. Select up to 5 key_entities only when their exact qualified names are available; otherwise leave them empty. Key entities are not synthesized later.
+  - For update_component only: copy the exact component_id from the existing-components list. Include refreshed name, description, or key_entities only when the component's architectural responsibility changed; otherwise preserve the existing metadata. An empty key_entities list preserves the current selection.
+  - For delete_component or noop only: copy the exact component_id from the existing-components list and leave name, description, and key_entities empty. Use delete_component only when the component has no remaining responsibility; use noop to preserve it unchanged.
 """
 
 

--- a/agents/prompts/kimi_prompts.py
+++ b/agents/prompts/kimi_prompts.py
@@ -396,14 +396,9 @@ Boundary rules: route each changed cluster to the most specific owning component
 Every cluster id listed in the "Cluster groups to assign" section must appear in exactly one routing entry."""
 
 
-PLANNING_MESSAGE = """You are Kimi, an AI assistant created by Moonshot AI.
+PLANNING_MESSAGE = """Reason about ownership, then return operations for one architecture scope only.
 
-Update one scope of the `{project_name}` architecture diagram. Reason about ownership, then return operations for this scope only.
-
-Project context:
 - Scope: `{scope_id}` (`root` means the top-level diagram)
-- Type: {project_type}
-- Meta: {meta_context}
 
 Existing components in this scope:
 {existing_components}
@@ -421,8 +416,15 @@ Rules:
 - For new clusters, decide from the structural diff whether they extend an existing responsibility or introduce a new component; do not infer this from file/package layout alone.
 - For reshaped groups, follow overlap counts to keep old cluster ownership stable. Only assign a reshaped new cluster to a different component when the diff proves a real responsibility move.
 - Use listGitChanges proactively but narrowly when the structural diff is not enough to judge semantic impact.
-- Do not reparent existing components. If reparenting seems required, use regenerate_scope.
+- Do not reparent existing components. Preserve their current scope; reparenting is not a valid incremental operation.
 - Every modified/new/reshaped new-side cluster listed below must appear in exactly one operation's cluster_refs.
+
+Architecture output contract:
+- This step plans component boundaries only. Do not define component relations; API surfaces and relations are generated later.
+- Preserve an existing component's name, description, and key entities unless its architectural responsibility changed.
+- For create_component, provide a clear name and description. Select up to 5 key_entities only when their exact qualified names are available; otherwise leave them empty. Key entities are not synthesized later.
+- For update_component, include refreshed name, description, or key_entities only when the component's responsibility changed. An empty key_entities list preserves the current selection.
+- For update_component, delete_component, and noop, copy the exact component_id from the existing-components list.
 """
 
 

--- a/agents/prompts/prompt_factory.py
+++ b/agents/prompts/prompt_factory.py
@@ -6,6 +6,9 @@ This module provides a factory for dynamically selecting prompts based on LLM ty
 
 import logging
 from enum import StrEnum
+
+from agents.agent_responses import MetaAnalysisInsights
+
 from .abstract_prompt_factory import AbstractPromptFactory
 from .gemini_flash_prompts import GeminiFlashPromptFactory
 from .gpt_prompts import GPTPromptFactory
@@ -124,6 +127,19 @@ def get_global_factory() -> PromptFactory:
 def get_prompt(prompt_name: str) -> str:
     """Convenience function to get a prompt using the global factory."""
     return get_global_factory().get_prompt(prompt_name)
+
+
+def format_project_system_message(
+    template: str,
+    project_name: str,
+    meta_context: MetaAnalysisInsights | None,
+) -> str:
+    """Render a provider system prompt with the shared project context."""
+    return template.format(
+        project_name=project_name,
+        project_type=meta_context.project_type if meta_context else "unknown",
+        meta_context=meta_context.llm_str() if meta_context else "No project context available.",
+    )
 
 
 # Convenience functions for backward compatibility - now use the factory methods directly

--- a/agents/relation_edges.py
+++ b/agents/relation_edges.py
@@ -3,7 +3,6 @@
 from pathlib import Path
 
 from agents.agent_responses import AnalysisInsights, Relation
-from agents.file_index_models import FileEntry, MethodEntry
 from repo_utils.path_utils import normalize_repo_path
 
 
@@ -32,32 +31,22 @@ def merge_relations_by_pair(relations: list[Relation], include_relation: bool = 
 
 
 def index_relation_endpoints(analysis: AnalysisInsights, repo_dir: Path) -> None:
-    """Add relation endpoint references to the analysis file index."""
-    methods_by_file: dict[str, dict[str, MethodEntry]] = {}
+    """Fill missing spans for relation endpoints already present in the file index."""
+    spans_by_file: dict[str, dict[str, tuple[int, int]]] = {}
     for relation in analysis.components_relations:
         for edge in [*relation.key_edges, *relation.all_edges]:
             for reference in (edge.source, edge.target):
                 if not reference.reference_file:
                     continue
                 file_path = normalize_repo_path(reference.reference_file, repo_dir)
-                entry = analysis.files.setdefault(file_path, FileEntry())
-                methods_by_qname = methods_by_file.setdefault(
-                    file_path,
-                    {method.qualified_name: method for method in entry.methods},
+                file_spans = spans_by_file.setdefault(file_path, {})
+                start_line, end_line = file_spans.get(reference.qualified_name, (0, 0))
+                file_spans[reference.qualified_name] = (
+                    start_line or reference.reference_start_line or 0,
+                    end_line or reference.reference_end_line or 0,
                 )
-                indexed = methods_by_qname.get(reference.qualified_name)
-                if indexed is None:
-                    indexed = MethodEntry(
-                        qualified_name=reference.qualified_name,
-                        start_line=reference.reference_start_line or 0,
-                        end_line=reference.reference_end_line or 0,
-                        node_type="REFERENCE",
-                    )
-                    entry.methods.append(indexed)
-                    methods_by_qname[reference.qualified_name] = indexed
-                elif indexed.node_type == "REFERENCE":
-                    indexed.start_line = indexed.start_line or reference.reference_start_line or 0
-                    indexed.end_line = indexed.end_line or reference.reference_end_line or 0
 
-    for entry in analysis.files.values():
-        entry.methods.sort(key=lambda method: (method.start_line, method.end_line, method.qualified_name))
+    for file_path, spans in spans_by_file.items():
+        entry = analysis.files.get(file_path)
+        if entry is not None:
+            entry.merge_method_spans(spans)

--- a/agents/relation_edges.py
+++ b/agents/relation_edges.py
@@ -1,14 +1,10 @@
+"""Merge component relations and index their source endpoints."""
+
 from pathlib import Path
 
-from agents.agent_responses import AnalysisInsights, Relation, RelationEdge
+from agents.agent_responses import AnalysisInsights, Relation
 from agents.file_index_models import FileEntry, MethodEntry
 from repo_utils.path_utils import normalize_repo_path
-
-
-def merge_relation_edges(
-    key_edges: list[RelationEdge], all_edges: list[RelationEdge]
-) -> tuple[list[RelationEdge], list[RelationEdge]]:
-    return Relation._merge_edges(key_edges, all_edges)
 
 
 def append_or_merge_relation(
@@ -37,24 +33,28 @@ def merge_relations_by_pair(relations: list[Relation], include_relation: bool = 
 
 def index_relation_endpoints(analysis: AnalysisInsights, repo_dir: Path) -> None:
     """Add relation endpoint references to the analysis file index."""
+    methods_by_file: dict[str, dict[str, MethodEntry]] = {}
     for relation in analysis.components_relations:
         for edge in [*relation.key_edges, *relation.all_edges]:
             for reference in (edge.source, edge.target):
-                file_path = normalize_repo_path(reference.reference_file or "", repo_dir)
+                if not reference.reference_file:
+                    continue
+                file_path = normalize_repo_path(reference.reference_file, repo_dir)
                 entry = analysis.files.setdefault(file_path, FileEntry())
-                indexed = next(
-                    (method for method in entry.methods if method.qualified_name == reference.qualified_name),
-                    None,
+                methods_by_qname = methods_by_file.setdefault(
+                    file_path,
+                    {method.qualified_name: method for method in entry.methods},
                 )
+                indexed = methods_by_qname.get(reference.qualified_name)
                 if indexed is None:
-                    entry.methods.append(
-                        MethodEntry(
-                            qualified_name=reference.qualified_name,
-                            start_line=reference.reference_start_line or 0,
-                            end_line=reference.reference_end_line or 0,
-                            node_type="REFERENCE",
-                        )
+                    indexed = MethodEntry(
+                        qualified_name=reference.qualified_name,
+                        start_line=reference.reference_start_line or 0,
+                        end_line=reference.reference_end_line or 0,
+                        node_type="REFERENCE",
                     )
+                    entry.methods.append(indexed)
+                    methods_by_qname[reference.qualified_name] = indexed
                 elif indexed.node_type == "REFERENCE":
                     indexed.start_line = indexed.start_line or reference.reference_start_line or 0
                     indexed.end_line = indexed.end_line or reference.reference_end_line or 0

--- a/agents/relation_edges.py
+++ b/agents/relation_edges.py
@@ -1,4 +1,8 @@
-from agents.agent_responses import Relation, RelationEdge
+from pathlib import Path
+
+from agents.agent_responses import AnalysisInsights, Relation, RelationEdge
+from agents.file_index_models import FileEntry, MethodEntry
+from repo_utils.path_utils import normalize_repo_path
 
 
 def merge_relation_edges(
@@ -29,3 +33,31 @@ def merge_relations_by_pair(relations: list[Relation], include_relation: bool = 
     for relation in relations:
         append_or_merge_relation(merged, relation, include_relation=include_relation)
     return merged
+
+
+def index_relation_endpoints(analysis: AnalysisInsights, repo_dir: Path) -> None:
+    """Add relation endpoint references to the analysis file index."""
+    for relation in analysis.components_relations:
+        for edge in [*relation.key_edges, *relation.all_edges]:
+            for reference in (edge.source, edge.target):
+                file_path = normalize_repo_path(reference.reference_file or "", repo_dir)
+                entry = analysis.files.setdefault(file_path, FileEntry())
+                indexed = next(
+                    (method for method in entry.methods if method.qualified_name == reference.qualified_name),
+                    None,
+                )
+                if indexed is None:
+                    entry.methods.append(
+                        MethodEntry(
+                            qualified_name=reference.qualified_name,
+                            start_line=reference.reference_start_line or 0,
+                            end_line=reference.reference_end_line or 0,
+                            node_type="REFERENCE",
+                        )
+                    )
+                elif indexed.node_type == "REFERENCE":
+                    indexed.start_line = indexed.start_line or reference.reference_start_line or 0
+                    indexed.end_line = indexed.end_line or reference.reference_end_line or 0
+
+    for entry in analysis.files.values():
+        entry.methods.sort(key=lambda method: (method.start_line, method.end_line, method.qualified_name))

--- a/agents/repair.py
+++ b/agents/repair.py
@@ -1,0 +1,255 @@
+"""Deterministic repairs for parsed LLM agent outputs."""
+
+import logging
+import re
+from dataclasses import dataclass, field
+from difflib import SequenceMatcher
+from typing import Protocol
+
+from agents.agent_responses import (
+    ClusterAnalysis,
+    Component,
+    ScopeOperation,
+    ScopeOperationAction,
+    ScopeUpdateDecision,
+    ScopedClusterRef,
+)
+from diagram_analysis.cluster_delta import ClusterRef
+from static_analyzer.graph import ClusterResult
+from static_analyzer.reference_resolver import StaticReferenceResolver
+
+logger = logging.getLogger(__name__)
+
+_EXISTING_COMPONENT_ACTIONS = frozenset(
+    {
+        ScopeOperationAction.UPDATE_COMPONENT,
+        ScopeOperationAction.DELETE_COMPONENT,
+        ScopeOperationAction.NOOP,
+    }
+)
+_KEY_ENTITY_METADATA_ACTIONS = frozenset(
+    {
+        ScopeOperationAction.CREATE_COMPONENT,
+        ScopeOperationAction.UPDATE_COMPONENT,
+    }
+)
+
+
+class ComponentRepairTarget(Protocol):
+    components: list[Component]
+
+
+@dataclass
+class ComponentRepairContext:
+    reference_resolver: StaticReferenceResolver
+    llm_cluster_analysis: ClusterAnalysis
+    cluster_results: dict[str, ClusterResult] = field(default_factory=dict)
+
+
+@dataclass
+class ScopeOperationRepairContext:
+    reference_resolver: StaticReferenceResolver
+    allowed_key_entity_qnames: set[str]
+    component_ids_by_cluster_ref: dict[ClusterRef, str] = field(default_factory=dict)
+    component_ids_by_name: dict[str, str] = field(default_factory=dict)
+
+
+def repair_unambiguous_routing_and_optional_key_entity_metadata(
+    decision: ScopeUpdateDecision,
+    context: ScopeOperationRepairContext,
+) -> None:
+    """Repair deterministic routing and optional key-entity metadata defects."""
+    routed_operations = _repair_unambiguous_operation_routing(decision, context)
+    canonicalized_qnames, dropped_qnames = _repair_optional_key_entity_metadata(
+        decision,
+        context,
+    )
+
+    if routed_operations or canonicalized_qnames:
+        logger.info(
+            "Repaired incremental plan: routed %d operation(s), canonicalized %d key-entity qname(s)",
+            routed_operations,
+            canonicalized_qnames,
+        )
+    if dropped_qnames:
+        logger.warning("Dropped unresolved optional key entities: %s", sorted(dropped_qnames))
+
+
+def _repair_unambiguous_operation_routing(
+    decision: ScopeUpdateDecision,
+    context: ScopeOperationRepairContext,
+) -> int:
+    routed_operations = 0
+    for operation in decision.operations:
+        needs_routing_repair = operation.component_id is None and operation.action in _EXISTING_COMPONENT_ACTIONS
+        if not needs_routing_repair:
+            continue
+
+        component_id = _resolve_unambiguous_component_id(operation, context)
+        if component_id is not None:
+            operation.component_id = component_id
+            if operation.action == ScopeOperationAction.NOOP:
+                operation.name = None
+            routed_operations += 1
+    return routed_operations
+
+
+def _resolve_unambiguous_component_id(
+    operation: ScopeOperation,
+    context: ScopeOperationRepairContext,
+) -> str | None:
+    refs = {_cluster_ref_from_scoped_ref(ref) for ref in operation.cluster_refs}
+    owner_ids = {
+        context.component_ids_by_cluster_ref[ref] for ref in refs if ref in context.component_ids_by_cluster_ref
+    }
+
+    # Existing cluster ownership is stronger evidence than a mutable component name.
+    if len(owner_ids) == 1:
+        return next(iter(owner_ids))
+
+    has_no_known_owner = not owner_ids
+    if has_no_known_owner and operation.name:
+        return context.component_ids_by_name.get(_normalize_component_name(operation.name))
+    return None
+
+
+def _normalize_component_name(name: str) -> str:
+    return " ".join(name.casefold().split())
+
+
+def _repair_optional_key_entity_metadata(
+    decision: ScopeUpdateDecision,
+    context: ScopeOperationRepairContext,
+) -> tuple[int, set[str]]:
+    canonicalized_qnames = 0
+    dropped_qnames: set[str] = set()
+    for operation in decision.operations:
+        has_optional_key_entity_metadata = operation.action in _KEY_ENTITY_METADATA_ACTIONS and bool(
+            operation.key_entities
+        )
+        if not has_optional_key_entity_metadata:
+            continue
+
+        repair = context.reference_resolver.repair_key_entity_references(
+            operation.key_entities,
+            force_resolve=True,
+        )
+        scoped_references = [
+            reference
+            for reference in repair.references
+            if _reference_is_in_scope(reference.qualified_name, context.allowed_key_entity_qnames)
+        ]
+        dropped_qnames.update(
+            reference.qualified_name
+            for reference in repair.references
+            if not _reference_is_in_scope(reference.qualified_name, context.allowed_key_entity_qnames)
+        )
+        operation.key_entities = scoped_references[:5]
+        canonicalized_qnames += repair.canonicalized_count
+        dropped_qnames.update(repair.unresolved_qnames)
+    return canonicalized_qnames, dropped_qnames
+
+
+def repair_component_group_names(result: ComponentRepairTarget, context: ComponentRepairContext) -> None:
+    """Canonicalize unambiguous component source-group names."""
+    expected_group_names = {group.name for group in context.llm_cluster_analysis.cluster_components}
+    canonical_names = {_normalize_group_name(name): name for name in expected_group_names}
+    corrected_count = 0
+
+    for component in result.components:
+        corrected_names: list[str] = []
+        for group_name in component.source_group_names:
+            canonical_name = _canonical_group_name(group_name, canonical_names)
+            if canonical_name is None:
+                corrected_names.append(group_name)
+                continue
+            corrected_names.append(canonical_name)
+            if canonical_name != group_name:
+                corrected_count += 1
+        component.source_group_names = corrected_names
+
+    if corrected_count:
+        logger.info("Repaired %d component source-group name(s)", corrected_count)
+
+
+def _canonical_group_name(group_name: str, canonical_names: dict[str, str]) -> str | None:
+    normalized_name = _normalize_group_name(group_name)
+    exact_match = canonical_names.get(normalized_name)
+    if exact_match is not None:
+        return exact_match
+    return _fuzzy_match_group_name(normalized_name, canonical_names)
+
+
+def _normalize_group_name(name: str) -> str:
+    normalized = re.sub(r"\s+", " ", name.lower().strip())
+    normalized = re.sub(r"[()&/\\,\-–—]", " ", normalized)
+    return re.sub(r"\s+", " ", normalized).strip()
+
+
+def _fuzzy_match_group_name(
+    normalized_name: str,
+    canonical_names: dict[str, str],
+    threshold: float = 0.75,
+) -> str | None:
+    best_score = 0.0
+    best_match: str | None = None
+    for candidate, canonical_name in canonical_names.items():
+        score = SequenceMatcher(None, normalized_name, candidate).ratio()
+        if score > best_score and score >= threshold:
+            best_score = score
+            best_match = canonical_name
+    return best_match
+
+
+def repair_key_entities(result: ComponentRepairTarget, context: ComponentRepairContext) -> None:
+    """Resolve key entities and remove references outside the current scope."""
+    nodes_in_scope = _nodes_in_scope(context.cluster_results)
+    canonicalized_count = 0
+    dropped_qnames: set[str] = set()
+
+    for component in result.components:
+        repair = context.reference_resolver.repair_key_entity_references(component.key_entities)
+        repaired_references = repair.references
+        canonicalized_count += repair.canonicalized_count
+        dropped_qnames.update(repair.unresolved_qnames)
+
+        if context.cluster_results:
+            dropped_qnames.update(
+                reference.qualified_name
+                for reference in repaired_references
+                if not _reference_is_in_scope(reference.qualified_name, nodes_in_scope)
+            )
+            repaired_references = [
+                reference
+                for reference in repaired_references
+                if _reference_is_in_scope(reference.qualified_name, nodes_in_scope)
+            ]
+
+        component.key_entities = repaired_references
+
+    if canonicalized_count:
+        logger.info("Repaired %d key-entity qualified name(s)", canonicalized_count)
+    if dropped_qnames:
+        logger.info("Dropped invalid or out-of-scope key entities: %s", sorted(dropped_qnames))
+
+
+def _nodes_in_scope(cluster_results: dict[str, ClusterResult]) -> set[str]:
+    return {
+        qualified_name
+        for cluster_result in cluster_results.values()
+        for members in cluster_result.clusters.values()
+        for qualified_name in members
+    }
+
+
+def _reference_is_in_scope(qualified_name: str, nodes_in_scope: set[str]) -> bool:
+    return any(
+        qualified_name == scope_node
+        or qualified_name.startswith(scope_node + ".")
+        or scope_node.startswith(qualified_name + ".")
+        for scope_node in nodes_in_scope
+    )
+
+
+def _cluster_ref_from_scoped_ref(ref: ScopedClusterRef) -> ClusterRef:
+    return ClusterRef(ref.language, ref.cluster_id, ref.scope_id)

--- a/agents/repair.py
+++ b/agents/repair.py
@@ -126,19 +126,9 @@ def _repair_optional_key_entity_metadata(
 
         repair = context.reference_resolver.repair_key_entity_references(
             operation.key_entities,
-            force_resolve=True,
+            allowed_qnames=context.allowed_key_entity_qnames,
         )
-        scoped_references = [
-            reference
-            for reference in repair.references
-            if _reference_is_in_scope(reference.qualified_name, context.allowed_key_entity_qnames)
-        ]
-        dropped_qnames.update(
-            reference.qualified_name
-            for reference in repair.references
-            if not _reference_is_in_scope(reference.qualified_name, context.allowed_key_entity_qnames)
-        )
-        operation.key_entities = scoped_references[:5]
+        operation.key_entities = repair.references[:5]
         canonicalized_qnames += repair.canonicalized_count
         dropped_qnames.update(repair.unresolved_qnames)
     return canonicalized_qnames, dropped_qnames
@@ -202,35 +192,15 @@ def repair_key_entities(result: ComponentRepairTarget, context: ComponentRepairC
     dropped_qnames: set[str] = set()
 
     for component in result.components:
-        repair = context.reference_resolver.repair_key_entity_references(component.key_entities)
-        repaired_references = repair.references
+        repair = context.reference_resolver.repair_key_entity_references(
+            component.key_entities,
+            allowed_qnames=nodes_in_scope if context.cluster_results else None,
+        )
         canonicalized_count += repair.canonicalized_count
         dropped_qnames.update(repair.unresolved_qnames)
-
-        if context.cluster_results:
-            dropped_qnames.update(
-                reference.qualified_name
-                for reference in repaired_references
-                if not _reference_is_in_scope(reference.qualified_name, nodes_in_scope)
-            )
-            repaired_references = [
-                reference
-                for reference in repaired_references
-                if _reference_is_in_scope(reference.qualified_name, nodes_in_scope)
-            ]
-
-        component.key_entities = repaired_references
+        component.key_entities = repair.references
 
     if canonicalized_count:
         logger.info("Repaired %d key-entity qualified name(s)", canonicalized_count)
     if dropped_qnames:
         logger.info("Dropped invalid or out-of-scope key entities: %s", sorted(dropped_qnames))
-
-
-def _reference_is_in_scope(qualified_name: str, nodes_in_scope: set[str]) -> bool:
-    return any(
-        qualified_name == scope_node
-        or qualified_name.startswith(scope_node + ".")
-        or scope_node.startswith(qualified_name + ".")
-        for scope_node in nodes_in_scope
-    )

--- a/agents/repair.py
+++ b/agents/repair.py
@@ -12,7 +12,12 @@ from agents.agent_responses import (
     ScopeOperation,
     ScopeOperationAction,
     ScopeUpdateDecision,
-    ScopedClusterRef,
+)
+from agents.scope_operations import (
+    EXISTING_COMPONENT_ACTIONS,
+    cluster_member_qnames,
+    cluster_ref_from_scoped_ref,
+    normalize_component_name,
 )
 from diagram_analysis.cluster_delta import ClusterRef
 from static_analyzer.graph import ClusterResult
@@ -20,13 +25,6 @@ from static_analyzer.reference_resolver import StaticReferenceResolver
 
 logger = logging.getLogger(__name__)
 
-_EXISTING_COMPONENT_ACTIONS = frozenset(
-    {
-        ScopeOperationAction.UPDATE_COMPONENT,
-        ScopeOperationAction.DELETE_COMPONENT,
-        ScopeOperationAction.NOOP,
-    }
-)
 _KEY_ENTITY_METADATA_ACTIONS = frozenset(
     {
         ScopeOperationAction.CREATE_COMPONENT,
@@ -81,16 +79,16 @@ def _repair_unambiguous_operation_routing(
 ) -> int:
     routed_operations = 0
     for operation in decision.operations:
-        needs_routing_repair = operation.component_id is None and operation.action in _EXISTING_COMPONENT_ACTIONS
-        if not needs_routing_repair:
-            continue
-
-        component_id = _resolve_unambiguous_component_id(operation, context)
-        if component_id is not None:
-            operation.component_id = component_id
-            if operation.action == ScopeOperationAction.NOOP:
-                operation.name = None
-            routed_operations += 1
+        needs_routing_repair = operation.component_id is None and operation.action in EXISTING_COMPONENT_ACTIONS
+        if needs_routing_repair:
+            component_id = _resolve_unambiguous_component_id(operation, context)
+            if component_id is not None:
+                operation.component_id = component_id
+                routed_operations += 1
+        if operation.action == ScopeOperationAction.NOOP:
+            operation.name = None
+            operation.description = None
+            operation.key_entities = []
     return routed_operations
 
 
@@ -98,7 +96,7 @@ def _resolve_unambiguous_component_id(
     operation: ScopeOperation,
     context: ScopeOperationRepairContext,
 ) -> str | None:
-    refs = {_cluster_ref_from_scoped_ref(ref) for ref in operation.cluster_refs}
+    refs = {cluster_ref_from_scoped_ref(ref) for ref in operation.cluster_refs}
     owner_ids = {
         context.component_ids_by_cluster_ref[ref] for ref in refs if ref in context.component_ids_by_cluster_ref
     }
@@ -109,12 +107,8 @@ def _resolve_unambiguous_component_id(
 
     has_no_known_owner = not owner_ids
     if has_no_known_owner and operation.name:
-        return context.component_ids_by_name.get(_normalize_component_name(operation.name))
+        return context.component_ids_by_name.get(normalize_component_name(operation.name))
     return None
-
-
-def _normalize_component_name(name: str) -> str:
-    return " ".join(name.casefold().split())
 
 
 def _repair_optional_key_entity_metadata(
@@ -203,7 +197,7 @@ def _fuzzy_match_group_name(
 
 def repair_key_entities(result: ComponentRepairTarget, context: ComponentRepairContext) -> None:
     """Resolve key entities and remove references outside the current scope."""
-    nodes_in_scope = _nodes_in_scope(context.cluster_results)
+    nodes_in_scope = cluster_member_qnames(context.cluster_results)
     canonicalized_count = 0
     dropped_qnames: set[str] = set()
 
@@ -233,15 +227,6 @@ def repair_key_entities(result: ComponentRepairTarget, context: ComponentRepairC
         logger.info("Dropped invalid or out-of-scope key entities: %s", sorted(dropped_qnames))
 
 
-def _nodes_in_scope(cluster_results: dict[str, ClusterResult]) -> set[str]:
-    return {
-        qualified_name
-        for cluster_result in cluster_results.values()
-        for members in cluster_result.clusters.values()
-        for qualified_name in members
-    }
-
-
 def _reference_is_in_scope(qualified_name: str, nodes_in_scope: set[str]) -> bool:
     return any(
         qualified_name == scope_node
@@ -249,7 +234,3 @@ def _reference_is_in_scope(qualified_name: str, nodes_in_scope: set[str]) -> boo
         or scope_node.startswith(qualified_name + ".")
         for scope_node in nodes_in_scope
     )
-
-
-def _cluster_ref_from_scoped_ref(ref: ScopedClusterRef) -> ClusterRef:
-    return ClusterRef(ref.language, ref.cluster_id, ref.scope_id)

--- a/agents/scope_operations.py
+++ b/agents/scope_operations.py
@@ -1,0 +1,35 @@
+"""Share contracts and normalization for incremental scope operations."""
+
+from agents.agent_responses import ScopeOperationAction, ScopedClusterRef
+from agents.scope_ids import ROOT_SCOPE_ID
+from diagram_analysis.cluster_delta import ClusterRef
+from static_analyzer.graph import ClusterResult
+
+
+EXISTING_COMPONENT_ACTIONS: frozenset[ScopeOperationAction] = frozenset(
+    {
+        ScopeOperationAction.UPDATE_COMPONENT,
+        ScopeOperationAction.DELETE_COMPONENT,
+        ScopeOperationAction.NOOP,
+    }
+)
+
+
+def cluster_ref_from_scoped_ref(ref: ScopedClusterRef) -> ClusterRef:
+    """Convert an LLM cluster reference to its canonical structural form."""
+    return ClusterRef(ref.language, ref.cluster_id, ref.scope_id or ROOT_SCOPE_ID)
+
+
+def cluster_member_qnames(cluster_results: dict[str, ClusterResult]) -> set[str]:
+    """Return every qualified name represented in a scope's clusters."""
+    return {
+        qualified_name
+        for cluster_result in cluster_results.values()
+        for members in cluster_result.clusters.values()
+        for qualified_name in members
+    }
+
+
+def normalize_component_name(name: str) -> str:
+    """Normalize a component name for deterministic routing."""
+    return " ".join(name.casefold().split())

--- a/agents/validation.py
+++ b/agents/validation.py
@@ -1,10 +1,8 @@
 """Validation utilities for LLM agent outputs."""
 
 import logging
-import re
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from difflib import SequenceMatcher
 from pathlib import Path
 from typing import Protocol
 
@@ -14,13 +12,16 @@ from agents.agent_responses import (
     Component,
     ComponentFiles,
     Relation,
+    ScopeOperationAction,
     ScopeRelations,
+    ScopeUpdateDecision,
+    ScopedClusterRef,
 )
+from diagram_analysis.cluster_delta import ClusterRef
 from repo_utils import normalize_path
-from static_analyzer.reference_resolver import StaticReferenceResolver
-from static_analyzer.graph import CallGraph, ClusterResult
-
 from static_analyzer.analysis_result import StaticAnalysisResults
+from static_analyzer.graph import CallGraph, ClusterResult
+from static_analyzer.reference_resolver import StaticReferenceResolver
 
 logger = logging.getLogger(__name__)
 
@@ -37,6 +38,14 @@ VALIDATOR_WEIGHTS: dict[str, float] = {
     "validate_file_classifications": 5.0,
 }
 DEFAULT_VALIDATOR_WEIGHT = 5.0
+
+_EXISTING_COMPONENT_ACTIONS = frozenset(
+    {
+        ScopeOperationAction.UPDATE_COMPONENT,
+        ScopeOperationAction.DELETE_COMPONENT,
+        ScopeOperationAction.NOOP,
+    }
+)
 
 
 @dataclass
@@ -60,6 +69,12 @@ class ValidationContext:
 
 
 @dataclass
+class ScopeOperationValidationContext:
+    expected_cluster_refs: set[ClusterRef] = field(default_factory=set)
+    existing_component_ids: set[str] = field(default_factory=set)
+
+
+@dataclass
 class ValidationResult:
     """Result of a validation check."""
 
@@ -70,6 +85,60 @@ class ValidationResult:
 
 class RelationValidationTarget(Protocol):
     components_relations: list[Relation]
+
+
+class ComponentValidationTarget(Protocol):
+    components: list[Component]
+
+
+def validate_scope_update_decision(
+    decision: ScopeUpdateDecision,
+    context: ScopeOperationValidationContext,
+) -> ValidationResult:
+    errors: list[str] = []
+    seen_refs: list[ClusterRef] = []
+    for operation in decision.operations:
+        refs = [_cluster_ref_from_scoped_ref(ref) for ref in operation.cluster_refs]
+        seen_refs.extend(refs)
+        if operation.action in _EXISTING_COMPONENT_ACTIONS:
+            if operation.component_id not in context.existing_component_ids:
+                errors.append(
+                    f"Operation {operation.action} references unknown component_id={operation.component_id!r}."
+                )
+        if operation.action == ScopeOperationAction.CREATE_COMPONENT:
+            if not operation.name or not operation.description:
+                errors.append("create_component operations must include name and description.")
+        if operation.action == ScopeOperationAction.NOOP and (
+            operation.name or operation.description or operation.key_entities
+        ):
+            errors.append("noop operations must preserve the component name, description, and key entities.")
+        if len(operation.key_entities) > 5:
+            errors.append(f"Operation {operation.action} includes more than five key entities.")
+        entity_qnames = [entity.qualified_name for entity in operation.key_entities]
+        duplicate_qnames = {qname for qname in entity_qnames if entity_qnames.count(qname) > 1}
+        if duplicate_qnames:
+            errors.append(f"Operation {operation.action} repeats key entities: {sorted(duplicate_qnames)}.")
+
+    seen_set = set(seen_refs)
+    missing = context.expected_cluster_refs - seen_set
+    extra = seen_set - context.expected_cluster_refs
+    duplicates = {ref for ref in seen_set if seen_refs.count(ref) > 1}
+    if missing:
+        errors.append(f"Missing cluster_refs: {_format_cluster_ref_list(missing)}")
+    if extra:
+        errors.append(f"Unexpected cluster_refs: {_format_cluster_ref_list(extra)}")
+    if duplicates:
+        errors.append(f"Duplicate cluster_refs: {_format_cluster_ref_list(duplicates)}")
+    return ValidationResult(is_valid=not errors, feedback_messages=errors)
+
+
+def _cluster_ref_from_scoped_ref(ref: ScopedClusterRef) -> ClusterRef:
+    return ClusterRef(ref.language, ref.cluster_id, ref.scope_id)
+
+
+def _format_cluster_ref_list(refs: set[ClusterRef]) -> str:
+    sorted_refs = sorted(refs, key=lambda ref: (ref.scope_id, ref.language, ref.cluster_id))
+    return ", ".join(f"{ref.scope_id}:{ref.language}:{ref.cluster_id}" for ref in sorted_refs) or "None"
 
 
 def _effective_validation_score(result: ValidationResult) -> float:
@@ -203,93 +272,12 @@ def validate_existing_component_ids(result: ClusterAnalysis, context: Validation
     return ValidationResult(is_valid=True)
 
 
-def _normalize_group_name(name: str) -> str:
-    """Normalize a group name for fuzzy comparison: lowercase, collapse whitespace, strip punctuation."""
-    name = name.lower().strip()
-    name = re.sub(r"\s+", " ", name)
-    # Remove common punctuation that LLMs might add/drop inconsistently
-    name = re.sub(r"[()&/\\,\-–—]", " ", name)
-    name = re.sub(r"\s+", " ", name).strip()
-    return name
-
-
-def _fuzzy_match_group_name(name: str, candidates: dict[str, str], threshold: float = 0.75) -> str | None:
-    """Find the best fuzzy match for *name* among *candidates*.
-
-    Args:
-        name: The name to match (already normalized).
-        candidates: Mapping of normalized_name -> original_name.
-        threshold: Minimum similarity ratio (0-1) to accept a match.
-
-    Returns:
-        The original (canonical) name of the best match, or None.
-    """
-    best_score = 0.0
-    best_match: str | None = None
-    for norm_candidate, original in candidates.items():
-        score = SequenceMatcher(None, name, norm_candidate).ratio()
-        if score > best_score and score >= threshold:
-            best_score = score
-            best_match = original
-    return best_match
-
-
-def _auto_correct_group_names(result: AnalysisInsights, expected_group_names: set[str]) -> int:
-    """Auto-correct source_group_names on components in-place.
-
-    Fixes case mismatches, whitespace differences, and close fuzzy matches
-    (similar to how validate_key_entities auto-corrects key_entity names).
-
-    Returns:
-        Number of names that were auto-corrected.
-    """
-    # Build lookup: normalized_name -> canonical_name
-    canonical_lookup: dict[str, str] = {_normalize_group_name(name): name for name in expected_group_names}
-
-    auto_corrected = 0
-    for component in result.components:
-        corrected_names: list[str] = []
-        for gname in component.source_group_names:
-            normalized = _normalize_group_name(gname)
-
-            # Exact normalized match (handles case + whitespace)
-            if normalized in canonical_lookup:
-                canonical = canonical_lookup[normalized]
-                if gname != canonical:
-                    logger.info(
-                        f"[Validation] Auto-corrected source_group_name: "
-                        f"'{gname}' -> '{canonical}' (component '{component.name}')"
-                    )
-                    auto_corrected += 1
-                corrected_names.append(canonical)
-                continue
-
-            # Fuzzy match for close typos
-            fuzzy_match = _fuzzy_match_group_name(normalized, canonical_lookup)
-            if fuzzy_match is not None:
-                logger.info(
-                    f"[Validation] Auto-corrected source_group_name (fuzzy): "
-                    f"'{gname}' -> '{fuzzy_match}' (component '{component.name}')"
-                )
-                auto_corrected += 1
-                corrected_names.append(fuzzy_match)
-                continue
-
-            # No match found, keep original for error reporting
-            corrected_names.append(gname)
-
-        component.source_group_names = corrected_names
-
-    return auto_corrected
-
-
-def validate_group_name_coverage(result: AnalysisInsights, context: ValidationContext) -> ValidationResult:
+def validate_group_name_coverage(result: ComponentValidationTarget, context: ValidationContext) -> ValidationResult:
     """
     Validate bidirectional coverage between cluster groups and components:
-    1. Auto-correct trivial mismatches (case, whitespace, close typos) in-place.
-    2. Every ClusterComponent must be referenced by at least one Component's source_group_names.
-    3. Every Component must have at least one source_group_name assigned.
-    4. Every source_group_name referenced by a Component must exist in the cluster analysis.
+    1. Every ClusterComponent must be referenced by at least one Component's source_group_names.
+    2. Every Component must have at least one source_group_name assigned.
+    3. Every source_group_name referenced by a Component must exist in the cluster analysis.
 
     Args:
         result: AnalysisInsights containing components with source_group_names
@@ -303,11 +291,6 @@ def validate_group_name_coverage(result: AnalysisInsights, context: ValidationCo
         return ValidationResult(is_valid=True)
 
     expected_group_names = {cc.name for cc in context.llm_cluster_analysis.cluster_components}
-
-    # Auto-correct trivial mismatches before validation
-    auto_corrected = _auto_correct_group_names(result, expected_group_names)
-    if auto_corrected:
-        logger.info(f"[Validation] Auto-corrected {auto_corrected} source_group_name(s)")
 
     referenced_group_names: set[str] = set()
     for component in result.components:
@@ -378,85 +361,12 @@ def validate_group_name_coverage(result: AnalysisInsights, context: ValidationCo
     return ValidationResult(is_valid=False, feedback_messages=feedback_messages)
 
 
-def validate_key_entities(result: AnalysisInsights, context: ValidationContext) -> ValidationResult:
-    """
-    Validate key_entities on every component:
-    1. Auto-correct qualified names via loose matching.
-    2. Silently drop invalid key entities (out of scope or not found).
-    3. Only fail if a component ends up with zero key_entities after dropping.
-
-    Args:
-        result: AnalysisInsights containing components with key_entities
-        context: ValidationContext with optional static_analysis for name resolution
-                 and cluster_results for scope validation
-
-    Returns:
-        ValidationResult with feedback only for components left with zero key entities
-    """
-    auto_corrected = 0
-
-    # Auto-correct qualified names via loose matching (always, when static_analysis available)
-    if context.static_analysis:
-        for component in result.components:
-            for key_entity in component.key_entities:
-                qname = key_entity.qualified_name.replace("/", ".")
-                node = context.static_analysis.resolve_across_languages(qname)
-                if node is not None and node.fully_qualified_name != qname:
-                    logger.info(
-                        f"[Validation] Auto-corrected qualified name: "
-                        f"'{key_entity.qualified_name}' -> '{node.fully_qualified_name}'"
-                    )
-                    key_entity.qualified_name = node.fully_qualified_name
-                    auto_corrected += 1
-        if auto_corrected:
-            logger.info(f"[Validation] Auto-corrected {auto_corrected} qualified names via loose matching")
-
-    # Silently drop invalid key entities
-    dropped = 0
-    if context.cluster_results:
-        nodes_in_scope: set[str] = set()
-        for cr in context.cluster_results.values():
-            for members in cr.clusters.values():
-                nodes_in_scope.update(members)
-
-        for component in result.components:
-            valid = []
-            for key_entity in component.key_entities:
-                qname = key_entity.qualified_name
-                in_scope = qname in nodes_in_scope
-                if not in_scope:
-                    for scope_node in nodes_in_scope:
-                        if qname.startswith(scope_node + ".") or scope_node.startswith(qname + "."):
-                            in_scope = True
-                            break
-                if in_scope:
-                    valid.append(key_entity)
-                else:
-                    dropped += 1
-            component.key_entities = valid
-
-    elif context.static_analysis:
-        for component in result.components:
-            valid = []
-            for key_entity in component.key_entities:
-                qname = key_entity.qualified_name.replace("/", ".")
-                node = context.static_analysis.resolve_across_languages(qname)
-                if node is not None:
-                    if node.fully_qualified_name != qname:
-                        key_entity.qualified_name = node.fully_qualified_name
-                    valid.append(key_entity)
-                else:
-                    dropped += 1
-            component.key_entities = valid
-
-    if dropped:
-        logger.info(f"[Validation] Silently dropped {dropped} invalid key entities")
-
-    # Only fail if any component ended up with zero key_entities
+def validate_key_entities(result: ComponentValidationTarget, context: ValidationContext) -> ValidationResult:
+    """Validate that every component retains at least one repaired key entity."""
     empty_components = [c.name for c in result.components if not c.key_entities]
     if empty_components:
         missing_str = ", ".join(empty_components)
-        logger.warning(f"[Validation] Components with no valid key entities after cleanup: {missing_str}")
+        logger.warning(f"[Validation] Components with no valid key entities: {missing_str}")
         return ValidationResult(
             is_valid=False,
             feedback_messages=[

--- a/agents/validation.py
+++ b/agents/validation.py
@@ -15,8 +15,8 @@ from agents.agent_responses import (
     ScopeOperationAction,
     ScopeRelations,
     ScopeUpdateDecision,
-    ScopedClusterRef,
 )
+from agents.scope_operations import EXISTING_COMPONENT_ACTIONS, cluster_ref_from_scoped_ref
 from diagram_analysis.cluster_delta import ClusterRef
 from repo_utils import normalize_path
 from static_analyzer.analysis_result import StaticAnalysisResults
@@ -38,14 +38,6 @@ VALIDATOR_WEIGHTS: dict[str, float] = {
     "validate_file_classifications": 5.0,
 }
 DEFAULT_VALIDATOR_WEIGHT = 5.0
-
-_EXISTING_COMPONENT_ACTIONS = frozenset(
-    {
-        ScopeOperationAction.UPDATE_COMPONENT,
-        ScopeOperationAction.DELETE_COMPONENT,
-        ScopeOperationAction.NOOP,
-    }
-)
 
 
 @dataclass
@@ -98,9 +90,9 @@ def validate_scope_update_decision(
     errors: list[str] = []
     seen_refs: list[ClusterRef] = []
     for operation in decision.operations:
-        refs = [_cluster_ref_from_scoped_ref(ref) for ref in operation.cluster_refs]
+        refs = [cluster_ref_from_scoped_ref(ref) for ref in operation.cluster_refs]
         seen_refs.extend(refs)
-        if operation.action in _EXISTING_COMPONENT_ACTIONS:
+        if operation.action in EXISTING_COMPONENT_ACTIONS:
             if operation.component_id not in context.existing_component_ids:
                 errors.append(
                     f"Operation {operation.action} references unknown component_id={operation.component_id!r}."
@@ -130,10 +122,6 @@ def validate_scope_update_decision(
     if duplicates:
         errors.append(f"Duplicate cluster_refs: {_format_cluster_ref_list(duplicates)}")
     return ValidationResult(is_valid=not errors, feedback_messages=errors)
-
-
-def _cluster_ref_from_scoped_ref(ref: ScopedClusterRef) -> ClusterRef:
-    return ClusterRef(ref.language, ref.cluster_id, ref.scope_id)
 
 
 def _format_cluster_ref_list(refs: set[ClusterRef]) -> str:
@@ -443,7 +431,9 @@ def validate_file_classifications(result: ComponentFiles, context: ValidationCon
     return ValidationResult(is_valid=False, feedback_messages=feedback_messages)
 
 
-def validate_relation_component_names(result: AnalysisInsights, _context: ValidationContext) -> ValidationResult:
+def validate_relation_component_names(
+    result: RelationValidationTarget, _context: ValidationContext
+) -> ValidationResult:
     """
     Validate that every src_name and dst_name in components_relations refers to an existing component.
 
@@ -573,7 +563,7 @@ def validate_relation_evidence(result: RelationValidationTarget, context: Valida
     )
 
 
-def validate_relations(result: AnalysisInsights, context: ValidationContext) -> ValidationResult:
+def validate_relations(result: RelationValidationTarget, context: ValidationContext) -> ValidationResult:
     """Validate relation endpoints and edge evidence as one structural check."""
     name_result = validate_relation_component_names(result, context)
     evidence_result = validate_relation_evidence(result, context)

--- a/diagram_analysis/analysis_json.py
+++ b/diagram_analysis/analysis_json.py
@@ -161,9 +161,31 @@ class UnifiedAnalysisJson(BaseModel):
     components_relations: list[RelationJson] = Field(description="List of relations among the components.")
 
 
-def _build_files_index_from_analysis(analysis: AnalysisInsights) -> dict[str, FileEntry]:
-    """Build a top-level files index from analysis."""
-    return {file_path: entry.model_copy(deep=True) for file_path, entry in analysis.files.items()}
+def _build_files_index_from_analysis(
+    analysis: AnalysisInsights,
+    sub_analyses: dict[str, tuple[AnalysisInsights, list[Component]]] | None = None,
+) -> dict[str, FileEntry]:
+    """Build a unified file index from the root and sub-analyses."""
+    analyses = [analysis]
+    if sub_analyses:
+        analyses.extend(sub_analysis for sub_analysis, _ in sub_analyses.values())
+
+    files_index: dict[str, FileEntry] = {}
+    for current_analysis in analyses:
+        for file_path, entry in current_analysis.files.items():
+            indexed_entry = files_index.setdefault(file_path, FileEntry())
+            if not indexed_entry.content_hash:
+                indexed_entry.content_hash = entry.content_hash
+            methods_by_qname = {method.qualified_name: method for method in indexed_entry.methods}
+            for method in entry.methods:
+                indexed = methods_by_qname.get(method.qualified_name)
+                if indexed is None or (indexed.node_type == "REFERENCE" and method.node_type != "REFERENCE"):
+                    methods_by_qname[method.qualified_name] = method.model_copy(deep=True)
+            indexed_entry.methods = sorted(
+                methods_by_qname.values(),
+                key=lambda method: (method.start_line, method.end_line, method.qualified_name),
+            )
+    return files_index
 
 
 def _method_key(file_path: str, qualified_name: str) -> str:
@@ -227,33 +249,6 @@ def _build_methods_index_from_files(files_index: dict[str, FileEntry]) -> dict[s
     return methods_index
 
 
-def _add_relation_endpoints_to_methods_index(
-    methods_index: dict[str, MethodIndexEntry],
-    analysis: AnalysisInsights,
-    repo_dir: Path,
-    sub_analyses: dict[str, tuple[AnalysisInsights, list[Component]]] | None = None,
-) -> None:
-    """Index relation endpoints that are not declared in the analyzed file set."""
-    analyses = [analysis]
-    if sub_analyses:
-        analyses.extend(sub_analysis for sub_analysis, _ in sub_analyses.values())
-
-    for current_analysis in analyses:
-        for relation in current_analysis.components_relations:
-            for edge in [*relation.key_edges, *relation.all_edges]:
-                for reference in (edge.source, edge.target):
-                    key = _source_reference_method_key(reference, repo_dir)
-                    if key in methods_index:
-                        continue
-                    methods_index[key] = MethodIndexEntry(
-                        file_path=normalize_repo_path(reference.reference_file or "", repo_dir),
-                        qualified_name=reference.qualified_name,
-                        start_line=reference.reference_start_line or 0,
-                        end_line=reference.reference_end_line or 0,
-                        type="REFERENCE",
-                    )
-
-
 def _build_file_entry_json_from_files(files_index: dict[str, FileEntry]) -> dict[str, FileEntryJson]:
     return {
         file_path: FileEntryJson(
@@ -261,6 +256,7 @@ def _build_file_entry_json_from_files(files_index: dict[str, FileEntry]) -> dict
             content_hash=entry.content_hash,
         )
         for file_path, entry in files_index.items()
+        if file_path
     }
 
 
@@ -374,9 +370,8 @@ def from_analysis_to_json(
         _relation_to_json(r, repo_dir)
         for r in merge_relations_by_pair(analysis.components_relations, include_relation=True)
     ]
-    files_index = _build_files_index_from_analysis(analysis)
+    files_index = _build_files_index_from_analysis(analysis, sub_analyses)
     methods_index = _build_methods_index_from_files(files_index)
-    _add_relation_endpoints_to_methods_index(methods_index, analysis, repo_dir, sub_analyses)
     files_json = _build_file_entry_json_from_files(files_index)
     data = {
         "description": analysis.description,
@@ -452,9 +447,8 @@ def build_unified_analysis_json(
     components_json = [
         from_component_to_json_component(c, expandable_components, repo_dir, sub_analyses) for c in analysis.components
     ]
-    files_index = _build_files_index_from_analysis(analysis)
+    files_index = _build_files_index_from_analysis(analysis, sub_analyses)
     methods_index = _build_methods_index_from_files(files_index)
-    _add_relation_endpoints_to_methods_index(methods_index, analysis, repo_dir, sub_analyses)
 
     # Use default summary if none provided
     if file_coverage_summary is None:
@@ -537,6 +531,22 @@ def _reconstruct_files_index(
         files_index[file_path] = FileEntry(
             methods=methods,
             content_hash=entry_raw.get("content_hash", ""),
+        )
+
+    for indexed in methods_index.values():
+        if indexed.type != "REFERENCE":
+            continue
+        entry = files_index.setdefault(indexed.file_path, FileEntry())
+        if any(method.qualified_name == indexed.qualified_name for method in entry.methods):
+            continue
+        entry.methods.append(
+            MethodEntry(
+                qualified_name=indexed.qualified_name,
+                start_line=indexed.start_line,
+                end_line=indexed.end_line,
+                node_type=indexed.type,
+                content_hash=indexed.content_hash,
+            )
         )
     return files_index
 

--- a/diagram_analysis/analysis_json.py
+++ b/diagram_analysis/analysis_json.py
@@ -227,6 +227,33 @@ def _build_methods_index_from_files(files_index: dict[str, FileEntry]) -> dict[s
     return methods_index
 
 
+def _add_relation_endpoints_to_methods_index(
+    methods_index: dict[str, MethodIndexEntry],
+    analysis: AnalysisInsights,
+    repo_dir: Path,
+    sub_analyses: dict[str, tuple[AnalysisInsights, list[Component]]] | None = None,
+) -> None:
+    """Index relation endpoints that are not declared in the analyzed file set."""
+    analyses = [analysis]
+    if sub_analyses:
+        analyses.extend(sub_analysis for sub_analysis, _ in sub_analyses.values())
+
+    for current_analysis in analyses:
+        for relation in current_analysis.components_relations:
+            for edge in [*relation.key_edges, *relation.all_edges]:
+                for reference in (edge.source, edge.target):
+                    key = _source_reference_method_key(reference, repo_dir)
+                    if key in methods_index:
+                        continue
+                    methods_index[key] = MethodIndexEntry(
+                        file_path=normalize_repo_path(reference.reference_file or "", repo_dir),
+                        qualified_name=reference.qualified_name,
+                        start_line=reference.reference_start_line or 0,
+                        end_line=reference.reference_end_line or 0,
+                        type="REFERENCE",
+                    )
+
+
 def _build_file_entry_json_from_files(files_index: dict[str, FileEntry]) -> dict[str, FileEntryJson]:
     return {
         file_path: FileEntryJson(
@@ -349,6 +376,7 @@ def from_analysis_to_json(
     ]
     files_index = _build_files_index_from_analysis(analysis)
     methods_index = _build_methods_index_from_files(files_index)
+    _add_relation_endpoints_to_methods_index(methods_index, analysis, repo_dir, sub_analyses)
     files_json = _build_file_entry_json_from_files(files_index)
     data = {
         "description": analysis.description,
@@ -426,6 +454,7 @@ def build_unified_analysis_json(
     ]
     files_index = _build_files_index_from_analysis(analysis)
     methods_index = _build_methods_index_from_files(files_index)
+    _add_relation_endpoints_to_methods_index(methods_index, analysis, repo_dir, sub_analyses)
 
     # Use default summary if none provided
     if file_coverage_summary is None:

--- a/diagram_analysis/analysis_json.py
+++ b/diagram_analysis/analysis_json.py
@@ -173,18 +173,7 @@ def _build_files_index_from_analysis(
     files_index: dict[str, FileEntry] = {}
     for current_analysis in analyses:
         for file_path, entry in current_analysis.files.items():
-            indexed_entry = files_index.setdefault(file_path, FileEntry())
-            if not indexed_entry.content_hash:
-                indexed_entry.content_hash = entry.content_hash
-            methods_by_qname = {method.qualified_name: method for method in indexed_entry.methods}
-            for method in entry.methods:
-                indexed = methods_by_qname.get(method.qualified_name)
-                if indexed is None or (indexed.node_type == "REFERENCE" and method.node_type != "REFERENCE"):
-                    methods_by_qname[method.qualified_name] = method.model_copy(deep=True)
-            indexed_entry.methods = sorted(
-                methods_by_qname.values(),
-                key=lambda method: (method.start_line, method.end_line, method.qualified_name),
-            )
+            files_index.setdefault(file_path, FileEntry()).merge_from(entry)
     return files_index
 
 
@@ -497,10 +486,10 @@ def parse_unified_analysis(
     files_raw = data.get("files", {})
     files_index = _reconstruct_files_index(files_raw, methods_index)
 
-    root_analysis.files = {path: entry.model_copy(deep=True) for path, entry in files_index.items()}
+    root_analysis.files = {path: FileEntry().merge_from(entry) for path, entry in files_index.items()}
     _hydrate_component_methods_from_refs(root_analysis, methods_index)
     for sub in sub_analyses.values():
-        sub.files = {path: entry.model_copy(deep=True) for path, entry in files_index.items()}
+        sub.files = {path: FileEntry().merge_from(entry) for path, entry in files_index.items()}
         _hydrate_component_methods_from_refs(sub, methods_index)
 
     return root_analysis, sub_analyses
@@ -513,13 +502,14 @@ def _reconstruct_files_index(
     """Rebuild in-memory ``FileEntry`` objects from persisted ``method_keys``."""
     files_index: dict[str, FileEntry] = {}
     for file_path, entry_raw in files_raw.items():
-        methods: list[MethodEntry] = []
+        entry = FileEntry(content_hash=entry_raw.get("content_hash", ""))
+        indexed_methods: list[MethodEntry] = []
         for key in entry_raw["method_keys"]:
             indexed = methods_index.get(key)
             if indexed is None:
                 logger.warning("Missing methods_index entry for key %s (file %s)", key, file_path)
                 continue
-            methods.append(
+            indexed_methods.append(
                 MethodEntry(
                     qualified_name=indexed.qualified_name,
                     start_line=indexed.start_line,
@@ -528,26 +518,8 @@ def _reconstruct_files_index(
                     content_hash=indexed.content_hash,
                 )
             )
-        files_index[file_path] = FileEntry(
-            methods=methods,
-            content_hash=entry_raw.get("content_hash", ""),
-        )
-
-    for indexed in methods_index.values():
-        if indexed.type != "REFERENCE":
-            continue
-        entry = files_index.setdefault(indexed.file_path, FileEntry())
-        if any(method.qualified_name == indexed.qualified_name for method in entry.methods):
-            continue
-        entry.methods.append(
-            MethodEntry(
-                qualified_name=indexed.qualified_name,
-                start_line=indexed.start_line,
-                end_line=indexed.end_line,
-                node_type=indexed.type,
-                content_hash=indexed.content_hash,
-            )
-        )
+        entry.merge_from(FileEntry(methods=indexed_methods))
+        files_index[file_path] = entry
     return files_index
 
 

--- a/diagram_analysis/diagram_generator.py
+++ b/diagram_analysis/diagram_generator.py
@@ -33,7 +33,7 @@ from agents.meta_agent import MetaAgent
 from agents.planner_agent import get_expandable_components
 from agents.relation_edges import index_relation_endpoints
 from agents.scope_ids import ROOT_SCOPE_ID
-from agents.content_hash import hash_repo_source_files, tree_hash_from_file_hashes
+from agents.content_hash import SourceCache, hash_repo_source_files, tree_hash_from_file_hashes
 from diagram_analysis.analysis_json import (
     FileCoverageReport,
     FileCoverageSummary,
@@ -277,11 +277,15 @@ class DiagramGenerator:
 
     def _get_static_with_new_analyzer(self) -> StaticAnalysisResults:
         """Run static analysis with a newly created analyzer."""
+        disable_reuse = os.getenv("CODEBOARDING_DISABLE_CACHE_REUSE", "").lower() in ("1", "true", "yes")
+        skip_cache = self.force_full_analysis or disable_reuse
         if self.force_full_analysis:
             logger.info("Force full analysis: skipping static analysis cache")
+        if disable_reuse:
+            logger.info("CODEBOARDING_DISABLE_CACHE_REUSE set; skipping static analysis cache")
         return get_static_analysis(
             self.repo_location,
-            skip_cache=self.force_full_analysis,
+            skip_cache=skip_cache,
             source_sha=self.source_sha,
             cache_dir=self.output_dir,
             changed_files=self._changed_files_for_static_analysis(),
@@ -872,9 +876,10 @@ class DiagramGenerator:
         """Rebuild live per-scope file indexes and union them into the root index."""
         assert self.static_analysis is not None
         analyses = (root_analysis, *sub_analyses.values())
+        source_cache: SourceCache = {}
         for analysis in analyses:
             refresh_method_spans_from_cfg(analysis, self.static_analysis, self.repo_location)
-            analysis.files = build_files_index(analysis, self.repo_location)
+            analysis.files = build_files_index(analysis, self.repo_location, source_cache)
             index_relation_endpoints(analysis, self.repo_location)
 
         unified_files = root_analysis.files
@@ -882,7 +887,7 @@ class DiagramGenerator:
             for fp, entry in sub.files.items():
                 indexed_entry = unified_files.get(fp)
                 if indexed_entry is None:
-                    unified_files[fp] = entry
+                    unified_files[fp] = entry.model_copy(deep=True)
                     continue
                 if not indexed_entry.content_hash:
                     indexed_entry.content_hash = entry.content_hash
@@ -890,7 +895,7 @@ class DiagramGenerator:
                 for method in entry.methods:
                     indexed = methods_by_qname.get(method.qualified_name)
                     if indexed is None or (indexed.node_type == "REFERENCE" and method.node_type != "REFERENCE"):
-                        methods_by_qname[method.qualified_name] = method
+                        methods_by_qname[method.qualified_name] = method.model_copy(deep=True)
                 indexed_entry.methods = sorted(
                     methods_by_qname.values(),
                     key=lambda method: (method.start_line, method.end_line, method.qualified_name),

--- a/diagram_analysis/diagram_generator.py
+++ b/diagram_analysis/diagram_generator.py
@@ -2,7 +2,6 @@ import json
 import logging
 import os
 import time
-from collections import defaultdict
 from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
 from contextlib import nullcontext
 from datetime import datetime, timezone
@@ -17,7 +16,6 @@ from agents.agent_responses import (
     Component,
     MetaAnalysisInsights,
 )
-from agents.file_index_models import MethodEntry
 from agents.cluster_methods_mixin import scoped_snapshot_from_lineage
 from agents.details_agent import DetailsAgent
 from agents.incremental_agent import (
@@ -27,6 +25,7 @@ from agents.incremental_agent import (
 )
 from agents.incremental_planning_agent import IncrementalPlanningAgent
 from agents.incremental_results import RecursiveScopeUpdateResult
+from agents.file_index_models import FileEntry
 from agents.llm_config import initialize_llms
 from agents.llm_errors import LLMAuthError
 from agents.meta_agent import MetaAgent
@@ -655,38 +654,6 @@ class DiagramGenerator:
             write_fingerprint(Path(self.output_dir), self._source_tree_fingerprint_map())
         return analysis_path
 
-    def _collect_method_entries_from_static_analysis(self) -> dict[str, list]:
-        assert self.static_analysis is not None
-        methods_by_file: dict[str, list[MethodEntry]] = defaultdict(list)
-
-        for language in self.static_analysis.get_languages():
-            try:
-                cfg = self.static_analysis.get_cfg(language)
-            except ValueError:
-                continue
-
-            for node in cfg.nodes.values():
-                if node.is_callback_or_anonymous():
-                    continue
-                if not (node.is_callable() or node.is_class()):
-                    continue
-                file_path = normalize_repo_path(node.file_path, self.repo_location)
-
-                methods_by_file[file_path].append(
-                    MethodEntry(
-                        qualified_name=node.fully_qualified_name,
-                        start_line=node.line_start,
-                        end_line=node.line_end,
-                        node_type=node.type.name,
-                    )
-                )
-
-        for file_path, methods in methods_by_file.items():
-            methods.sort(key=lambda method: (method.start_line, method.end_line, method.qualified_name))
-            methods_by_file[file_path] = methods
-
-        return methods_by_file
-
     def _build_file_coverage_summary(self) -> FileCoverageSummary | None:
         if not self.file_coverage_data:
             return None
@@ -721,7 +688,7 @@ class DiagramGenerator:
             removed_ids=set(apply_result.removed_ids),
         )
         if apply_result.refresh_ids or apply_result.removed_ids:
-            result.touched_scopes.add(scope_id)
+            result.relation_contexts[scope_id] = apply_result.relation_context
 
         components_by_id = {
             component.component_id: component for component in scope.components if component.component_id
@@ -753,7 +720,7 @@ class DiagramGenerator:
             result.refresh_ids |= child_result.refresh_ids
             result.new_component_ids |= child_result.new_component_ids
             result.removed_ids |= child_result.removed_ids
-            result.touched_scopes |= child_result.touched_scopes
+            result.relation_contexts.update(child_result.relation_contexts)
         return result
 
     @track_analysis
@@ -849,11 +816,11 @@ class DiagramGenerator:
                 _, redetailed_subs = self._generate_subcomponents(root_analysis, new_components)
                 _merge_sub_analyses(sub_analyses, redetailed_subs)
 
-            if apply_result.touched_scopes:
+            if apply_result.relation_contexts:
                 self.incremental_agent.generate_all_scope_relations(
                     root_analysis,
                     sub_analyses,
-                    apply_result.touched_scopes,
+                    apply_result.relation_contexts,
                 )
 
             self._refresh_files_index(root_analysis, sub_analyses)
@@ -882,24 +849,10 @@ class DiagramGenerator:
             analysis.files = build_files_index(analysis, self.repo_location, source_cache)
             index_relation_endpoints(analysis, self.repo_location)
 
-        unified_files = root_analysis.files
-        for sub in sub_analyses.values():
-            for fp, entry in sub.files.items():
-                indexed_entry = unified_files.get(fp)
-                if indexed_entry is None:
-                    unified_files[fp] = entry.model_copy(deep=True)
-                    continue
-                if not indexed_entry.content_hash:
-                    indexed_entry.content_hash = entry.content_hash
-                methods_by_qname = {method.qualified_name: method for method in indexed_entry.methods}
-                for method in entry.methods:
-                    indexed = methods_by_qname.get(method.qualified_name)
-                    if indexed is None or (indexed.node_type == "REFERENCE" and method.node_type != "REFERENCE"):
-                        methods_by_qname[method.qualified_name] = method.model_copy(deep=True)
-                indexed_entry.methods = sorted(
-                    methods_by_qname.values(),
-                    key=lambda method: (method.start_line, method.end_line, method.qualified_name),
-                )
+        unified_files: dict[str, FileEntry] = {}
+        for analysis in analyses:
+            for fp, entry in analysis.files.items():
+                unified_files.setdefault(fp, FileEntry()).merge_from(entry)
         root_analysis.files = unified_files
 
 

--- a/diagram_analysis/diagram_generator.py
+++ b/diagram_analysis/diagram_generator.py
@@ -9,6 +9,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from langchain_core.language_models import BaseChatModel
+
 from agents.abstraction_agent import AbstractionAgent
 from agents.agent_responses import (
     AnalysisInsights,
@@ -29,6 +31,7 @@ from agents.llm_config import initialize_llms
 from agents.llm_errors import LLMAuthError
 from agents.meta_agent import MetaAgent
 from agents.planner_agent import get_expandable_components
+from agents.relation_edges import index_relation_endpoints
 from agents.scope_ids import ROOT_SCOPE_ID
 from agents.content_hash import hash_repo_source_files, tree_hash_from_file_hashes
 from diagram_analysis.analysis_json import (
@@ -47,8 +50,9 @@ from diagram_analysis.cluster_snapshot import (
     ClusterSnapshot,
     snapshot_from_static_analysis,
 )
-from diagram_analysis.exceptions import IncrementalCacheMissingError, IncrementalScopeRegenerationRequiredError
+from diagram_analysis.exceptions import IncrementalCacheMissingError
 from diagram_analysis.file_coverage import FileCoverage
+from diagram_analysis.file_index import build_files_index, refresh_method_spans_from_cfg
 from diagram_analysis.io_utils import load_analysis_metadata, normalize_repo_path, save_analysis, write_fingerprint
 from health.config import initialize_health_dir, load_health_config
 from health.runner import run_health_checks
@@ -129,6 +133,8 @@ class DiagramGenerator:
         self.static_analysis: StaticAnalysisResults | None = None  # Cache static analysis for reuse
         self.abstraction_agent: AbstractionAgent | None = None
         self.meta_agent: MetaAgent | None = None
+        self.incremental_planning_agent: IncrementalPlanningAgent | None = None
+        self.incremental_agent: IncrementalAgent | None = None
         self.meta_context: MetaAnalysisInsights | None = None
         self.file_coverage_data: dict | None = None
 
@@ -251,20 +257,35 @@ class DiagramGenerator:
         rel_paths = self.changes.added_files + self.changes.modified_files + self.changes.deleted_files
         return {(self.repo_location / rel).resolve() for rel in rel_paths}
 
-    def _get_static_from_injected_analyzer(
-        self,
-        skip_cache: bool = False,
-        source_sha: str | None = None,
-    ) -> StaticAnalysisResults:
+    def _get_static_with_injected_analyzer(self) -> StaticAnalysisResults:
+        """Run the injected analyzer with the configured cache policy."""
         assert self._static_analyzer is not None
+        disable_reuse = os.getenv("CODEBOARDING_DISABLE_CACHE_REUSE", "").lower() in ("1", "true", "yes")
+        skip_cache = self.force_full_analysis or disable_reuse
+        if self.force_full_analysis:
+            logger.info("Force full analysis: skipping static analysis cache")
+        if disable_reuse:
+            logger.info("CODEBOARDING_DISABLE_CACHE_REUSE set; skipping static analysis cache")
         self._static_analyzer.changed_files = self._changed_files_for_static_analysis()
         result = self._static_analyzer.analyze(
             skip_cache=skip_cache,
-            source_sha=source_sha,
+            source_sha=self.source_sha,
             cache_dir=self.output_dir,
         )
         result.diagnostics = self._static_analyzer.collected_diagnostics
         return result
+
+    def _get_static_with_new_analyzer(self) -> StaticAnalysisResults:
+        """Run static analysis with a newly created analyzer."""
+        if self.force_full_analysis:
+            logger.info("Force full analysis: skipping static analysis cache")
+        return get_static_analysis(
+            self.repo_location,
+            skip_cache=self.force_full_analysis,
+            source_sha=self.source_sha,
+            cache_dir=self.output_dir,
+            changed_files=self._changed_files_for_static_analysis(),
+        )
 
     def _seed_incremental_cluster_cache(self, cluster_results: dict[str, ClusterResult]) -> None:
         """Write post-delta ``cluster_results`` into each language CFG's ``_cluster_cache``.
@@ -302,6 +323,69 @@ class DiagramGenerator:
         """The source-tree version key aggregated from the cached fingerprint."""
         return tree_hash_from_file_hashes(self._source_tree_fingerprint_map())
 
+    def _initialize_meta_agent(self, agent_llm: BaseChatModel, parsing_llm: BaseChatModel) -> None:
+        """Initialize the metadata agent needed before the other agents."""
+        self.meta_agent = MetaAgent(
+            repo_dir=self.repo_location,
+            project_name=self.repo_name,
+            agent_llm=agent_llm,
+            parsing_llm=parsing_llm,
+            run_id=self.run_id,
+        )
+        self._monitoring_agents["MetaAgent"] = self.meta_agent
+
+    def _initialize_agents(
+        self,
+        static_analysis: StaticAnalysisResults,
+        meta_context: MetaAnalysisInsights,
+        agent_llm: BaseChatModel,
+        parsing_llm: BaseChatModel,
+    ) -> None:
+        """Initialize agents that depend on static analysis and project metadata."""
+        self.details_agent = DetailsAgent(
+            repo_dir=self.repo_location,
+            project_name=self.repo_name,
+            static_analysis=static_analysis,
+            meta_context=meta_context,
+            agent_llm=agent_llm,
+            parsing_llm=parsing_llm,
+            run_id=self.run_id,
+        )
+        self.abstraction_agent = AbstractionAgent(
+            repo_dir=self.repo_location,
+            project_name=self.repo_name,
+            static_analysis=static_analysis,
+            meta_context=meta_context,
+            agent_llm=agent_llm,
+            parsing_llm=parsing_llm,
+        )
+        self.incremental_planning_agent = IncrementalPlanningAgent(
+            repo_dir=self.repo_location,
+            static_analysis=static_analysis,
+            project_name=self.repo_name,
+            meta_context=meta_context,
+            agent_llm=agent_llm,
+            parsing_llm=parsing_llm,
+            changes=self.changes,
+        )
+        self.incremental_agent = IncrementalAgent(
+            repo_dir=self.repo_location,
+            static_analysis=static_analysis,
+            project_name=self.repo_name,
+            meta_context=meta_context,
+            agent_llm=agent_llm,
+            parsing_llm=parsing_llm,
+            changes=self.changes,
+        )
+        self._monitoring_agents.update(
+            {
+                "DetailsAgent": self.details_agent,
+                "AbstractionAgent": self.abstraction_agent,
+                "IncrementalPlanningAgent": self.incremental_planning_agent,
+                "IncrementalAgent": self.incremental_agent,
+            }
+        )
+
     def pre_analysis(self):
         analysis_start_time = time.time()
 
@@ -317,46 +401,15 @@ class DiagramGenerator:
         # Initialize LLMs before spawning threads so both share the same instances
         agent_llm, parsing_llm = initialize_llms()
 
-        self.meta_agent = MetaAgent(
-            repo_dir=self.repo_location,
-            project_name=self.repo_name,
-            agent_llm=agent_llm,
-            parsing_llm=parsing_llm,
-            run_id=self.run_id,
-        )
-        self._monitoring_agents["MetaAgent"] = self.meta_agent
-
-        def get_static_with_injected_analyzer() -> StaticAnalysisResults:
-            # ``CODEBOARDING_DISABLE_CACHE_REUSE=1`` is the post-deploy kill
-            # switch that reverts to "always re-LSP everything" without a code
-            # change; useful if telemetry surfaces a warm-start regression.
-            disable_reuse = os.getenv("CODEBOARDING_DISABLE_CACHE_REUSE", "").lower() in ("1", "true", "yes")
-            skip_cache = self.force_full_analysis or disable_reuse
-            if self.force_full_analysis:
-                logger.info("Force full analysis: skipping static analysis cache")
-            if disable_reuse:
-                logger.info("CODEBOARDING_DISABLE_CACHE_REUSE set; skipping static analysis cache")
-            return self._get_static_from_injected_analyzer(skip_cache=skip_cache, source_sha=self.source_sha)
-
-        def get_static_with_new_analyzer() -> StaticAnalysisResults:
-            skip_cache = self.force_full_analysis
-            if skip_cache:
-                logger.info("Force full analysis: skipping static analysis cache")
-            return get_static_analysis(
-                self.repo_location,
-                skip_cache=skip_cache,
-                source_sha=self.source_sha,
-                cache_dir=self.output_dir,
-                changed_files=self._changed_files_for_static_analysis(),
-            )
+        self._initialize_meta_agent(agent_llm, parsing_llm)
 
         # Decide how to obtain static analysis results, then run it in parallel
         # with the meta-context computation so neither blocks the other.
         if self._static_analyzer is not None:
             logger.info("Using injected StaticAnalyzer (clients already running)")
-            static_callable = get_static_with_injected_analyzer
+            static_callable = self._get_static_with_injected_analyzer
         else:
-            static_callable = get_static_with_new_analyzer
+            static_callable = self._get_static_with_new_analyzer
 
         with ThreadPoolExecutor(max_workers=2) as executor:
             meta_agent = self.meta_agent
@@ -385,25 +438,7 @@ class DiagramGenerator:
 
         self._run_health_report(static_analysis)
 
-        self.details_agent = DetailsAgent(
-            repo_dir=self.repo_location,
-            project_name=self.repo_name,
-            static_analysis=static_analysis,
-            meta_context=meta_context,
-            agent_llm=agent_llm,
-            parsing_llm=parsing_llm,
-            run_id=self.run_id,
-        )
-        self._monitoring_agents["DetailsAgent"] = self.details_agent
-        self.abstraction_agent = AbstractionAgent(
-            repo_dir=self.repo_location,
-            project_name=self.repo_name,
-            static_analysis=static_analysis,
-            meta_context=meta_context,
-            agent_llm=agent_llm,
-            parsing_llm=parsing_llm,
-        )
-        self._monitoring_agents["AbstractionAgent"] = self.abstraction_agent
+        self._initialize_agents(static_analysis, meta_context, agent_llm, parsing_llm)
 
         if self.monitoring_enabled:
             monitoring_dir = get_monitoring_run_dir(self.log_path, create=True)
@@ -665,22 +700,24 @@ class DiagramGenerator:
         scope: AnalysisInsights,
         structural_diff: StructuralClusterDiff,
         cluster_results: dict[str, ClusterResult],
-        planning_agent: IncrementalPlanningAgent,
-        incremental_agent: IncrementalAgent,
         sub_analyses: dict[str, AnalysisInsights],
     ) -> RecursiveScopeUpdateResult:
-        decision = planning_agent.decide_scope_update(scope_id, scope, structural_diff)
-        apply_result = incremental_agent.update_scope(scope_id, scope, decision, cluster_results)
+        assert self.incremental_planning_agent is not None
+        assert self.incremental_agent is not None
+        decision = self.incremental_planning_agent.decide_scope_update(
+            scope_id,
+            scope,
+            structural_diff,
+            cluster_results,
+        )
+        apply_result = self.incremental_agent.update_scope(scope_id, scope, decision, cluster_results)
         result = RecursiveScopeUpdateResult(
             refresh_ids=set(apply_result.refresh_ids),
             new_component_ids=set(apply_result.new_component_ids),
             removed_ids=set(apply_result.removed_ids),
-            regenerate_scope=apply_result.regenerate_scope,
         )
         if apply_result.refresh_ids or apply_result.removed_ids:
             result.touched_scopes.add(scope_id)
-        if result.regenerate_scope:
-            raise IncrementalScopeRegenerationRequiredError(scope_id)
 
         components_by_id = {
             component.component_id: component for component in scope.components if component.component_id
@@ -694,7 +731,7 @@ class DiagramGenerator:
             child_cluster_results, child_diff = _build_scope_incremental_inputs(
                 child_component,
                 component_id,
-                incremental_agent,
+                self.incremental_agent,
                 self.changes,
                 self.repo_location,
             )
@@ -707,17 +744,12 @@ class DiagramGenerator:
                 child_scope,
                 child_diff,
                 child_cluster_results,
-                planning_agent,
-                incremental_agent,
                 sub_analyses,
             )
             result.refresh_ids |= child_result.refresh_ids
             result.new_component_ids |= child_result.new_component_ids
             result.removed_ids |= child_result.removed_ids
             result.touched_scopes |= child_result.touched_scopes
-            result.regenerate_scope = result.regenerate_scope or child_result.regenerate_scope
-            if result.regenerate_scope:
-                raise IncrementalScopeRegenerationRequiredError(scope_id)
         return result
 
     @track_analysis
@@ -732,10 +764,12 @@ class DiagramGenerator:
         then ``_generate_subcomponents`` seeded with the changed components.
         Raises when no trustworthy baseline or scoped update plan is available.
         """
-        if self.details_agent is None or self.abstraction_agent is None:
+        if self.details_agent is None or self.incremental_planning_agent is None or self.incremental_agent is None:
             self.pre_analysis()
         assert self.static_analysis is not None
-        assert self.abstraction_agent is not None
+        assert self.details_agent is not None
+        assert self.incremental_planning_agent is not None
+        assert self.incremental_agent is not None
 
         monitor = self.stats_writer if self.stats_writer else nullcontext()
         with monitor:
@@ -781,45 +815,20 @@ class DiagramGenerator:
                 self._refresh_files_index(root_analysis, sub_analyses)
                 return self.finalize_and_save(root_analysis, sub_analyses)
 
-            agent_llm, parsing_llm = initialize_llms()
-            planning_agent = IncrementalPlanningAgent(
-                repo_dir=self.repo_location,
-                static_analysis=self.static_analysis,
-                project_name=self.repo_name,
-                meta_context=self.meta_context,
-                agent_llm=agent_llm,
-                parsing_llm=parsing_llm,
-                changes=self.changes,
-            )
-            self._monitoring_agents["IncrementalPlanningAgent"] = planning_agent
             structural_diff = structural_diff_from_delta(
                 old_snapshot,
                 delta,
                 changes=self.changes,
                 repo_dir=self.repo_location,
             )
-            incremental_agent = IncrementalAgent(
-                repo_dir=self.repo_location,
-                static_analysis=self.static_analysis,
-                project_name=self.repo_name,
-                meta_context=self.meta_context,
-                agent_llm=agent_llm,
-                parsing_llm=parsing_llm,
-                changes=self.changes,
-            )
-            self._monitoring_agents["IncrementalAgent"] = incremental_agent
             protected_empty_ids = _cluster_backed_empty_component_ids(root_analysis, sub_analyses)
             apply_result = self._apply_incremental_scope_recursively(
                 ROOT_SCOPE_ID,
                 root_analysis,
                 structural_diff,
                 delta.cluster_results(),
-                planning_agent,
-                incremental_agent,
                 sub_analyses,
             )
-            if apply_result.regenerate_scope:
-                raise IncrementalScopeRegenerationRequiredError(ROOT_SCOPE_ID)
 
             removed_ids = prune_empty_components(root_analysis, sub_analyses, protected_empty_ids)
             if removed_ids:
@@ -837,7 +846,11 @@ class DiagramGenerator:
                 _merge_sub_analyses(sub_analyses, redetailed_subs)
 
             if apply_result.touched_scopes:
-                incremental_agent.generate_all_scope_relations(root_analysis, sub_analyses, apply_result.touched_scopes)
+                self.incremental_agent.generate_all_scope_relations(
+                    root_analysis,
+                    sub_analyses,
+                    apply_result.touched_scopes,
+                )
 
             self._refresh_files_index(root_analysis, sub_analyses)
 
@@ -856,25 +869,32 @@ class DiagramGenerator:
         root_analysis: AnalysisInsights,
         sub_analyses: dict[str, AnalysisInsights],
     ) -> None:
-        """Rebuild the global files index from live source, unioning every
-        sub-analysis's files into root.
+        """Rebuild live per-scope file indexes and union them into the root index."""
+        assert self.static_analysis is not None
+        analyses = (root_analysis, *sub_analyses.values())
+        for analysis in analyses:
+            refresh_method_spans_from_cfg(analysis, self.static_analysis, self.repo_location)
+            analysis.files = build_files_index(analysis, self.repo_location)
+            index_relation_endpoints(analysis, self.repo_location)
 
-        The incremental flow never reruns AbstractionAgent over the full CFG, so
-        root.files lags behind deeper levels; build_unified_analysis_json reads
-        only root.files for the top index, so we must surface every depth's files
-        there. Refreshing spans from the live CFG first means build_files_index
-        hashes the current body even for components that weren't re-detailed, so a
-        body-only edit is reflected.
-        """
-        assert self.abstraction_agent is not None
-        for analysis in (root_analysis, *sub_analyses.values()):
-            self.abstraction_agent.refresh_method_spans_from_cfg(analysis)
-        for sub in sub_analyses.values():
-            sub.files = self.abstraction_agent.build_files_index(sub)
-        unified_files = self.abstraction_agent.build_files_index(root_analysis)
+        unified_files = root_analysis.files
         for sub in sub_analyses.values():
             for fp, entry in sub.files.items():
-                unified_files.setdefault(fp, entry)
+                indexed_entry = unified_files.get(fp)
+                if indexed_entry is None:
+                    unified_files[fp] = entry
+                    continue
+                if not indexed_entry.content_hash:
+                    indexed_entry.content_hash = entry.content_hash
+                methods_by_qname = {method.qualified_name: method for method in indexed_entry.methods}
+                for method in entry.methods:
+                    indexed = methods_by_qname.get(method.qualified_name)
+                    if indexed is None or (indexed.node_type == "REFERENCE" and method.node_type != "REFERENCE"):
+                        methods_by_qname[method.qualified_name] = method
+                indexed_entry.methods = sorted(
+                    methods_by_qname.values(),
+                    key=lambda method: (method.start_line, method.end_line, method.qualified_name),
+                )
         root_analysis.files = unified_files
 
 

--- a/diagram_analysis/diagram_generator.py
+++ b/diagram_analysis/diagram_generator.py
@@ -47,7 +47,7 @@ from diagram_analysis.cluster_snapshot import (
     ClusterSnapshot,
     snapshot_from_static_analysis,
 )
-from diagram_analysis.exceptions import IncrementalCacheMissingError
+from diagram_analysis.exceptions import IncrementalCacheMissingError, IncrementalScopeRegenerationRequiredError
 from diagram_analysis.file_coverage import FileCoverage
 from diagram_analysis.io_utils import load_analysis_metadata, normalize_repo_path, save_analysis, write_fingerprint
 from health.config import initialize_health_dir, load_health_config
@@ -677,10 +677,10 @@ class DiagramGenerator:
             removed_ids=set(apply_result.removed_ids),
             regenerate_scope=apply_result.regenerate_scope,
         )
-        if apply_result.refresh_ids:
+        if apply_result.refresh_ids or apply_result.removed_ids:
             result.touched_scopes.add(scope_id)
         if result.regenerate_scope:
-            return result
+            raise IncrementalScopeRegenerationRequiredError(scope_id)
 
         components_by_id = {
             component.component_id: component for component in scope.components if component.component_id
@@ -717,7 +717,7 @@ class DiagramGenerator:
             result.touched_scopes |= child_result.touched_scopes
             result.regenerate_scope = result.regenerate_scope or child_result.regenerate_scope
             if result.regenerate_scope:
-                return result
+                raise IncrementalScopeRegenerationRequiredError(scope_id)
         return result
 
     @track_analysis
@@ -730,7 +730,7 @@ class DiagramGenerator:
 
         Deterministic cluster delta, one LLM call to route delta clusters,
         then ``_generate_subcomponents`` seeded with the changed components.
-        Falls back to a full run when no baseline cluster info exists.
+        Raises when no trustworthy baseline or scoped update plan is available.
         """
         if self.details_agent is None or self.abstraction_agent is None:
             self.pre_analysis()
@@ -819,8 +819,7 @@ class DiagramGenerator:
                 sub_analyses,
             )
             if apply_result.regenerate_scope:
-                logger.info("Incremental planning agent requested root regeneration; running full analysis.")
-                return self.generate_analysis()
+                raise IncrementalScopeRegenerationRequiredError(ROOT_SCOPE_ID)
 
             removed_ids = prune_empty_components(root_analysis, sub_analyses, protected_empty_ids)
             if removed_ids:

--- a/diagram_analysis/exceptions.py
+++ b/diagram_analysis/exceptions.py
@@ -51,11 +51,3 @@ class InvalidIncrementalPlanError(RuntimeError):
         super().__init__(f"Incremental plan for scope {scope_id!r} is invalid: {issue_summary}")
         self.scope_id = scope_id
         self.issues = issues
-
-
-class IncrementalScopeContextMissingError(RuntimeError):
-    """Raised when relation regeneration lacks its scoped static context."""
-
-    def __init__(self, scope_id: str):
-        super().__init__(f"No incremental relation context was recorded for scope {scope_id!r}")
-        self.scope_id = scope_id

--- a/diagram_analysis/exceptions.py
+++ b/diagram_analysis/exceptions.py
@@ -41,3 +41,34 @@ class IncrementalCacheMissingError(RuntimeError):
             f"Incremental analysis cannot proceed: {reason}. " "Run a full analysis first to seed the cache."
         )
         self.artifact_dir = artifact_dir
+
+
+class InvalidIncrementalPlanError(RuntimeError):
+    """Raised when the planner cannot produce a trustworthy scoped update."""
+
+    def __init__(self, scope_id: str, issues: list[str]):
+        issue_summary = "; ".join(issues)
+        super().__init__(f"Incremental plan for scope {scope_id!r} is invalid: {issue_summary}")
+        self.scope_id = scope_id
+        self.issues = issues
+
+
+class IncrementalScopeContextMissingError(RuntimeError):
+    """Raised when relation regeneration lacks its scoped static context."""
+
+    def __init__(self, scope_id: str):
+        super().__init__(f"No incremental relation context was recorded for scope {scope_id!r}")
+        self.scope_id = scope_id
+
+
+class IncrementalScopeRegenerationRequiredError(RuntimeError):
+    """Raised when a requested boundary change cannot be applied incrementally."""
+
+    def __init__(self, scope_id: str, rationale: str = ""):
+        suffix = f" Planner rationale: {rationale}" if rationale else ""
+        super().__init__(
+            f"Incremental analysis cannot safely regenerate or reparent scope {scope_id!r}. "
+            f"Run a full analysis explicitly if that boundary change is intended.{suffix}"
+        )
+        self.scope_id = scope_id
+        self.rationale = rationale

--- a/diagram_analysis/exceptions.py
+++ b/diagram_analysis/exceptions.py
@@ -59,16 +59,3 @@ class IncrementalScopeContextMissingError(RuntimeError):
     def __init__(self, scope_id: str):
         super().__init__(f"No incremental relation context was recorded for scope {scope_id!r}")
         self.scope_id = scope_id
-
-
-class IncrementalScopeRegenerationRequiredError(RuntimeError):
-    """Raised when a requested boundary change cannot be applied incrementally."""
-
-    def __init__(self, scope_id: str, rationale: str = ""):
-        suffix = f" Planner rationale: {rationale}" if rationale else ""
-        super().__init__(
-            f"Incremental analysis cannot safely regenerate or reparent scope {scope_id!r}. "
-            f"Run a full analysis explicitly if that boundary change is intended.{suffix}"
-        )
-        self.scope_id = scope_id
-        self.rationale = rationale

--- a/diagram_analysis/file_index.py
+++ b/diagram_analysis/file_index.py
@@ -1,0 +1,84 @@
+from pathlib import Path
+
+from agents.agent_responses import AnalysisInsights
+from agents.content_hash import (
+    MethodRef,
+    MethodSpan,
+    SourceCache,
+    hash_method_body,
+    hash_whole_file,
+    read_source_lines,
+)
+from agents.file_index_models import FileEntry
+from repo_utils.path_utils import normalize_repo_path
+from static_analyzer.analysis_result import StaticAnalysisResults
+
+
+def build_files_index(
+    analysis: AnalysisInsights,
+    repo_dir: Path,
+    source_cache: SourceCache | None = None,
+) -> dict[str, FileEntry]:
+    """Build the file index and hash each method at its current span."""
+    file_cache = source_cache if source_cache is not None else {}
+    files: dict[str, FileEntry] = {}
+    for component in analysis.components:
+        for file_methods in component.file_methods:
+            entry = files.get(file_methods.file_path)
+            if entry is None:
+                entry = FileEntry(
+                    methods=[],
+                    content_hash=hash_whole_file(read_source_lines(repo_dir, file_methods.file_path, file_cache)),
+                )
+                files[file_methods.file_path] = entry
+
+            methods_by_qname = {method.qualified_name: method for method in entry.methods}
+            for method in file_methods.methods:
+                if method.qualified_name in methods_by_qname:
+                    continue
+                indexed_method = method.model_copy(deep=True)
+                indexed_method.content_hash = hash_method_body(
+                    read_source_lines(repo_dir, file_methods.file_path, file_cache),
+                    method.start_line,
+                    method.end_line,
+                )
+                methods_by_qname[method.qualified_name] = indexed_method
+
+            entry.methods = sorted(
+                methods_by_qname.values(),
+                key=lambda method: (method.start_line, method.end_line, method.qualified_name),
+            )
+    return files
+
+
+def refresh_method_spans_from_cfg(
+    analysis: AnalysisInsights,
+    static_analysis: StaticAnalysisResults,
+    repo_dir: Path,
+) -> None:
+    """Refresh persisted method spans from the live CFG."""
+    spans = _cfg_method_spans(static_analysis, repo_dir)
+    for component in analysis.components:
+        for file_methods in component.file_methods:
+            for method in file_methods.methods:
+                span = spans.get(MethodRef(file_methods.file_path, method.qualified_name))
+                if span is None:
+                    method.start_line, method.end_line = 0, 0
+                else:
+                    method.start_line, method.end_line = span
+
+
+def _cfg_method_spans(
+    static_analysis: StaticAnalysisResults,
+    repo_dir: Path,
+) -> dict[MethodRef, MethodSpan]:
+    spans: dict[MethodRef, MethodSpan] = {}
+    for language in static_analysis.get_languages():
+        try:
+            cfg = static_analysis.get_cfg(language)
+        except (KeyError, ValueError):
+            continue
+        for qualified_name, node in cfg.nodes.items():
+            file_path = normalize_repo_path(node.file_path, repo_dir)
+            spans.setdefault(MethodRef(file_path, qualified_name), MethodSpan(node.line_start, node.line_end))
+    return spans

--- a/diagram_analysis/file_index.py
+++ b/diagram_analysis/file_index.py
@@ -1,3 +1,5 @@
+"""Build file indexes and refresh method spans from live control-flow graphs."""
+
 from pathlib import Path
 
 from agents.agent_responses import AnalysisInsights

--- a/diagram_analysis/file_index.py
+++ b/diagram_analysis/file_index.py
@@ -11,7 +11,7 @@ from agents.content_hash import (
     hash_whole_file,
     read_source_lines,
 )
-from agents.file_index_models import FileEntry
+from agents.file_index_models import FileEntry, MethodEntry
 from repo_utils.path_utils import normalize_repo_path
 from static_analyzer.analysis_result import StaticAnalysisResults
 
@@ -26,29 +26,23 @@ def build_files_index(
     files: dict[str, FileEntry] = {}
     for component in analysis.components:
         for file_methods in component.file_methods:
-            entry = files.get(file_methods.file_path)
-            if entry is None:
-                entry = FileEntry(
-                    methods=[],
-                    content_hash=hash_whole_file(read_source_lines(repo_dir, file_methods.file_path, file_cache)),
-                )
-                files[file_methods.file_path] = entry
-
-            methods_by_qname = {method.qualified_name: method for method in entry.methods}
+            entry = files.setdefault(file_methods.file_path, FileEntry())
+            source_lines = read_source_lines(repo_dir, file_methods.file_path, file_cache)
+            indexed_methods: list[MethodEntry] = []
             for method in file_methods.methods:
-                if method.qualified_name in methods_by_qname:
-                    continue
                 indexed_method = method.model_copy(deep=True)
                 indexed_method.content_hash = hash_method_body(
-                    read_source_lines(repo_dir, file_methods.file_path, file_cache),
+                    source_lines,
                     method.start_line,
                     method.end_line,
                 )
-                methods_by_qname[method.qualified_name] = indexed_method
+                indexed_methods.append(indexed_method)
 
-            entry.methods = sorted(
-                methods_by_qname.values(),
-                key=lambda method: (method.start_line, method.end_line, method.qualified_name),
+            entry.merge_from(
+                FileEntry(
+                    methods=indexed_methods,
+                    content_hash=hash_whole_file(source_lines),
+                )
             )
     return files
 

--- a/static_analyzer/cluster_relations.py
+++ b/static_analyzer/cluster_relations.py
@@ -116,15 +116,20 @@ def _collect_component_names(
     return id_to_name
 
 
-def _collect_llm_relations(
+def _collect_authoritative_relations(
     root_analysis: AnalysisInsights, sub_analyses: dict[str, AnalysisInsights]
 ) -> list[Relation]:
-    relations: list[Relation] = []
-    for _, sub_analysis in sorted(sub_analyses.items()):
-        relations.extend(sub_analysis.components_relations)
-    # Refreshed scope relations override stale global copies loaded on root.
-    relations.extend(root_analysis.components_relations)
-    return relations
+    """Select one metadata source per component pair, preferring live scopes."""
+    relations_by_pair: dict[tuple[str, str], Relation] = {}
+    analyses = [
+        root_analysis,
+        *(sub_analyses[scope_id] for scope_id in sorted(sub_analyses, key=lambda item: (item.count("."), item))),
+    ]
+    for analysis in analyses:
+        for relation in analysis.components_relations:
+            if relation.src_id and relation.dst_id:
+                relations_by_pair[(relation.src_id, relation.dst_id)] = relation
+    return list(relations_by_pair.values())
 
 
 def _ancestor_relation(src_id: str, dst_id: str, llm_relations: list[Relation]) -> Relation | None:
@@ -138,9 +143,7 @@ def _ancestor_relation(src_id: str, dst_id: str, llm_relations: list[Relation]) 
     ]
     if not candidates:
         return None
-    candidates.sort(
-        key=lambda rel: (-(rel.src_id.count(".") + rel.dst_id.count(".")), rel.src_id, rel.dst_id, rel.relation)
-    )
+    candidates.sort(key=lambda rel: (-(rel.src_id.count(".") + rel.dst_id.count(".")), rel.src_id, rel.dst_id))
     return candidates[0]
 
 
@@ -170,9 +173,9 @@ def build_global_relations(
     static_relations = build_component_relations(node_to_component, cfg_graphs)
     id_to_name = _collect_component_names(root_analysis, sub_analyses)
     live_ids = set(id_to_name)
-    llm_relations = _collect_llm_relations(root_analysis, sub_analyses)
+    llm_relations = _collect_authoritative_relations(root_analysis, sub_analyses)
 
-    global_relations: list[Relation] = []
+    global_relations: dict[tuple[str, str], Relation] = {}
     static_pairs = {(rel.src_cluster_id, rel.dst_cluster_id) for rel in static_relations}
     superseded_llm_pairs: set[tuple[str, str]] = set()
 
@@ -212,20 +215,17 @@ def build_global_relations(
                 is_static=True,
                 all_edges=all_edges,
             )
-        append_or_merge_relation(
-            global_relations,
-            relation,
-        )
+        global_relations[(src_id, dst_id)] = relation
 
-    for llm_rel in sorted(llm_relations, key=lambda rel: (rel.src_id, rel.dst_id, rel.relation)):
+    for llm_rel in llm_relations:
         pair = (llm_rel.src_id, llm_rel.dst_id)
-        if not llm_rel.src_id or not llm_rel.dst_id or llm_rel.src_id not in live_ids or llm_rel.dst_id not in live_ids:
+        if llm_rel.src_id not in live_ids or llm_rel.dst_id not in live_ids:
             continue
         if pair in static_pairs or pair in superseded_llm_pairs:
             continue
-        append_or_merge_relation(global_relations, llm_rel)
+        global_relations[pair] = llm_rel.with_merged_edges()
 
-    return sorted(global_relations, key=lambda rel: (rel.src_id, rel.dst_id, rel.relation))
+    return sorted(global_relations.values(), key=lambda rel: (rel.src_id, rel.dst_id))
 
 
 def merge_relations(

--- a/static_analyzer/cluster_relations.py
+++ b/static_analyzer/cluster_relations.py
@@ -128,7 +128,7 @@ def _collect_llm_relations(
     return relations
 
 
-def _ancestor_relation_label(src_id: str, dst_id: str, llm_relations: list[Relation]) -> str:
+def _ancestor_relation(src_id: str, dst_id: str, llm_relations: list[Relation]) -> Relation | None:
     candidates = [
         rel
         for rel in llm_relations
@@ -138,11 +138,27 @@ def _ancestor_relation_label(src_id: str, dst_id: str, llm_relations: list[Relat
         and is_self_or_descendant(dst_id, rel.dst_id)
     ]
     if not candidates:
-        return DEFAULT_STATIC_RELATION_LABEL
+        return None
     candidates.sort(
         key=lambda rel: (-(rel.src_id.count(".") + rel.dst_id.count(".")), rel.src_id, rel.dst_id, rel.relation)
     )
-    return candidates[0].relation
+    return candidates[0]
+
+
+def _relation_key_edges_for_pair(
+    relation: Relation,
+    src_id: str,
+    dst_id: str,
+    node_to_component: dict[str, str],
+) -> list[RelationEdge]:
+    if (relation.src_id, relation.dst_id) == (src_id, dst_id):
+        return relation.key_edges
+    return [
+        edge
+        for edge in relation.key_edges
+        if node_to_component.get(edge.source.qualified_name) == src_id
+        and node_to_component.get(edge.target.qualified_name) == dst_id
+    ]
 
 
 def build_global_relations(
@@ -172,17 +188,34 @@ def build_global_relations(
                 and is_self_or_descendant(dst_id, llm_rel.dst_id)
             ):
                 superseded_llm_pairs.add((llm_rel.src_id, llm_rel.dst_id))
-        append_or_merge_relation(
-            global_relations,
-            Relation.from_edges(
-                _ancestor_relation_label(src_id, dst_id, llm_relations),
+        llm_relation = _ancestor_relation(src_id, dst_id, llm_relations)
+        if llm_relation is None:
+            relation = Relation.from_edges(
+                DEFAULT_STATIC_RELATION_LABEL,
                 id_to_name.get(src_id, src_id),
                 id_to_name.get(dst_id, dst_id),
                 src_id,
                 dst_id,
                 static_rel.all_edges,
                 True,
-            ),
+            )
+        else:
+            inherited_key_edges = _relation_key_edges_for_pair(llm_relation, src_id, dst_id, node_to_component)
+            key_edges, all_edges = merge_relation_edges(inherited_key_edges, static_rel.all_edges)
+            relation = Relation(
+                relation=llm_relation.relation,
+                src_name=id_to_name.get(src_id, src_id),
+                dst_name=id_to_name.get(dst_id, dst_id),
+                evidence=llm_relation.evidence,
+                key_edges=key_edges,
+                src_id=src_id,
+                dst_id=dst_id,
+                is_static=True,
+                all_edges=all_edges,
+            )
+        append_or_merge_relation(
+            global_relations,
+            relation,
         )
 
     for llm_rel in sorted(llm_relations, key=lambda rel: (rel.src_id, rel.dst_id, rel.relation)):

--- a/static_analyzer/cluster_relations.py
+++ b/static_analyzer/cluster_relations.py
@@ -122,9 +122,11 @@ def _collect_component_names(
 def _collect_llm_relations(
     root_analysis: AnalysisInsights, sub_analyses: dict[str, AnalysisInsights]
 ) -> list[Relation]:
-    relations = list(root_analysis.components_relations)
+    relations: list[Relation] = []
     for _, sub_analysis in sorted(sub_analyses.items()):
         relations.extend(sub_analysis.components_relations)
+    # Refreshed scope relations override stale global copies loaded on root.
+    relations.extend(root_analysis.components_relations)
     return relations
 
 

--- a/static_analyzer/cluster_relations.py
+++ b/static_analyzer/cluster_relations.py
@@ -12,10 +12,7 @@ from dataclasses import dataclass, field
 
 from constants import DEFAULT_STATIC_RELATION_LABEL
 from agents.agent_responses import AnalysisInsights, Relation, RelationEdge
-from agents.relation_edges import (
-    append_or_merge_relation,
-    merge_relation_edges,
-)
+from agents.relation_edges import append_or_merge_relation
 from static_analyzer.graph import CallGraph, Edge
 
 logger = logging.getLogger(__name__)
@@ -203,7 +200,7 @@ def build_global_relations(
             )
         else:
             inherited_key_edges = _relation_key_edges_for_pair(llm_relation, src_id, dst_id, node_to_component)
-            key_edges, all_edges = merge_relation_edges(inherited_key_edges, static_rel.all_edges)
+            key_edges, all_edges = Relation._merge_edges(inherited_key_edges, static_rel.all_edges)
             relation = Relation(
                 relation=llm_relation.relation,
                 src_name=id_to_name.get(src_id, src_id),
@@ -279,7 +276,7 @@ def merge_relations(
                 llm_rel.evidence,
             )
 
-        key_edges, all_edges = merge_relation_edges(llm_rel.key_edges, static_edges)
+        key_edges, all_edges = Relation._merge_edges(llm_rel.key_edges, static_edges)
         for edge in static_edges:
             matched_static_edge_ids.add((src_id, dst_id, edge.identity()))
         append_or_merge_relation(

--- a/static_analyzer/engine/edge_builder.py
+++ b/static_analyzer/engine/edge_builder.py
@@ -21,7 +21,8 @@ from static_analyzer.engine.lsp_constants import (
 from static_analyzer.engine.models import CallSite, SymbolInfo
 from static_analyzer.engine.protocols import EdgeBuildAdapter
 from static_analyzer.engine.symbol_table import SymbolTable
-from static_analyzer.engine.utils import uri_to_path
+from static_analyzer.engine.utils import definition_location, uri_to_path
+from static_analyzer.internal_references import parent_qualified_name
 
 logger = logging.getLogger(__name__)
 
@@ -358,14 +359,10 @@ def _resolve_definitions(
                     if adapter.is_callable(target.kind) and target.parent_chain:
                         _, parent_kind = target.parent_chain[-1]
                         if adapter.is_class_like(parent_kind):
-                            parent_qname = target.qualified_name.rsplit(".", 1)[0]
-                            paren_idx = parent_qname.find("(")
-                            if paren_idx != -1:
-                                parent_qname = parent_qname[:paren_idx]
-                            if parent_qname in st.symbols:
-                                parent_sym = st.symbols[parent_qname]
-                                if _is_valid_edge(caller, parent_sym):
-                                    _add_edge_call_site(edge_set, caller.qualified_name, parent_qname, call_site)
+                            parent_qname = parent_qualified_name(target.qualified_name)
+                            parent_sym = st.symbols.get(parent_qname)
+                            if parent_sym is not None and _is_valid_edge(caller, parent_sym):
+                                _add_edge_call_site(edge_set, caller.qualified_name, parent_qname, call_site)
 
                     # Queue implementation query for polymorphic dispatch
                     if adapter.is_callable(target.kind):
@@ -495,20 +492,10 @@ def _resolve_definition_to_symbol(
     line_to_syms: dict[tuple[str, int], list[SymbolInfo]],
 ) -> SymbolInfo | None:
     """Resolve a definition LSP result to a SymbolInfo in our table."""
-    if "targetUri" in def_result:
-        uri = def_result["targetUri"]
-        sel_range = def_result.get("targetSelectionRange", def_result.get("targetRange", {}))
-    else:
-        uri = def_result.get("uri", "")
-        sel_range = def_result.get("range", {})
-
-    file_path = uri_to_path(uri)
-    if file_path is None:
+    location = definition_location(def_result)
+    if location is None:
         return None
-
-    start = sel_range.get("start", {})
-    line = start.get("line", -1)
-    char = start.get("character", -1)
+    file_path, line, char = location
     file_key = str(file_path)
 
     # Exact match on (file, line, char)

--- a/static_analyzer/engine/utils.py
+++ b/static_analyzer/engine/utils.py
@@ -32,6 +32,25 @@ def uri_to_path(uri: str) -> Path | None:
         return None
 
 
+def definition_location(definition: dict) -> tuple[Path, int, int] | None:
+    """Return the file and start position from an LSP definition result."""
+    uri = definition.get("targetUri", definition.get("uri", ""))
+    file_path = uri_to_path(uri)
+    if file_path is None:
+        return None
+
+    selection_range = definition.get(
+        "targetSelectionRange",
+        definition.get("targetRange", definition.get("range", {})),
+    )
+    start = selection_range.get("start", {})
+    line = start.get("line")
+    character = start.get("character")
+    if not isinstance(line, int) or not isinstance(character, int):
+        return None
+    return file_path, line, character
+
+
 class _MemoryStatusEx(ctypes.Structure):
     _fields_ = [
         ("dwLength", ctypes.c_ulong),

--- a/static_analyzer/incremental_orchestrator.py
+++ b/static_analyzer/incremental_orchestrator.py
@@ -3,8 +3,8 @@
 Warm-start flow:
 1. Keep unchanged files from the pkl and invalidate changed/deleted files.
 2. Re-LSP existing changed files and merge their fresh nodes/references back in.
-3. Rebuild inbound edges: keep ``unchanged -> changed`` only when references still prove it.
-4. Rebuild outbound edges: resolve changed-file call sites with definitions.
+3. Restore cached cross-boundary edges only when live references still prove them.
+4. Add new outbound edges by resolving changed-file call sites with definitions.
 5. Keep unchanged-only edges cached and let ``StaticAnalyzer`` persist the new pkl.
 """
 
@@ -114,13 +114,13 @@ def _rebuild_changed_file_edges(
     adapter: LanguageAdapter,
     engine_client: LSPClient,
 ) -> None:
-    _restore_inbound_edges(
+    _restore_cross_boundary_edges(
         merged_analysis.call_graph, invalidated_edges, changed_file_strs, adapter, engine_client, SourceInspector()
     )
     _add_outbound_edges_from_changed_files(merged_analysis.call_graph, changed_source_files, engine_client)
 
 
-def _restore_inbound_edges(
+def _restore_cross_boundary_edges(
     call_graph: CallGraph,
     invalidated_edges: list[InvalidatedEdge],
     changed_file_strs: set[str],
@@ -131,20 +131,23 @@ def _restore_inbound_edges(
     if not invalidated_edges:
         return
 
-    restored = 0
-    checked = 0
+    checked = {"inbound": 0, "outbound": 0}
+    restored = {"inbound": 0, "outbound": 0}
     references_cache: dict[str, list[dict]] = {}
 
     for src_name, dst_name, old_src_node, old_dst_node in invalidated_edges:
-        if old_src_node.file_path in changed_file_strs or old_dst_node.file_path not in changed_file_strs:
+        src_changed = old_src_node.file_path in changed_file_strs
+        dst_changed = old_dst_node.file_path in changed_file_strs
+        if src_changed == dst_changed:
             continue
         if not call_graph.has_node(src_name) or not call_graph.has_node(dst_name):
             continue
 
         src_node = call_graph.nodes[src_name]
         dst_node = call_graph.nodes[dst_name]
+        direction = "outbound" if src_changed else "inbound"
 
-        checked += 1
+        checked[direction] += 1
         refs = references_cache.get(dst_name)
         if refs is None:
             try:
@@ -155,29 +158,31 @@ def _restore_inbound_edges(
                 refs = []
             references_cache[dst_name] = refs
 
-        # Inbound: unchanged B -> changed A is kept only if references(A) still lands inside B.
-        if _edge_reference_still_exists(src_node, dst_node, refs, adapter, source_inspector):
+        call_sites = _edge_reference_call_sites(src_node, dst_node, refs, adapter, source_inspector)
+        if call_sites:
             try:
-                call_graph.add_edge(src_name, dst_name)
-                restored += 1
+                call_graph.add_edge(src_name, dst_name, call_sites=call_sites)
+                restored[direction] += 1
             except ValueError:
                 logger.debug("Failed to restore edge %s -> %s", src_name, dst_name, exc_info=True)
 
     logger.info(
-        "Validated %d inbound cached edge(s), restored %d/%d",
-        len(invalidated_edges),
-        restored,
-        checked,
+        "Validated cached cross-boundary edges, restored inbound %d/%d and outbound %d/%d",
+        restored["inbound"],
+        checked["inbound"],
+        restored["outbound"],
+        checked["outbound"],
     )
 
 
-def _edge_reference_still_exists(
+def _edge_reference_call_sites(
     src_node: Node,
     dst_node: Node,
     refs: list[dict],
     adapter: LanguageAdapter,
     source_inspector: SourceInspector,
-) -> bool:
+) -> list[dict[str, str | int]]:
+    call_sites: list[dict[str, str | int]] = []
     for ref in refs:
         ref_file = uri_to_path(ref.get("uri", ""))
         if ref_file is None or str(ref_file) != src_node.file_path:
@@ -195,8 +200,8 @@ def _edge_reference_still_exists(
             dst_node, ref_file, ref_line, ref_char, ref_end_char, adapter, source_inspector
         ):
             continue
-        return True
-    return False
+        call_sites.append({"file": str(ref_file), "line": ref_line + 1, "column": ref_char + 1})
+    return call_sites
 
 
 def _add_outbound_edges_from_changed_files(
@@ -264,7 +269,20 @@ def _containing_callable_nodes(call_graph: CallGraph, file_path: Path, line: int
 
 
 def _definition_nodes(call_graph: CallGraph, definition: dict) -> list[Node]:
-    return [node for node in call_graph.nodes.values() if _definition_points_to_node(definition, node)]
+    matches = [node for node in call_graph.nodes.values() if _definition_points_to_node(definition, node)]
+    if not matches:
+        return []
+    return [
+        max(
+            matches,
+            key=lambda node: (
+                node.line_start,
+                node.col_start,
+                -node.line_end,
+                len(node.fully_qualified_name),
+            ),
+        )
+    ]
 
 
 def _definition_points_to_node(definition: dict, dst_node: Node) -> bool:

--- a/static_analyzer/incremental_orchestrator.py
+++ b/static_analyzer/incremental_orchestrator.py
@@ -114,10 +114,16 @@ def _rebuild_changed_file_edges(
     adapter: LanguageAdapter,
     engine_client: LSPClient,
 ) -> None:
+    source_inspector = SourceInspector()
     _restore_cross_boundary_edges(
-        merged_analysis.call_graph, invalidated_edges, changed_file_strs, adapter, engine_client, SourceInspector()
+        merged_analysis.call_graph, invalidated_edges, changed_file_strs, adapter, engine_client, source_inspector
     )
-    _add_outbound_edges_from_changed_files(merged_analysis.call_graph, changed_source_files, engine_client)
+    _add_outbound_edges_from_changed_files(
+        merged_analysis.call_graph,
+        changed_source_files,
+        engine_client,
+        source_inspector,
+    )
 
 
 def _restore_cross_boundary_edges(
@@ -208,11 +214,11 @@ def _add_outbound_edges_from_changed_files(
     call_graph: CallGraph,
     changed_source_files: list[Path],
     engine_client: LSPClient,
+    source_inspector: SourceInspector,
 ) -> None:
     if not changed_source_files:
         return
 
-    source_inspector = SourceInspector()
     added = 0
 
     for file_path in changed_source_files:

--- a/static_analyzer/incremental_orchestrator.py
+++ b/static_analyzer/incremental_orchestrator.py
@@ -24,8 +24,9 @@ from static_analyzer.engine.language_adapter import LanguageAdapter
 from static_analyzer.engine.lsp_client import LSPClient
 from static_analyzer.engine.result_converter import convert_to_codeboarding_format
 from static_analyzer.engine.source_inspector import SourceInspector
-from static_analyzer.engine.utils import uri_to_path
+from static_analyzer.engine.utils import definition_location, uri_to_path
 from static_analyzer.graph import CallGraph
+from static_analyzer.internal_references import parent_qualified_name
 from static_analyzer.node import Node
 
 logger = logging.getLogger(__name__)
@@ -235,12 +236,9 @@ def _add_outbound_edges_from_changed_files(
         for site, definitions in zip(call_sites, definition_results):
             line = site.lsp_line
             char = site.lsp_column
-            containing_nodes = _containing_callable_nodes(call_graph, file_path, line, char)
-            if not containing_nodes:
+            src_node = _most_specific_node_at_position(call_graph, file_path, line, char, callable_only=True)
+            if src_node is None:
                 continue
-            src_node = max(
-                containing_nodes, key=lambda node: (node.line_start, node.col_start, len(node.fully_qualified_name))
-            )
             for definition in definitions:
                 for dst_node in _definition_nodes(call_graph, definition):
                     if dst_node.fully_qualified_name == src_node.fully_qualified_name:
@@ -266,41 +264,48 @@ def _add_outbound_edges_from_changed_files(
         logger.info("Added %d new outbound edge(s) from changed files", added)
 
 
-def _containing_callable_nodes(call_graph: CallGraph, file_path: Path, line: int, char: int) -> list[Node]:
-    return [
+def _most_specific_node_at_position(
+    call_graph: CallGraph,
+    file_path: Path,
+    line: int,
+    char: int,
+    callable_only: bool = False,
+) -> Node | None:
+    matches = [
         node
         for node in call_graph.nodes.values()
-        if node.is_callable() and node.file_path == str(file_path) and _position_inside_node(node, line, char)
+        if node.file_path == str(file_path)
+        and (not callable_only or node.is_callable())
+        and _position_inside_node(node, line, char)
     ]
+    if not matches:
+        return None
+    return max(
+        matches,
+        key=lambda node: (
+            node.line_start,
+            node.col_start,
+            -node.line_end,
+            len(node.fully_qualified_name),
+        ),
+    )
 
 
 def _definition_nodes(call_graph: CallGraph, definition: dict) -> list[Node]:
-    matches = [node for node in call_graph.nodes.values() if _definition_points_to_node(definition, node)]
-    if not matches:
+    location = definition_location(definition)
+    if location is None:
         return []
-    return [
-        max(
-            matches,
-            key=lambda node: (
-                node.line_start,
-                node.col_start,
-                -node.line_end,
-                len(node.fully_qualified_name),
-            ),
-        )
-    ]
+    file_path, line, character = location
+    target = _most_specific_node_at_position(call_graph, file_path, line, character)
+    if target is None:
+        return []
 
-
-def _definition_points_to_node(definition: dict, dst_node: Node) -> bool:
-    uri = definition.get("targetUri", definition.get("uri", ""))
-    file_path = uri_to_path(uri)
-    if file_path is None or str(file_path) != dst_node.file_path:
-        return False
-    selection_range = definition.get("targetSelectionRange", definition.get("targetRange", definition.get("range", {})))
-    start = selection_range.get("start", {})
-    line = start.get("line", -1)
-    character = start.get("character", -1)
-    return _position_inside_node(dst_node, line, character)
+    targets = [target]
+    if target.is_callable():
+        parent = call_graph.nodes.get(parent_qualified_name(target.fully_qualified_name))
+        if parent is not None and parent.is_class():
+            targets.append(parent)
+    return targets
 
 
 def _position_inside_node(node: Node, zero_based_line: int, character: int) -> bool:

--- a/static_analyzer/internal_references.py
+++ b/static_analyzer/internal_references.py
@@ -20,6 +20,14 @@ def reference_tokens(qualified_name: str) -> list[str]:
     return [token.lower() for token in re.split(r"[.:/\\]+", qualified_name) if token]
 
 
+def parent_qualified_name(qualified_name: str) -> str:
+    """Return the class-like parent portion of a qualified symbol name."""
+    parent, separator, _ = qualified_name.rpartition(".")
+    if not separator:
+        return ""
+    return parent.split("(", 1)[0]
+
+
 def looks_internal_reference(static_analysis: InternalReferenceSource, qualified_name: str) -> bool:
     tokens = reference_tokens(qualified_name)
     if not tokens:

--- a/static_analyzer/reference_resolver.py
+++ b/static_analyzer/reference_resolver.py
@@ -50,6 +50,7 @@ class StaticReferenceResolver:
         self,
         analysis: AnalysisInsights,
         component_ids: set[str] | None = None,
+        force_resolve: bool = False,
     ) -> None:
         """Resolve component key entity references."""
         for component in analysis.components:
@@ -58,6 +59,7 @@ class StaticReferenceResolver:
             repair = self.repair_key_entity_references(
                 component.key_entities,
                 component.file_paths() or None,
+                force_resolve=force_resolve,
             )
             component.key_entities = repair.references
 
@@ -65,6 +67,7 @@ class StaticReferenceResolver:
         self,
         references: list[SourceCodeReference],
         file_candidates: list[str] | None = None,
+        force_resolve: bool = False,
     ) -> KeyEntityRepair:
         """Resolve key entities, dropping unresolved and duplicate references."""
         resolved_references: list[SourceCodeReference] = []
@@ -73,15 +76,22 @@ class StaticReferenceResolver:
         unresolved_qnames: set[str] = set()
         for reference in references:
             original_qname = reference.qualified_name
-            has_existing_file = reference.reference_file is not None and self.reference_file_exists(
-                reference.reference_file
-            )
-            has_complete_location = (
-                has_existing_file
-                and reference.reference_start_line is not None
-                and reference.reference_end_line is not None
-            )
-            resolved = has_complete_location or self.resolve_reference(reference, file_candidates)
+            if force_resolve:
+                reference.reference_file = None
+                reference.reference_start_line = None
+                reference.reference_end_line = None
+                resolved = self._resolve_symbol_reference(reference, original_qname.replace(os.sep, "."))
+                has_existing_file = False
+            else:
+                has_existing_file = reference.reference_file is not None and self.reference_file_exists(
+                    reference.reference_file
+                )
+                has_complete_location = (
+                    has_existing_file
+                    and reference.reference_start_line is not None
+                    and reference.reference_end_line is not None
+                )
+                resolved = has_complete_location or self.resolve_reference(reference, file_candidates)
             if not resolved and not has_existing_file:
                 unresolved_qnames.add(original_qname)
                 continue
@@ -114,25 +124,28 @@ class StaticReferenceResolver:
     def resolve_reference(self, reference: SourceCodeReference, file_candidates: list[str] | None = None) -> bool:
         """Resolve a source reference in-place."""
         qname = reference.qualified_name.replace(os.sep, ".")
-        languages = self.static_analysis.get_languages()
+        if self._resolve_symbol_reference(reference, qname):
+            return True
 
-        for lang in languages:
-            if self._try_exact_match(reference, qname, lang):
-                return True
-
-        for lang in languages:
-            if self._try_loose_match(reference, qname, lang):
-                return True
-
-        for lang in languages:
-            if self._try_symbol_token_match(reference, qname, lang):
-                return True
-
-        for lang in languages:
+        for lang in self.static_analysis.get_languages():
             if self._try_file_path_resolution(reference, qname, lang, file_candidates):
                 return True
 
         logger.warning(f"[Reference Resolution] Could not resolve reference {reference.qualified_name} in any language")
+        return False
+
+    def _resolve_symbol_reference(self, reference: SourceCodeReference, qname: str) -> bool:
+        """Resolve a reference to a current static-analysis symbol."""
+        languages = self.static_analysis.get_languages()
+        for lang in languages:
+            if self._try_exact_match(reference, qname, lang):
+                return True
+        for lang in languages:
+            if self._try_loose_match(reference, qname, lang):
+                return True
+        for lang in languages:
+            if self._try_symbol_token_match(reference, qname, lang):
+                return True
         return False
 
     def resolve_node(self, reference: SourceCodeReference):

--- a/static_analyzer/reference_resolver.py
+++ b/static_analyzer/reference_resolver.py
@@ -23,6 +23,15 @@ class KeyEdgeResolution:
     unresolved: bool = False
 
 
+@dataclass(frozen=True)
+class KeyEntityRepair:
+    """Resolved, unique key entities and repair metadata."""
+
+    references: list[SourceCodeReference]
+    canonicalized_count: int
+    unresolved_qnames: set[str]
+
+
 class StaticReferenceResolver:
     """Resolve LLM source references against static-analysis results."""
 
@@ -37,20 +46,57 @@ class StaticReferenceResolver:
         self.remove_unresolved_references(analysis)
         return self.relative_paths(analysis)
 
-    def fix_key_entities_refs(self, analysis: AnalysisInsights) -> None:
+    def fix_key_entities_refs(
+        self,
+        analysis: AnalysisInsights,
+        component_ids: set[str] | None = None,
+    ) -> None:
         """Resolve component key entity references."""
         for component in analysis.components:
-            for reference in component.key_entities:
-                if (
-                    reference.reference_file is not None
-                    and os.path.exists(reference.reference_file)
-                    and reference.reference_start_line is not None
-                    and reference.reference_end_line is not None
-                ):
-                    continue
+            if component_ids is not None and component.component_id not in component_ids:
+                continue
+            repair = self.repair_key_entity_references(
+                component.key_entities,
+                component.file_paths() or None,
+            )
+            component.key_entities = repair.references
 
-                file_candidates = component.file_paths() or None
-                self.resolve_reference(reference, file_candidates)
+    def repair_key_entity_references(
+        self,
+        references: list[SourceCodeReference],
+        file_candidates: list[str] | None = None,
+    ) -> KeyEntityRepair:
+        """Resolve key entities, dropping unresolved and duplicate references."""
+        resolved_references: list[SourceCodeReference] = []
+        seen_qnames: set[str] = set()
+        canonicalized_count = 0
+        unresolved_qnames: set[str] = set()
+        for reference in references:
+            original_qname = reference.qualified_name
+            has_existing_file = reference.reference_file is not None and self.reference_file_exists(
+                reference.reference_file
+            )
+            has_complete_location = (
+                has_existing_file
+                and reference.reference_start_line is not None
+                and reference.reference_end_line is not None
+            )
+            resolved = has_complete_location or self.resolve_reference(reference, file_candidates)
+            if not resolved and not has_existing_file:
+                unresolved_qnames.add(original_qname)
+                continue
+            if reference.qualified_name in seen_qnames:
+                continue
+            if reference.qualified_name != original_qname:
+                canonicalized_count += 1
+            resolved_references.append(reference)
+            seen_qnames.add(reference.qualified_name)
+
+        return KeyEntityRepair(
+            references=resolved_references,
+            canonicalized_count=canonicalized_count,
+            unresolved_qnames=unresolved_qnames,
+        )
 
     def fix_edge_refs(self, analysis: AnalysisInsights) -> None:
         """Resolve relation edge endpoint references."""
@@ -65,28 +111,29 @@ class StaticReferenceResolver:
                 self.resolve_reference(edge.target, dst_candidates)
                 self.attach_static_call_sites(edge)
 
-    def resolve_reference(self, reference: SourceCodeReference, file_candidates: list[str] | None = None) -> None:
+    def resolve_reference(self, reference: SourceCodeReference, file_candidates: list[str] | None = None) -> bool:
         """Resolve a source reference in-place."""
         qname = reference.qualified_name.replace(os.sep, ".")
         languages = self.static_analysis.get_languages()
 
         for lang in languages:
             if self._try_exact_match(reference, qname, lang):
-                return
+                return True
 
         for lang in languages:
             if self._try_loose_match(reference, qname, lang):
-                return
+                return True
 
         for lang in languages:
             if self._try_symbol_token_match(reference, qname, lang):
-                return
+                return True
 
         for lang in languages:
             if self._try_file_path_resolution(reference, qname, lang, file_candidates):
-                return
+                return True
 
         logger.warning(f"[Reference Resolution] Could not resolve reference {reference.qualified_name} in any language")
+        return False
 
     def resolve_node(self, reference: SourceCodeReference):
         """Resolve a source reference to a static-analysis node without mutating it."""

--- a/static_analyzer/reference_resolver.py
+++ b/static_analyzer/reference_resolver.py
@@ -8,6 +8,7 @@ from agents.agent_responses import AnalysisInsights, RelationCallSite, RelationE
 from static_analyzer.analysis_result import StaticAnalysisResults
 from static_analyzer.constants import LANGUAGE_EXTENSIONS, Language
 from static_analyzer.internal_references import looks_internal_reference, reference_tokens
+from static_analyzer.node import Node
 
 logger = logging.getLogger(__name__)
 
@@ -49,49 +50,49 @@ class StaticReferenceResolver:
         self,
         analysis: AnalysisInsights,
         component_ids: set[str] | None = None,
-        force_resolve: bool = False,
     ) -> None:
         """Resolve component key entity references."""
         for component in analysis.components:
             if component_ids is not None and component.component_id not in component_ids:
                 continue
+            allowed_qnames = {
+                method.qualified_name for file_method in component.file_methods for method in file_method.methods
+            }
             repair = self.repair_key_entity_references(
                 component.key_entities,
-                component.file_paths() or None,
-                force_resolve=force_resolve,
+                allowed_qnames=allowed_qnames,
+                allowed_files=set(component.file_paths()),
             )
             component.key_entities = repair.references
 
     def repair_key_entity_references(
         self,
         references: list[SourceCodeReference],
-        file_candidates: list[str] | None = None,
-        force_resolve: bool = False,
+        allowed_qnames: set[str] | None = None,
+        allowed_files: set[str] | None = None,
     ) -> KeyEntityRepair:
         """Resolve key entities, dropping unresolved and duplicate references."""
         resolved_references: list[SourceCodeReference] = []
         seen_qnames: set[str] = set()
         canonicalized_count = 0
         unresolved_qnames: set[str] = set()
+        scope_files = (
+            {self._absolute_reference_path(file_path) for file_path in allowed_files}
+            if allowed_files is not None
+            else None
+        )
         for reference in references:
             original_qname = reference.qualified_name
-            if force_resolve:
-                reference.reference_file = None
-                reference.reference_start_line = None
-                reference.reference_end_line = None
-                resolved = self._resolve_symbol_reference(reference, original_qname.replace(os.sep, "."))
-                has_existing_file = False
-            else:
-                has_existing_file = reference.reference_file is not None and self.reference_file_exists(
-                    reference.reference_file
-                )
-                has_complete_location = (
-                    has_existing_file
-                    and reference.reference_start_line is not None
-                    and reference.reference_end_line is not None
-                )
-                resolved = has_complete_location or self.resolve_reference(reference, file_candidates)
-            if not resolved and not has_existing_file:
+            reference.reference_file = None
+            reference.reference_start_line = None
+            reference.reference_end_line = None
+            resolved = self._resolve_symbol_reference(
+                reference,
+                original_qname.replace(os.sep, "."),
+                allowed_qnames,
+                scope_files,
+            )
+            if not resolved:
                 unresolved_qnames.add(original_qname)
                 continue
             if reference.qualified_name in seen_qnames:
@@ -133,19 +134,58 @@ class StaticReferenceResolver:
         logger.warning(f"[Reference Resolution] Could not resolve reference {reference.qualified_name} in any language")
         return False
 
-    def _resolve_symbol_reference(self, reference: SourceCodeReference, qname: str) -> bool:
+    def _resolve_symbol_reference(
+        self,
+        reference: SourceCodeReference,
+        qname: str,
+        allowed_qnames: set[str] | None = None,
+        allowed_files: set[Path] | None = None,
+    ) -> bool:
         """Resolve a reference to a current static-analysis symbol."""
         languages = self.static_analysis.get_languages()
+        exact_matches: list[Node] = []
         for lang in languages:
-            if self._try_exact_match(reference, qname, lang):
-                return True
-        for lang in languages:
-            if self._try_loose_match(reference, qname, lang):
-                return True
-        for lang in languages:
-            if self._try_symbol_token_match(reference, qname, lang):
-                return True
-        return False
+            try:
+                exact_matches.append(self.static_analysis.get_reference(lang, qname))
+            except (ValueError, FileExistsError):
+                continue
+
+        if exact_matches:
+            node = next(
+                (
+                    candidate
+                    for candidate in exact_matches
+                    if self._node_in_scope(candidate, allowed_qnames, allowed_files)
+                ),
+                None,
+            )
+            if node is None:
+                return False
+            self._apply_resolved_node(reference, node)
+            return True
+
+        if allowed_qnames is None and allowed_files is None:
+            for lang in languages:
+                try:
+                    _, node = self.static_analysis.get_loose_reference(lang, qname)
+                except Exception as error:
+                    logger.warning("[Reference Resolution] Loose match failed for %s in %s: %s", qname, lang, error)
+                    continue
+                if node is not None:
+                    self._apply_resolved_node(reference, node)
+                    return True
+
+        candidates = [
+            node
+            for lang in languages
+            for node in self.static_analysis.iter_reference_nodes(lang)
+            if self._node_in_scope(node, allowed_qnames, allowed_files)
+        ]
+        node = self._unique_token_match(qname, candidates)
+        if node is None:
+            return False
+        self._apply_resolved_node(reference, node)
+        return True
 
     def resolve_node(self, reference: SourceCodeReference):
         """Resolve a source reference to a static-analysis node without mutating it."""
@@ -345,86 +385,47 @@ class StaticReferenceResolver:
                     edge.target.reference_file = os.path.relpath(edge.target.reference_file, self.repo_dir)
         return analysis
 
-    def _try_exact_match(self, reference: SourceCodeReference, qname: str, lang: Language) -> bool:
-        try:
-            node = self.static_analysis.get_reference(lang, qname)
-            reference.reference_file = node.file_path
-            reference.reference_start_line = node.line_start
-            reference.reference_end_line = node.line_end
-            reference.qualified_name = qname
-            logger.info(
-                f"[Reference Resolution] Matched {reference.qualified_name} in {lang} at {reference.reference_file}"
-            )
-            return True
-        except (ValueError, FileExistsError) as e:
-            logger.warning(f"[Reference Resolution] Exact match failed for {reference.qualified_name} in {lang}: {e}")
-            return False
-
-    def _try_loose_match(self, reference: SourceCodeReference, qname: str, lang: Language) -> bool:
-        try:
-            _, node = self.static_analysis.get_loose_reference(lang, qname)
-            if node is not None:
-                self._apply_resolved_node(reference, node)
-                logger.info(
-                    f"[Reference Resolution] Loosely matched {reference.qualified_name} in {lang} at {reference.reference_file}"
-                )
-                return True
-        except Exception as e:
-            logger.warning(f"[Reference Resolution] Loose match failed for {qname} in {lang}: {e}")
-        return False
-
-    def _try_symbol_token_match(self, reference: SourceCodeReference, qname: str, lang: Language) -> bool:
+    @staticmethod
+    def _unique_token_match(qname: str, candidates: list[Node]) -> Node | None:
         query_tokens = reference_tokens(qname)
         if not query_tokens:
-            return False
+            return None
 
-        candidates = [
-            node
-            for node in self.static_analysis.iter_reference_nodes(lang)
-            if self._candidate_tokens_match(query_tokens, reference_tokens(node.fully_qualified_name))
-        ]
-        if not candidates:
-            return False
+        matches: list[Node] = []
+        for node in candidates:
+            candidate_tokens = reference_tokens(node.fully_qualified_name)
+            if candidate_tokens[-1:] != query_tokens[-1:]:
+                continue
+            if all(token in candidate_tokens for token in query_tokens[:-1] if token.startswith("_")):
+                matches.append(node)
 
-        selected = self._unique_backwards_token_match(query_tokens, candidates)
-        if selected is None:
-            return False
-
-        self._apply_resolved_node(reference, selected)
-        logger.info(
-            f"[Reference Resolution] Token matched {qname} -> {reference.qualified_name} in {lang} at {reference.reference_file}"
-        )
-        return True
+        unique_matches = {
+            (node.fully_qualified_name, node.file_path, node.line_start, node.line_end): node for node in matches
+        }
+        return next(iter(unique_matches.values())) if len(unique_matches) == 1 else None
 
     @staticmethod
-    def _apply_resolved_node(reference: SourceCodeReference, node: Any) -> None:
+    def _apply_resolved_node(reference: SourceCodeReference, node: Node) -> None:
         reference.reference_file = node.file_path
         reference.reference_start_line = node.line_start
         reference.reference_end_line = node.line_end
         reference.qualified_name = node.fully_qualified_name
 
-    def _unique_backwards_token_match(self, query_tokens: list[str], candidates: list[Any]) -> Any | None:
-        matching = candidates
-        for suffix_len in range(1, len(query_tokens) + 1):
-            query_suffix = query_tokens[-suffix_len:]
-            narrowed = [
-                node
-                for node in matching
-                if len(reference_tokens(node.fully_qualified_name)) >= suffix_len
-                and reference_tokens(node.fully_qualified_name)[-suffix_len:] == query_suffix
-            ]
-            if len(narrowed) == 1:
-                return narrowed[0]
-            if narrowed:
-                matching = narrowed
-        return None
-
-    @staticmethod
-    def _candidate_tokens_match(query_tokens: list[str], candidate_tokens: list[str]) -> bool:
-        if candidate_tokens[-1:] != query_tokens[-1:]:
+    def _node_in_scope(
+        self,
+        node: Node,
+        allowed_qnames: set[str] | None,
+        allowed_files: set[Path] | None,
+    ) -> bool:
+        if allowed_qnames is not None and node.fully_qualified_name not in allowed_qnames:
             return False
-        required_context = [token for token in query_tokens[:-1] if token.startswith("_")]
-        return all(token in candidate_tokens for token in required_context)
+        if allowed_files is not None and self._absolute_reference_path(node.file_path) not in allowed_files:
+            return False
+        return True
+
+    def _absolute_reference_path(self, file_path: str) -> Path:
+        path = Path(file_path)
+        return path.resolve() if path.is_absolute() else (self.repo_dir / path).resolve()
 
     def _try_file_path_resolution(
         self, reference: SourceCodeReference, qname: str, lang: Language, file_candidates: list[str] | None = None

--- a/static_analyzer/reference_resolver.py
+++ b/static_analyzer/reference_resolver.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -8,7 +7,7 @@ from typing import Any
 from agents.agent_responses import AnalysisInsights, RelationCallSite, RelationEdge, SourceCodeReference
 from static_analyzer.analysis_result import StaticAnalysisResults
 from static_analyzer.constants import LANGUAGE_EXTENSIONS, Language
-from static_analyzer.internal_references import looks_internal_reference
+from static_analyzer.internal_references import looks_internal_reference, reference_tokens
 
 logger = logging.getLogger(__name__)
 
@@ -375,14 +374,14 @@ class StaticReferenceResolver:
         return False
 
     def _try_symbol_token_match(self, reference: SourceCodeReference, qname: str, lang: Language) -> bool:
-        query_tokens = self._symbol_tokens(qname)
+        query_tokens = reference_tokens(qname)
         if not query_tokens:
             return False
 
         candidates = [
             node
             for node in self.static_analysis.iter_reference_nodes(lang)
-            if self._candidate_tokens_match(query_tokens, self._symbol_tokens(node.fully_qualified_name))
+            if self._candidate_tokens_match(query_tokens, reference_tokens(node.fully_qualified_name))
         ]
         if not candidates:
             return False
@@ -411,18 +410,14 @@ class StaticReferenceResolver:
             narrowed = [
                 node
                 for node in matching
-                if len(self._symbol_tokens(node.fully_qualified_name)) >= suffix_len
-                and self._symbol_tokens(node.fully_qualified_name)[-suffix_len:] == query_suffix
+                if len(reference_tokens(node.fully_qualified_name)) >= suffix_len
+                and reference_tokens(node.fully_qualified_name)[-suffix_len:] == query_suffix
             ]
             if len(narrowed) == 1:
                 return narrowed[0]
             if narrowed:
                 matching = narrowed
         return None
-
-    @staticmethod
-    def _symbol_tokens(qualified_name: str) -> list[str]:
-        return [token.lower() for token in re.split(r"[.:/\\]+", qualified_name) if token]
 
     @staticmethod
     def _candidate_tokens_match(query_tokens: list[str], candidate_tokens: list[str]) -> bool:
@@ -457,7 +452,7 @@ class StaticReferenceResolver:
         full_path = os.path.join(self.repo_dir, file_path)
         file_ref = ".".join(full_path.rsplit(os.sep, 1))
         language_extensions = LANGUAGE_EXTENSIONS[Language(lang)]
-        paths = [full_path, *(f"{file_path}{extension}" for extension in language_extensions), file_ref]
+        paths = [full_path, *(f"{full_path}{extension}" for extension in language_extensions), file_ref]
 
         for path in paths:
             if os.path.exists(path):

--- a/tests/agents/prompts/test_prompts.py
+++ b/tests/agents/prompts/test_prompts.py
@@ -236,13 +236,18 @@ class TestConvenienceFunctions(unittest.TestCase):
 
     def test_planning_prompt_available_for_all_models(self):
         required_variables = {
-            "{project_name}",
             "{scope_id}",
-            "{project_type}",
-            "{meta_context}",
             "{existing_components}",
             "{changed_files}",
             "{structural_diff}",
+        }
+        system_context_variables = {"{project_name}", "{project_type}", "{meta_context}"}
+        contract_requirements = {
+            "this step plans component boundaries only",
+            "api surfaces and relations are generated later",
+            "for create_component",
+            "for update_component",
+            "copy the exact component_id",
         }
 
         for llm_type in LLMType:
@@ -251,6 +256,31 @@ class TestConvenienceFunctions(unittest.TestCase):
             self.assertGreater(len(prompt), 0)
             for variable in required_variables:
                 self.assertIn(variable, prompt)
+            for variable in system_context_variables:
+                self.assertNotIn(variable, prompt)
+            normalized_prompt = prompt.casefold()
+            for requirement in contract_requirements:
+                self.assertIn(requirement, normalized_prompt)
+
+    def test_project_context_is_reserved_for_system_prompts(self):
+        context_variables = {"{project_name}", "{project_type}", "{meta_context}"}
+
+        for llm_type in LLMType:
+            factory = PromptFactory(llm_type)._prompt_factory
+            system_prompt = factory.get_system_message()
+            api_prompt = factory.get_api_surfaces_message()
+            relation_prompt = factory.get_relation_analysis_message()
+            for variable in context_variables:
+                self.assertIn(variable, system_prompt)
+                self.assertNotIn(variable, api_prompt)
+                self.assertNotIn(variable, relation_prompt)
+            formatted_system_prompt = system_prompt.format(
+                project_name="Example",
+                project_type="library",
+                meta_context="Example context",
+            )
+            for variable in context_variables:
+                self.assertNotIn(variable, formatted_system_prompt)
 
 
 if __name__ == "__main__":

--- a/tests/agents/prompts/test_prompts.py
+++ b/tests/agents/prompts/test_prompts.py
@@ -247,7 +247,10 @@ class TestConvenienceFunctions(unittest.TestCase):
             "api surfaces and relations are generated later",
             "for create_component",
             "for update_component",
+            "for delete_component or noop",
             "copy the exact component_id",
+            "mutually exclusive branches",
+            "unsupported by the current incremental schema",
         }
 
         for llm_type in LLMType:
@@ -268,12 +271,21 @@ class TestConvenienceFunctions(unittest.TestCase):
         for llm_type in LLMType:
             factory = PromptFactory(llm_type)._prompt_factory
             system_prompt = factory.get_system_message()
-            api_prompt = factory.get_api_surfaces_message()
-            relation_prompt = factory.get_relation_analysis_message()
+            concrete_prompts = [
+                factory.get_cluster_grouping_message(),
+                factory.get_final_analysis_message(),
+                factory.get_cfg_details_message(),
+                factory.get_details_message(),
+                factory.get_incremental_grouping_message(),
+                factory.get_planning_message(),
+                factory.get_scope_relations_message(),
+                factory.get_api_surfaces_message(),
+                factory.get_relation_analysis_message(),
+            ]
             for variable in context_variables:
                 self.assertIn(variable, system_prompt)
-                self.assertNotIn(variable, api_prompt)
-                self.assertNotIn(variable, relation_prompt)
+                for concrete_prompt in concrete_prompts:
+                    self.assertNotIn(variable, concrete_prompt)
             formatted_system_prompt = system_prompt.format(
                 project_name="Example",
                 project_type="library",

--- a/tests/agents/test_abstraction_agent.py
+++ b/tests/agents/test_abstraction_agent.py
@@ -69,8 +69,8 @@ class TestAbstractionAgent(unittest.TestCase):
         self.assertIn("group_clusters", agent.prompts)
         self.assertIn("final_analysis", agent.prompts)
 
-    @patch("agents.abstraction_agent.AbstractionAgent._invoke_repair_validate")
-    def test_step_clusters_grouping_single_language(self, mock_invoke_repair_validate):
+    @patch("agents.abstraction_agent.AbstractionAgent._invoke_validate")
+    def test_step_clusters_grouping_single_language(self, mock_invoke_validate):
         # Test step_clusters_grouping with single language
         mock_llm = MagicMock()
         mock_parsing_llm = MagicMock()
@@ -86,7 +86,7 @@ class TestAbstractionAgent(unittest.TestCase):
         mock_response = ClusterAnalysis(
             cluster_components=[],
         )
-        mock_invoke_repair_validate.return_value = mock_response
+        mock_invoke_validate.return_value = mock_response
 
         mock_cluster_result = ClusterResult(clusters={1: {"node1"}})
         cluster_results = {"python": mock_cluster_result}
@@ -94,10 +94,10 @@ class TestAbstractionAgent(unittest.TestCase):
         result = agent.step_clusters_grouping(cluster_results)
 
         self.assertEqual(result, mock_response)
-        mock_invoke_repair_validate.assert_called_once()
+        mock_invoke_validate.assert_called_once()
 
-    @patch("agents.abstraction_agent.AbstractionAgent._invoke_repair_validate")
-    def test_step_clusters_grouping_multiple_languages(self, mock_invoke_repair_validate):
+    @patch("agents.abstraction_agent.AbstractionAgent._invoke_validate")
+    def test_step_clusters_grouping_multiple_languages(self, mock_invoke_validate):
         # Test step_clusters_grouping with multiple languages
         self.mock_static_analysis.get_languages.return_value = ["python", "javascript"]
 
@@ -115,7 +115,7 @@ class TestAbstractionAgent(unittest.TestCase):
         mock_response = ClusterAnalysis(
             cluster_components=[],
         )
-        mock_invoke_repair_validate.return_value = mock_response
+        mock_invoke_validate.return_value = mock_response
 
         # Create mock cluster_results for both languages
         from static_analyzer.graph import ClusterResult
@@ -128,8 +128,8 @@ class TestAbstractionAgent(unittest.TestCase):
         self.assertEqual(result, mock_response)
         self.mock_static_analysis.get_cfg.assert_called()
 
-    @patch("agents.abstraction_agent.AbstractionAgent._invoke_repair_validate")
-    def test_step_clusters_grouping_no_languages(self, mock_invoke_repair_validate):
+    @patch("agents.abstraction_agent.AbstractionAgent._invoke_validate")
+    def test_step_clusters_grouping_no_languages(self, mock_invoke_validate):
         # Test step_clusters_grouping with no languages detected
         self.mock_static_analysis.get_languages.return_value = []
 
@@ -147,7 +147,7 @@ class TestAbstractionAgent(unittest.TestCase):
         mock_response = ClusterAnalysis(
             cluster_components=[],
         )
-        mock_invoke_repair_validate.return_value = mock_response
+        mock_invoke_validate.return_value = mock_response
 
         # Empty cluster_results for no languages
         cluster_results: dict = {}

--- a/tests/agents/test_abstraction_agent.py
+++ b/tests/agents/test_abstraction_agent.py
@@ -69,8 +69,8 @@ class TestAbstractionAgent(unittest.TestCase):
         self.assertIn("group_clusters", agent.prompts)
         self.assertIn("final_analysis", agent.prompts)
 
-    @patch("agents.abstraction_agent.AbstractionAgent._validation_invoke")
-    def test_step_clusters_grouping_single_language(self, mock_validation_invoke):
+    @patch("agents.abstraction_agent.AbstractionAgent._invoke_repair_validate")
+    def test_step_clusters_grouping_single_language(self, mock_invoke_repair_validate):
         # Test step_clusters_grouping with single language
         mock_llm = MagicMock()
         mock_parsing_llm = MagicMock()
@@ -86,7 +86,7 @@ class TestAbstractionAgent(unittest.TestCase):
         mock_response = ClusterAnalysis(
             cluster_components=[],
         )
-        mock_validation_invoke.return_value = mock_response
+        mock_invoke_repair_validate.return_value = mock_response
 
         mock_cluster_result = ClusterResult(clusters={1: {"node1"}})
         cluster_results = {"python": mock_cluster_result}
@@ -94,10 +94,10 @@ class TestAbstractionAgent(unittest.TestCase):
         result = agent.step_clusters_grouping(cluster_results)
 
         self.assertEqual(result, mock_response)
-        mock_validation_invoke.assert_called_once()
+        mock_invoke_repair_validate.assert_called_once()
 
-    @patch("agents.abstraction_agent.AbstractionAgent._validation_invoke")
-    def test_step_clusters_grouping_multiple_languages(self, mock_validation_invoke):
+    @patch("agents.abstraction_agent.AbstractionAgent._invoke_repair_validate")
+    def test_step_clusters_grouping_multiple_languages(self, mock_invoke_repair_validate):
         # Test step_clusters_grouping with multiple languages
         self.mock_static_analysis.get_languages.return_value = ["python", "javascript"]
 
@@ -115,7 +115,7 @@ class TestAbstractionAgent(unittest.TestCase):
         mock_response = ClusterAnalysis(
             cluster_components=[],
         )
-        mock_validation_invoke.return_value = mock_response
+        mock_invoke_repair_validate.return_value = mock_response
 
         # Create mock cluster_results for both languages
         from static_analyzer.graph import ClusterResult
@@ -128,8 +128,8 @@ class TestAbstractionAgent(unittest.TestCase):
         self.assertEqual(result, mock_response)
         self.mock_static_analysis.get_cfg.assert_called()
 
-    @patch("agents.abstraction_agent.AbstractionAgent._validation_invoke")
-    def test_step_clusters_grouping_no_languages(self, mock_validation_invoke):
+    @patch("agents.abstraction_agent.AbstractionAgent._invoke_repair_validate")
+    def test_step_clusters_grouping_no_languages(self, mock_invoke_repair_validate):
         # Test step_clusters_grouping with no languages detected
         self.mock_static_analysis.get_languages.return_value = []
 
@@ -147,7 +147,7 @@ class TestAbstractionAgent(unittest.TestCase):
         mock_response = ClusterAnalysis(
             cluster_components=[],
         )
-        mock_validation_invoke.return_value = mock_response
+        mock_invoke_repair_validate.return_value = mock_response
 
         # Empty cluster_results for no languages
         cluster_results: dict = {}
@@ -156,8 +156,8 @@ class TestAbstractionAgent(unittest.TestCase):
 
         self.assertEqual(result, mock_response)
 
-    @patch("agents.abstraction_agent.AbstractionAgent._validation_invoke")
-    def test_step_final_analysis(self, mock_validation_invoke):
+    @patch("agents.abstraction_agent.AbstractionAgent._invoke_repair_validate")
+    def test_step_final_analysis(self, mock_invoke_repair_validate):
         # Test step_final_analysis
         mock_llm = MagicMock()
         mock_parsing_llm = MagicMock()
@@ -179,7 +179,7 @@ class TestAbstractionAgent(unittest.TestCase):
             components=[],
             components_relations=[],
         )
-        mock_validation_invoke.return_value = mock_response
+        mock_invoke_repair_validate.return_value = mock_response
 
         # Create mock cluster_results
         from static_analyzer.graph import ClusterResult

--- a/tests/agents/test_agent.py
+++ b/tests/agents/test_agent.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel
 
 from agents.agent import CodeBoardingAgent
 from agents.agent_responses import AnalysisInsights, ClusterAnalysis, ClustersComponent, Relation
+from agents.validation import ValidationResult
 from static_analyzer.analysis_result import StaticAnalysisResults
 from monitoring.stats import RunStats, current_stats
 
@@ -23,6 +24,13 @@ class TestResponse(BaseModel):
     @staticmethod
     def extractor_str(include_hidden: bool = False):
         return "Extract the value field: "
+
+
+class RepairableResponse(BaseModel):
+    value: str
+
+    def llm_str(self) -> str:
+        return self.value
 
 
 class TestCodeBoardingAgent(unittest.TestCase):
@@ -95,6 +103,42 @@ class TestCodeBoardingAgent(unittest.TestCase):
         )
         self.assertIsNotNone(agent)
         self.assertEqual(agent.parsing_llm, mock_parsing_llm)
+
+    @patch("agents.agent.create_agent")
+    def test_invoke_repair_validate_repairs_before_validation(self, mock_create_agent):
+        mock_create_agent.return_value = Mock()
+        agent = CodeBoardingAgent(
+            repo_dir=self.repo_dir,
+            static_analysis=self.mock_analysis,
+            system_message="Test",
+            agent_llm=self.mock_llm,
+            parsing_llm=Mock(spec=BaseChatModel),
+        )
+        agent._parse_invoke = MagicMock(return_value=RepairableResponse(value="raw"))
+        events: list[str] = []
+
+        def repair(result: RepairableResponse, context: object) -> None:
+            self.assertEqual(context, "repair context")
+            events.append("repair")
+            result.value = "repaired"
+
+        def validate(result: RepairableResponse, context: object) -> ValidationResult:
+            self.assertEqual(context, "validation context")
+            self.assertEqual(result.value, "repaired")
+            events.append("validate")
+            return ValidationResult(is_valid=True)
+
+        result = agent._invoke_repair_validate(
+            "prompt",
+            RepairableResponse,
+            repairs=[repair],
+            validators=[validate],
+            repair_context="repair context",
+            validation_context="validation context",
+        )
+
+        self.assertEqual(result.value, "repaired")
+        self.assertEqual(events, ["repair", "validate"])
 
     @patch("agents.agent.create_agent")
     def test_invoke_success(self, mock_create_agent):

--- a/tests/agents/test_cluster_methods_mixin.py
+++ b/tests/agents/test_cluster_methods_mixin.py
@@ -135,6 +135,10 @@ class TestClusterResult(unittest.TestCase):
 
 
 class TestCodeBoardingClusterIds(unittest.TestCase):
+    def test_prefix_for_scope_omits_root_sentinel(self):
+        self.assertEqual(CodeBoardingClusterIds.prefix_for_scope("root"), "")
+        self.assertEqual(CodeBoardingClusterIds.prefix_for_scope("1.1"), "1.1")
+
     def test_sort_groups_by_depth_then_uses_natural_order(self):
         self.assertEqual(CodeBoardingClusterIds.sort({"10", "2.1", "3.4", "1", "2"}), ["1", "2", "10", "2.1", "3.4"])
 

--- a/tests/agents/test_details_agent.py
+++ b/tests/agents/test_details_agent.py
@@ -386,7 +386,7 @@ class TestDetailsAgent(unittest.TestCase):
         mock_invoke_repair_validate.side_effect = [cluster_response, final_response, api_response, relation_response]
         mock_fix_ref.return_value = final_response
 
-        analysis, subgraph_results = agent.run(self.test_component)
+        analysis, _subgraph_results = agent.run(self.test_component)
 
         self.assertEqual(analysis, final_response)
         self.assertEqual(mock_invoke_repair_validate.call_count, 4)

--- a/tests/agents/test_details_agent.py
+++ b/tests/agents/test_details_agent.py
@@ -1,7 +1,7 @@
 import shutil
 import unittest
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, call, patch
 
 from agents.details_agent import DetailsAgent
 from agents.agent_responses import (
@@ -149,8 +149,8 @@ class TestDetailsAgent(unittest.TestCase):
         mock_cfg.filter_by_nodes.assert_called_with(expected_qnames)
         mock_subgraph.cluster.assert_called_once()
 
-    @patch("agents.details_agent.DetailsAgent._invoke_repair_validate")
-    def test_step_clusters_grouping(self, mock_invoke_repair_validate):
+    @patch("agents.details_agent.DetailsAgent._invoke_validate")
+    def test_step_clusters_grouping(self, mock_invoke_validate):
         # Test step_clusters_grouping
         mock_llm = MagicMock()
         mock_parsing_llm = MagicMock()
@@ -164,7 +164,7 @@ class TestDetailsAgent(unittest.TestCase):
             run_id="test-run-id",
         )
         mock_response = ClusterAnalysis(cluster_components=[])
-        mock_invoke_repair_validate.return_value = mock_response
+        mock_invoke_validate.return_value = mock_response
 
         # Mock CFG to return a proper cluster string
         mock_cfg = MagicMock()
@@ -177,7 +177,7 @@ class TestDetailsAgent(unittest.TestCase):
         result = agent.step_clusters_grouping(self.test_component, subgraph_cluster_results)
 
         self.assertEqual(result, mock_response)
-        mock_invoke_repair_validate.assert_called_once()
+        mock_invoke_validate.assert_called_once()
 
     @patch("agents.details_agent.DetailsAgent._invoke_repair_validate")
     def test_step_final_analysis(self, mock_invoke_repair_validate):
@@ -324,9 +324,11 @@ class TestDetailsAgent(unittest.TestCase):
         self.assertEqual(analysis.components[0].source_cluster_ids, ["5.3.1", "5.3.2"])
         self.assertEqual(analysis.components[1].source_cluster_ids, ["5.3.7"])
 
+    @patch("agents.details_agent.DetailsAgent._parse_invoke")
+    @patch("agents.details_agent.DetailsAgent._invoke_validate")
     @patch("agents.details_agent.DetailsAgent._invoke_repair_validate")
     @patch("static_analyzer.reference_resolver.StaticReferenceResolver.fix_source_code_reference_lines")
-    def test_run(self, mock_fix_ref, mock_invoke_repair_validate):
+    def test_run(self, mock_fix_ref, mock_invoke_repair_validate, mock_invoke_validate, mock_parse_invoke):
         mock_llm = MagicMock()
         mock_parsing_llm = MagicMock()
         agent = DetailsAgent(
@@ -383,13 +385,34 @@ class TestDetailsAgent(unittest.TestCase):
 
         api_response = ComponentApiSurfaces(api_surfaces=[])
         relation_response = ComponentRelations(components_relations=[])
-        mock_invoke_repair_validate.side_effect = [cluster_response, final_response, api_response, relation_response]
+        mock_invoke_validate.side_effect = [cluster_response, relation_response]
+        mock_invoke_repair_validate.return_value = final_response
+        mock_parse_invoke.return_value = api_response
         mock_fix_ref.return_value = final_response
 
         analysis, _subgraph_results = agent.run(self.test_component)
 
         self.assertEqual(analysis, final_response)
-        self.assertEqual(mock_invoke_repair_validate.call_count, 4)
+        mock_invoke_validate.assert_has_calls(
+            [
+                call(
+                    ANY,
+                    ClusterAnalysis,
+                    validators=ANY,
+                    validation_context=ANY,
+                    max_validation_attempts=3,
+                ),
+                call(
+                    ANY,
+                    ComponentRelations,
+                    validators=ANY,
+                    validation_context=ANY,
+                    max_validation_attempts=3,
+                ),
+            ]
+        )
+        mock_invoke_repair_validate.assert_called_once()
+        mock_parse_invoke.assert_called_once_with(ANY, ComponentApiSurfaces)
         mock_fix_ref.assert_called_once()
 
     def test_populate_file_methods(self):

--- a/tests/agents/test_details_agent.py
+++ b/tests/agents/test_details_agent.py
@@ -16,6 +16,7 @@ from agents.agent_responses import (
 )
 from agents.file_index_models import FileMethodGroup, MethodEntry
 
+from diagram_analysis.file_index import build_files_index
 from static_analyzer.analysis_result import StaticAnalysisResults
 from static_analyzer.constants import NodeType
 from static_analyzer.graph import CallGraph, ClusterResult
@@ -148,8 +149,8 @@ class TestDetailsAgent(unittest.TestCase):
         mock_cfg.filter_by_nodes.assert_called_with(expected_qnames)
         mock_subgraph.cluster.assert_called_once()
 
-    @patch("agents.details_agent.DetailsAgent._validation_invoke")
-    def test_step_clusters_grouping(self, mock_validation_invoke):
+    @patch("agents.details_agent.DetailsAgent._invoke_repair_validate")
+    def test_step_clusters_grouping(self, mock_invoke_repair_validate):
         # Test step_clusters_grouping
         mock_llm = MagicMock()
         mock_parsing_llm = MagicMock()
@@ -163,7 +164,7 @@ class TestDetailsAgent(unittest.TestCase):
             run_id="test-run-id",
         )
         mock_response = ClusterAnalysis(cluster_components=[])
-        mock_validation_invoke.return_value = mock_response
+        mock_invoke_repair_validate.return_value = mock_response
 
         # Mock CFG to return a proper cluster string
         mock_cfg = MagicMock()
@@ -176,10 +177,10 @@ class TestDetailsAgent(unittest.TestCase):
         result = agent.step_clusters_grouping(self.test_component, subgraph_cluster_results)
 
         self.assertEqual(result, mock_response)
-        mock_validation_invoke.assert_called_once()
+        mock_invoke_repair_validate.assert_called_once()
 
-    @patch("agents.details_agent.DetailsAgent._validation_invoke")
-    def test_step_final_analysis(self, mock_validation_invoke):
+    @patch("agents.details_agent.DetailsAgent._invoke_repair_validate")
+    def test_step_final_analysis(self, mock_invoke_repair_validate):
         # Test step_final_analysis
         mock_llm = MagicMock()
         mock_parsing_llm = MagicMock()
@@ -197,13 +198,13 @@ class TestDetailsAgent(unittest.TestCase):
             components=[],
             components_relations=[],
         )
-        mock_validation_invoke.return_value = mock_response
+        mock_invoke_repair_validate.return_value = mock_response
 
         cluster_analysis = ClusterAnalysis(cluster_components=[])
         result = agent.step_final_analysis(self.test_component, cluster_analysis, {}, {})
 
         self.assertEqual(result, mock_response)
-        mock_validation_invoke.assert_called_once()
+        mock_invoke_repair_validate.assert_called_once()
 
     def test_resolve_cluster_ids_from_groups(self):
         # Test _resolve_cluster_ids_from_groups
@@ -323,9 +324,9 @@ class TestDetailsAgent(unittest.TestCase):
         self.assertEqual(analysis.components[0].source_cluster_ids, ["5.3.1", "5.3.2"])
         self.assertEqual(analysis.components[1].source_cluster_ids, ["5.3.7"])
 
-    @patch("agents.details_agent.DetailsAgent._validation_invoke")
+    @patch("agents.details_agent.DetailsAgent._invoke_repair_validate")
     @patch("static_analyzer.reference_resolver.StaticReferenceResolver.fix_source_code_reference_lines")
-    def test_run(self, mock_fix_ref, mock_validation_invoke):
+    def test_run(self, mock_fix_ref, mock_invoke_repair_validate):
         mock_llm = MagicMock()
         mock_parsing_llm = MagicMock()
         agent = DetailsAgent(
@@ -382,13 +383,13 @@ class TestDetailsAgent(unittest.TestCase):
 
         api_response = ComponentApiSurfaces(api_surfaces=[])
         relation_response = ComponentRelations(components_relations=[])
-        mock_validation_invoke.side_effect = [cluster_response, final_response, api_response, relation_response]
+        mock_invoke_repair_validate.side_effect = [cluster_response, final_response, api_response, relation_response]
         mock_fix_ref.return_value = final_response
 
         analysis, subgraph_results = agent.run(self.test_component)
 
         self.assertEqual(analysis, final_response)
-        self.assertEqual(mock_validation_invoke.call_count, 4)
+        self.assertEqual(mock_invoke_repair_validate.call_count, 4)
         mock_fix_ref.assert_called_once()
 
     def test_populate_file_methods(self):
@@ -441,18 +442,6 @@ class TestDetailsAgent(unittest.TestCase):
         self.assertEqual(sub_component.file_methods[1].methods[0].qualified_name, "pkg.TestClass")
 
     def test_build_files_index_merges_shared_file_methods(self):
-        mock_llm = MagicMock()
-        mock_parsing_llm = MagicMock()
-        agent = DetailsAgent(
-            repo_dir=self.repo_dir,
-            static_analysis=self.mock_static_analysis,
-            project_name=self.project_name,
-            meta_context=self.mock_meta_context,
-            agent_llm=mock_llm,
-            parsing_llm=mock_parsing_llm,
-            run_id="test-run-id",
-        )
-
         component_a = Component(
             name="CompA",
             description="A",
@@ -496,7 +485,7 @@ class TestDetailsAgent(unittest.TestCase):
             components_relations=[],
         )
 
-        files_index = agent.build_files_index(analysis)
+        files_index = build_files_index(analysis, self.repo_dir)
 
         self.assertIn("shared.py", files_index)
         self.assertEqual(

--- a/tests/agents/test_file_index_models.py
+++ b/tests/agents/test_file_index_models.py
@@ -1,0 +1,59 @@
+from agents.file_index_models import FileEntry, MethodEntry
+
+
+def test_file_entry_merge_prefers_source_metadata_and_completes_span() -> None:
+    endpoint = MethodEntry(
+        qualified_name="pkg.run",
+        start_line=0,
+        end_line=8,
+        node_type="METHOD",
+    )
+    analyzed = MethodEntry(
+        qualified_name="pkg.run",
+        start_line=3,
+        end_line=0,
+        node_type="FUNCTION",
+        content_hash="abc123",
+    )
+
+    merged = FileEntry(methods=[endpoint]).merge_from(FileEntry(methods=[analyzed]))
+
+    assert merged.methods == [
+        MethodEntry(
+            qualified_name="pkg.run",
+            start_line=3,
+            end_line=8,
+            node_type="FUNCTION",
+            content_hash="abc123",
+        )
+    ]
+
+
+def test_file_entry_merge_does_not_change_existing_node_kind_without_source_metadata() -> None:
+    existing = FileEntry(
+        methods=[MethodEntry(qualified_name="pkg.Service", start_line=1, end_line=10, node_type="CLASS")]
+    )
+    duplicate = FileEntry(
+        methods=[MethodEntry(qualified_name="pkg.Service", start_line=1, end_line=10, node_type="METHOD")]
+    )
+
+    existing.merge_from(duplicate)
+
+    assert existing.methods[0].node_type == "CLASS"
+
+
+def test_file_entry_merge_sorts_and_takes_deep_copy_ownership() -> None:
+    source = FileEntry(
+        methods=[
+            MethodEntry(qualified_name="pkg.later", start_line=20, end_line=25, node_type="FUNCTION"),
+            MethodEntry(qualified_name="pkg.earlier", start_line=2, end_line=5, node_type="FUNCTION"),
+        ],
+        content_hash="file123",
+    )
+
+    merged = FileEntry().merge_from(source)
+    source.methods[1].qualified_name = "changed"
+
+    assert merged.content_hash == "file123"
+    assert [method.qualified_name for method in merged.methods] == ["pkg.earlier", "pkg.later"]
+    assert merged.methods[0] is not source.methods[1]

--- a/tests/agents/test_incremental_agent.py
+++ b/tests/agents/test_incremental_agent.py
@@ -16,7 +16,7 @@ from agents.agent_responses import (
     ScopedClusterRef,
     ScopeUpdateDecision,
 )
-from agents.file_index_models import FileMethodGroup, MethodEntry
+from agents.file_index_models import FileEntry, FileMethodGroup, MethodEntry
 from agents.incremental_agent import (
     IncrementalAgent,
     _cluster_analysis_for_scope,
@@ -24,7 +24,7 @@ from agents.incremental_agent import (
     prune_empty_components,
     remove_deleted_files,
 )
-from diagram_analysis.exceptions import IncrementalScopeContextMissingError
+from agents.incremental_results import ScopeRelationContext
 from static_analyzer.analysis_result import StaticAnalysisResults
 from static_analyzer.constants import NodeType
 from static_analyzer.graph import CallGraph, ClusterResult
@@ -148,7 +148,6 @@ class TestUpdateScope(unittest.TestCase):
         agent.static_analysis.get_languages.return_value = []
         agent.static_analysis.get_cfg.return_value.filter_by_nodes.return_value = "cfg"
         agent.reference_resolver = MagicMock()
-        agent._scope_relation_contexts = {}
 
         def populate(scope, _cluster_results, _cfg_graphs, _touched_ids, source_cluster_id_prefix=""):
             for component in scope.components:
@@ -196,11 +195,12 @@ class TestUpdateScope(unittest.TestCase):
         self.assertEqual(component.key_entities, [])
         self.assertEqual(result.refresh_ids, {"1"})
         self.assertEqual(result.new_component_ids, set())
-        reference_resolver.fix_key_entities_refs.assert_called_once_with(scope, {"1"}, force_resolve=True)
+        reference_resolver.fix_key_entities_refs.assert_called_once_with(scope, {"1"})
 
     def test_update_preserves_planner_selected_key_entities(self) -> None:
         component = _component("API", "1", source_cluster_ids=["1"])
         selected = SourceCodeReference(qualified_name="alias.method", reference_file="selected.py")
+        expected = selected.model_copy(deep=True)
         scope = AnalysisInsights(description="root", components=[component], components_relations=[])
         decision = ScopeUpdateDecision(
             operations=[
@@ -218,15 +218,15 @@ class TestUpdateScope(unittest.TestCase):
         reference_resolver = MagicMock()
         agent.reference_resolver = reference_resolver
 
-        def resolve_selected_key_entity(analysis, _component_ids, force_resolve=False):
-            self.assertTrue(force_resolve)
-            analysis.components[0].key_entities[0].qualified_name = "1.method"
+        def resolve_selected_key_entity(_analysis: AnalysisInsights, _component_ids: set[str]) -> None:
+            self.assertIs(_analysis, scope)
+            self.assertEqual(_component_ids, {"1"})
 
         reference_resolver.fix_key_entities_refs.side_effect = resolve_selected_key_entity
 
         agent.update_scope("root", scope, decision, {"python": ClusterResult()})
 
-        self.assertEqual(component.key_entities, [selected])
+        self.assertEqual(component.key_entities, [expected])
 
     def test_update_scope_moves_reassigned_clusters_between_siblings(self) -> None:
         first = _component("Core", "1.1", source_cluster_ids=["1.1", "1.2"])
@@ -272,7 +272,8 @@ class TestUpdateScope(unittest.TestCase):
         self.assertEqual(component.name, "API")
         self.assertEqual(component.description, "API description")
         self.assertEqual(result.refresh_ids, {"1"})
-        self.assertIn("root", agent._scope_relation_contexts)
+        self.assertEqual(result.relation_context.cluster_results, {"python": ClusterResult()})
+        self.assertEqual(result.relation_context.cfg_graphs, {})
 
     def test_create_component_assigns_id_clusters_methods_and_key_entities(self) -> None:
         existing = Component(name="API", description="", key_entities=[], component_id="1")
@@ -446,6 +447,10 @@ class TestIncrementalRelations(unittest.TestCase):
         ]
         scope = AnalysisInsights(
             description="root",
+            files={
+                "api.py": FileEntry(methods=[api.file_methods[0].methods[0].model_copy(deep=True)]),
+                "worker.py": FileEntry(methods=[worker.file_methods[0].methods[0].model_copy(deep=True)]),
+            },
             components=[api, worker],
             components_relations=[Relation(relation="legacy relation", src_name="API", dst_name="Worker")],
         )
@@ -484,7 +489,8 @@ class TestIncrementalRelations(unittest.TestCase):
                 agent_llm=MagicMock(),
                 parsing_llm=MagicMock(),
             )
-        agent._invoke_repair_validate = MagicMock(side_effect=[api_surfaces, relation_result])
+        agent._parse_invoke = MagicMock(return_value=api_surfaces)
+        agent._invoke_validate = MagicMock(return_value=relation_result)
         agent.reference_resolver = MagicMock()
         agent.reference_resolver.fix_source_code_reference_lines.side_effect = lambda analysis: analysis
 
@@ -493,12 +499,16 @@ class TestIncrementalRelations(unittest.TestCase):
         self.assertIn("unknown", system_message)
         self.assertNotIn("{project_name}", system_message)
 
-        generated = agent.generate_scope_relations(scope, "root", cluster_results, {"python": cfg})
+        generated = agent.generate_scope_relations(
+            scope,
+            "root",
+            ScopeRelationContext(cluster_results=cluster_results, cfg_graphs={"python": cfg}),
+        )
 
         self.assertEqual(generated, relation_result.components_relations)
-        self.assertEqual(agent._invoke_repair_validate.call_args_list[0].args[1], ComponentApiSurfaces)
-        self.assertNotIn("legacy relation", agent._invoke_repair_validate.call_args_list[0].args[0])
-        relation_call = agent._invoke_repair_validate.call_args_list[1]
+        self.assertEqual(agent._parse_invoke.call_args.args[1], ComponentApiSurfaces)
+        self.assertNotIn("legacy relation", agent._parse_invoke.call_args.args[0])
+        relation_call = agent._invoke_validate.call_args
         self.assertEqual(relation_call.args[1], ComponentRelations)
         self.assertNotIn("legacy relation", relation_call.args[0])
         self.assertEqual(relation_call.kwargs["validators"][0].__name__, "validate_relations")
@@ -509,16 +519,17 @@ class TestIncrementalRelations(unittest.TestCase):
         self.assertTrue(relation.is_static)
         self.assertTrue(any(edge.call_sites[0].line == 3 for edge in relation.all_edges if edge.call_sites))
         self.assertEqual(scope.files["api.py"].methods[0].qualified_name, source.fully_qualified_name)
-        self.assertEqual(scope.files["api.py"].methods[0].node_type, "REFERENCE")
+        self.assertEqual(scope.files["api.py"].methods[0].node_type, NodeType.FUNCTION.name)
 
     def test_generate_all_scope_relations_includes_root_scope_id(self) -> None:
         agent = object.__new__(IncrementalAgent)
         agent.generate_scope_relations = MagicMock(return_value=[])
         root = AnalysisInsights(description="root", components=[], components_relations=[])
+        context = ScopeRelationContext(cluster_results={}, cfg_graphs={})
 
-        agent.generate_all_scope_relations(root, {}, {"root"})
+        agent.generate_all_scope_relations(root, {}, {"root": context})
 
-        agent.generate_scope_relations.assert_called_once_with(root, "root")
+        agent.generate_scope_relations.assert_called_once_with(root, "root", context)
 
     def test_single_component_scope_clears_stale_relations_and_resolves_references(self) -> None:
         agent = object.__new__(IncrementalAgent)
@@ -530,23 +541,15 @@ class TestIncrementalRelations(unittest.TestCase):
             components_relations=[Relation(relation="stale", src_name="Only", dst_name="Removed")],
         )
 
-        result = agent.generate_scope_relations(scope, "root")
+        result = agent.generate_scope_relations(
+            scope,
+            "root",
+            ScopeRelationContext(cluster_results={}, cfg_graphs={}),
+        )
 
         self.assertEqual(result, [])
         self.assertEqual(scope.components_relations, [])
         agent.reference_resolver.fix_source_code_reference_lines.assert_called_once_with(scope)
-
-    def test_relation_generation_requires_recorded_scope_context(self) -> None:
-        agent = object.__new__(IncrementalAgent)
-        agent._scope_relation_contexts = {}
-        scope = AnalysisInsights(
-            description="root",
-            components=[_component("A", "1"), _component("B", "2")],
-            components_relations=[],
-        )
-
-        with self.assertRaises(IncrementalScopeContextMissingError):
-            agent.generate_scope_relations(scope, "root")
 
 
 class TestPatchFileMethods(unittest.TestCase):

--- a/tests/agents/test_incremental_agent.py
+++ b/tests/agents/test_incremental_agent.py
@@ -1,10 +1,15 @@
 import unittest
-from unittest.mock import MagicMock
+from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 from agents.agent_responses import (
     AnalysisInsights,
+    ComponentApiSurface,
+    ComponentApiSurfaces,
+    ComponentRelations,
     Component,
     Relation,
+    RelationEdge,
     SourceCodeReference,
     ScopeOperation,
     ScopeOperationAction,
@@ -12,8 +17,18 @@ from agents.agent_responses import (
     ScopeUpdateDecision,
 )
 from agents.file_index_models import FileMethodGroup, MethodEntry
-from agents.incremental_agent import IncrementalAgent, _patch_file_methods, prune_empty_components, remove_deleted_files
-from static_analyzer.graph import ClusterResult
+from agents.incremental_agent import (
+    IncrementalAgent,
+    _cluster_analysis_for_scope,
+    _patch_file_methods,
+    prune_empty_components,
+    remove_deleted_files,
+)
+from diagram_analysis.exceptions import IncrementalScopeContextMissingError, IncrementalScopeRegenerationRequiredError
+from static_analyzer.analysis_result import StaticAnalysisResults
+from static_analyzer.constants import NodeType
+from static_analyzer.graph import CallGraph, ClusterResult
+from static_analyzer.node import Node
 
 
 def _component(name: str, component_id: str, source_cluster_ids: list[str] | None = None) -> Component:
@@ -169,13 +184,34 @@ class TestUpdateScope(unittest.TestCase):
             ]
         )
 
-        result = self._agent().update_scope("root", scope, decision, {"python": ClusterResult()})
+        agent = self._agent()
+        result = agent.update_scope("root", scope, decision, {"python": ClusterResult()})
 
         self.assertEqual(component.description, "New")
         self.assertEqual(component.source_cluster_ids, ["1", "2"])
         self.assertEqual(component.key_entities[0].qualified_name, "1.method")
         self.assertEqual(result.refresh_ids, {"1"})
         self.assertEqual(result.new_component_ids, set())
+
+    def test_update_preserves_planner_selected_key_entities(self) -> None:
+        component = _component("API", "1", source_cluster_ids=["1"])
+        selected = SourceCodeReference(qualified_name="1.method", reference_file="selected.py")
+        scope = AnalysisInsights(description="root", components=[component], components_relations=[])
+        decision = ScopeUpdateDecision(
+            operations=[
+                ScopeOperation(
+                    action=ScopeOperationAction.UPDATE_COMPONENT,
+                    cluster_refs=[ScopedClusterRef(scope_id="root", language="python", cluster_id=2)],
+                    component_id="1",
+                    key_entities=[selected],
+                    rationale="The API responsibility changed.",
+                )
+            ]
+        )
+
+        self._agent().update_scope("root", scope, decision, {"python": ClusterResult()})
+
+        self.assertEqual(component.key_entities, [selected])
 
     def test_update_scope_moves_reassigned_clusters_between_siblings(self) -> None:
         first = _component("Core", "1.1", source_cluster_ids=["1.1", "1.2"])
@@ -198,6 +234,30 @@ class TestUpdateScope(unittest.TestCase):
         self.assertEqual(first.source_cluster_ids, ["1.1"])
         self.assertEqual(second.source_cluster_ids, ["1.2", "1.3"])
         self.assertEqual(result.refresh_ids, {"1.1", "1.2"})
+
+    def test_noop_preserves_metadata_but_refreshes_derived_scope_data(self) -> None:
+        component = _component("API", "1", source_cluster_ids=["1"])
+        scope = AnalysisInsights(description="root", components=[component], components_relations=[])
+        decision = ScopeUpdateDecision(
+            operations=[
+                ScopeOperation(
+                    action=ScopeOperationAction.NOOP,
+                    cluster_refs=[ScopedClusterRef(scope_id="root", language="python", cluster_id=1)],
+                    component_id="1",
+                    name="Ignored rename",
+                    description="Ignored description",
+                    rationale="Only implementation details changed.",
+                )
+            ]
+        )
+
+        agent = self._agent()
+        result = agent.update_scope("root", scope, decision, {"python": ClusterResult()})
+
+        self.assertEqual(component.name, "API")
+        self.assertEqual(component.description, "API description")
+        self.assertEqual(result.refresh_ids, {"1"})
+        self.assertIn("root", agent._scope_contexts())
 
     def test_create_component_assigns_id_clusters_methods_and_key_entities(self) -> None:
         existing = Component(name="API", description="", key_entities=[], component_id="1")
@@ -319,7 +379,7 @@ class TestUpdateScope(unittest.TestCase):
         self.assertEqual(result.removed_ids, set())
         self.assertEqual(result.refresh_ids, {"1"})
 
-    def test_regenerate_scope_sets_flag_without_mutation(self) -> None:
+    def test_regenerate_scope_fails_without_mutation(self) -> None:
         component = _component("A", "1")
         scope = AnalysisInsights(description="root", components=[component], components_relations=[])
         decision = ScopeUpdateDecision(
@@ -332,10 +392,155 @@ class TestUpdateScope(unittest.TestCase):
             ]
         )
 
-        result = self._agent().update_scope("root", scope, decision, {})
+        with self.assertRaises(IncrementalScopeRegenerationRequiredError):
+            self._agent().update_scope("root", scope, decision, {})
 
-        self.assertTrue(result.regenerate_scope)
         self.assertEqual(scope.components, [component])
+
+
+class TestIncrementalRelations(unittest.TestCase):
+    def test_reconstructs_nested_cluster_context_from_persisted_components(self) -> None:
+        component = _component("Worker", "1.1", source_cluster_ids=["1.2", "9.9"])
+        component.source_group_names = []
+        scope = AnalysisInsights(description="nested", components=[component], components_relations=[])
+
+        cluster_analysis = _cluster_analysis_for_scope(
+            scope,
+            "1",
+            {"python": ClusterResult(clusters={2: {"worker.run"}})},
+        )
+
+        self.assertEqual(component.source_group_names, ["Worker"])
+        self.assertEqual(cluster_analysis.cluster_components[0].cluster_ids, [2])
+
+    def test_uses_api_surface_relation_pipeline_and_attaches_static_call_sites(self) -> None:
+        source = Node("pkg.api.run", NodeType.FUNCTION, "api.py", 1, 5)
+        target = Node("pkg.worker.load", NodeType.FUNCTION, "worker.py", 10, 15)
+        cfg = CallGraph(nodes={source.fully_qualified_name: source, target.fully_qualified_name: target})
+        cfg.add_edge(source.fully_qualified_name, target.fully_qualified_name, [{"line": 3, "column": 7}])
+        static_analysis = MagicMock(spec=StaticAnalysisResults)
+        static_analysis.get_languages.return_value = ["python"]
+        static_analysis.get_cfg.return_value = cfg
+        static_analysis.available_cfgs.return_value = {"python": cfg}
+
+        api = _component("API", "1", source_cluster_ids=["1"])
+        api.file_methods = [
+            FileMethodGroup(
+                file_path="api.py",
+                methods=[
+                    MethodEntry(
+                        qualified_name=source.fully_qualified_name, start_line=1, end_line=5, node_type="FUNCTION"
+                    )
+                ],
+            )
+        ]
+        worker = _component("Worker", "2", source_cluster_ids=["2"])
+        worker.file_methods = [
+            FileMethodGroup(
+                file_path="worker.py",
+                methods=[
+                    MethodEntry(
+                        qualified_name=target.fully_qualified_name, start_line=10, end_line=15, node_type="FUNCTION"
+                    )
+                ],
+            )
+        ]
+        scope = AnalysisInsights(
+            description="root",
+            components=[api, worker],
+            components_relations=[Relation(relation="legacy relation", src_name="API", dst_name="Worker")],
+        )
+        api_surfaces = ComponentApiSurfaces(
+            api_surfaces=[
+                ComponentApiSurface(component_name="API", outgoing_api_paths=["dispatches jobs"]),
+                ComponentApiSurface(component_name="Worker", incoming_api_paths=["receives jobs"]),
+            ]
+        )
+        key_edge = RelationEdge(
+            source=SourceCodeReference(qualified_name=source.fully_qualified_name),
+            target=SourceCodeReference(qualified_name=target.fully_qualified_name),
+            description="API dispatches work.",
+        )
+        relation_result = ComponentRelations(
+            components_relations=[
+                Relation(
+                    relation="dispatches jobs to",
+                    src_name="API",
+                    dst_name="Worker",
+                    evidence="Queue-backed job dispatch.",
+                    key_edges=[key_edge],
+                )
+            ]
+        )
+        cluster_results = {
+            "python": ClusterResult(clusters={1: {source.fully_qualified_name}, 2: {target.fully_qualified_name}})
+        }
+
+        with patch("agents.agent.create_agent", return_value=MagicMock()):
+            agent = IncrementalAgent(
+                repo_dir=Path("/tmp/fake-repo"),
+                static_analysis=static_analysis,
+                project_name="Test",
+                meta_context=None,
+                agent_llm=MagicMock(),
+                parsing_llm=MagicMock(),
+            )
+        agent._validation_invoke = MagicMock(side_effect=[api_surfaces, relation_result])
+        agent.reference_resolver = MagicMock()
+        agent.reference_resolver.fix_source_code_reference_lines.side_effect = lambda analysis: analysis
+
+        generated = agent.generate_scope_relations(scope, "root", cluster_results, {"python": cfg})
+
+        self.assertEqual(generated, relation_result.components_relations)
+        self.assertEqual(agent._validation_invoke.call_args_list[0].args[1], ComponentApiSurfaces)
+        self.assertNotIn("legacy relation", agent._validation_invoke.call_args_list[0].args[0])
+        relation_call = agent._validation_invoke.call_args_list[1]
+        self.assertEqual(relation_call.args[1], ComponentRelations)
+        self.assertNotIn("legacy relation", relation_call.args[0])
+        self.assertEqual(relation_call.kwargs["validators"][0].__name__, "validate_relations")
+        self.assertEqual(len(scope.components_relations), 1)
+        relation = scope.components_relations[0]
+        self.assertEqual(relation.evidence, "Queue-backed job dispatch.")
+        self.assertEqual(relation.key_edges, [key_edge])
+        self.assertTrue(relation.is_static)
+        self.assertTrue(any(edge.call_sites[0].line == 3 for edge in relation.all_edges if edge.call_sites))
+
+    def test_generate_all_scope_relations_includes_root_scope_id(self) -> None:
+        agent = object.__new__(IncrementalAgent)
+        agent.generate_scope_relations = MagicMock(return_value=[])
+        root = AnalysisInsights(description="root", components=[], components_relations=[])
+
+        agent.generate_all_scope_relations(root, {}, {"root"})
+
+        agent.generate_scope_relations.assert_called_once_with(root, "root")
+
+    def test_single_component_scope_clears_stale_relations_and_resolves_references(self) -> None:
+        agent = object.__new__(IncrementalAgent)
+        agent.reference_resolver = MagicMock()
+        component = _component("Only", "1")
+        scope = AnalysisInsights(
+            description="root",
+            components=[component],
+            components_relations=[Relation(relation="stale", src_name="Only", dst_name="Removed")],
+        )
+
+        result = agent.generate_scope_relations(scope, "root")
+
+        self.assertEqual(result, [])
+        self.assertEqual(scope.components_relations, [])
+        agent.reference_resolver.fix_source_code_reference_lines.assert_called_once_with(scope)
+
+    def test_relation_generation_requires_recorded_scope_context(self) -> None:
+        agent = object.__new__(IncrementalAgent)
+        agent._scope_relation_contexts = {}
+        scope = AnalysisInsights(
+            description="root",
+            components=[_component("A", "1"), _component("B", "2")],
+            components_relations=[],
+        )
+
+        with self.assertRaises(IncrementalScopeContextMissingError):
+            agent.generate_scope_relations(scope, "root")
 
 
 class TestPatchFileMethods(unittest.TestCase):

--- a/tests/agents/test_incremental_agent.py
+++ b/tests/agents/test_incremental_agent.py
@@ -147,6 +147,7 @@ class TestUpdateScope(unittest.TestCase):
         agent.static_analysis = MagicMock()
         agent.static_analysis.get_languages.return_value = []
         agent.static_analysis.get_cfg.return_value.filter_by_nodes.return_value = "cfg"
+        agent.reference_resolver = MagicMock()
 
         def populate(scope, _cluster_results, _cfg_graphs, _touched_ids, source_cluster_id_prefix=""):
             for component in scope.components:
@@ -185,6 +186,8 @@ class TestUpdateScope(unittest.TestCase):
         )
 
         agent = self._agent()
+        reference_resolver = MagicMock()
+        agent.reference_resolver = reference_resolver
         result = agent.update_scope("root", scope, decision, {"python": ClusterResult()})
 
         self.assertEqual(component.description, "New")
@@ -192,10 +195,11 @@ class TestUpdateScope(unittest.TestCase):
         self.assertEqual(component.key_entities[0].qualified_name, "1.method")
         self.assertEqual(result.refresh_ids, {"1"})
         self.assertEqual(result.new_component_ids, set())
+        reference_resolver.fix_key_entities_refs.assert_called_once_with(scope, {"1"})
 
     def test_update_preserves_planner_selected_key_entities(self) -> None:
         component = _component("API", "1", source_cluster_ids=["1"])
-        selected = SourceCodeReference(qualified_name="1.method", reference_file="selected.py")
+        selected = SourceCodeReference(qualified_name="alias.method", reference_file="selected.py")
         scope = AnalysisInsights(description="root", components=[component], components_relations=[])
         decision = ScopeUpdateDecision(
             operations=[
@@ -209,7 +213,16 @@ class TestUpdateScope(unittest.TestCase):
             ]
         )
 
-        self._agent().update_scope("root", scope, decision, {"python": ClusterResult()})
+        agent = self._agent()
+        reference_resolver = MagicMock()
+        agent.reference_resolver = reference_resolver
+
+        def resolve_selected_key_entity(analysis, _component_ids):
+            analysis.components[0].key_entities[0].qualified_name = "1.method"
+
+        reference_resolver.fix_key_entities_refs.side_effect = resolve_selected_key_entity
+
+        agent.update_scope("root", scope, decision, {"python": ClusterResult()})
 
         self.assertEqual(component.key_entities, [selected])
 

--- a/tests/agents/test_incremental_agent.py
+++ b/tests/agents/test_incremental_agent.py
@@ -24,7 +24,7 @@ from agents.incremental_agent import (
     prune_empty_components,
     remove_deleted_files,
 )
-from diagram_analysis.exceptions import IncrementalScopeContextMissingError, IncrementalScopeRegenerationRequiredError
+from diagram_analysis.exceptions import IncrementalScopeContextMissingError
 from static_analyzer.analysis_result import StaticAnalysisResults
 from static_analyzer.constants import NodeType
 from static_analyzer.graph import CallGraph, ClusterResult
@@ -170,7 +170,7 @@ class TestUpdateScope(unittest.TestCase):
         agent.build_static_relations = MagicMock()
         return agent
 
-    def test_update_existing_component_updates_description_clusters_and_key_entities(self) -> None:
+    def test_update_without_selected_key_entities_does_not_synthesize_them(self) -> None:
         component = _component("API", "1", source_cluster_ids=["1"])
         scope = AnalysisInsights(description="root", components=[component], components_relations=[])
         decision = ScopeUpdateDecision(
@@ -192,10 +192,10 @@ class TestUpdateScope(unittest.TestCase):
 
         self.assertEqual(component.description, "New")
         self.assertEqual(component.source_cluster_ids, ["1", "2"])
-        self.assertEqual(component.key_entities[0].qualified_name, "1.method")
+        self.assertEqual(component.key_entities, [])
         self.assertEqual(result.refresh_ids, {"1"})
         self.assertEqual(result.new_component_ids, set())
-        reference_resolver.fix_key_entities_refs.assert_called_once_with(scope, {"1"})
+        reference_resolver.fix_key_entities_refs.assert_called_once_with(scope, {"1"}, force_resolve=True)
 
     def test_update_preserves_planner_selected_key_entities(self) -> None:
         component = _component("API", "1", source_cluster_ids=["1"])
@@ -217,7 +217,8 @@ class TestUpdateScope(unittest.TestCase):
         reference_resolver = MagicMock()
         agent.reference_resolver = reference_resolver
 
-        def resolve_selected_key_entity(analysis, _component_ids):
+        def resolve_selected_key_entity(analysis, _component_ids, force_resolve=False):
+            self.assertTrue(force_resolve)
             analysis.components[0].key_entities[0].qualified_name = "1.method"
 
         reference_resolver.fix_key_entities_refs.side_effect = resolve_selected_key_entity
@@ -275,6 +276,7 @@ class TestUpdateScope(unittest.TestCase):
     def test_create_component_assigns_id_clusters_methods_and_key_entities(self) -> None:
         existing = Component(name="API", description="", key_entities=[], component_id="1")
         scope = AnalysisInsights(description="root", components=[existing], components_relations=[])
+        selected = SourceCodeReference(qualified_name="worker.run")
         decision = ScopeUpdateDecision(
             operations=[
                 ScopeOperation(
@@ -282,6 +284,7 @@ class TestUpdateScope(unittest.TestCase):
                     cluster_refs=[ScopedClusterRef(scope_id="root", language="python", cluster_id=7)],
                     name="Worker",
                     description="Runs jobs.",
+                    key_entities=[selected],
                     rationale="New isolated responsibility.",
                 )
             ]
@@ -294,7 +297,7 @@ class TestUpdateScope(unittest.TestCase):
         self.assertEqual(created.name, "Worker")
         self.assertEqual(created.source_cluster_ids, ["7"])
         self.assertEqual(created.file_methods[0].methods[0].qualified_name, "2.method")
-        self.assertEqual(created.key_entities[0].qualified_name, "2.method")
+        self.assertEqual(created.key_entities, [selected])
         self.assertEqual(result.refresh_ids, {"2"})
         self.assertEqual(result.new_component_ids, {"2"})
 
@@ -392,24 +395,6 @@ class TestUpdateScope(unittest.TestCase):
         self.assertEqual(result.removed_ids, set())
         self.assertEqual(result.refresh_ids, {"1"})
 
-    def test_regenerate_scope_fails_without_mutation(self) -> None:
-        component = _component("A", "1")
-        scope = AnalysisInsights(description="root", components=[component], components_relations=[])
-        decision = ScopeUpdateDecision(
-            operations=[
-                ScopeOperation(
-                    action=ScopeOperationAction.REGENERATE_SCOPE,
-                    cluster_refs=[],
-                    rationale="Ambiguous reparenting required.",
-                )
-            ]
-        )
-
-        with self.assertRaises(IncrementalScopeRegenerationRequiredError):
-            self._agent().update_scope("root", scope, decision, {})
-
-        self.assertEqual(scope.components, [component])
-
 
 class TestIncrementalRelations(unittest.TestCase):
     def test_reconstructs_nested_cluster_context_from_persisted_components(self) -> None:
@@ -498,16 +483,21 @@ class TestIncrementalRelations(unittest.TestCase):
                 agent_llm=MagicMock(),
                 parsing_llm=MagicMock(),
             )
-        agent._validation_invoke = MagicMock(side_effect=[api_surfaces, relation_result])
+        agent._invoke_repair_validate = MagicMock(side_effect=[api_surfaces, relation_result])
         agent.reference_resolver = MagicMock()
         agent.reference_resolver.fix_source_code_reference_lines.side_effect = lambda analysis: analysis
+
+        system_message = str(agent.system_message.content)
+        self.assertIn("Test", system_message)
+        self.assertIn("unknown", system_message)
+        self.assertNotIn("{project_name}", system_message)
 
         generated = agent.generate_scope_relations(scope, "root", cluster_results, {"python": cfg})
 
         self.assertEqual(generated, relation_result.components_relations)
-        self.assertEqual(agent._validation_invoke.call_args_list[0].args[1], ComponentApiSurfaces)
-        self.assertNotIn("legacy relation", agent._validation_invoke.call_args_list[0].args[0])
-        relation_call = agent._validation_invoke.call_args_list[1]
+        self.assertEqual(agent._invoke_repair_validate.call_args_list[0].args[1], ComponentApiSurfaces)
+        self.assertNotIn("legacy relation", agent._invoke_repair_validate.call_args_list[0].args[0])
+        relation_call = agent._invoke_repair_validate.call_args_list[1]
         self.assertEqual(relation_call.args[1], ComponentRelations)
         self.assertNotIn("legacy relation", relation_call.args[0])
         self.assertEqual(relation_call.kwargs["validators"][0].__name__, "validate_relations")
@@ -517,6 +507,8 @@ class TestIncrementalRelations(unittest.TestCase):
         self.assertEqual(relation.key_edges, [key_edge])
         self.assertTrue(relation.is_static)
         self.assertTrue(any(edge.call_sites[0].line == 3 for edge in relation.all_edges if edge.call_sites))
+        self.assertEqual(scope.files["api.py"].methods[0].qualified_name, source.fully_qualified_name)
+        self.assertEqual(scope.files["api.py"].methods[0].node_type, "REFERENCE")
 
     def test_generate_all_scope_relations_includes_root_scope_id(self) -> None:
         agent = object.__new__(IncrementalAgent)

--- a/tests/agents/test_incremental_agent.py
+++ b/tests/agents/test_incremental_agent.py
@@ -148,6 +148,7 @@ class TestUpdateScope(unittest.TestCase):
         agent.static_analysis.get_languages.return_value = []
         agent.static_analysis.get_cfg.return_value.filter_by_nodes.return_value = "cfg"
         agent.reference_resolver = MagicMock()
+        agent._scope_relation_contexts = {}
 
         def populate(scope, _cluster_results, _cfg_graphs, _touched_ids, source_cluster_id_prefix=""):
             for component in scope.components:
@@ -271,7 +272,7 @@ class TestUpdateScope(unittest.TestCase):
         self.assertEqual(component.name, "API")
         self.assertEqual(component.description, "API description")
         self.assertEqual(result.refresh_ids, {"1"})
-        self.assertIn("root", agent._scope_contexts())
+        self.assertIn("root", agent._scope_relation_contexts)
 
     def test_create_component_assigns_id_clusters_methods_and_key_entities(self) -> None:
         existing = Component(name="API", description="", key_entities=[], component_id="1")

--- a/tests/agents/test_incremental_planning_agent.py
+++ b/tests/agents/test_incremental_planning_agent.py
@@ -1,14 +1,18 @@
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from agents.agent_responses import (
     AnalysisInsights,
     Component,
+    SourceCodeReference,
     ScopeOperation,
     ScopeOperationAction,
     ScopedClusterRef,
     ScopeUpdateDecision,
 )
+from diagram_analysis.exceptions import InvalidIncrementalPlanError, IncrementalScopeRegenerationRequiredError
 from agents.incremental_planning_agent import (
     ScopeOperationValidationContext,
     IncrementalPlanningAgent,
@@ -203,6 +207,7 @@ def test_validate_scope_update_decision_allows_create_when_llm_chooses_new_compo
                 cluster_refs=[ScopedClusterRef(scope_id="root", language="python", cluster_id=7)],
                 name="Document Utilities",
                 description="Shared document utilities.",
+                key_entities=[SourceCodeReference(qualified_name="docs.render")],
                 rationale="The structural diff introduces a distinct responsibility.",
             )
         ]
@@ -210,11 +215,35 @@ def test_validate_scope_update_decision_allows_create_when_llm_chooses_new_compo
     context = ScopeOperationValidationContext(
         expected_cluster_refs={ClusterRef(language="python", cluster_id=7)},
         existing_component_ids={"3"},
+        known_qnames={"docs.render"},
     )
 
     result = validate_scope_update_decision(decision, context)
 
     assert result.is_valid
+
+
+def test_validate_scope_update_decision_rejects_metadata_changes_on_noop() -> None:
+    decision = ScopeUpdateDecision(
+        operations=[
+            ScopeOperation(
+                action=ScopeOperationAction.NOOP,
+                cluster_refs=[ScopedClusterRef(scope_id="root", language="python", cluster_id=1)],
+                component_id="1",
+                description="This should be an update instead.",
+                rationale="No boundary change.",
+            )
+        ]
+    )
+    context = ScopeOperationValidationContext(
+        expected_cluster_refs={ClusterRef(language="python", cluster_id=1)},
+        existing_component_ids={"1"},
+    )
+
+    result = validate_scope_update_decision(decision, context)
+
+    assert not result.is_valid
+    assert "noop operations must preserve" in result.feedback_messages[0]
 
 
 def test_incremental_planning_agent_uses_narrow_diff_aware_toolkit() -> None:
@@ -306,6 +335,7 @@ def test_decide_scope_update_passes_structural_diff_to_validator() -> None:
     assert "Existing components in this scope" in prompt
     assert '1 "API" clusters=[2, 10, 1.3]' in prompt
     assert "api.new" in prompt
+    assert "Do not define component relations" in prompt
     assert context.expected_cluster_refs == {ClusterRef(language="python", cluster_id=1)}
     assert context.existing_component_ids == {"1"}
 
@@ -351,9 +381,9 @@ def test_decide_scope_update_tracks_invalid_decision_after_retries() -> None:
     agent._validation_invoke = MagicMock(return_value=invalid)
 
     with patch("agents.incremental_planning_agent.telemetry") as mock_telemetry:
-        result = agent.decide_scope_update("root", scope, structural)
+        with pytest.raises(InvalidIncrementalPlanError, match="Missing cluster_refs"):
+            agent.decide_scope_update("root", scope, structural)
 
-    assert result is invalid
     mock_telemetry.capture_exception.assert_called_once()
     exc = mock_telemetry.capture_exception.call_args.args[0]
     properties = mock_telemetry.capture_exception.call_args.kwargs["properties"]
@@ -363,3 +393,35 @@ def test_decide_scope_update_tracks_invalid_decision_after_retries() -> None:
     assert properties["issue_count"] == 1
     assert "Missing cluster_refs" in properties["issues"][0]
     mock_telemetry.flush.assert_called_once()
+
+
+def test_decide_scope_update_fails_when_scope_regeneration_is_required() -> None:
+    static_analysis = MagicMock(spec=StaticAnalysisResults)
+    static_analysis.get_languages.return_value = []
+    scope = AnalysisInsights(description="root", components=[], components_relations=[])
+    decision = ScopeUpdateDecision(
+        operations=[
+            ScopeOperation(
+                action=ScopeOperationAction.REGENERATE_SCOPE,
+                cluster_refs=[],
+                rationale="The component must move to another parent.",
+            )
+        ]
+    )
+
+    with (
+        patch("agents.agent.create_agent", return_value=MagicMock()),
+        patch("agents.incremental_planning_agent.create_agent", return_value=MagicMock()),
+    ):
+        agent = IncrementalPlanningAgent(
+            repo_dir=Path("/tmp/fake-repo"),
+            static_analysis=static_analysis,
+            project_name="Test",
+            meta_context=None,
+            agent_llm=MagicMock(),
+            parsing_llm=MagicMock(),
+        )
+    agent._validation_invoke = MagicMock(return_value=decision)
+
+    with pytest.raises(IncrementalScopeRegenerationRequiredError, match="Run a full analysis explicitly"):
+        agent.decide_scope_update("root", scope, StructuralClusterDiff())

--- a/tests/agents/test_incremental_planning_agent.py
+++ b/tests/agents/test_incremental_planning_agent.py
@@ -174,6 +174,27 @@ def test_validate_scope_update_decision_accepts_root_scope() -> None:
     assert result.is_valid
 
 
+def test_validate_scope_update_decision_normalizes_empty_root_scope() -> None:
+    decision = ScopeUpdateDecision(
+        operations=[
+            ScopeOperation(
+                action=ScopeOperationAction.UPDATE_COMPONENT,
+                cluster_refs=[ScopedClusterRef(scope_id="", language="python", cluster_id=1)],
+                component_id="1",
+                rationale="An empty LLM scope id still represents root.",
+            )
+        ]
+    )
+    context = ScopeOperationValidationContext(
+        expected_cluster_refs={ClusterRef(language="python", cluster_id=1)},
+        existing_component_ids={"1"},
+    )
+
+    result = validate_scope_update_decision(decision, context)
+
+    assert result.is_valid
+
+
 def test_validate_scope_update_decision_rejects_missing_duplicate_and_unknown_ids() -> None:
     decision = ScopeUpdateDecision(
         operations=[
@@ -468,6 +489,39 @@ def test_repair_scope_update_decision_clears_name_used_to_route_noop() -> None:
     assert decision.operations[0].name is None
 
 
+def test_repair_scope_update_decision_clears_noop_metadata_with_existing_id() -> None:
+    decision = ScopeUpdateDecision(
+        operations=[
+            ScopeOperation(
+                action=ScopeOperationAction.NOOP,
+                cluster_refs=[ScopedClusterRef(scope_id="root", language="python", cluster_id=1)],
+                component_id="1",
+                name="API Gateway",
+                description="This should be preserved from the existing component.",
+                key_entities=[SourceCodeReference(qualified_name="api.handle")],
+                rationale="The component boundary is unchanged.",
+            )
+        ]
+    )
+    repair_context = ScopeOperationRepairContext(
+        reference_resolver=_reference_resolver(),
+        allowed_key_entity_qnames=set(),
+    )
+    validation_context = ScopeOperationValidationContext(
+        expected_cluster_refs={ClusterRef(language="python", cluster_id=1)},
+        existing_component_ids={"1"},
+    )
+
+    repair_unambiguous_routing_and_optional_key_entity_metadata(decision, repair_context)
+    result = validate_scope_update_decision(decision, validation_context)
+
+    assert result.is_valid
+    assert decision.operations[0].component_id == "1"
+    assert decision.operations[0].name is None
+    assert decision.operations[0].description is None
+    assert decision.operations[0].key_entities == []
+
+
 def test_repair_scope_update_decision_drops_key_entities_outside_scope() -> None:
     scoped_qname = "nested.worker.run"
     decision = ScopeUpdateDecision(
@@ -591,6 +645,74 @@ def test_decide_scope_update_passes_structural_diff_to_validator() -> None:
     assert repair_context.allowed_key_entity_qnames == {"api.new"}
     assert validation_context.expected_cluster_refs == {ClusterRef(language="python", cluster_id=1)}
     assert validation_context.existing_component_ids == {"1"}
+
+
+def test_decide_scope_update_runs_repair_before_final_validation() -> None:
+    static_analysis = MagicMock(spec=StaticAnalysisResults)
+    scope = AnalysisInsights(
+        description="root",
+        components=[
+            Component(
+                name="API",
+                description="Handles requests",
+                key_entities=[],
+                component_id="1",
+                source_cluster_ids=["1"],
+            )
+        ],
+        components_relations=[],
+    )
+    structural = StructuralClusterDiff(
+        by_language={
+            "python": LanguageStructuralDiff(
+                language="python",
+                modified=[
+                    ClusterMemberDelta(
+                        old_cluster=ClusterRef(language="python", cluster_id=1),
+                        new_cluster=ClusterRef(language="python", cluster_id=1),
+                    )
+                ],
+            )
+        }
+    )
+    decision = ScopeUpdateDecision(
+        operations=[
+            ScopeOperation(
+                action=ScopeOperationAction.NOOP,
+                cluster_refs=[ScopedClusterRef(scope_id="root", language="python", cluster_id=1)],
+                component_id="1",
+                name="API",
+                description="Handles requests",
+                key_entities=[SourceCodeReference(qualified_name="api.handle")],
+                rationale="The component boundary is unchanged.",
+            )
+        ]
+    )
+
+    with (
+        patch("agents.agent.create_agent", return_value=MagicMock()),
+        patch("agents.incremental_planning_agent.create_agent", return_value=MagicMock()),
+    ):
+        agent = IncrementalPlanningAgent(
+            repo_dir=Path("/tmp/fake-repo"),
+            static_analysis=static_analysis,
+            project_name="Test",
+            meta_context=None,
+            agent_llm=MagicMock(),
+            parsing_llm=MagicMock(),
+        )
+    agent._parse_invoke = MagicMock(return_value=decision)
+
+    result = agent.decide_scope_update(
+        "root",
+        scope,
+        structural,
+        {"python": ClusterResult(clusters={1: {"api.handle"}})},
+    )
+
+    assert result.operations[0].name is None
+    assert result.operations[0].description is None
+    assert result.operations[0].key_entities == []
 
 
 def test_decide_scope_update_tracks_invalid_decision_after_retries() -> None:

--- a/tests/agents/test_incremental_planning_agent.py
+++ b/tests/agents/test_incremental_planning_agent.py
@@ -16,6 +16,7 @@ from diagram_analysis.exceptions import InvalidIncrementalPlanError, Incremental
 from agents.incremental_planning_agent import (
     ScopeOperationValidationContext,
     IncrementalPlanningAgent,
+    _component_ids_by_cluster_ref,
     format_structural_diff,
     validate_scope_update_decision,
 )
@@ -221,6 +222,136 @@ def test_validate_scope_update_decision_allows_create_when_llm_chooses_new_compo
     result = validate_scope_update_decision(decision, context)
 
     assert result.is_valid
+
+
+def test_validate_scope_update_decision_repairs_full_scope_planner_output() -> None:
+    components = [
+        Component(
+            name="Orchestration & Dispatcher",
+            description="Routes conversions.",
+            key_entities=[],
+            component_id="1",
+            source_cluster_ids=["1", "2", "5"],
+        )
+    ]
+    modified = [
+        ClusterMemberDelta(
+            old_cluster=ClusterRef(language="python", cluster_id=cluster_id),
+            new_cluster=ClusterRef(language="python", cluster_id=cluster_id),
+        )
+        for cluster_id in (1, 2, 5)
+    ]
+    structural = StructuralClusterDiff(
+        by_language={
+            "python": LanguageStructuralDiff(
+                language="python",
+                modified=modified,
+                new=[
+                    ClusterRef(language="python", cluster_id=31),
+                    ClusterRef(language="python", cluster_id=32),
+                    ClusterRef(language="python", cluster_id=33),
+                ],
+            )
+        }
+    )
+    update_refs = [1, 2, 5, 31, 32]
+    decision = ScopeUpdateDecision(
+        operations=[
+            ScopeOperation(
+                action=ScopeOperationAction.UPDATE_COMPONENT,
+                cluster_refs=[
+                    ScopedClusterRef(scope_id="root", language="python", cluster_id=cluster_id)
+                    for cluster_id in update_refs
+                ],
+                name="Orchestration & Dispatcher",
+                description="Routes conversions and result handling.",
+                component_id=None,
+                rationale="The responsibility expanded.",
+            ),
+            ScopeOperation(
+                action=ScopeOperationAction.CREATE_COMPONENT,
+                cluster_refs=[ScopedClusterRef(scope_id="root", language="python", cluster_id=33)],
+                name="OCR Extension",
+                description="Adds OCR converters.",
+                key_entities=[
+                    SourceCodeReference(
+                        qualified_name="packages.markitdown_ocr.src.markitdown_ocr._plugin.register_converters"
+                    ),
+                    SourceCodeReference(qualified_name="hallucinated.missing"),
+                ],
+                rationale="A new extension package was added.",
+            ),
+        ]
+    )
+    expected_refs = {ClusterRef(language="python", cluster_id=cluster_id) for cluster_id in (*update_refs, 33)}
+    canonical_qname = "packages.markitdown-ocr.src.markitdown_ocr._plugin.register_converters"
+    context = ScopeOperationValidationContext(
+        expected_cluster_refs=expected_refs,
+        existing_component_ids={"1"},
+        known_qnames={canonical_qname},
+        component_ids_by_cluster_ref=_component_ids_by_cluster_ref("root", components, structural),
+        component_ids_by_name={"orchestration & dispatcher": "1"},
+    )
+
+    result = validate_scope_update_decision(decision, context)
+
+    assert result.is_valid
+    assert decision.operations[0].component_id == "1"
+    assert [entity.qualified_name for entity in decision.operations[1].key_entities] == [canonical_qname]
+
+
+def test_validate_scope_update_decision_keeps_ownerless_update_invalid() -> None:
+    ref = ClusterRef(language="python", cluster_id=7)
+    decision = ScopeUpdateDecision(
+        operations=[
+            ScopeOperation(
+                action=ScopeOperationAction.UPDATE_COMPONENT,
+                cluster_refs=[ScopedClusterRef(scope_id="root", language="python", cluster_id=7)],
+                name="New Responsibility",
+                description="Owns a new cluster.",
+                component_id=None,
+                rationale="The parser emitted update without an existing target.",
+            )
+        ]
+    )
+    context = ScopeOperationValidationContext(expected_cluster_refs={ref}, existing_component_ids={"1"})
+
+    result = validate_scope_update_decision(decision, context)
+
+    assert not result.is_valid
+    assert decision.operations[0].action == ScopeOperationAction.UPDATE_COMPONENT
+    assert "component_id=None" in "\n".join(result.feedback_messages)
+
+
+def test_validate_scope_update_decision_keeps_ambiguous_missing_owner_invalid() -> None:
+    first = ClusterRef(language="python", cluster_id=1)
+    second = ClusterRef(language="python", cluster_id=2)
+    decision = ScopeUpdateDecision(
+        operations=[
+            ScopeOperation(
+                action=ScopeOperationAction.UPDATE_COMPONENT,
+                cluster_refs=[
+                    ScopedClusterRef(scope_id="root", language="python", cluster_id=1),
+                    ScopedClusterRef(scope_id="root", language="python", cluster_id=2),
+                ],
+                name="Merged Responsibility",
+                description="Would span two existing owners.",
+                component_id=None,
+                rationale="Ambiguous merge.",
+            )
+        ]
+    )
+    context = ScopeOperationValidationContext(
+        expected_cluster_refs={first, second},
+        existing_component_ids={"1", "2"},
+        component_ids_by_cluster_ref={first: "1", second: "2"},
+    )
+
+    result = validate_scope_update_decision(decision, context)
+
+    assert not result.is_valid
+    assert decision.operations[0].action == ScopeOperationAction.UPDATE_COMPONENT
+    assert "component_id=None" in "\n".join(result.feedback_messages)
 
 
 def test_validate_scope_update_decision_rejects_metadata_changes_on_noop() -> None:

--- a/tests/agents/test_incremental_planning_agent.py
+++ b/tests/agents/test_incremental_planning_agent.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+from pydantic import ValidationError
 
 from agents.agent_responses import (
     AnalysisInsights,
@@ -12,14 +13,17 @@ from agents.agent_responses import (
     ScopedClusterRef,
     ScopeUpdateDecision,
 )
-from diagram_analysis.exceptions import InvalidIncrementalPlanError, IncrementalScopeRegenerationRequiredError
+from diagram_analysis.exceptions import InvalidIncrementalPlanError
 from agents.incremental_planning_agent import (
-    ScopeOperationValidationContext,
     IncrementalPlanningAgent,
     _component_ids_by_cluster_ref,
     format_structural_diff,
-    validate_scope_update_decision,
 )
+from agents.repair import (
+    ScopeOperationRepairContext,
+    repair_unambiguous_routing_and_optional_key_entity_metadata,
+)
+from agents.validation import ScopeOperationValidationContext, validate_scope_update_decision
 from diagram_analysis.cluster_delta import (
     ClusterMemberDelta,
     ClusterRef,
@@ -30,6 +34,7 @@ from diagram_analysis.cluster_delta import (
 from repo_utils.change_detector import ChangeSet, FileChange
 from static_analyzer.analysis_result import StaticAnalysisResults
 from static_analyzer.constants import Language, NodeType
+from static_analyzer.graph import ClusterResult
 from static_analyzer.node import Node
 from static_analyzer.reference_resolver import StaticReferenceResolver
 
@@ -139,7 +144,6 @@ def test_validate_scope_update_decision_enforces_cluster_coverage_and_component_
         ]
     )
     context = ScopeOperationValidationContext(
-        reference_resolver=_reference_resolver(),
         expected_cluster_refs={ClusterRef(language="python", cluster_id=1)},
         existing_component_ids={"1"},
     )
@@ -161,7 +165,6 @@ def test_validate_scope_update_decision_accepts_root_scope() -> None:
         ]
     )
     context = ScopeOperationValidationContext(
-        reference_resolver=_reference_resolver(),
         expected_cluster_refs={ClusterRef(language="python", cluster_id=1)},
         existing_component_ids={"1"},
     )
@@ -186,7 +189,6 @@ def test_validate_scope_update_decision_rejects_missing_duplicate_and_unknown_id
         ]
     )
     context = ScopeOperationValidationContext(
-        reference_resolver=_reference_resolver(),
         expected_cluster_refs={
             ClusterRef(language="python", cluster_id=1),
             ClusterRef(language="python", cluster_id=2),
@@ -215,7 +217,6 @@ def test_validate_scope_update_decision_allows_update_for_new_cluster_when_llm_c
         ]
     )
     context = ScopeOperationValidationContext(
-        reference_resolver=_reference_resolver(),
         expected_cluster_refs={ClusterRef(language="python", cluster_id=5)},
         existing_component_ids={"1"},
     )
@@ -239,7 +240,6 @@ def test_validate_scope_update_decision_allows_create_when_llm_chooses_new_compo
         ]
     )
     context = ScopeOperationValidationContext(
-        reference_resolver=_reference_resolver("docs.render"),
         expected_cluster_refs={ClusterRef(language="python", cluster_id=7)},
         existing_component_ids={"3"},
     )
@@ -249,7 +249,7 @@ def test_validate_scope_update_decision_allows_create_when_llm_chooses_new_compo
     assert result.is_valid
 
 
-def test_validate_scope_update_decision_repairs_full_scope_planner_output() -> None:
+def test_repair_scope_update_decision_repairs_full_scope_planner_output() -> None:
     components = [
         Component(
             name="Orchestration & Dispatcher",
@@ -310,15 +310,19 @@ def test_validate_scope_update_decision_repairs_full_scope_planner_output() -> N
     )
     expected_refs = {ClusterRef(language="python", cluster_id=cluster_id) for cluster_id in (*update_refs, 33)}
     canonical_qname = "packages.markitdown-ocr.src.markitdown_ocr._plugin.register_converters"
-    context = ScopeOperationValidationContext(
+    repair_context = ScopeOperationRepairContext(
         reference_resolver=_reference_resolver(canonical_qname),
-        expected_cluster_refs=expected_refs,
-        existing_component_ids={"1"},
+        allowed_key_entity_qnames={canonical_qname},
         component_ids_by_cluster_ref=_component_ids_by_cluster_ref("root", components, structural),
         component_ids_by_name={"orchestration & dispatcher": "1"},
     )
+    validation_context = ScopeOperationValidationContext(
+        expected_cluster_refs=expected_refs,
+        existing_component_ids={"1"},
+    )
 
-    result = validate_scope_update_decision(decision, context)
+    repair_unambiguous_routing_and_optional_key_entity_metadata(decision, repair_context)
+    result = validate_scope_update_decision(decision, validation_context)
 
     assert result.is_valid
     assert decision.operations[0].component_id == "1"
@@ -340,7 +344,6 @@ def test_validate_scope_update_decision_keeps_ownerless_update_invalid() -> None
         ]
     )
     context = ScopeOperationValidationContext(
-        reference_resolver=_reference_resolver(),
         expected_cluster_refs={ref},
         existing_component_ids={"1"},
     )
@@ -352,7 +355,7 @@ def test_validate_scope_update_decision_keeps_ownerless_update_invalid() -> None
     assert "component_id=None" in "\n".join(result.feedback_messages)
 
 
-def test_validate_scope_update_decision_repairs_missing_component_id_from_unique_name() -> None:
+def test_repair_scope_update_decision_routes_missing_component_id_from_unique_name() -> None:
     ref = ClusterRef(language="python", cluster_id=7)
     decision = ScopeUpdateDecision(
         operations=[
@@ -365,14 +368,15 @@ def test_validate_scope_update_decision_repairs_missing_component_id_from_unique
             )
         ]
     )
-    context = ScopeOperationValidationContext(
+    repair_context = ScopeOperationRepairContext(
         reference_resolver=_reference_resolver(),
-        expected_cluster_refs={ref},
-        existing_component_ids={"1"},
+        allowed_key_entity_qnames=set(),
         component_ids_by_name={"api gateway": "1"},
     )
+    validation_context = ScopeOperationValidationContext(expected_cluster_refs={ref}, existing_component_ids={"1"})
 
-    result = validate_scope_update_decision(decision, context)
+    repair_unambiguous_routing_and_optional_key_entity_metadata(decision, repair_context)
+    result = validate_scope_update_decision(decision, validation_context)
 
     assert result.is_valid
     assert decision.operations[0].component_id == "1"
@@ -396,14 +400,18 @@ def test_validate_scope_update_decision_keeps_ambiguous_missing_owner_invalid() 
             )
         ]
     )
-    context = ScopeOperationValidationContext(
+    repair_context = ScopeOperationRepairContext(
         reference_resolver=_reference_resolver(),
-        expected_cluster_refs={first, second},
-        existing_component_ids={"1", "2"},
+        allowed_key_entity_qnames=set(),
         component_ids_by_cluster_ref={first: "1", second: "2"},
     )
+    validation_context = ScopeOperationValidationContext(
+        expected_cluster_refs={first, second},
+        existing_component_ids={"1", "2"},
+    )
 
-    result = validate_scope_update_decision(decision, context)
+    repair_unambiguous_routing_and_optional_key_entity_metadata(decision, repair_context)
+    result = validate_scope_update_decision(decision, validation_context)
 
     assert not result.is_valid
     assert decision.operations[0].action == ScopeOperationAction.UPDATE_COMPONENT
@@ -423,7 +431,6 @@ def test_validate_scope_update_decision_rejects_metadata_changes_on_noop() -> No
         ]
     )
     context = ScopeOperationValidationContext(
-        reference_resolver=_reference_resolver(),
         expected_cluster_refs={ClusterRef(language="python", cluster_id=1)},
         existing_component_ids={"1"},
     )
@@ -432,6 +439,60 @@ def test_validate_scope_update_decision_rejects_metadata_changes_on_noop() -> No
 
     assert not result.is_valid
     assert "noop operations must preserve" in result.feedback_messages[0]
+
+
+def test_repair_scope_update_decision_clears_name_used_to_route_noop() -> None:
+    ref = ClusterRef(language="python", cluster_id=1)
+    decision = ScopeUpdateDecision(
+        operations=[
+            ScopeOperation(
+                action=ScopeOperationAction.NOOP,
+                cluster_refs=[ScopedClusterRef(scope_id="root", language="python", cluster_id=1)],
+                name="API Gateway",
+                rationale="The component boundary is unchanged.",
+            )
+        ]
+    )
+    repair_context = ScopeOperationRepairContext(
+        reference_resolver=_reference_resolver(),
+        allowed_key_entity_qnames=set(),
+        component_ids_by_name={"api gateway": "1"},
+    )
+    validation_context = ScopeOperationValidationContext(expected_cluster_refs={ref}, existing_component_ids={"1"})
+
+    repair_unambiguous_routing_and_optional_key_entity_metadata(decision, repair_context)
+    result = validate_scope_update_decision(decision, validation_context)
+
+    assert result.is_valid
+    assert decision.operations[0].component_id == "1"
+    assert decision.operations[0].name is None
+
+
+def test_repair_scope_update_decision_drops_key_entities_outside_scope() -> None:
+    scoped_qname = "nested.worker.run"
+    decision = ScopeUpdateDecision(
+        operations=[
+            ScopeOperation(
+                action=ScopeOperationAction.CREATE_COMPONENT,
+                cluster_refs=[ScopedClusterRef(scope_id="1", language="python", cluster_id=2)],
+                name="Worker",
+                description="Runs nested jobs.",
+                key_entities=[
+                    SourceCodeReference(qualified_name=scoped_qname),
+                    SourceCodeReference(qualified_name="sibling.service.run"),
+                ],
+                rationale="A new nested responsibility was added.",
+            )
+        ]
+    )
+    repair_context = ScopeOperationRepairContext(
+        reference_resolver=_reference_resolver(scoped_qname, "sibling.service.run"),
+        allowed_key_entity_qnames={scoped_qname},
+    )
+
+    repair_unambiguous_routing_and_optional_key_entity_metadata(decision, repair_context)
+
+    assert [entity.qualified_name for entity in decision.operations[0].key_entities] == [scoped_qname]
 
 
 def test_incremental_planning_agent_uses_narrow_diff_aware_toolkit() -> None:
@@ -513,19 +574,23 @@ def test_decide_scope_update_passes_structural_diff_to_validator() -> None:
             agent_llm=MagicMock(),
             parsing_llm=MagicMock(),
         )
-    agent._validation_invoke = MagicMock(return_value=expected)
+    agent._invoke_repair_validate = MagicMock(return_value=expected)
 
-    result = agent.decide_scope_update("root", scope, structural)
+    cluster_results = {"python": ClusterResult(clusters={1: {"api.new"}})}
+    result = agent.decide_scope_update("root", scope, structural, cluster_results)
 
     assert result is expected
-    prompt = agent._validation_invoke.call_args.args[0]
-    context = agent._validation_invoke.call_args.kwargs["context"]
+    prompt = agent._invoke_repair_validate.call_args.args[0]
+    repair_context = agent._invoke_repair_validate.call_args.kwargs["repair_context"]
+    validation_context = agent._invoke_repair_validate.call_args.kwargs["validation_context"]
     assert "Existing components in this scope" in prompt
     assert '1 "API" clusters=[2, 10, 1.3]' in prompt
     assert "api.new" in prompt
     assert "Do not define component relations" in prompt
-    assert context.expected_cluster_refs == {ClusterRef(language="python", cluster_id=1)}
-    assert context.existing_component_ids == {"1"}
+    assert repair_context.component_ids_by_name == {"api": "1"}
+    assert repair_context.allowed_key_entity_qnames == {"api.new"}
+    assert validation_context.expected_cluster_refs == {ClusterRef(language="python", cluster_id=1)}
+    assert validation_context.existing_component_ids == {"1"}
 
 
 def test_decide_scope_update_tracks_invalid_decision_after_retries() -> None:
@@ -566,11 +631,11 @@ def test_decide_scope_update_tracks_invalid_decision_after_retries() -> None:
             agent_llm=MagicMock(),
             parsing_llm=MagicMock(),
         )
-    agent._validation_invoke = MagicMock(return_value=invalid)
+    agent._invoke_repair_validate = MagicMock(return_value=invalid)
 
     with patch("agents.incremental_planning_agent.telemetry") as mock_telemetry:
         with pytest.raises(InvalidIncrementalPlanError, match="Missing cluster_refs"):
-            agent.decide_scope_update("root", scope, structural)
+            agent.decide_scope_update("root", scope, structural, {})
 
     mock_telemetry.capture_exception.assert_called_once()
     exc = mock_telemetry.capture_exception.call_args.args[0]
@@ -583,33 +648,12 @@ def test_decide_scope_update_tracks_invalid_decision_after_retries() -> None:
     mock_telemetry.flush.assert_called_once()
 
 
-def test_decide_scope_update_fails_when_scope_regeneration_is_required() -> None:
-    static_analysis = MagicMock(spec=StaticAnalysisResults)
-    static_analysis.get_languages.return_value = []
-    scope = AnalysisInsights(description="root", components=[], components_relations=[])
-    decision = ScopeUpdateDecision(
-        operations=[
-            ScopeOperation(
-                action=ScopeOperationAction.REGENERATE_SCOPE,
-                cluster_refs=[],
-                rationale="The component must move to another parent.",
-            )
-        ]
-    )
-
-    with (
-        patch("agents.agent.create_agent", return_value=MagicMock()),
-        patch("agents.incremental_planning_agent.create_agent", return_value=MagicMock()),
-    ):
-        agent = IncrementalPlanningAgent(
-            repo_dir=Path("/tmp/fake-repo"),
-            static_analysis=static_analysis,
-            project_name="Test",
-            meta_context=None,
-            agent_llm=MagicMock(),
-            parsing_llm=MagicMock(),
+def test_scope_operation_rejects_regenerate_scope() -> None:
+    with pytest.raises(ValidationError):
+        ScopeOperation.model_validate(
+            {
+                "action": "regenerate_scope",
+                "cluster_refs": [],
+                "rationale": "Reparenting is not a valid incremental operation.",
+            }
         )
-    agent._validation_invoke = MagicMock(return_value=decision)
-
-    with pytest.raises(IncrementalScopeRegenerationRequiredError, match="Run a full analysis explicitly"):
-        agent.decide_scope_update("root", scope, StructuralClusterDiff())

--- a/tests/agents/test_incremental_planning_agent.py
+++ b/tests/agents/test_incremental_planning_agent.py
@@ -29,6 +29,27 @@ from diagram_analysis.cluster_delta import (
 )
 from repo_utils.change_detector import ChangeSet, FileChange
 from static_analyzer.analysis_result import StaticAnalysisResults
+from static_analyzer.constants import Language, NodeType
+from static_analyzer.node import Node
+from static_analyzer.reference_resolver import StaticReferenceResolver
+
+
+def _reference_resolver(*qnames: str) -> StaticReferenceResolver:
+    static_analysis = StaticAnalysisResults()
+    static_analysis.add_references(
+        Language.PYTHON,
+        [
+            Node(
+                fully_qualified_name=qname,
+                node_type=NodeType.FUNCTION,
+                file_path=f"/tmp/fake-repo/reference-{index}.py",
+                line_start=1,
+                line_end=2,
+            )
+            for index, qname in enumerate(qnames)
+        ],
+    )
+    return StaticReferenceResolver(Path("/tmp/fake-repo"), static_analysis)
 
 
 def test_format_structural_diff_includes_modified_new_and_dirty_files() -> None:
@@ -118,6 +139,7 @@ def test_validate_scope_update_decision_enforces_cluster_coverage_and_component_
         ]
     )
     context = ScopeOperationValidationContext(
+        reference_resolver=_reference_resolver(),
         expected_cluster_refs={ClusterRef(language="python", cluster_id=1)},
         existing_component_ids={"1"},
     )
@@ -139,6 +161,7 @@ def test_validate_scope_update_decision_accepts_root_scope() -> None:
         ]
     )
     context = ScopeOperationValidationContext(
+        reference_resolver=_reference_resolver(),
         expected_cluster_refs={ClusterRef(language="python", cluster_id=1)},
         existing_component_ids={"1"},
     )
@@ -163,6 +186,7 @@ def test_validate_scope_update_decision_rejects_missing_duplicate_and_unknown_id
         ]
     )
     context = ScopeOperationValidationContext(
+        reference_resolver=_reference_resolver(),
         expected_cluster_refs={
             ClusterRef(language="python", cluster_id=1),
             ClusterRef(language="python", cluster_id=2),
@@ -191,6 +215,7 @@ def test_validate_scope_update_decision_allows_update_for_new_cluster_when_llm_c
         ]
     )
     context = ScopeOperationValidationContext(
+        reference_resolver=_reference_resolver(),
         expected_cluster_refs={ClusterRef(language="python", cluster_id=5)},
         existing_component_ids={"1"},
     )
@@ -214,9 +239,9 @@ def test_validate_scope_update_decision_allows_create_when_llm_chooses_new_compo
         ]
     )
     context = ScopeOperationValidationContext(
+        reference_resolver=_reference_resolver("docs.render"),
         expected_cluster_refs={ClusterRef(language="python", cluster_id=7)},
         existing_component_ids={"3"},
-        known_qnames={"docs.render"},
     )
 
     result = validate_scope_update_decision(decision, context)
@@ -286,9 +311,9 @@ def test_validate_scope_update_decision_repairs_full_scope_planner_output() -> N
     expected_refs = {ClusterRef(language="python", cluster_id=cluster_id) for cluster_id in (*update_refs, 33)}
     canonical_qname = "packages.markitdown-ocr.src.markitdown_ocr._plugin.register_converters"
     context = ScopeOperationValidationContext(
+        reference_resolver=_reference_resolver(canonical_qname),
         expected_cluster_refs=expected_refs,
         existing_component_ids={"1"},
-        known_qnames={canonical_qname},
         component_ids_by_cluster_ref=_component_ids_by_cluster_ref("root", components, structural),
         component_ids_by_name={"orchestration & dispatcher": "1"},
     )
@@ -314,13 +339,43 @@ def test_validate_scope_update_decision_keeps_ownerless_update_invalid() -> None
             )
         ]
     )
-    context = ScopeOperationValidationContext(expected_cluster_refs={ref}, existing_component_ids={"1"})
+    context = ScopeOperationValidationContext(
+        reference_resolver=_reference_resolver(),
+        expected_cluster_refs={ref},
+        existing_component_ids={"1"},
+    )
 
     result = validate_scope_update_decision(decision, context)
 
     assert not result.is_valid
     assert decision.operations[0].action == ScopeOperationAction.UPDATE_COMPONENT
     assert "component_id=None" in "\n".join(result.feedback_messages)
+
+
+def test_validate_scope_update_decision_repairs_missing_component_id_from_unique_name() -> None:
+    ref = ClusterRef(language="python", cluster_id=7)
+    decision = ScopeUpdateDecision(
+        operations=[
+            ScopeOperation(
+                action=ScopeOperationAction.UPDATE_COMPONENT,
+                cluster_refs=[ScopedClusterRef(scope_id="root", language="python", cluster_id=7)],
+                name="  API   Gateway ",
+                component_id=None,
+                rationale="The new cluster belongs to the existing API gateway.",
+            )
+        ]
+    )
+    context = ScopeOperationValidationContext(
+        reference_resolver=_reference_resolver(),
+        expected_cluster_refs={ref},
+        existing_component_ids={"1"},
+        component_ids_by_name={"api gateway": "1"},
+    )
+
+    result = validate_scope_update_decision(decision, context)
+
+    assert result.is_valid
+    assert decision.operations[0].component_id == "1"
 
 
 def test_validate_scope_update_decision_keeps_ambiguous_missing_owner_invalid() -> None:
@@ -342,6 +397,7 @@ def test_validate_scope_update_decision_keeps_ambiguous_missing_owner_invalid() 
         ]
     )
     context = ScopeOperationValidationContext(
+        reference_resolver=_reference_resolver(),
         expected_cluster_refs={first, second},
         existing_component_ids={"1", "2"},
         component_ids_by_cluster_ref={first: "1", second: "2"},
@@ -367,6 +423,7 @@ def test_validate_scope_update_decision_rejects_metadata_changes_on_noop() -> No
         ]
     )
     context = ScopeOperationValidationContext(
+        reference_resolver=_reference_resolver(),
         expected_cluster_refs={ClusterRef(language="python", cluster_id=1)},
         existing_component_ids={"1"},
     )

--- a/tests/agents/test_relation_edges.py
+++ b/tests/agents/test_relation_edges.py
@@ -1,0 +1,101 @@
+from pathlib import Path
+
+from agents.agent_responses import AnalysisInsights, Relation, RelationEdge, SourceCodeReference
+from agents.file_index_models import FileEntry, MethodEntry
+from agents.relation_edges import index_relation_endpoints
+from static_analyzer.constants import NodeType
+
+
+def test_index_relation_endpoints_keeps_analyzed_kind_and_merges_endpoint_spans() -> None:
+    analyzed = MethodEntry(
+        qualified_name="pkg.source",
+        start_line=2,
+        end_line=6,
+        node_type=NodeType.FUNCTION.name,
+        content_hash="source123",
+    )
+    target = MethodEntry(
+        qualified_name="pkg.target",
+        start_line=0,
+        end_line=0,
+        node_type=NodeType.CLASS.name,
+    )
+    target_start = SourceCodeReference(
+        qualified_name="pkg.target",
+        reference_file="target.py",
+        reference_start_line=12,
+    )
+    target_end = SourceCodeReference(
+        qualified_name="pkg.target",
+        reference_file="target.py",
+        reference_end_line=18,
+    )
+    analysis = AnalysisInsights(
+        description="",
+        components=[],
+        components_relations=[
+            Relation(
+                relation="calls",
+                src_name="Source",
+                dst_name="Target",
+                key_edges=[
+                    RelationEdge(
+                        source=SourceCodeReference(
+                            qualified_name="pkg.source",
+                            reference_file="source.py",
+                            reference_start_line=1,
+                            reference_end_line=20,
+                        ),
+                        target=target_start,
+                    )
+                ],
+                all_edges=[
+                    RelationEdge(
+                        source=SourceCodeReference(qualified_name="pkg.source", reference_file="source.py"),
+                        target=target_end,
+                    )
+                ],
+            )
+        ],
+        files={
+            "source.py": FileEntry(methods=[analyzed]),
+            "target.py": FileEntry(methods=[target]),
+        },
+    )
+
+    index_relation_endpoints(analysis, Path("/repo"))
+
+    indexed_source = analysis.files["source.py"].methods[0]
+    indexed_target = analysis.files["target.py"].methods[0]
+    assert indexed_source.node_type == NodeType.FUNCTION.name
+    assert (indexed_source.start_line, indexed_source.end_line) == (2, 6)
+    assert indexed_source.content_hash == "source123"
+    assert indexed_target.node_type == NodeType.CLASS.name
+    assert (indexed_target.start_line, indexed_target.end_line) == (12, 18)
+
+
+def test_index_relation_endpoints_does_not_invent_unknown_method_kinds() -> None:
+    analysis = AnalysisInsights(
+        description="",
+        components=[],
+        components_relations=[
+            Relation(
+                relation="calls",
+                src_name="Source",
+                dst_name="Target",
+                key_edges=[
+                    RelationEdge(
+                        source=SourceCodeReference(
+                            qualified_name="pkg.unknown",
+                            reference_file="unknown.py",
+                        ),
+                        target=SourceCodeReference(qualified_name="external.call"),
+                    )
+                ],
+            )
+        ],
+    )
+
+    index_relation_endpoints(analysis, Path("/repo"))
+
+    assert analysis.files == {}

--- a/tests/agents/test_repair.py
+++ b/tests/agents/test_repair.py
@@ -1,0 +1,106 @@
+from pathlib import Path
+
+from agents.agent_responses import (
+    ClusterAnalysis,
+    ClustersComponent,
+    Component,
+    ComponentArchitecture,
+    SourceCodeReference,
+)
+from agents.repair import ComponentRepairContext, repair_component_group_names, repair_key_entities
+from agents.validation import ValidationContext, validate_group_name_coverage, validate_key_entities
+from static_analyzer.analysis_result import StaticAnalysisResults
+from static_analyzer.constants import Language, NodeType
+from static_analyzer.graph import ClusterResult
+from static_analyzer.node import Node
+from static_analyzer.reference_resolver import StaticReferenceResolver
+
+
+def _component_repair_context() -> ComponentRepairContext:
+    static_analysis = StaticAnalysisResults()
+    static_analysis.add_references(
+        Language.PYTHON,
+        [
+            Node(
+                fully_qualified_name="pkg.service.run",
+                node_type=NodeType.FUNCTION,
+                file_path="/tmp/fake-repo/pkg/service.py",
+                line_start=1,
+                line_end=2,
+            ),
+            Node(
+                fully_qualified_name="other.service.run",
+                node_type=NodeType.FUNCTION,
+                file_path="/tmp/fake-repo/other/service.py",
+                line_start=1,
+                line_end=2,
+            ),
+        ],
+    )
+    cluster_results = {
+        "python": ClusterResult(
+            clusters={1: {"pkg.service.run"}},
+            file_to_clusters={},
+            cluster_to_files={},
+            strategy="test",
+        )
+    }
+    cluster_analysis = ClusterAnalysis(
+        cluster_components=[ClustersComponent(name="API Handler", cluster_ids=[1], description="Handles requests.")]
+    )
+    return ComponentRepairContext(
+        reference_resolver=StaticReferenceResolver(Path("/tmp/fake-repo"), static_analysis),
+        cluster_results=cluster_results,
+        llm_cluster_analysis=cluster_analysis,
+    )
+
+
+def test_component_repairs_canonicalize_names_and_keep_only_resolved_in_scope_entities() -> None:
+    architecture = ComponentArchitecture(
+        description="Test architecture.",
+        components=[
+            Component(
+                name="API",
+                description="Handles requests.",
+                source_group_names=["API Handlr"],
+                key_entities=[
+                    SourceCodeReference(qualified_name="pkg/service.run"),
+                    SourceCodeReference(qualified_name="other.service.run"),
+                    SourceCodeReference(qualified_name="missing.service.run"),
+                ],
+            )
+        ],
+    )
+    context = _component_repair_context()
+
+    repair_component_group_names(architecture, context)
+    repair_key_entities(architecture, context)
+
+    assert architecture.components[0].source_group_names == ["API Handler"]
+    assert [entity.qualified_name for entity in architecture.components[0].key_entities] == ["pkg.service.run"]
+
+
+def test_component_validators_do_not_mutate_repairable_metadata() -> None:
+    architecture = ComponentArchitecture(
+        description="Test architecture.",
+        components=[
+            Component(
+                name="API",
+                description="Handles requests.",
+                source_group_names=["API Handlr"],
+                key_entities=[SourceCodeReference(qualified_name="pkg/service.run")],
+            )
+        ],
+    )
+    repair_context = _component_repair_context()
+    validation_context = ValidationContext(
+        cluster_results=repair_context.cluster_results,
+        static_analysis=repair_context.reference_resolver.static_analysis,
+        llm_cluster_analysis=repair_context.llm_cluster_analysis,
+    )
+    before = architecture.model_dump()
+
+    validate_group_name_coverage(architecture, validation_context)
+    validate_key_entities(architecture, validation_context)
+
+    assert architecture.model_dump() == before

--- a/tests/diagram_analysis/test_content_hash.py
+++ b/tests/diagram_analysis/test_content_hash.py
@@ -1,15 +1,13 @@
 import hashlib
 from pathlib import Path
+from unittest.mock import MagicMock
 
 from agents.agent_responses import (
     AnalysisInsights,
     Component,
 )
 from agents.file_index_models import FileEntry, FileMethodGroup, MethodEntry
-from agents.cluster_methods_mixin import ClusterMethodsMixin
 from agents.content_hash import (
-    MethodRef,
-    MethodSpan,
     compute_source_tree_hash,
     hash_method_body,
     hash_repo_source_files,
@@ -24,6 +22,11 @@ from diagram_analysis.analysis_json import (
     _build_methods_index_from_files,
     _reconstruct_files_index,
 )
+from diagram_analysis.file_index import build_files_index, refresh_method_spans_from_cfg
+from static_analyzer.analysis_result import StaticAnalysisResults
+from static_analyzer.constants import NodeType
+from static_analyzer.graph import CallGraph
+from static_analyzer.node import Node
 
 
 def test_method_entry_content_hash_defaults_empty():
@@ -179,18 +182,6 @@ def test_source_tree_hash_reproducible_from_fingerprint_map(tmp_path: Path):
     assert tree_hash_from_file_hashes(fps) == compute_source_tree_hash(tmp_path)
 
 
-class _StubMixin(ClusterMethodsMixin):
-    """Minimal host for ``build_files_index`` / ``refresh_method_spans_from_cfg``
-    — it only reads ``repo_dir`` and the live-CFG spans."""
-
-    def __init__(self, repo_dir: Path, cfg_spans: dict):
-        self.repo_dir = repo_dir
-        self._spans = cfg_spans
-
-    def _cfg_method_spans(self):
-        return self._spans
-
-
 def _analysis_with_method(file_path: str, qname: str, start: int, end: int) -> AnalysisInsights:
     return AnalysisInsights(
         description="",
@@ -214,11 +205,19 @@ def _analysis_with_method(file_path: str, qname: str, start: int, end: int) -> A
     )
 
 
+def _static_analysis_with_nodes(*nodes: Node) -> StaticAnalysisResults:
+    cfg = CallGraph(nodes={node.fully_qualified_name: node for node in nodes})
+    static_analysis = MagicMock(spec=StaticAnalysisResults)
+    static_analysis.get_languages.return_value = ["python"]
+    static_analysis.get_cfg.return_value = cfg
+    return static_analysis
+
+
 def test_build_files_index_hashes_carried_span(tmp_path: Path):
     # build_files_index hashes each method at the span it carries — no CFG lookup.
     (tmp_path / "m.py").write_text("def foo():\n    return 1\n", encoding="utf-8")
     analysis = _analysis_with_method("m.py", "foo", start=1, end=2)
-    files = _StubMixin(tmp_path, cfg_spans={}).build_files_index(analysis)
+    files = build_files_index(analysis, tmp_path)
     method = files["m.py"].methods[0]
     assert method.content_hash == hash_method_body(["def foo():", "    return 1"], 1, 2)
     assert method.content_hash != ""
@@ -230,10 +229,9 @@ def test_refresh_spans_then_index_reflects_live_cfg_span(tmp_path: Path):
     # not the stale carried-forward line numbers.
     (tmp_path / "m.py").write_text("# added line\ndef foo():\n    return 1\n", encoding="utf-8")
     analysis = _analysis_with_method("m.py", "foo", start=1, end=2)  # stale carried-forward span
-    live = {MethodRef("m.py", "foo"): MethodSpan(2, 3)}  # live CFG span of foo() now
-    mixin = _StubMixin(tmp_path, live)
-    mixin.refresh_method_spans_from_cfg(analysis)
-    files = mixin.build_files_index(analysis)
+    static_analysis = _static_analysis_with_nodes(Node("foo", NodeType.FUNCTION, "m.py", 2, 3))
+    refresh_method_spans_from_cfg(analysis, static_analysis, tmp_path)
+    files = build_files_index(analysis, tmp_path)
     method = files["m.py"].methods[0]
     assert method.content_hash == hash_method_body(["# added line", "def foo():", "    return 1"], 2, 3)
     assert method.content_hash != ""
@@ -245,9 +243,8 @@ def test_refresh_spans_empty_hash_when_method_absent_from_live_cfg(tmp_path: Pat
     # to the ''-unavailable sentinel rather than a stable-but-wrong value.
     (tmp_path / "m.py").write_text("def something_else():\n    return 42\n", encoding="utf-8")
     analysis = _analysis_with_method("m.py", "foo", start=1, end=2)
-    mixin = _StubMixin(tmp_path, cfg_spans={})
-    mixin.refresh_method_spans_from_cfg(analysis)
-    files = mixin.build_files_index(analysis)
+    refresh_method_spans_from_cfg(analysis, _static_analysis_with_nodes(), tmp_path)
+    files = build_files_index(analysis, tmp_path)
     method = files["m.py"].methods[0]
     assert method.content_hash == ""
 

--- a/tests/diagram_analysis/test_content_hash.py
+++ b/tests/diagram_analysis/test_content_hash.py
@@ -1,12 +1,7 @@
 import hashlib
 from pathlib import Path
-from unittest.mock import MagicMock
 
-from agents.agent_responses import (
-    AnalysisInsights,
-    Component,
-)
-from agents.file_index_models import FileEntry, FileMethodGroup, MethodEntry
+from agents.file_index_models import FileEntry, MethodEntry
 from agents.content_hash import (
     compute_source_tree_hash,
     hash_method_body,
@@ -22,11 +17,6 @@ from diagram_analysis.analysis_json import (
     _build_methods_index_from_files,
     _reconstruct_files_index,
 )
-from diagram_analysis.file_index import build_files_index, refresh_method_spans_from_cfg
-from static_analyzer.analysis_result import StaticAnalysisResults
-from static_analyzer.constants import NodeType
-from static_analyzer.graph import CallGraph
-from static_analyzer.node import Node
 
 
 def test_method_entry_content_hash_defaults_empty():
@@ -180,73 +170,6 @@ def test_source_tree_hash_reproducible_from_fingerprint_map(tmp_path: Path):
     (tmp_path / "docs.md").write_text("hello\n", encoding="utf-8")
     fps = hash_repo_source_files(tmp_path)
     assert tree_hash_from_file_hashes(fps) == compute_source_tree_hash(tmp_path)
-
-
-def _analysis_with_method(file_path: str, qname: str, start: int, end: int) -> AnalysisInsights:
-    return AnalysisInsights(
-        description="",
-        components=[
-            Component(
-                name="C",
-                description="d",
-                key_entities=[],
-                component_id="c1",
-                file_methods=[
-                    FileMethodGroup(
-                        file_path=file_path,
-                        methods=[
-                            MethodEntry(qualified_name=qname, start_line=start, end_line=end, node_type="FUNCTION")
-                        ],
-                    )
-                ],
-            )
-        ],
-        components_relations=[],
-    )
-
-
-def _static_analysis_with_nodes(*nodes: Node) -> StaticAnalysisResults:
-    cfg = CallGraph(nodes={node.fully_qualified_name: node for node in nodes})
-    static_analysis = MagicMock(spec=StaticAnalysisResults)
-    static_analysis.get_languages.return_value = ["python"]
-    static_analysis.get_cfg.return_value = cfg
-    return static_analysis
-
-
-def test_build_files_index_hashes_carried_span(tmp_path: Path):
-    # build_files_index hashes each method at the span it carries — no CFG lookup.
-    (tmp_path / "m.py").write_text("def foo():\n    return 1\n", encoding="utf-8")
-    analysis = _analysis_with_method("m.py", "foo", start=1, end=2)
-    files = build_files_index(analysis, tmp_path)
-    method = files["m.py"].methods[0]
-    assert method.content_hash == hash_method_body(["def foo():", "    return 1"], 1, 2)
-    assert method.content_hash != ""
-
-
-def test_refresh_spans_then_index_reflects_live_cfg_span(tmp_path: Path):
-    # The method moved down (edit above it). refresh_method_spans_from_cfg pulls
-    # the real span from the live CFG so build_files_index hashes the CURRENT body,
-    # not the stale carried-forward line numbers.
-    (tmp_path / "m.py").write_text("# added line\ndef foo():\n    return 1\n", encoding="utf-8")
-    analysis = _analysis_with_method("m.py", "foo", start=1, end=2)  # stale carried-forward span
-    static_analysis = _static_analysis_with_nodes(Node("foo", NodeType.FUNCTION, "m.py", 2, 3))
-    refresh_method_spans_from_cfg(analysis, static_analysis, tmp_path)
-    files = build_files_index(analysis, tmp_path)
-    method = files["m.py"].methods[0]
-    assert method.content_hash == hash_method_body(["# added line", "def foo():", "    return 1"], 2, 3)
-    assert method.content_hash != ""
-
-
-def test_refresh_spans_empty_hash_when_method_absent_from_live_cfg(tmp_path: Path):
-    # The carried-forward method is NOT in the live CFG (deleted/renamed in source).
-    # refresh_method_spans_from_cfg zeroes its span, so build_files_index hashes it
-    # to the ''-unavailable sentinel rather than a stable-but-wrong value.
-    (tmp_path / "m.py").write_text("def something_else():\n    return 42\n", encoding="utf-8")
-    analysis = _analysis_with_method("m.py", "foo", start=1, end=2)
-    refresh_method_spans_from_cfg(analysis, _static_analysis_with_nodes(), tmp_path)
-    files = build_files_index(analysis, tmp_path)
-    method = files["m.py"].methods[0]
-    assert method.content_hash == ""
 
 
 def test_invalid_utf8_bytes_do_not_collide(tmp_path: Path):

--- a/tests/diagram_analysis/test_diagram_analysis.py
+++ b/tests/diagram_analysis/test_diagram_analysis.py
@@ -473,7 +473,7 @@ class TestAnalysisJsonConversion(unittest.TestCase):
             [site.model_dump() for site in edge.call_sites], [{"line": 14, "column": 6}, {"line": 16, "column": 10}]
         )
 
-    def test_unified_analysis_parse_skips_edges_missing_from_methods_index(self):
+    def test_unified_analysis_parse_recovers_edges_missing_from_methods_index(self):
         data = json.loads(
             build_unified_analysis_json(self.analysis, [], "repo", repo_dir=self.repo_dir, source_tree_hash="")
         )
@@ -499,7 +499,45 @@ class TestAnalysisJsonConversion(unittest.TestCase):
         parsed, _ = parse_unified_analysis(data)
 
         self.assertEqual(len(parsed.components_relations), 1)
-        self.assertEqual(parsed.components_relations[0].key_edges, [])
+        edge = parsed.components_relations[0].key_edges[0]
+        self.assertEqual(edge.source.qualified_name, "missing.call")
+        self.assertEqual(edge.source.reference_file, "missing.py")
+        self.assertEqual(edge.target.qualified_name, "component2.load")
+        self.assertEqual(edge.target.reference_file, "component2.py")
+
+    def test_unified_analysis_indexes_relation_endpoints_outside_files(self):
+        self.analysis.components_relations = [
+            Relation(
+                relation="registers",
+                src_name="Component1",
+                dst_name="Component2",
+                src_id="1",
+                dst_id="2",
+                key_edges=[
+                    RelationEdge(
+                        source=SourceCodeReference(qualified_name="importlib.metadata.entry_points"),
+                        target=SourceCodeReference(
+                            qualified_name="plugin.register",
+                            reference_file="plugin.py",
+                            reference_start_line=12,
+                            reference_end_line=18,
+                        ),
+                    )
+                ],
+            )
+        ]
+
+        data = json.loads(
+            build_unified_analysis_json(self.analysis, [], "repo", repo_dir=self.repo_dir, source_tree_hash="")
+        )
+
+        self.assertEqual(data["methods_index"]["|importlib.metadata.entry_points"]["type"], "REFERENCE")
+        self.assertEqual(data["methods_index"]["plugin.py|plugin.register"]["start_line"], 12)
+        parsed, _ = parse_unified_analysis(data)
+        edge = parsed.components_relations[0].key_edges[0]
+        self.assertEqual(edge.source.qualified_name, "importlib.metadata.entry_points")
+        self.assertIsNone(edge.source.reference_file)
+        self.assertEqual(edge.target.reference_file, "plugin.py")
 
     def test_source_tree_hash_written_to_metadata(self):
         # The precomputed hash the caller passes is what lands in metadata — the

--- a/tests/diagram_analysis/test_diagram_analysis.py
+++ b/tests/diagram_analysis/test_diagram_analysis.py
@@ -34,7 +34,7 @@ from diagram_analysis.analysis_json import (
 )
 from diagram_analysis.cluster_delta import ClusterMemberDelta, ClusterRef, LanguageStructuralDiff, StructuralClusterDiff
 from diagram_analysis.diagram_generator import DiagramGenerator, _component_depth, _component_expansion_seeds
-from diagram_analysis.exceptions import IncrementalCacheMissingError
+from diagram_analysis.exceptions import IncrementalCacheMissingError, IncrementalScopeRegenerationRequiredError
 from repo_utils.change_detector import ChangeSet
 from static_analyzer.analysis_cache import StaticAnalysisCache
 from static_analyzer.analysis_result import StaticAnalysisResults
@@ -1093,6 +1093,58 @@ class TestDiagramGenerator(unittest.TestCase):
         self.assertEqual([component.component_id for component in expanded_components], ["1.1"])
         self.assertEqual(set(sub_analyses), {"1.1"})
         self.assertEqual(mock_save_analysis.call_count, 1)
+
+    def test_removed_only_incremental_update_marks_scope_for_relation_refresh(self):
+        gen = DiagramGenerator(
+            repo_location=self.repo_location,
+            temp_folder=self.temp_folder,
+            repo_name="test_repo",
+            output_dir=self.output_dir,
+            depth_level=2,
+            run_id="test-run-id",
+            log_path="test_repo/test-run-log",
+        )
+        planning_agent = MagicMock()
+        incremental_agent = MagicMock()
+        incremental_agent.update_scope.return_value = ScopeUpdateResult(removed_ids={"2"})
+        scope = AnalysisInsights(description="root", components=[], components_relations=[])
+
+        result = gen._apply_incremental_scope_recursively(
+            "root",
+            scope,
+            StructuralClusterDiff(),
+            {},
+            planning_agent,
+            incremental_agent,
+            {},
+        )
+
+        self.assertEqual(result.touched_scopes, {"root"})
+
+    def test_incremental_regeneration_request_fails_instead_of_running_full(self):
+        gen = DiagramGenerator(
+            repo_location=self.repo_location,
+            temp_folder=self.temp_folder,
+            repo_name="test_repo",
+            output_dir=self.output_dir,
+            depth_level=2,
+            run_id="test-run-id",
+            log_path="test_repo/test-run-log",
+        )
+        incremental_agent = MagicMock()
+        incremental_agent.update_scope.return_value = ScopeUpdateResult(regenerate_scope=True)
+        scope = AnalysisInsights(description="root", components=[], components_relations=[])
+
+        with self.assertRaises(IncrementalScopeRegenerationRequiredError):
+            gen._apply_incremental_scope_recursively(
+                "root",
+                scope,
+                StructuralClusterDiff(),
+                {},
+                MagicMock(),
+                incremental_agent,
+                {},
+            )
 
     @patch("diagram_analysis.diagram_generator.save_analysis")
     @patch("diagram_analysis.diagram_generator.prune_empty_components", return_value=set())

--- a/tests/diagram_analysis/test_diagram_analysis.py
+++ b/tests/diagram_analysis/test_diagram_analysis.py
@@ -21,7 +21,7 @@ from agents.agent_responses import (
     assign_component_ids,
 )
 from agents.file_index_models import FileEntry, FileMethodGroup, MethodEntry
-from agents.incremental_results import ScopeUpdateResult
+from agents.incremental_results import ScopeRelationContext, ScopeUpdateResult
 from agents.relation_edges import index_relation_endpoints
 from diagram_analysis.analysis_json import (
     ComponentFileMethodGroupJson,
@@ -506,7 +506,7 @@ class TestAnalysisJsonConversion(unittest.TestCase):
         self.assertEqual(edge.target.qualified_name, "component2.load")
         self.assertEqual(edge.target.reference_file, "component2.py")
 
-    def test_unified_analysis_serializes_indexed_relation_endpoints_outside_files(self):
+    def test_unified_analysis_does_not_invent_kinds_for_endpoints_outside_files(self):
         self.analysis.components_relations = [
             Relation(
                 relation="registers",
@@ -534,7 +534,7 @@ class TestAnalysisJsonConversion(unittest.TestCase):
         )
 
         self.assertNotIn("|importlib.metadata.entry_points", data["methods_index"])
-        self.assertEqual(data["methods_index"]["plugin.py|plugin.register"]["start_line"], 12)
+        self.assertNotIn("plugin.py|plugin.register", data["methods_index"])
         self.assertNotIn("", data["files"])
         parsed, _ = parse_unified_analysis(data)
         edge = parsed.components_relations[0].key_edges[0]
@@ -1178,7 +1178,11 @@ class TestDiagramGenerator(unittest.TestCase):
         )
         planning_agent = MagicMock()
         incremental_agent = MagicMock()
-        incremental_agent.update_scope.return_value = ScopeUpdateResult(removed_ids={"2"})
+        relation_context = ScopeRelationContext(cluster_results={}, cfg_graphs={})
+        incremental_agent.update_scope.return_value = ScopeUpdateResult(
+            relation_context=relation_context,
+            removed_ids={"2"},
+        )
         gen.incremental_planning_agent = planning_agent
         gen.incremental_agent = incremental_agent
         scope = AnalysisInsights(description="root", components=[], components_relations=[])
@@ -1191,7 +1195,78 @@ class TestDiagramGenerator(unittest.TestCase):
             {},
         )
 
-        self.assertEqual(result.touched_scopes, {"root"})
+        self.assertEqual(result.relation_contexts, {"root": relation_context})
+
+    @patch("diagram_analysis.diagram_generator._build_scope_incremental_inputs")
+    def test_recursive_scope_update_aggregates_relation_contexts(self, mock_build_scope_inputs):
+        gen = DiagramGenerator(
+            repo_location=self.repo_location,
+            temp_folder=self.temp_folder,
+            repo_name="test_repo",
+            output_dir=self.output_dir,
+            depth_level=3,
+            run_id="test-run-id",
+            log_path="test_repo/test-run-log",
+        )
+        root_context = ScopeRelationContext(cluster_results={}, cfg_graphs={})
+        child_context = ScopeRelationContext(
+            cluster_results={"python": ClusterResult(clusters={2: {"pkg.changed"}})},
+            cfg_graphs={},
+        )
+        incremental_agent = MagicMock()
+        incremental_agent.update_scope.side_effect = [
+            ScopeUpdateResult(relation_context=root_context, refresh_ids={"1"}),
+            ScopeUpdateResult(relation_context=child_context, refresh_ids={"1.1"}),
+        ]
+        gen.incremental_planning_agent = MagicMock()
+        gen.incremental_agent = incremental_agent
+        root_component = Component(name="Parent", description="", key_entities=[], component_id="1")
+        child_component = Component(
+            name="Child",
+            description="",
+            key_entities=[],
+            component_id="1.1",
+            file_methods=[
+                FileMethodGroup(
+                    file_path="pkg/module.py",
+                    methods=[
+                        MethodEntry(
+                            qualified_name="pkg.changed",
+                            start_line=1,
+                            end_line=2,
+                            node_type="FUNCTION",
+                        )
+                    ],
+                )
+            ],
+        )
+        root = AnalysisInsights(description="root", components=[root_component], components_relations=[])
+        child = AnalysisInsights(description="child", components=[child_component], components_relations=[])
+        child_diff = StructuralClusterDiff(
+            by_language={
+                "python": LanguageStructuralDiff(
+                    language="python",
+                    modified=[
+                        ClusterMemberDelta(
+                            old_cluster=ClusterRef(language="python", cluster_id=2),
+                            new_cluster=ClusterRef(language="python", cluster_id=2),
+                            removed_methods={"pkg.changed"},
+                        )
+                    ],
+                )
+            }
+        )
+        mock_build_scope_inputs.return_value = (child_context.cluster_results, child_diff)
+
+        result = gen._apply_incremental_scope_recursively(
+            "root",
+            root,
+            StructuralClusterDiff(),
+            {},
+            {"1": child},
+        )
+
+        self.assertEqual(result.relation_contexts, {"root": root_context, "1": child_context})
 
     @patch("diagram_analysis.diagram_generator.save_analysis")
     @patch("diagram_analysis.diagram_generator.prune_empty_components", return_value=set())
@@ -1302,8 +1377,16 @@ class TestDiagramGenerator(unittest.TestCase):
         )
         mock_planning_agent.return_value.decide_scope_update.side_effect = [root_decision, child_decision]
         _mock_incremental_agent.return_value.update_scope.side_effect = [
-            ScopeUpdateResult(refresh_ids={"1"}, new_component_ids=set()),
-            ScopeUpdateResult(refresh_ids={"1.1"}, new_component_ids=set()),
+            ScopeUpdateResult(
+                relation_context=ScopeRelationContext(cluster_results={}, cfg_graphs={}),
+                refresh_ids={"1"},
+                new_component_ids=set(),
+            ),
+            ScopeUpdateResult(
+                relation_context=ScopeRelationContext(cluster_results={}, cfg_graphs={}),
+                refresh_ids={"1.1"},
+                new_component_ids=set(),
+            ),
         ]
         mock_save_analysis.return_value = self.output_dir / "analysis.json"
 
@@ -1387,7 +1470,9 @@ class TestDiagramGenerator(unittest.TestCase):
             ]
         )
         _mock_incremental_agent.return_value.update_scope.return_value = ScopeUpdateResult(
-            refresh_ids={"1"}, new_component_ids=set()
+            relation_context=ScopeRelationContext(cluster_results={}, cfg_graphs={}),
+            refresh_ids={"1"},
+            new_component_ids=set(),
         )
         mock_build_scope_inputs.return_value = ({}, StructuralClusterDiff())
         mock_save_analysis.return_value = self.output_dir / "analysis.json"

--- a/tests/diagram_analysis/test_diagram_analysis.py
+++ b/tests/diagram_analysis/test_diagram_analysis.py
@@ -22,6 +22,7 @@ from agents.agent_responses import (
 )
 from agents.file_index_models import FileEntry, FileMethodGroup, MethodEntry
 from agents.incremental_results import ScopeUpdateResult
+from agents.relation_edges import index_relation_endpoints
 from diagram_analysis.analysis_json import (
     ComponentFileMethodGroupJson,
     ComponentJson,
@@ -34,7 +35,7 @@ from diagram_analysis.analysis_json import (
 )
 from diagram_analysis.cluster_delta import ClusterMemberDelta, ClusterRef, LanguageStructuralDiff, StructuralClusterDiff
 from diagram_analysis.diagram_generator import DiagramGenerator, _component_depth, _component_expansion_seeds
-from diagram_analysis.exceptions import IncrementalCacheMissingError, IncrementalScopeRegenerationRequiredError
+from diagram_analysis.exceptions import IncrementalCacheMissingError
 from repo_utils.change_detector import ChangeSet
 from static_analyzer.analysis_cache import StaticAnalysisCache
 from static_analyzer.analysis_result import StaticAnalysisResults
@@ -505,7 +506,7 @@ class TestAnalysisJsonConversion(unittest.TestCase):
         self.assertEqual(edge.target.qualified_name, "component2.load")
         self.assertEqual(edge.target.reference_file, "component2.py")
 
-    def test_unified_analysis_indexes_relation_endpoints_outside_files(self):
+    def test_unified_analysis_serializes_indexed_relation_endpoints_outside_files(self):
         self.analysis.components_relations = [
             Relation(
                 relation="registers",
@@ -526,6 +527,7 @@ class TestAnalysisJsonConversion(unittest.TestCase):
                 ],
             )
         ]
+        index_relation_endpoints(self.analysis, self.repo_dir)
 
         data = json.loads(
             build_unified_analysis_json(self.analysis, [], "repo", repo_dir=self.repo_dir, source_tree_hash="")
@@ -533,11 +535,13 @@ class TestAnalysisJsonConversion(unittest.TestCase):
 
         self.assertEqual(data["methods_index"]["|importlib.metadata.entry_points"]["type"], "REFERENCE")
         self.assertEqual(data["methods_index"]["plugin.py|plugin.register"]["start_line"], 12)
+        self.assertNotIn("", data["files"])
         parsed, _ = parse_unified_analysis(data)
         edge = parsed.components_relations[0].key_edges[0]
         self.assertEqual(edge.source.qualified_name, "importlib.metadata.entry_points")
         self.assertIsNone(edge.source.reference_file)
         self.assertEqual(edge.target.reference_file, "plugin.py")
+        self.assertEqual(parsed.files[""].methods[0].qualified_name, "importlib.metadata.entry_points")
 
     def test_source_tree_hash_written_to_metadata(self):
         # The precomputed hash the caller passes is what lands in metadata — the
@@ -739,6 +743,8 @@ class TestDiagramGenerator(unittest.TestCase):
         self.assertEqual(gen.depth_level, 2)
         self.assertIsNone(gen.details_agent)
         self.assertIsNone(gen.abstraction_agent)
+        self.assertIsNone(gen.incremental_planning_agent)
+        self.assertIsNone(gen.incremental_agent)
 
     @patch("diagram_analysis.diagram_generator.ProjectScanner")
     @patch("diagram_analysis.diagram_generator.get_static_analysis")
@@ -795,14 +801,19 @@ class TestDiagramGenerator(unittest.TestCase):
             log_path="test_repo/test-run-log",
         )
 
-        gen.pre_analysis()
+        with (
+            patch("diagram_analysis.diagram_generator.IncrementalPlanningAgent") as mock_incremental_planning,
+            patch("diagram_analysis.diagram_generator.IncrementalAgent") as mock_incremental,
+        ):
+            gen.pre_analysis()
 
         # Verify agents were created
         self.assertIsNotNone(gen.meta_agent)
         self.assertIsNotNone(gen.details_agent)
         self.assertIsNotNone(gen.abstraction_agent)
+        self.assertIs(gen.incremental_planning_agent, mock_incremental_planning.return_value)
+        self.assertIs(gen.incremental_agent, mock_incremental.return_value)
         mock_meta_instance.analyze_project_metadata.assert_called_once_with(skip_cache=False)
-        # Note: planner is now a module function, not an agent instance
 
     def test_process_component_with_exception(self):
         # Test processing a component that raises an exception
@@ -1046,6 +1057,8 @@ class TestDiagramGenerator(unittest.TestCase):
         )
         gen.details_agent = Mock()
         gen.abstraction_agent = Mock()
+        gen.incremental_planning_agent = Mock()
+        gen.incremental_agent = Mock()
         gen.abstraction_agent.run.return_value = (analysis, {})
 
         gen.generate_analysis()
@@ -1065,6 +1078,8 @@ class TestDiagramGenerator(unittest.TestCase):
         )
         gen.details_agent = Mock()
         gen.abstraction_agent = Mock()
+        gen.incremental_planning_agent = Mock()
+        gen.incremental_agent = Mock()
         # Empty static analysis -> snapshot has no cluster ids -> incremental
         # path must refuse rather than silently re-deriving from scratch.
         gen.static_analysis = StaticAnalysisResults()
@@ -1145,6 +1160,8 @@ class TestDiagramGenerator(unittest.TestCase):
         planning_agent = MagicMock()
         incremental_agent = MagicMock()
         incremental_agent.update_scope.return_value = ScopeUpdateResult(removed_ids={"2"})
+        gen.incremental_planning_agent = planning_agent
+        gen.incremental_agent = incremental_agent
         scope = AnalysisInsights(description="root", components=[], components_relations=[])
 
         result = gen._apply_incremental_scope_recursively(
@@ -1152,37 +1169,10 @@ class TestDiagramGenerator(unittest.TestCase):
             scope,
             StructuralClusterDiff(),
             {},
-            planning_agent,
-            incremental_agent,
             {},
         )
 
         self.assertEqual(result.touched_scopes, {"root"})
-
-    def test_incremental_regeneration_request_fails_instead_of_running_full(self):
-        gen = DiagramGenerator(
-            repo_location=self.repo_location,
-            temp_folder=self.temp_folder,
-            repo_name="test_repo",
-            output_dir=self.output_dir,
-            depth_level=2,
-            run_id="test-run-id",
-            log_path="test_repo/test-run-log",
-        )
-        incremental_agent = MagicMock()
-        incremental_agent.update_scope.return_value = ScopeUpdateResult(regenerate_scope=True)
-        scope = AnalysisInsights(description="root", components=[], components_relations=[])
-
-        with self.assertRaises(IncrementalScopeRegenerationRequiredError):
-            gen._apply_incremental_scope_recursively(
-                "root",
-                scope,
-                StructuralClusterDiff(),
-                {},
-                MagicMock(),
-                incremental_agent,
-                {},
-            )
 
     @patch("diagram_analysis.diagram_generator.save_analysis")
     @patch("diagram_analysis.diagram_generator.prune_empty_components", return_value=set())
@@ -1190,14 +1180,12 @@ class TestDiagramGenerator(unittest.TestCase):
     @patch("diagram_analysis.diagram_generator.structural_diff_from_delta")
     @patch("diagram_analysis.diagram_generator.IncrementalPlanningAgent")
     @patch("diagram_analysis.diagram_generator.IncrementalAgent")
-    @patch("diagram_analysis.diagram_generator.initialize_llms", return_value=(Mock(), Mock()))
     @patch("diagram_analysis.diagram_generator.compute_cluster_delta")
     @patch("diagram_analysis.diagram_generator.snapshot_from_static_analysis")
     def test_incremental_refresh_updates_existing_parent_scope(
         self,
         mock_snapshot,
         mock_delta,
-        _mock_llms,
         _mock_incremental_agent,
         mock_planning_agent,
         _mock_structural_diff,
@@ -1215,8 +1203,8 @@ class TestDiagramGenerator(unittest.TestCase):
             log_path="test_repo/test-run-log",
         )
         gen.details_agent = Mock()
-        gen.abstraction_agent = Mock()
-        gen.abstraction_agent.build_files_index.return_value = {}
+        gen.incremental_planning_agent = mock_planning_agent.return_value
+        gen.incremental_agent = _mock_incremental_agent.return_value
         gen.static_analysis = Mock()
         gen.static_analysis.get_languages.return_value = []
         base_static_analysis = Mock()
@@ -1302,8 +1290,15 @@ class TestDiagramGenerator(unittest.TestCase):
 
         gen.generate_analysis_incremental(root_analysis, sub_analyses)
 
+        self.assertIs(gen.incremental_planning_agent, mock_planning_agent.return_value)
+        self.assertIs(gen.incremental_agent, _mock_incremental_agent.return_value)
         mock_snapshot.assert_called_once_with(base_static_analysis)
-        mock_planning_agent.return_value.decide_scope_update.assert_called_once_with("root", root_analysis, root_diff)
+        mock_planning_agent.return_value.decide_scope_update.assert_called_once_with(
+            "root",
+            root_analysis,
+            root_diff,
+            {},
+        )
         _mock_incremental_agent.return_value.update_scope.assert_called_once()
         mock_build_scope_inputs.assert_called_once_with(
             root_component,
@@ -1321,14 +1316,12 @@ class TestDiagramGenerator(unittest.TestCase):
     @patch("diagram_analysis.diagram_generator.structural_diff_from_delta")
     @patch("diagram_analysis.diagram_generator.IncrementalPlanningAgent")
     @patch("diagram_analysis.diagram_generator.IncrementalAgent")
-    @patch("diagram_analysis.diagram_generator.initialize_llms", return_value=(Mock(), Mock()))
     @patch("diagram_analysis.diagram_generator.compute_cluster_delta")
     @patch("diagram_analysis.diagram_generator.snapshot_from_static_analysis")
     def test_incremental_refresh_skips_child_scope_when_local_diff_is_empty(
         self,
         mock_snapshot,
         mock_delta,
-        _mock_llms,
         _mock_incremental_agent,
         mock_planning_agent,
         _mock_structural_diff,
@@ -1346,8 +1339,8 @@ class TestDiagramGenerator(unittest.TestCase):
             log_path="test_repo/test-run-log",
         )
         gen.details_agent = Mock()
-        gen.abstraction_agent = Mock()
-        gen.abstraction_agent.build_files_index.return_value = {}
+        gen.incremental_planning_agent = mock_planning_agent.return_value
+        gen.incremental_agent = _mock_incremental_agent.return_value
         gen.static_analysis = Mock()
         gen.static_analysis.get_languages.return_value = []
         gen.static_analysis.incremental_base_results = Mock()
@@ -1407,10 +1400,8 @@ class TestDiagramGenerator(unittest.TestCase):
             log_path="test_repo/test-run-log",
         )
         gen.details_agent = Mock()
-        gen.abstraction_agent = Mock()
-        # The empty-delta path rebuilds the files index from live source; return a
-        # plain dict so the union in _refresh_files_index is iterable.
-        gen.abstraction_agent.build_files_index.return_value = {}
+        gen.incremental_planning_agent = Mock()
+        gen.incremental_agent = Mock()
         gen.static_analysis = Mock()
         gen.static_analysis.get_languages.return_value = []
         gen.static_analysis.incremental_base_results = Mock()
@@ -1429,14 +1420,13 @@ class TestDiagramGenerator(unittest.TestCase):
         mock_delta.return_value.has_changes = False
         mock_save_analysis.return_value = self.output_dir / "analysis.json"
 
-        gen.generate_analysis_incremental(root_analysis, sub_analyses)
+        with patch("diagram_analysis.diagram_generator.build_files_index", return_value={}) as mock_build_index:
+            gen.generate_analysis_incremental(root_analysis, sub_analyses)
 
         mock_prune.assert_not_called()
         self.assertEqual(sub_analyses["1.1"].components[0].name, "Stable Leaf")
-        # Even with an empty delta (body-only edit, no structural change), the
-        # files index is rebuilt from live source so content_hash / source_tree_hash
-        # don't go stale. Root + each sub-analysis => 3 rebuilds here.
-        self.assertEqual(gen.abstraction_agent.build_files_index.call_count, 1 + len(sub_analyses))
+        self.assertIsNone(gen.abstraction_agent)
+        self.assertEqual(mock_build_index.call_count, 1 + len(sub_analyses))
 
     def test_persist_static_analysis_artifact_saves_cluster_cache_without_injected_analyzer(self):
         gen = DiagramGenerator(

--- a/tests/diagram_analysis/test_diagram_analysis.py
+++ b/tests/diagram_analysis/test_diagram_analysis.py
@@ -533,7 +533,7 @@ class TestAnalysisJsonConversion(unittest.TestCase):
             build_unified_analysis_json(self.analysis, [], "repo", repo_dir=self.repo_dir, source_tree_hash="")
         )
 
-        self.assertEqual(data["methods_index"]["|importlib.metadata.entry_points"]["type"], "REFERENCE")
+        self.assertNotIn("|importlib.metadata.entry_points", data["methods_index"])
         self.assertEqual(data["methods_index"]["plugin.py|plugin.register"]["start_line"], 12)
         self.assertNotIn("", data["files"])
         parsed, _ = parse_unified_analysis(data)
@@ -541,7 +541,7 @@ class TestAnalysisJsonConversion(unittest.TestCase):
         self.assertEqual(edge.source.qualified_name, "importlib.metadata.entry_points")
         self.assertIsNone(edge.source.reference_file)
         self.assertEqual(edge.target.reference_file, "plugin.py")
-        self.assertEqual(parsed.files[""].methods[0].qualified_name, "importlib.metadata.entry_points")
+        self.assertNotIn("", parsed.files)
 
     def test_source_tree_hash_written_to_metadata(self):
         # The precomputed hash the caller passes is what lands in metadata — the
@@ -745,6 +745,25 @@ class TestDiagramGenerator(unittest.TestCase):
         self.assertIsNone(gen.abstraction_agent)
         self.assertIsNone(gen.incremental_planning_agent)
         self.assertIsNone(gen.incremental_agent)
+
+    @patch("diagram_analysis.diagram_generator.get_static_analysis")
+    def test_new_analyzer_honors_cache_reuse_override(self, mock_get_static_analysis):
+        gen = DiagramGenerator(
+            repo_location=self.repo_location,
+            temp_folder=self.temp_folder,
+            repo_name="test_repo",
+            output_dir=self.output_dir,
+            depth_level=2,
+            run_id="test-run-id",
+            log_path="test_repo/test-run-log",
+        )
+        gen.source_sha = "current-sha"
+        mock_get_static_analysis.return_value = MagicMock(spec=StaticAnalysisResults)
+
+        with patch.dict(os.environ, {"CODEBOARDING_DISABLE_CACHE_REUSE": "true"}):
+            gen._get_static_with_new_analyzer()
+
+        self.assertTrue(mock_get_static_analysis.call_args.kwargs["skip_cache"])
 
     @patch("diagram_analysis.diagram_generator.ProjectScanner")
     @patch("diagram_analysis.diagram_generator.get_static_analysis")
@@ -1427,6 +1446,45 @@ class TestDiagramGenerator(unittest.TestCase):
         self.assertEqual(sub_analyses["1.1"].components[0].name, "Stable Leaf")
         self.assertIsNone(gen.abstraction_agent)
         self.assertEqual(mock_build_index.call_count, 1 + len(sub_analyses))
+
+    def test_refresh_files_index_reuses_sources_and_copies_sub_entries(self):
+        gen = DiagramGenerator(
+            repo_location=self.repo_location,
+            temp_folder=self.temp_folder,
+            repo_name="test_repo",
+            output_dir=self.output_dir,
+            depth_level=2,
+            run_id="test-run-id",
+            log_path="test_repo/test-run-log",
+        )
+        gen.static_analysis = MagicMock(spec=StaticAnalysisResults)
+        root_analysis = AnalysisInsights(description="root", components=[], components_relations=[])
+        sub_analysis = AnalysisInsights(description="sub", components=[], components_relations=[])
+        root_method = MethodEntry(qualified_name="root.method", start_line=1, end_line=2, node_type="FUNCTION")
+        shared_sub_method = MethodEntry(qualified_name="sub.method", start_line=3, end_line=4, node_type="FUNCTION")
+        sub_only_method = MethodEntry(qualified_name="sub.only", start_line=5, end_line=6, node_type="FUNCTION")
+        root_entry = FileEntry(methods=[root_method])
+        shared_sub_entry = FileEntry(methods=[shared_sub_method])
+        sub_only_entry = FileEntry(methods=[sub_only_method])
+
+        with (
+            patch("diagram_analysis.diagram_generator.refresh_method_spans_from_cfg"),
+            patch("diagram_analysis.diagram_generator.index_relation_endpoints"),
+            patch(
+                "diagram_analysis.diagram_generator.build_files_index",
+                side_effect=[
+                    {"shared.py": root_entry},
+                    {"shared.py": shared_sub_entry, "sub.py": sub_only_entry},
+                ],
+            ) as mock_build_index,
+        ):
+            gen._refresh_files_index(root_analysis, {"1": sub_analysis})
+
+        root_methods = {method.qualified_name: method for method in root_analysis.files["shared.py"].methods}
+        self.assertIsNot(root_methods["sub.method"], shared_sub_method)
+        self.assertIsNot(root_analysis.files["sub.py"], sub_only_entry)
+        self.assertIsNot(root_analysis.files["sub.py"].methods[0], sub_only_method)
+        self.assertIs(mock_build_index.call_args_list[0].args[2], mock_build_index.call_args_list[1].args[2])
 
     def test_persist_static_analysis_artifact_saves_cluster_cache_without_injected_analyzer(self):
         gen = DiagramGenerator(

--- a/tests/diagram_analysis/test_file_index.py
+++ b/tests/diagram_analysis/test_file_index.py
@@ -1,0 +1,76 @@
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from agents.agent_responses import AnalysisInsights, Component
+from agents.content_hash import hash_method_body
+from agents.file_index_models import FileMethodGroup, MethodEntry
+from diagram_analysis.file_index import build_files_index, refresh_method_spans_from_cfg
+from static_analyzer.analysis_result import StaticAnalysisResults
+from static_analyzer.constants import NodeType
+from static_analyzer.graph import CallGraph
+from static_analyzer.node import Node
+
+
+def _analysis_with_method(file_path: str, qname: str, start: int, end: int) -> AnalysisInsights:
+    return AnalysisInsights(
+        description="",
+        components=[
+            Component(
+                name="C",
+                description="d",
+                key_entities=[],
+                component_id="c1",
+                file_methods=[
+                    FileMethodGroup(
+                        file_path=file_path,
+                        methods=[
+                            MethodEntry(qualified_name=qname, start_line=start, end_line=end, node_type="FUNCTION")
+                        ],
+                    )
+                ],
+            )
+        ],
+        components_relations=[],
+    )
+
+
+def _static_analysis_with_nodes(*nodes: Node) -> StaticAnalysisResults:
+    cfg = CallGraph(nodes={node.fully_qualified_name: node for node in nodes})
+    static_analysis = MagicMock(spec=StaticAnalysisResults)
+    static_analysis.get_languages.return_value = ["python"]
+    static_analysis.get_cfg.return_value = cfg
+    return static_analysis
+
+
+def test_build_files_index_hashes_carried_span(tmp_path: Path) -> None:
+    (tmp_path / "m.py").write_text("def foo():\n    return 1\n", encoding="utf-8")
+    analysis = _analysis_with_method("m.py", "foo", start=1, end=2)
+
+    files = build_files_index(analysis, tmp_path)
+
+    method = files["m.py"].methods[0]
+    assert method.content_hash == hash_method_body(["def foo():", "    return 1"], 1, 2)
+    assert method.content_hash != ""
+
+
+def test_refresh_spans_then_index_reflects_live_cfg_span(tmp_path: Path) -> None:
+    (tmp_path / "m.py").write_text("# added line\ndef foo():\n    return 1\n", encoding="utf-8")
+    analysis = _analysis_with_method("m.py", "foo", start=1, end=2)
+    static_analysis = _static_analysis_with_nodes(Node("foo", NodeType.FUNCTION, "m.py", 2, 3))
+
+    refresh_method_spans_from_cfg(analysis, static_analysis, tmp_path)
+    files = build_files_index(analysis, tmp_path)
+
+    method = files["m.py"].methods[0]
+    assert method.content_hash == hash_method_body(["# added line", "def foo():", "    return 1"], 2, 3)
+    assert method.content_hash != ""
+
+
+def test_refresh_spans_empty_hash_when_method_absent_from_live_cfg(tmp_path: Path) -> None:
+    (tmp_path / "m.py").write_text("def something_else():\n    return 42\n", encoding="utf-8")
+    analysis = _analysis_with_method("m.py", "foo", start=1, end=2)
+
+    refresh_method_spans_from_cfg(analysis, _static_analysis_with_nodes(), tmp_path)
+    files = build_files_index(analysis, tmp_path)
+
+    assert files["m.py"].methods[0].content_hash == ""

--- a/tests/integration/test_static_analysis_consistency.py
+++ b/tests/integration/test_static_analysis_consistency.py
@@ -304,7 +304,14 @@ class TestStaticAnalysisConsistency:
         # Run static analysis with mocked scanner and measure execution time
         mock_scan = create_mock_scanner(config.mock_language)
         start_time = time.perf_counter()
-        with patch("static_analyzer.scanner.ProjectScanner.scan", mock_scan):
+        # Persistence is intentionally excluded from this benchmark. The fixture
+        # timings were recorded for analysis itself, while serializing the large
+        # result (especially with Windows filesystem flushing) is environment-
+        # dependent and can dominate the measurement.
+        with (
+            patch("static_analyzer.scanner.ProjectScanner.scan", mock_scan),
+            patch("static_analyzer.analysis_cache.StaticAnalysisCache.save"),
+        ):
             static_analysis = get_static_analysis(repo_path, cache_dir=get_artifact_dir(repo_path))
         end_time = time.perf_counter()
         actual_execution_time = end_time - start_time

--- a/tests/static_analyzer/test_analysis_cache_inmem.py
+++ b/tests/static_analyzer/test_analysis_cache_inmem.py
@@ -376,7 +376,7 @@ class TestWarmStartDeletion(unittest.TestCase):
 
 
 class TestWarmStartOutboundEdges(unittest.TestCase):
-    def test_definition_resolution_selects_the_most_specific_node(self) -> None:
+    def test_definition_resolution_includes_the_most_specific_node_and_its_class(self) -> None:
         file_path = Path("/repo/pkg/converter.py")
         call_graph = CallGraph(language="python")
         call_graph.add_node(
@@ -407,7 +407,10 @@ class TestWarmStartOutboundEdges(unittest.TestCase):
 
         self.assertEqual(
             [node.fully_qualified_name for node in matches],
-            ["pkg.converter.DocumentConverter.convert"],
+            [
+                "pkg.converter.DocumentConverter.convert",
+                "pkg.converter.DocumentConverter",
+            ],
         )
 
     def test_cached_outbound_edge_is_restored_from_live_non_call_reference(self) -> None:

--- a/tests/static_analyzer/test_analysis_cache_inmem.py
+++ b/tests/static_analyzer/test_analysis_cache_inmem.py
@@ -15,7 +15,12 @@ from static_analyzer.analysis_result import AnalysisData, StaticAnalysisResults
 from static_analyzer.constants import Language, NodeType
 from static_analyzer.graph import CallGraph, ClusterResult, Edge
 from static_analyzer.node import Node
-from static_analyzer.incremental_orchestrator import update_cfg_for_changed_files
+from static_analyzer.incremental_orchestrator import (
+    _definition_nodes,
+    _restore_cross_boundary_edges,
+    update_cfg_for_changed_files,
+)
+from static_analyzer.engine.source_inspector import SourceInspector
 from utils import CODEBOARDING_DIR_NAME
 
 
@@ -368,6 +373,95 @@ class TestWarmStartDeletion(unittest.TestCase):
             self.assertNotIn("a.foo", updated["call_graph"].nodes)
             self.assertIn("b.bar", updated["call_graph"].nodes)
             self.assertEqual([str(path) for path in updated["source_files"]], [str(live_file)])
+
+
+class TestWarmStartOutboundEdges(unittest.TestCase):
+    def test_definition_resolution_selects_the_most_specific_node(self) -> None:
+        file_path = Path("/repo/pkg/converter.py")
+        call_graph = CallGraph(language="python")
+        call_graph.add_node(
+            Node(
+                fully_qualified_name="pkg.converter.DocumentConverter",
+                node_type=NodeType.CLASS,
+                file_path=str(file_path),
+                line_start=1,
+                line_end=40,
+            )
+        )
+        call_graph.add_node(
+            Node(
+                fully_qualified_name="pkg.converter.DocumentConverter.convert",
+                node_type=NodeType.METHOD,
+                file_path=str(file_path),
+                line_start=10,
+                line_end=20,
+                col_start=4,
+            )
+        )
+        definition = {
+            "uri": file_path.as_uri(),
+            "range": {"start": {"line": 9, "character": 8}, "end": {"line": 9, "character": 15}},
+        }
+
+        matches = _definition_nodes(call_graph, definition)
+
+        self.assertEqual(
+            [node.fully_qualified_name for node in matches],
+            ["pkg.converter.DocumentConverter.convert"],
+        )
+
+    def test_cached_outbound_edge_is_restored_from_live_non_call_reference(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            changed_file = Path(temp_dir) / "changed.py"
+            target_file = Path(temp_dir) / "target.py"
+            changed_file.write_text("def convert():\n    return result.text_content\n", encoding="utf-8")
+            target_file.write_text("class Result:\n    def text_content(self): ...\n", encoding="utf-8")
+            source = Node(
+                fully_qualified_name="changed.convert",
+                node_type=NodeType.FUNCTION,
+                file_path=str(changed_file),
+                line_start=1,
+                line_end=2,
+            )
+            target = Node(
+                fully_qualified_name="target.Result.text_content",
+                node_type=NodeType.METHOD,
+                file_path=str(target_file),
+                line_start=2,
+                line_end=2,
+                col_start=4,
+            )
+            call_graph = CallGraph(language="python")
+            call_graph.add_node(source)
+            call_graph.add_node(target)
+            engine_client = MagicMock()
+            engine_client.references.return_value = [
+                {
+                    "uri": changed_file.as_uri(),
+                    "range": {
+                        "start": {"line": 1, "character": 11},
+                        "end": {"line": 1, "character": 30},
+                    },
+                }
+            ]
+            adapter = MagicMock()
+            adapter.language_id = "python"
+            adapter.is_class_like.return_value = False
+
+            _restore_cross_boundary_edges(
+                call_graph,
+                [(source.fully_qualified_name, target.fully_qualified_name, source, target)],
+                {str(changed_file)},
+                adapter,
+                engine_client,
+                SourceInspector(),
+            )
+
+            self.assertEqual(len(call_graph.edges), 1)
+            self.assertEqual(
+                call_graph.edges[0].call_sites,
+                [{"file": str(changed_file), "line": 2, "column": 12}],
+            )
 
 
 if __name__ == "__main__":

--- a/tests/static_analyzer/test_edge_builder.py
+++ b/tests/static_analyzer/test_edge_builder.py
@@ -152,6 +152,14 @@ class TestResolveDefinitionToSymbol:
         )
         assert result is None
 
+    def test_returns_none_for_missing_position(self):
+        result = _resolve_definition_to_symbol(
+            {"uri": Path("/p/a.py").as_uri(), "range": {}},
+            {},
+            {},
+        )
+        assert result is None
+
     def test_returns_none_when_no_match(self):
         result = _resolve_definition_to_symbol(
             {"uri": Path("/p/a.py").as_uri(), "range": {"start": {"line": 100, "character": 0}}},

--- a/tests/static_analyzer/test_global_relations.py
+++ b/tests/static_analyzer/test_global_relations.py
@@ -426,6 +426,42 @@ class TestLabelInheritance(unittest.TestCase):
         unrelated = next(item for item in relations if (item.src_id, item.dst_id) == ("1.1.1", "2.1.1"))
         self.assertEqual(unrelated.key_edges, [])
 
+    def test_refreshed_scope_payload_overrides_persisted_global_copy(self):
+        root = _build_root_analysis()
+        sub_analyses = _build_sub_analyses()
+        refreshed_relation = sub_analyses["2.1"].components_relations[0]
+        refreshed_relation.evidence = "Fresh scoped evidence."
+        refreshed_relation.key_edges = [
+            RelationEdge(
+                source=SourceCodeReference(qualified_name="core.auth.login"),
+                target=SourceCodeReference(qualified_name="core.profiles.get"),
+                description="Fresh scoped edge.",
+            )
+        ]
+        root.components_relations.append(
+            Relation(
+                relation=refreshed_relation.relation,
+                src_name=refreshed_relation.src_name,
+                dst_name=refreshed_relation.dst_name,
+                evidence="Stale persisted evidence.",
+                key_edges=[
+                    RelationEdge(
+                        source=SourceCodeReference(qualified_name="core.auth.login"),
+                        target=SourceCodeReference(qualified_name="core.profiles.get"),
+                        description="Stale persisted edge.",
+                    )
+                ],
+                src_id="2.1.1",
+                dst_id="2.1.2",
+            )
+        )
+
+        relations = build_global_relations(root, sub_analyses, {"python": _build_cfg()})
+        relation = next(item for item in relations if (item.src_id, item.dst_id) == ("2.1.1", "2.1.2"))
+
+        self.assertEqual(relation.evidence, "Fresh scoped evidence.")
+        self.assertEqual([edge.description for edge in relation.key_edges], ["Fresh scoped edge."])
+
     def test_llm_only_relation_survives_with_payload(self):
         # "2.1"->"2.2" ("bills") has no CFG edge crossing Users->Billing, so it
         # must survive as an LLM-only relation with its label, is_static=False,

--- a/tests/static_analyzer/test_global_relations.py
+++ b/tests/static_analyzer/test_global_relations.py
@@ -42,6 +42,8 @@ from agents.agent_responses import (
     AnalysisInsights,
     Component,
     Relation,
+    RelationEdge,
+    SourceCodeReference,
     assign_component_ids,
 )
 from agents.file_index_models import FileMethodGroup, MethodEntry
@@ -402,6 +404,27 @@ class TestLabelInheritance(unittest.TestCase):
         # search ran; "calls" would also be the fallback and hide a regression.
         r = self.by_pair[("1.1.1", "2.1.2")]
         self.assertEqual(r.relation, "orchestrates")
+
+    def test_ancestor_evidence_and_key_edges_are_preserved(self):
+        root = _build_root_analysis()
+        root_relation = root.components_relations[0]
+        root_relation.evidence = "The public API invokes core services."
+        root_relation.key_edges = [
+            RelationEdge(
+                source=SourceCodeReference(qualified_name="api.rest.list", reference_file="api/public/rest.py"),
+                target=SourceCodeReference(qualified_name="core.profiles.get", reference_file="core/users/profiles.py"),
+                description="List requests load profiles.",
+            )
+        ]
+
+        relations = build_global_relations(root, _build_sub_analyses(), {"python": _build_cfg()})
+        relation = next(item for item in relations if (item.src_id, item.dst_id) == ("1.1.1", "2.1.2"))
+
+        self.assertEqual(relation.evidence, root_relation.evidence)
+        self.assertEqual(relation.key_edges, root_relation.key_edges)
+        self.assertGreaterEqual(len(relation.all_edges), 1)
+        unrelated = next(item for item in relations if (item.src_id, item.dst_id) == ("1.1.1", "2.1.1"))
+        self.assertEqual(unrelated.key_edges, [])
 
     def test_llm_only_relation_survives_with_payload(self):
         # "2.1"->"2.2" ("bills") has no CFG edge crossing Users->Billing, so it

--- a/tests/static_analyzer/test_global_relations.py
+++ b/tests/static_analyzer/test_global_relations.py
@@ -426,10 +426,11 @@ class TestLabelInheritance(unittest.TestCase):
         unrelated = next(item for item in relations if (item.src_id, item.dst_id) == ("1.1.1", "2.1.1"))
         self.assertEqual(unrelated.key_edges, [])
 
-    def test_refreshed_scope_payload_overrides_persisted_global_copy(self):
+    def test_refreshed_scope_metadata_overrides_static_backed_global_copy(self):
         root = _build_root_analysis()
         sub_analyses = _build_sub_analyses()
         refreshed_relation = sub_analyses["2.1"].components_relations[0]
+        refreshed_relation.relation = "publishes to"
         refreshed_relation.evidence = "Fresh scoped evidence."
         refreshed_relation.key_edges = [
             RelationEdge(
@@ -440,7 +441,7 @@ class TestLabelInheritance(unittest.TestCase):
         ]
         root.components_relations.append(
             Relation(
-                relation=refreshed_relation.relation,
+                relation="calls",
                 src_name=refreshed_relation.src_name,
                 dst_name=refreshed_relation.dst_name,
                 evidence="Stale persisted evidence.",
@@ -459,6 +460,7 @@ class TestLabelInheritance(unittest.TestCase):
         relations = build_global_relations(root, sub_analyses, {"python": _build_cfg()})
         relation = next(item for item in relations if (item.src_id, item.dst_id) == ("2.1.1", "2.1.2"))
 
+        self.assertEqual(relation.relation, "publishes to")
         self.assertEqual(relation.evidence, "Fresh scoped evidence.")
         self.assertEqual([edge.description for edge in relation.key_edges], ["Fresh scoped edge."])
 
@@ -643,9 +645,8 @@ class TestDeterministicOrder(unittest.TestCase):
 
     Why: sub_analyses is populated in ThreadPoolExecutor completion order on a full
     run, so an unsorted result produced analysis.json diff churn. The final sort by
-    (src_id, dst_id, relation) makes the serialized leaf set reproducible regardless
-    of completion order. (The render-time rolled-up label choice is covered
-    separately in test_rendering.py.)
+    component pair makes the serialized leaf set reproducible regardless of completion
+    order.
     """
 
     def _serialize(self, rels):
@@ -664,40 +665,49 @@ class TestDeterministicOrder(unittest.TestCase):
 
     def test_result_is_sorted(self):
         rels = build_global_relations(_build_root_analysis(), _build_sub_analyses(), {"python": _build_cfg()})
-        keys = [(r.src_id, r.dst_id, r.relation) for r in rels]
+        keys = [(r.src_id, r.dst_id) for r in rels]
         self.assertEqual(keys, sorted(keys))
 
 
 class TestLlmOnlyRelations(unittest.TestCase):
     """Unbacked (LLM-only) relations: deduped by pair, and filtered to live endpoints."""
 
-    def test_duplicate_llm_only_pairs_deduped(self):
-        # Root and a sub-analysis both declare the same unbacked (1 -> 2) relation
-        # with different labels. Only one survives, deterministically (post-sort).
+    def test_refreshed_scope_metadata_overrides_llm_only_global_copy(self):
         root = AnalysisInsights(
             description="root",
-            components=[_comp("A", []), _comp("B", [])],
-            components_relations=[Relation(relation="calls", src_name="A", dst_name="B", src_id="1", dst_id="2")],
+            components=[_comp("A", [])],
+            components_relations=[],
         )
-        assign_component_ids(root)  # A -> "1", B -> "2"
-        # Sub-analysis of component "1": its children are 1.1/1.2, but it also
-        # re-declares the sibling relation 1 -> 2 with a different label.
+        assign_component_ids(root)
+        root.components_relations = [
+            Relation(
+                relation="calls",
+                src_name="Public",
+                dst_name="Internal",
+                evidence="Stale persisted evidence.",
+                src_id="1.1",
+                dst_id="1.2",
+            )
+        ]
         sub = AnalysisInsights(
             description="sub",
-            components=[_comp("A.pub", []), _comp("A.int", [])],
-            components_relations=[Relation(relation="delegates", src_name="A", dst_name="B", src_id="1", dst_id="2")],
+            components=[_comp("Public", []), _comp("Internal", [])],
+            components_relations=[
+                Relation(
+                    relation="publishes to",
+                    src_name="Public",
+                    dst_name="Internal",
+                    evidence="Fresh scoped evidence.",
+                )
+            ],
         )
-        assign_component_ids(sub, parent_id="1")  # children -> 1.1/1.2
-        # Re-pin the sibling relation to 1->2 after assign (name lookup would have
-        # blanked it, since A/B aren't components of this sub-scope).
-        sub.components_relations[0].src_id, sub.components_relations[0].dst_id = "1", "2"
+        assign_component_ids(sub, parent_id="1")
 
         rels = build_global_relations(root, {"1": sub}, {"python": CallGraph()})
-        pairs = [(r.src_id, r.dst_id) for r in rels]
-        self.assertEqual(pairs.count(("1", "2")), 1, "duplicate LLM-only pair must be deduped")
-        # Surviving label is deterministic (smallest by relation), not input-order dependent.
-        survivor = next(r for r in rels if (r.src_id, r.dst_id) == ("1", "2"))
-        self.assertEqual(survivor.relation, "calls")
+        relation = next(item for item in rels if (item.src_id, item.dst_id) == ("1.1", "1.2"))
+
+        self.assertEqual(relation.relation, "publishes to")
+        self.assertEqual(relation.evidence, "Fresh scoped evidence.")
 
     def test_llm_only_relation_to_missing_component_dropped(self):
         # An LLM relation whose endpoint id has no matching live component (e.g. a

--- a/tests/static_analyzer/test_internal_references.py
+++ b/tests/static_analyzer/test_internal_references.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 
 from static_analyzer.constants import Language
-from static_analyzer.internal_references import looks_internal_reference
+from static_analyzer.internal_references import looks_internal_reference, parent_qualified_name
 
 
 @dataclass
@@ -48,3 +48,9 @@ def test_internal_reference_keeps_private_token_signal():
     source = _ReferenceSource(["app.pipeline._internal_dispatch.run"])
 
     assert looks_internal_reference(source, "plugin._internal_dispatch")
+
+
+def test_parent_qualified_name_strips_member_and_signature():
+    assert parent_qualified_name("pkg.Dog.__init__") == "pkg.Dog"
+    assert parent_qualified_name("pkg.Dog(args).run") == "pkg.Dog"
+    assert parent_qualified_name("standalone") == ""

--- a/tests/static_analyzer/test_reference_resolve_real_refs.py
+++ b/tests/static_analyzer/test_reference_resolve_real_refs.py
@@ -17,7 +17,7 @@ from agents.agent_responses import (
     Component,
     SourceCodeReference,
 )
-from agents.file_index_models import FileMethodGroup
+from agents.file_index_models import FileMethodGroup, MethodEntry
 from static_analyzer.analysis_result import StaticAnalysisResults
 from static_analyzer.constants import NodeType
 from static_analyzer.node import Node
@@ -71,9 +71,14 @@ def _make_node(repo_dir: Path, qname: str, rel_file: str) -> Node:
     )
 
 
-def _make_file_methods(file_paths: list[str]) -> list[FileMethodGroup]:
-    """Create FileMethodGroup objects from file paths for testing."""
-    return [FileMethodGroup(file_path=fp, methods=[]) for fp in file_paths]
+def _make_file_methods(entities: list[tuple[str, str]]) -> list[FileMethodGroup]:
+    """Create component method scope from qualified-name/file pairs."""
+    by_file: dict[str, list[MethodEntry]] = {}
+    for qname, file_path in entities:
+        by_file.setdefault(file_path, []).append(
+            MethodEntry(qualified_name=qname, start_line=0, end_line=5, node_type="CLASS")
+        )
+    return [FileMethodGroup(file_path=file_path, methods=methods) for file_path, methods in by_file.items()]
 
 
 # ---------------------------------------------------------------------------
@@ -81,29 +86,29 @@ def _make_file_methods(file_paths: list[str]) -> list[FileMethodGroup]:
 # ---------------------------------------------------------------------------
 
 
-class TestRelativePathAlreadyResolved(unittest.TestCase):
-    """The LLM provides a correct *relative* reference_file.
-
-    fix_source_code_reference_lines should recognise this as already resolved
-    (joining with repo_dir) instead of re-resolving or dropping the reference.
-    """
+class TestPersistedRelativePathRefresh(unittest.TestCase):
+    """Persisted relative paths are revalidated against current scoped symbols."""
 
     def setUp(self):
         self.tmp = Path(tempfile.mkdtemp())
         _make_repo_tree(self.tmp)
         self.sa = MagicMock(spec=StaticAnalysisResults)
         self.sa.get_languages.return_value = ["python"]
-        self.sa.get_reference.side_effect = ValueError("not found")
-        self.sa.get_loose_reference.side_effect = Exception("not found")
+        nodes = {qname: _make_node(self.tmp, qname, file_path) for qname, file_path in ANALYSIS_KEY_ENTITIES}
+        self.sa.get_reference.side_effect = lambda _lang, qname: nodes[qname]
         self.resolver = StaticReferenceResolver(self.tmp, self.sa)
 
     def tearDown(self):
         shutil.rmtree(self.tmp, ignore_errors=True)
 
-    def test_all_analysis_json_refs_preserved(self):
-        """Every key_entity from analysis.json should survive resolution unchanged."""
+    def test_all_analysis_json_refs_are_refreshed(self):
         refs = [SourceCodeReference(qualified_name=qn, reference_file=rf) for qn, rf in ANALYSIS_KEY_ENTITIES]
-        comp = Component(name="C", description="d", key_entities=refs)
+        comp = Component(
+            name="C",
+            description="d",
+            key_entities=refs,
+            file_methods=_make_file_methods(ANALYSIS_KEY_ENTITIES),
+        )
         analysis = AnalysisInsights(description="d", components=[comp], components_relations=[])
 
         result = self.resolver.fix_source_code_reference_lines(analysis)
@@ -115,7 +120,12 @@ class TestRelativePathAlreadyResolved(unittest.TestCase):
     def test_relative_paths_stay_relative(self):
         """After resolution the reference_file should be a relative path."""
         refs = [SourceCodeReference(qualified_name=qn, reference_file=rf) for qn, rf in ANALYSIS_KEY_ENTITIES]
-        comp = Component(name="C", description="d", key_entities=refs)
+        comp = Component(
+            name="C",
+            description="d",
+            key_entities=refs,
+            file_methods=_make_file_methods(ANALYSIS_KEY_ENTITIES),
+        )
         analysis = AnalysisInsights(description="d", components=[comp], components_relations=[])
 
         result = self.resolver.fix_source_code_reference_lines(analysis)
@@ -154,7 +164,9 @@ class TestResolveFromQualifiedNameOnly(unittest.TestCase):
         self.sa.get_reference.return_value = node
 
         ref = SourceCodeReference(qualified_name=qname, reference_file=None)
-        comp = Component(name="C", description="d", key_entities=[ref])
+        comp = Component(
+            name="C", description="d", key_entities=[ref], file_methods=_make_file_methods([(qname, expected_file)])
+        )
         analysis = AnalysisInsights(description="d", components=[comp], components_relations=[])
 
         result = self.resolver.fix_source_code_reference_lines(analysis)
@@ -171,10 +183,12 @@ class TestResolveFromQualifiedNameOnly(unittest.TestCase):
         node = _make_node(self.tmp, qname, expected_file)
 
         self.sa.get_reference.side_effect = ValueError("not found")
-        self.sa.get_loose_reference.return_value = (qname, node)
+        self.sa.iter_reference_nodes.return_value = [node]
 
         ref = SourceCodeReference(qualified_name=qname, reference_file=None)
-        comp = Component(name="C", description="d", key_entities=[ref])
+        comp = Component(
+            name="C", description="d", key_entities=[ref], file_methods=_make_file_methods([(qname, expected_file)])
+        )
         analysis = AnalysisInsights(description="d", components=[comp], components_relations=[])
 
         result = self.resolver.fix_source_code_reference_lines(analysis)
@@ -182,11 +196,7 @@ class TestResolveFromQualifiedNameOnly(unittest.TestCase):
         self.assertEqual(len(result.components[0].key_entities), 1)
         self.assertEqual(result.components[0].key_entities[0].reference_file, expected_file)
 
-    def test_file_path_fallback_resolves(self):
-        """When static analysis fails, qualified_name -> file path conversion should work.
-
-        e.g. agents.llm_config.LLMConfig -> agents/llm_config.py  (strip last segment, add .py)
-        """
+    def test_file_path_without_static_symbol_is_dropped(self):
         qname = "agents.llm_config.LLMConfig"
         expected_file = "agents/llm_config.py"
 
@@ -195,22 +205,18 @@ class TestResolveFromQualifiedNameOnly(unittest.TestCase):
 
         ref = SourceCodeReference(qualified_name=qname, reference_file=None)
         comp = Component(
-            name="C", description="d", key_entities=[ref], file_methods=_make_file_methods([expected_file])
+            name="C",
+            description="d",
+            key_entities=[ref],
+            file_methods=_make_file_methods([(qname, expected_file)]),
         )
         analysis = AnalysisInsights(description="d", components=[comp], components_relations=[])
 
         result = self.resolver.fix_source_code_reference_lines(analysis)
 
-        self.assertEqual(len(result.components[0].key_entities), 1)
-        resolved = result.components[0].key_entities[0]
-        self.assertEqual(resolved.reference_file, expected_file)
+        self.assertEqual(result.components[0].key_entities, [])
 
-    def test_deep_nested_qname_resolves(self):
-        """Deeply nested qualified names should resolve.
-
-        e.g. diagram_analysis.cluster_delta.ClusterDelta
-             -> diagram_analysis/cluster_delta.py
-        """
+    def test_deep_nested_qname_without_static_symbol_is_dropped(self):
         qname = "diagram_analysis.cluster_delta.ClusterDelta"
         expected_file = "diagram_analysis/cluster_delta.py"
 
@@ -219,17 +225,18 @@ class TestResolveFromQualifiedNameOnly(unittest.TestCase):
 
         ref = SourceCodeReference(qualified_name=qname, reference_file=None)
         comp = Component(
-            name="C", description="d", key_entities=[ref], file_methods=_make_file_methods([expected_file])
+            name="C",
+            description="d",
+            key_entities=[ref],
+            file_methods=_make_file_methods([(qname, expected_file)]),
         )
         analysis = AnalysisInsights(description="d", components=[comp], components_relations=[])
 
         result = self.resolver.fix_source_code_reference_lines(analysis)
 
-        self.assertEqual(len(result.components[0].key_entities), 1)
-        self.assertEqual(result.components[0].key_entities[0].reference_file, expected_file)
+        self.assertEqual(result.components[0].key_entities, [])
 
-    def test_module_level_function_resolves(self):
-        """Module-level function: github_action.main -> github_action.py"""
+    def test_module_level_function_without_static_symbol_is_dropped(self):
         qname = "github_action.main"
         expected_file = "github_action.py"
 
@@ -238,24 +245,20 @@ class TestResolveFromQualifiedNameOnly(unittest.TestCase):
 
         ref = SourceCodeReference(qualified_name=qname, reference_file=None)
         comp = Component(
-            name="C", description="d", key_entities=[ref], file_methods=_make_file_methods([expected_file])
+            name="C",
+            description="d",
+            key_entities=[ref],
+            file_methods=_make_file_methods([(qname, expected_file)]),
         )
         analysis = AnalysisInsights(description="d", components=[comp], components_relations=[])
 
         result = self.resolver.fix_source_code_reference_lines(analysis)
 
-        self.assertEqual(len(result.components[0].key_entities), 1)
-        self.assertEqual(result.components[0].key_entities[0].reference_file, expected_file)
+        self.assertEqual(result.components[0].key_entities, [])
 
 
-class TestRelativePathCWDBug(unittest.TestCase):
-    """Expose bug: os.path.exists(relative_path) is CWD-dependent.
-
-    When CWD == repo_dir, the relative path check passes and the reference
-    is skipped — no line numbers are ever populated.  When CWD != repo_dir
-    the same reference falls through to resolution and gets different treatment.
-    The resolver should behave identically regardless of CWD.
-    """
+class TestStrictStaticResolution(unittest.TestCase):
+    """Key entities require a current symbol inside their component scope."""
 
     def setUp(self):
         self.tmp = Path(tempfile.mkdtemp())
@@ -267,17 +270,17 @@ class TestRelativePathCWDBug(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self.tmp, ignore_errors=True)
 
-    def test_relative_ref_resolved_regardless_of_cwd(self):
-        """A relative reference_file must be recognized even when CWD != repo_dir.
-
-        The check should use repo_dir to resolve the relative path, not rely on
-        os.path.exists with a bare relative path.
-        """
+    def test_relative_ref_without_static_symbol_is_dropped_regardless_of_cwd(self):
         self.sa.get_reference.side_effect = ValueError("not found")
         self.sa.get_loose_reference.side_effect = Exception("not found")
 
         ref = SourceCodeReference(qualified_name="core.registry.Registry", reference_file="core/registry.py")
-        comp = Component(name="C", description="d", key_entities=[ref])
+        comp = Component(
+            name="C",
+            description="d",
+            key_entities=[ref],
+            file_methods=_make_file_methods([("core.registry.Registry", "core/registry.py")]),
+        )
         analysis = AnalysisInsights(description="d", components=[comp], components_relations=[])
 
         # Run from a different CWD to ensure the resolver doesn't depend on it
@@ -288,8 +291,7 @@ class TestRelativePathCWDBug(unittest.TestCase):
         finally:
             os.chdir(original_cwd)
 
-        self.assertEqual(len(result.components[0].key_entities), 1)
-        self.assertEqual(result.components[0].key_entities[0].reference_file, "core/registry.py")
+        self.assertEqual(result.components[0].key_entities, [])
 
     def test_line_numbers_populated_from_static_analysis(self):
         """When static analysis knows the entity, line numbers must be populated.
@@ -306,7 +308,12 @@ class TestRelativePathCWDBug(unittest.TestCase):
             reference_start_line=None,
             reference_end_line=None,
         )
-        comp = Component(name="C", description="d", key_entities=[ref])
+        comp = Component(
+            name="C",
+            description="d",
+            key_entities=[ref],
+            file_methods=_make_file_methods([("core.registry.Registry", "core/registry.py")]),
+        )
         analysis = AnalysisInsights(description="d", components=[comp], components_relations=[])
 
         result = self.resolver.fix_source_code_reference_lines(analysis)
@@ -315,29 +322,22 @@ class TestRelativePathCWDBug(unittest.TestCase):
         self.assertIsNotNone(resolved.reference_start_line, "start_line should be populated from static analysis")
         self.assertIsNotNone(resolved.reference_end_line, "end_line should be populated from static analysis")
 
-    def test_file_path_resolution_populates_no_line_numbers(self):
-        """Expose: file-path fallback resolves the file but leaves line numbers None.
-
-        This is acceptable but should be documented — line numbers are only
-        available through static analysis (exact/loose match).
-        """
+    def test_file_path_resolution_without_static_symbol_is_dropped(self):
         self.sa.get_reference.side_effect = ValueError("not found")
         self.sa.get_loose_reference.side_effect = Exception("not found")
 
         ref = SourceCodeReference(qualified_name="core.registry.Registry", reference_file=None)
         comp = Component(
-            name="C", description="d", key_entities=[ref], file_methods=_make_file_methods(["core/registry.py"])
+            name="C",
+            description="d",
+            key_entities=[ref],
+            file_methods=_make_file_methods([("core.registry.Registry", "core/registry.py")]),
         )
         analysis = AnalysisInsights(description="d", components=[comp], components_relations=[])
 
         result = self.resolver.fix_source_code_reference_lines(analysis)
 
-        self.assertEqual(len(result.components[0].key_entities), 1)
-        resolved = result.components[0].key_entities[0]
-        # File is found but line numbers are NOT populated by file-path fallback
-        self.assertIsNotNone(resolved.reference_file)
-        self.assertIsNone(resolved.reference_start_line)
-        self.assertIsNone(resolved.reference_end_line)
+        self.assertEqual(result.components[0].key_entities, [])
 
 
 class TestMultiComponentAnalysis(unittest.TestCase):
@@ -396,7 +396,6 @@ class TestMultiComponentAnalysis(unittest.TestCase):
         components = []
         for name, entities in component_groups.items():
             refs = []
-            file_paths = []
             for qn, rf in entities:
                 refs.append(
                     SourceCodeReference(
@@ -404,18 +403,16 @@ class TestMultiComponentAnalysis(unittest.TestCase):
                         reference_file=rf if ref_file_present else None,
                     )
                 )
-                if rf not in file_paths:
-                    file_paths.append(rf)
             components.append(
-                Component(name=name, description="d", key_entities=refs, file_methods=_make_file_methods(file_paths))
+                Component(name=name, description="d", key_entities=refs, file_methods=_make_file_methods(entities))
             )
 
         return AnalysisInsights(description="CodeBoarding analysis", components=components, components_relations=[])
 
     def test_all_refs_resolved_with_reference_file(self):
         """When LLM provides reference_file, every entity must survive."""
-        self.sa.get_reference.side_effect = ValueError("not found")
-        self.sa.get_loose_reference.side_effect = Exception("not found")
+        nodes = {qname: _make_node(self.tmp, qname, file_path) for qname, file_path in ANALYSIS_KEY_ENTITIES}
+        self.sa.get_reference.side_effect = lambda _lang, qname: nodes[qname]
 
         analysis = self._build_analysis(ref_file_present=True)
         result = self.resolver.fix_source_code_reference_lines(analysis)
@@ -446,8 +443,8 @@ class TestMultiComponentAnalysis(unittest.TestCase):
 
     def test_output_paths_are_all_relative(self):
         """No matter the resolution strategy, output paths must be relative."""
-        self.sa.get_reference.side_effect = ValueError("not found")
-        self.sa.get_loose_reference.side_effect = Exception("not found")
+        nodes = {qname: _make_node(self.tmp, qname, file_path) for qname, file_path in ANALYSIS_KEY_ENTITIES}
+        self.sa.get_reference.side_effect = lambda _lang, qname: nodes[qname]
 
         analysis = self._build_analysis(ref_file_present=True)
         result = self.resolver.fix_source_code_reference_lines(analysis)

--- a/tests/static_analyzer/test_reference_resolver.py
+++ b/tests/static_analyzer/test_reference_resolver.py
@@ -118,6 +118,38 @@ class TestStaticReferenceResolver(unittest.TestCase):
         self.assertEqual(repair.canonicalized_count, 1)
         self.assertEqual(repair.unresolved_qnames, {"hallucinated.missing"})
 
+    def test_force_resolve_refreshes_persisted_key_entity_location(self):
+        node = self._node("service.OCR.extract_text", "service.py", 30, 40)
+        self.static_analysis.get_reference.return_value = node
+        reference = SourceCodeReference(
+            qualified_name="service.OCR.extract_text",
+            reference_file="service.py",
+            reference_start_line=3,
+            reference_end_line=4,
+        )
+        component = Component(name="Service", description="", key_entities=[reference], component_id="1")
+        analysis = AnalysisInsights(description="", components=[component], components_relations=[])
+
+        self.resolver.fix_key_entities_refs(analysis, {"1"}, force_resolve=True)
+
+        self.assertEqual(reference.reference_start_line, 30)
+        self.assertEqual(reference.reference_end_line, 40)
+
+    def test_force_resolve_drops_deleted_symbol_even_when_file_still_exists(self):
+        self.static_analysis.get_reference.side_effect = ValueError("not found")
+        self.static_analysis.get_loose_reference.return_value = ("", None)
+        reference = SourceCodeReference(
+            qualified_name="service.deleted",
+            reference_file="service.py",
+            reference_start_line=3,
+            reference_end_line=4,
+        )
+
+        repair = self.resolver.repair_key_entity_references([reference], force_resolve=True)
+
+        self.assertEqual(repair.references, [])
+        self.assertEqual(repair.unresolved_qnames, {"service.deleted"})
+
     def test_fix_source_code_reference_lines_resolves_relation_edges_and_call_sites(self):
         source_node = self._node("service.OCR.extract_text", "service.py", 1, 2)
         target_node = self._node("module.file.test_function", "module/file.py", 3, 4)

--- a/tests/static_analyzer/test_reference_resolver.py
+++ b/tests/static_analyzer/test_reference_resolver.py
@@ -89,6 +89,35 @@ class TestStaticReferenceResolver(unittest.TestCase):
 
         self.assertEqual(reference.reference_file, str(self.repo_dir / "module" / "file.py"))
 
+    def test_repair_key_entity_references_canonicalizes_deduplicates_and_drops_unresolved(self):
+        canonical_qname = "service.OCR.extract_text"
+        node = self._node(canonical_qname, "service.py", 3, 4)
+
+        def get_reference(_language, qname):
+            if qname == canonical_qname:
+                return node
+            raise ValueError("not found")
+
+        def get_loose_reference(_language, qname):
+            if qname == "OCR.extract_text":
+                return canonical_qname, node
+            return None, None
+
+        self.static_analysis.get_reference.side_effect = get_reference
+        self.static_analysis.get_loose_reference.side_effect = get_loose_reference
+        self.static_analysis.iter_reference_nodes.return_value = [node]
+        references = [
+            SourceCodeReference(qualified_name="OCR.extract_text"),
+            SourceCodeReference(qualified_name=canonical_qname),
+            SourceCodeReference(qualified_name="hallucinated.missing"),
+        ]
+
+        repair = self.resolver.repair_key_entity_references(references)
+
+        self.assertEqual([reference.qualified_name for reference in repair.references], [canonical_qname])
+        self.assertEqual(repair.canonicalized_count, 1)
+        self.assertEqual(repair.unresolved_qnames, {"hallucinated.missing"})
+
     def test_fix_source_code_reference_lines_resolves_relation_edges_and_call_sites(self):
         source_node = self._node("service.OCR.extract_text", "service.py", 1, 2)
         target_node = self._node("module.file.test_function", "module/file.py", 3, 4)

--- a/tests/static_analyzer/test_reference_resolver.py
+++ b/tests/static_analyzer/test_reference_resolver.py
@@ -89,16 +89,25 @@ class TestStaticReferenceResolver(unittest.TestCase):
 
         self.assertEqual(reference.reference_file, str(self.repo_dir / "module" / "file.py"))
 
-    def test_repair_key_entity_references_canonicalizes_deduplicates_and_drops_unresolved(self):
+    def test_resolve_reference_uses_repo_relative_path_without_candidates(self) -> None:
+        self.static_analysis.get_reference.side_effect = ValueError("not found")
+        self.static_analysis.get_loose_reference.side_effect = ValueError("not found")
+        reference = SourceCodeReference(qualified_name="module.file")
+
+        self.resolver.resolve_reference(reference)
+
+        self.assertEqual(reference.reference_file, str(self.repo_dir / "module" / "file.py"))
+
+    def test_repair_key_entity_references_canonicalizes_deduplicates_and_drops_unresolved(self) -> None:
         canonical_qname = "service.OCR.extract_text"
         node = self._node(canonical_qname, "service.py", 3, 4)
 
-        def get_reference(_language, qname):
+        def get_reference(_language: object, qname: str) -> Node:
             if qname == canonical_qname:
                 return node
             raise ValueError("not found")
 
-        def get_loose_reference(_language, qname):
+        def get_loose_reference(_language: object, qname: str) -> tuple[str | None, Node | None]:
             if qname == "OCR.extract_text":
                 return canonical_qname, node
             return None, None

--- a/tests/static_analyzer/test_reference_resolver.py
+++ b/tests/static_analyzer/test_reference_resolver.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 from agents.agent_responses import AnalysisInsights, Component, Relation, RelationEdge, SourceCodeReference
+from agents.file_index_models import FileMethodGroup, MethodEntry
 from static_analyzer.analysis_result import StaticAnalysisResults
 from static_analyzer.constants import NodeType
 from static_analyzer.graph import Edge
@@ -30,6 +31,14 @@ class TestStaticReferenceResolver(unittest.TestCase):
     def _node(self, qname: str, rel_file: str, start: int = 1, end: int = 2) -> Node:
         return Node(qname, NodeType.FUNCTION, str(self.repo_dir / rel_file), start, end)
 
+    def _file_methods(self, qname: str, rel_file: str) -> list[FileMethodGroup]:
+        return [
+            FileMethodGroup(
+                file_path=rel_file,
+                methods=[MethodEntry(qualified_name=qname, start_line=1, end_line=2, node_type="FUNCTION")],
+            )
+        ]
+
     def test_fix_source_code_reference_lines_resolves_key_entities_and_returns_relative_paths(self):
         node = self._node("service.OCR.extract_text", "service.py", 3, 4)
         self.static_analysis.get_reference.return_value = node
@@ -37,6 +46,7 @@ class TestStaticReferenceResolver(unittest.TestCase):
             name="Service",
             description="",
             key_entities=[SourceCodeReference(qualified_name="service.OCR.extract_text")],
+            file_methods=self._file_methods("service.OCR.extract_text", "service.py"),
         )
         analysis = AnalysisInsights(description="", components=[component], components_relations=[])
 
@@ -127,7 +137,7 @@ class TestStaticReferenceResolver(unittest.TestCase):
         self.assertEqual(repair.canonicalized_count, 1)
         self.assertEqual(repair.unresolved_qnames, {"hallucinated.missing"})
 
-    def test_force_resolve_refreshes_persisted_key_entity_location(self):
+    def test_key_entity_resolution_refreshes_persisted_location(self):
         node = self._node("service.OCR.extract_text", "service.py", 30, 40)
         self.static_analysis.get_reference.return_value = node
         reference = SourceCodeReference(
@@ -136,15 +146,21 @@ class TestStaticReferenceResolver(unittest.TestCase):
             reference_start_line=3,
             reference_end_line=4,
         )
-        component = Component(name="Service", description="", key_entities=[reference], component_id="1")
+        component = Component(
+            name="Service",
+            description="",
+            key_entities=[reference],
+            component_id="1",
+            file_methods=self._file_methods("service.OCR.extract_text", "service.py"),
+        )
         analysis = AnalysisInsights(description="", components=[component], components_relations=[])
 
-        self.resolver.fix_key_entities_refs(analysis, {"1"}, force_resolve=True)
+        self.resolver.fix_key_entities_refs(analysis, {"1"})
 
         self.assertEqual(reference.reference_start_line, 30)
         self.assertEqual(reference.reference_end_line, 40)
 
-    def test_force_resolve_drops_deleted_symbol_even_when_file_still_exists(self):
+    def test_key_entity_resolution_drops_deleted_symbol_even_when_file_still_exists(self):
         self.static_analysis.get_reference.side_effect = ValueError("not found")
         self.static_analysis.get_loose_reference.return_value = ("", None)
         reference = SourceCodeReference(
@@ -154,10 +170,48 @@ class TestStaticReferenceResolver(unittest.TestCase):
             reference_end_line=4,
         )
 
-        repair = self.resolver.repair_key_entity_references([reference], force_resolve=True)
+        repair = self.resolver.repair_key_entity_references([reference])
 
         self.assertEqual(repair.references, [])
         self.assertEqual(repair.unresolved_qnames, {"service.deleted"})
+
+    def test_component_scope_prevents_fuzzy_resolution_into_another_component(self):
+        scoped = self._node("a.Handler.run", "service.py")
+        other = self._node("b.Worker.run", "module/file.py")
+        self.static_analysis.get_reference.side_effect = ValueError("not found")
+        self.static_analysis.iter_reference_nodes.return_value = [other, scoped]
+        reference = SourceCodeReference(qualified_name="Handler.run")
+        component = Component(
+            name="Service",
+            description="",
+            key_entities=[reference],
+            component_id="1",
+            file_methods=self._file_methods("a.Handler.run", "service.py"),
+        )
+        analysis = AnalysisInsights(description="", components=[component], components_relations=[])
+
+        self.resolver.fix_key_entities_refs(analysis, {"1"})
+
+        self.assertEqual([entity.qualified_name for entity in component.key_entities], ["a.Handler.run"])
+
+    def test_component_scope_rejects_exact_reference_owned_by_another_component(self):
+        scoped = self._node("a.Handler.run", "service.py")
+        other = self._node("b.Worker.run", "module/file.py")
+        self.static_analysis.get_reference.return_value = other
+        self.static_analysis.iter_reference_nodes.return_value = [other, scoped]
+        reference = SourceCodeReference(qualified_name="b.Worker.run")
+        component = Component(
+            name="Service",
+            description="",
+            key_entities=[reference],
+            component_id="1",
+            file_methods=self._file_methods("a.Handler.run", "service.py"),
+        )
+        analysis = AnalysisInsights(description="", components=[component], components_relations=[])
+
+        self.resolver.fix_key_entities_refs(analysis, {"1"})
+
+        self.assertEqual(component.key_entities, [])
 
     def test_fix_source_code_reference_lines_resolves_relation_edges_and_call_sites(self):
         source_node = self._node("service.OCR.extract_text", "service.py", 1, 2)


### PR DESCRIPTION
## Summary
- align incremental relation generation with the API-surface and evidence-validation stages used by full and detail analysis
- preserve evidence, key/all edges, and call-site metadata through global relation projection and JSON round trips
- repair missing planner component IDs only when prior cluster ownership or an exact existing component name identifies one unique target
- canonicalize unique hyphen/underscore qualified-name aliases and let deterministic materialization select missing optional key entities
- preserve warm-start CFG edges by validating cached inbound and outbound cross-boundary references against the live LSP
- resolve outbound definitions to the most-specific symbol instead of every enclosing class
- fail explicitly on ambiguous plans or required scope regeneration; incremental analysis never silently becomes full analysis

## Incremental pipeline evaluation

**Source:** local editable core at `../CodeBoarding-core/CodeBoarding`  
**Judge model:** Gemini 3.1 Pro

### LLM scorecard — depth 2 vs depth 3

| Metric | D2 | D3 |
|---|---:|---:|
| Components judged | 5 | 6 |
| Mean component score | 0.48 | 0.63 |
| Correct | 0 | 1 |
| Partial | 5 | 5 |
| Incorrect | 0 | 0 |
| LLM structural score | Not completed | 1.00 — justified |
| Deterministic structural checks | PASS | PASS |
| Edge-integrity check | PASS — 98.1% | PASS — 94.9% |

### Interpretation

- D2 is weak: every changed component was judged partial. The main issues are false method removals and absorbing MCP/OCR changes into unrelated existing components.
- D3 is better: one component was judged fully correct, with the remaining five partial. It correctly added the OCR component and received a fully justified structural score.
- No incorrect verdicts were recorded at either depth.
- D2’s structural LLM call hung after the five component judgments, so its structural score is unavailable; its deterministic structural check passed.

## Repository validation
- `uv run black .` passed
- `mypy .` passed across 312 source files
- repository suite: 1,775 passed, 28 skipped
- coverage gate passed at 80.05% (required 80%)
- focused incremental/diagram/static suites passed, including regressions for the supplied planner and edge failures

## Local test-environment caveat
- the repository-wide command has one unrelated failure in `tests/test_pyproject_packages.py`: user-populated `temp/repos/*` clones are discovered as undeclared CodeBoarding packages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Incremental updates now use staged relation discovery with deterministic relation IDs and improved preservation/repair of component key-entity metadata.
  * Relation endpoint evidence is indexed from source-level references, and diagram JSON/file indexing now supports nested sub-analyses.
* **Bug Fixes**
  * Improved handling for missing/invalid relation endpoints and clearer failures for invalid incremental plans or missing relation context.
  * Warm-start cross-boundary edge restoration now requires live reference validation.
* **Tests**
  * Expanded coverage for incremental planning/repair, relation generation, diagram refresh/indexing, warm-start edge restoration, and reference/key-entity resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Incremental Pipeline Eval — Run 3

After `005e7ef` — **Harden incremental analysis pipeline**

**Engine:** CodeBoarding Core commit `005e7ef` (`3d287cc` Restructure of method calling + reference resolver, plus `005e7ef` Harden incremental analysis pipeline)  
**Agent:** `google/gemini-3-flash-preview`  
**Judge:** `google/gemini-3.1-pro-preview`  
**Date:** 2026-07-12

### Summary scorecard — Run 2 vs Run 3

| Scenario | Depth | Run 2 eval | Run 3 eval | Run 2 judge | Run 3 judge |
|---|---:|---:|---:|---:|---:|
| `markitdown-small-scope` | 2 | 11/11 (100%) | 11/11 (100%) | — (0 changes) | — (0 changes) |
| `markitdown` (full) | 2 | 8/9 (89%) | 8/9 (89%) | 0.68 | **0.78** |
| `markitdown-small-scope-l3` | 3 | 11/11 (100%) | 11/11 (100%) | — (0 changes) | — (0 changes) |
| `markitdown-l3` (full) | 3 | 8/9 (89%) | 8/9 (89%) | 0.68 | 0.63 |

### Small-scope results — perfect stability at both depths

| Scenario | Depth | Baseline | Incremental | Token savings |
|---|---:|---:|---:|---:|
| `markitdown-small-scope` | 2 | 530s / 1.68M tok / 26 comps | 15.3s / 24.4K tok / 26 comps | **69x** |
| `markitdown-small-scope-l3` | 3 | 980s / 7.19M tok / 77 comps | 21.1s / 24.6K tok / 77 comps | **292x** |

Zero component churn, zero relation churn, and zero edge churn at both depths: **11/11 PASS**.

### Full-scope results — depth 2

#### Eval checks

| Check | Result | Detail |
|---|---|---|
| `depth_level_unchanged` | PASS | expected 2; baseline=2, incremental=2 |
| `baseline_has_components` | PASS | 15 components |
| `incremental_has_components` | PASS | 23 components |
| `baseline_artifact_present` | PASS | artifact written |
| `incremental_artifact_present` | PASS | artifact written |
| `l1_component_count_stable` | PASS | 4→6, delta +2, max ±2 |
| `total_component_churn_bounded` | **FAIL** | 15→23, +53%, max ±50% (3pp over threshold) |
| `relation_pair_churn_bounded` | PASS | 42 pairs, 19 added, 1 removed, 48% churn |
| `edge_endpoint_churn_bounded` | PASS | 0 churn |

#### Performance

| Phase | Time | Tokens | Components |
|---|---:|---:|---:|
| Baseline | 433s | 1.22M | 15 (4 L1 + 11 L2) |
| Incremental | 481s | 806K | 23 (6 L1 + 17 L2) |
| Savings | — | **1.5x fewer tokens** | +8 new comps (OCR + MCP) |

#### LLM judge — depth-2 full

Mean: **0.78**, up from 0.68.

| Component | Status | Verdict | Score |
|---|---|---|---:|
| OCR-Enhanced Converters (5) | added | correct | **1.00** |
| MCP Server Interface (6) | added | correct | **1.00** |
| Binary & AI-Powered Converters (3) | modified | correct | **1.00** |
| Textual & Structured Converters (2) | modified | partial | 0.50 |
| Conversion Orchestrator (1) | modified | partial | 0.40 |

**Improvement vs Run 2:** Binary & AI-Powered Converters moved from partial (0.60) to correct (1.00). The judge noted the `accepts` baseline-correction artifact but scored it correct because “the core changes are accurately and comprehensively captured.”

**Structure verdict:** justified (1.00). The +2 L1 and +6 L2 components fully map to the new `markitdown-ocr` and `markitdown-mcp` packages.

### Full-scope results — depth 3

#### Eval checks

| Check | Result | Detail |
|---|---|---|
| `depth_level_unchanged` | PASS | expected 3; baseline=3, incremental=3 |
| `baseline_has_components` | PASS | 86 components |
| `incremental_has_components` | PASS | 112 components |
| `baseline_artifact_present` | PASS | artifact written |
| `incremental_artifact_present` | PASS | artifact written |
| `l1_component_count_stable` | PASS | 6→8, delta +2, max ±2 |
| `total_component_churn_bounded` | PASS | 86→112, +30%, max ±50% |
| `relation_pair_churn_bounded` | PASS | 223 pairs, 54 added, 3 removed, 26% churn |
| `edge_endpoint_churn_bounded` | **FAIL** | 3 base edges, 3 churned (+100%); tiny-base artifact on non-static edges |

#### Performance

| Phase | Time | Tokens | Components |
|---|---:|---:|---:|
| Baseline | 961s | 7.25M | 86 (6 L1 + 20 L2 + 60 L3) |
| Incremental | 801s | 2.28M | 112 (8 L1 + 26 L2 + 78 L3) |
| Savings | **1.2x faster** | **3.2x fewer tokens** | +26 new comps |

#### LLM judge — depth-3 full

Mean: **0.63**, with 7 changes judged.

| Component | Status | Verdict | Score | Core issue |
|---|---|---|---:|---|
| OCR-Enhanced Conversion Suite (7) | added | correct | **1.00** | None |
| MCP Server Interface (8) | added | correct | **1.00** | None |
| Component 4 | modified | partial | 0.70 | New files/methods correctly caught; accepts baseline-recovery noise |
| Component 5 | modified | partial | 0.60 | File-level additions correct; method extraction gaps on `DocumentIntelligenceConverter` |
| Orchestration & Registry (2) | modified | partial | 0.50 | Correctly found new converters; false `accepts` removals |
| Entry Point & Input Handling (1) | modified | partial | 0.40 | `_cu_converter.py` mis-assigned to this component |
| Conversion Framework (3) | modified | incorrect | 0.20 | Flagged as modified with hallucinated reasons; missed the real `_markitdown._convert` change |

**Structure verdict:** justified (1.00). The +2 L1, +6 L2, and +18 L3 components all map to new packages and modules.

### Key findings

#### What improved from Run 2 to Run 3

- Depth-2 judge score improved from 0.68 to **0.78** (+10pp), with one component moving from partial to fully correct.
- Edge churn now passes at depth 2; the previous tiny-base edge volatility is resolved.
- Depth-3 total churn improved from 35% to **30%**, with more components correctly carried forward from the baseline.

#### What regressed

- Depth-3 judge score decreased from 0.68 to **0.63** (-5pp). A new component split created 7 judged changes instead of 6, and Conversion Framework scored 0.20 because the pipeline flagged it as modified with hallucinated reasons while missing the real `MarkItDown._convert` change.
- Depth-2 `total_component_churn_bounded` now fails at +53%, compared with +40% previously. The baseline produced fewer components (15 instead of 20), so the same +8 absolute growth is a higher percentage. This is baseline non-determinism rather than an incremental regression.

#### Persistent issue across all runs

The `accepts` method hallucination remains: baseline extraction misses `accepts` methods on several converters, so the incremental pass “discovers” them and reports them as added or removed. This affects 4 of 5 modified components at depth 2 and 5 of 7 at depth 3. The judge identifies this as a baseline-completeness gap rather than an incremental-logic error.