### PR TITLE
feat(core): fail fast on LLM auth errors instead of retrying blind

### DIFF
--- a/agents/agent.py
+++ b/agents/agent.py
@@ -33,6 +33,21 @@ class EmptyExtractorMessageError(ValueError):
     """Raised when extractor returns an empty message payload."""
 
 
+def _raise_if_auth_error(exc: Exception) -> None:
+    """Re-raise *exc* as a typed :class:`LLMAuthError` when it's a rejected key.
+
+    Shared by the retry classifiers in ``_invoke`` and ``_parse_response``: a
+    401 is permanent for the run, so raising here propagates it terminally (the
+    retry loop never sees a RETRY decision) and the CLI can surface an
+    actionable message. Non-auth exceptions fall through untouched.
+    """
+    provider, key_tail = current_provider_key_context()
+    auth_error = detect_auth_error(exc, provider=provider, key_tail=key_tail)
+    if auth_error is not None:
+        logger.error("LLM auth failure — not retrying: %s", auth_error)
+        raise auth_error from exc
+
+
 class CodeBoardingAgent(MonitoringMixin):
     def __init__(
         self,
@@ -137,14 +152,7 @@ class CodeBoardingAgent(MonitoringMixin):
             return ""  # unreachable for AIMessage but satisfies typing
 
         def classify(exc: Exception, attempt: int) -> RetryDecision:
-            provider, key_tail = current_provider_key_context()
-            auth_error = detect_auth_error(exc, provider=provider, key_tail=key_tail)
-            if auth_error is not None:
-                # A rejected key is permanent for the run: raise the typed error
-                # so it propagates terminally (no retry) and the CLI can surface
-                # an actionable message instead of a traceback.
-                logger.error("LLM auth failure — not retrying: %s", auth_error)
-                raise auth_error from exc
+            _raise_if_auth_error(exc)
             if getattr(exc, "status_code", None) == 404:
                 logger.error(f"Permanent HTTP 404 — not retrying: {type(exc).__name__}: {exc}")
                 return RetryDecision(action=RetryAction.GIVE_UP)
@@ -368,11 +376,7 @@ class CodeBoardingAgent(MonitoringMixin):
             return self._extractor_parse(response, return_type, parser, include_hidden=include_hidden)
 
         def classify(exc: Exception, attempt: int) -> RetryDecision:
-            provider, key_tail = current_provider_key_context()
-            auth_error = detect_auth_error(exc, provider=provider, key_tail=key_tail)
-            if auth_error is not None:
-                logger.error("LLM auth failure during parsing — not retrying: %s", auth_error)
-                raise auth_error from exc
+            _raise_if_auth_error(exc)
             if isinstance(exc, ResourceExhausted):
                 return RetryDecision(
                     action=RetryAction.RETRY,

--- a/agents/agent.py
+++ b/agents/agent.py
@@ -21,7 +21,8 @@ from agents.validation import ValidationResult, score_validation_results, VALIDA
 from monitoring.mixin import MonitoringMixin
 from repo_utils.ignore import RepoIgnoreManager
 from agents.agent_responses import LLMBaseModel
-from agents.llm_config import MONITORING_CALLBACK
+from agents.llm_config import MONITORING_CALLBACK, current_provider_key_context
+from agents.llm_errors import detect_auth_error
 from static_analyzer.analysis_result import StaticAnalysisResults
 from static_analyzer.reference_resolver import StaticReferenceResolver
 
@@ -136,6 +137,14 @@ class CodeBoardingAgent(MonitoringMixin):
             return ""  # unreachable for AIMessage but satisfies typing
 
         def classify(exc: Exception, attempt: int) -> RetryDecision:
+            provider, key_tail = current_provider_key_context()
+            auth_error = detect_auth_error(exc, provider=provider, key_tail=key_tail)
+            if auth_error is not None:
+                # A rejected key is permanent for the run: raise the typed error
+                # so it propagates terminally (no retry) and the CLI can surface
+                # an actionable message instead of a traceback.
+                logger.error("LLM auth failure — not retrying: %s", auth_error)
+                raise auth_error from exc
             if getattr(exc, "status_code", None) == 404:
                 logger.error(f"Permanent HTTP 404 — not retrying: {type(exc).__name__}: {exc}")
                 return RetryDecision(action=RetryAction.GIVE_UP)
@@ -359,6 +368,11 @@ class CodeBoardingAgent(MonitoringMixin):
             return self._extractor_parse(response, return_type, parser, include_hidden=include_hidden)
 
         def classify(exc: Exception, attempt: int) -> RetryDecision:
+            provider, key_tail = current_provider_key_context()
+            auth_error = detect_auth_error(exc, provider=provider, key_tail=key_tail)
+            if auth_error is not None:
+                logger.error("LLM auth failure during parsing — not retrying: %s", auth_error)
+                raise auth_error from exc
             if isinstance(exc, ResourceExhausted):
                 return RetryDecision(
                     action=RetryAction.RETRY,

--- a/agents/llm_config.py
+++ b/agents/llm_config.py
@@ -454,6 +454,23 @@ def get_current_agent_model_ref() -> str:
     return f"{name}/{model_name}"
 
 
+def current_provider_key_context() -> tuple[str, str]:
+    """The selected provider name and a masked key tail, for auth-error messages.
+
+    Returns ``(provider_name, key_tail)`` where ``key_tail`` is the last 4
+    characters of the provider's key (or ``"unknown"`` when no provider is
+    selected or the SDK reads its own credentials, e.g. AWS/Ollama). Never
+    returns the full secret — only enough for the user to recognize which key.
+    """
+    selected = selected_providers()
+    if not selected:
+        return "unknown", "unknown"
+    name = selected[0]
+    key = LLM_PROVIDERS[name].get_api_key()
+    key_tail = key[-4:] if key and len(key) >= 4 else "unknown"
+    return name, key_tail
+
+
 def initialize_parsing_llm(model_override: str | None = None) -> BaseChatModel:
     model, _ = _initialize_llm(model_override, "parsing_model", "parsing_temperature", "Extractor ")
     return model

--- a/agents/llm_errors.py
+++ b/agents/llm_errors.py
@@ -17,6 +17,12 @@ from __future__ import annotations
 
 import re
 
+# Process exit code for a rejected key. Distinct from 1 (generic failure) so the
+# OSS CLI and the wrapper subprocess both signal "fix your key" the same way, and
+# callers/CI can branch on it. Lives here (not in main.py) so the wrapper can
+# import it without pulling in Core's whole CLI module.
+EXIT_AUTH_ERROR = 2
+
 # Class names, across SDKs, that always mean "credentials were rejected".
 # openai/anthropic/cerebras raise ``AuthenticationError``; google raises
 # ``Unauthenticated``/``PermissionDenied``; Bedrock (botocore) surfaces

--- a/agents/llm_errors.py
+++ b/agents/llm_errors.py
@@ -1,0 +1,119 @@
+"""Provider-agnostic detection and typing of LLM authentication failures.
+
+A rejected API key (HTTP 401, or a provider's equivalent auth/permission
+error) is *permanent* for the run: retrying it wastes minutes of backoff and
+floods telemetry with identical ``$exception`` events. The agent retry loop and
+the CLI both need to recognize one when they see it, regardless of which SDK
+raised it.
+
+``detect_auth_error`` maps a raw provider exception to an :class:`LLMAuthError`
+(or ``None`` when it isn't an auth failure). The typed error carries the
+provider, a masked key tail, and the provider's own message, and forwards them
+as ``telemetry_properties`` so the PostHog ``$exception`` event — and the
+dashboard's structured ``error`` columns — populate instead of staying null.
+"""
+
+from __future__ import annotations
+
+import re
+
+# Class names, across SDKs, that always mean "credentials were rejected".
+# openai/anthropic/cerebras raise ``AuthenticationError``; google raises
+# ``Unauthenticated``/``PermissionDenied``; Bedrock (botocore) surfaces
+# ``AccessDeniedException``/``UnrecognizedClientException`` in the error text.
+_AUTH_TYPE_NAMES = {
+    "AuthenticationError",
+    "Unauthenticated",
+    "PermissionDeniedError",
+    "AccessDeniedException",
+    "UnrecognizedClientException",
+}
+
+# Substrings in a provider's message that indicate an auth failure even when the
+# status code isn't exposed on the exception (e.g. errors re-wrapped by langchain
+# or botocore, where only the string survives).
+_AUTH_MESSAGE_PATTERNS = (
+    re.compile(r"\b401\b"),
+    re.compile(r"invalid[\s_-]*x?[\s_-]*api[\s_-]*key", re.IGNORECASE),
+    re.compile(r"incorrect api key", re.IGNORECASE),
+    re.compile(r"api key.*invalid", re.IGNORECASE),
+    re.compile(r"authentication[\s_]*error", re.IGNORECASE),
+    re.compile(r"authentication fails", re.IGNORECASE),
+    re.compile(r"\bunauthorized\b", re.IGNORECASE),
+    re.compile(r"missing authentication", re.IGNORECASE),
+    re.compile(r"access denied", re.IGNORECASE),
+    re.compile(r"invalid github oidc token", re.IGNORECASE),
+)
+
+
+class LLMAuthError(RuntimeError):
+    """An LLM provider rejected our credentials (HTTP 401 or equivalent).
+
+    Terminal by construction: the agent retry loop gives up immediately and the
+    CLI surfaces an actionable message instead of a traceback. ``provider`` and
+    ``key_tail`` identify *which* key to fix without leaking the secret.
+
+    ``telemetry_properties`` is forwarded into the PostHog ``$exception`` event
+    (see ``telemetry.events._exception_properties``).
+    """
+
+    def __init__(self, message: str, *, provider: str, key_tail: str, telemetry_properties: dict):
+        super().__init__(message)
+        self.provider = provider
+        self.key_tail = key_tail
+        self.telemetry_properties = telemetry_properties
+
+
+def _status_code(exc: BaseException) -> int | None:
+    code = getattr(exc, "status_code", None)
+    if code is None:
+        code = getattr(exc, "code", None)  # google GoogleAPICallError.code
+    if code is None:
+        return None
+    try:
+        return int(code)
+    except (TypeError, ValueError):
+        return None
+
+
+def _is_auth_failure(exc: BaseException) -> bool:
+    """True when *exc* represents rejected credentials, across providers."""
+    if _status_code(exc) in (401, 403):
+        return True
+    if type(exc).__name__ in _AUTH_TYPE_NAMES:
+        return True
+    text = str(exc)
+    return any(p.search(text) for p in _AUTH_MESSAGE_PATTERNS)
+
+
+def detect_auth_error(exc: BaseException, *, provider: str, key_tail: str) -> LLMAuthError | None:
+    """Return an :class:`LLMAuthError` if *exc* is an auth failure, else ``None``.
+
+    Already-typed :class:`LLMAuthError` instances pass through unchanged so a
+    re-raise doesn't wrap them twice or lose their original provenance.
+    """
+    if isinstance(exc, LLMAuthError):
+        return exc
+    if not _is_auth_failure(exc):
+        return None
+
+    status = _status_code(exc)
+    provider_message = str(exc)
+    friendly = (
+        f"Your {provider} API key was rejected"
+        + (f" (HTTP {status})" if status is not None else "")
+        + f". Verify the key ending in '…{key_tail}' and try again."
+    )
+    telemetry_properties = {
+        "error_type": "auth",
+        "error_provider": provider,
+        "error_status_code": status,
+        "error_key_tail": key_tail,
+        "error_message": provider_message[:500],
+    }
+    return LLMAuthError(
+        friendly,
+        provider=provider,
+        key_tail=key_tail,
+        telemetry_properties=telemetry_properties,
+    )

--- a/diagram_analysis/diagram_generator.py
+++ b/diagram_analysis/diagram_generator.py
@@ -26,6 +26,7 @@ from agents.incremental_agent import (
 from agents.incremental_planning_agent import IncrementalPlanningAgent
 from agents.incremental_results import RecursiveScopeUpdateResult
 from agents.llm_config import initialize_llms
+from agents.llm_errors import LLMAuthError
 from agents.meta_agent import MetaAgent
 from agents.planner_agent import get_expandable_components
 from agents.scope_ids import ROOT_SCOPE_ID
@@ -156,6 +157,10 @@ class DiagramGenerator:
             new_components = get_expandable_components(analysis, parent_had_clusters=parent_had_clusters)
 
             return component.component_id, analysis, new_components
+        except LLMAuthError:
+            # A rejected key fails every component identically; don't swallow it
+            # per-component and grind through the rest — abort the whole run.
+            raise
         except Exception as e:
             logging.error(f"Error processing component {component.name}: {e}")
             return None, None, []
@@ -483,6 +488,10 @@ class DiagramGenerator:
 
                             logger.info("Expanded '%s' with %d new children.", comp_name, len(new_components))
 
+                    except LLMAuthError:
+                        # Rejected key: abort the whole run rather than logging one
+                        # error per component and continuing with a dead key.
+                        raise
                     except Exception:
                         stats["errors"] += 1
                         logger.exception("Component '%s' generated an exception", component.name)

--- a/main.py
+++ b/main.py
@@ -3,9 +3,13 @@ import os
 import sys
 from pathlib import Path
 
+from agents.llm_errors import LLMAuthError
 from codeboarding_cli.commands import full_analysis, incremental_analysis, partial_analysis
 
 _SUBCOMMANDS = {"full", "incremental", "partial"}
+
+# Distinct from 1 (generic failure) so callers/CI can branch on "fix your key".
+EXIT_AUTH_ERROR = 2
 
 
 def _build_shared_parser() -> argparse.ArgumentParser:
@@ -75,6 +79,25 @@ def _inject_default_subcommand(argv: list[str]) -> list[str]:
     return ["full", *argv]
 
 
+def _dispatch(args: argparse.Namespace, parser: argparse.ArgumentParser) -> None:
+    try:
+        if args.command == "incremental":
+            incremental_analysis.run_from_args(args, parser)
+        elif args.command == "partial":
+            partial_analysis.run_from_args(args, parser)
+        else:
+            full_analysis.run_from_args(args, parser)
+    except LLMAuthError as exc:
+        # A rejected API key is the user's to fix, not a crash: print one
+        # actionable line (no traceback) and exit with a distinct code.
+        print(f"\nCodeBoarding: {exc}", file=sys.stderr)
+        print(
+            "Check your LLM provider API key (shell env or ~/.codeboarding/config.toml) and re-run.",
+            file=sys.stderr,
+        )
+        raise SystemExit(EXIT_AUTH_ERROR) from exc
+
+
 def main(argv: list[str] | None = None) -> None:
     os.environ.setdefault("CODEBOARDING_SOURCE", "oss")
     if argv is None:
@@ -82,13 +105,7 @@ def main(argv: list[str] | None = None) -> None:
     argv = _inject_default_subcommand(list(argv))
     parser = build_parser()
     args = parser.parse_args(argv)
-    if args.command == "incremental":
-        incremental_analysis.run_from_args(args, parser)
-        return
-    if args.command == "partial":
-        partial_analysis.run_from_args(args, parser)
-        return
-    full_analysis.run_from_args(args, parser)
+    _dispatch(args, parser)
 
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -3,13 +3,10 @@ import os
 import sys
 from pathlib import Path
 
-from agents.llm_errors import LLMAuthError
+from agents.llm_errors import EXIT_AUTH_ERROR, LLMAuthError
 from codeboarding_cli.commands import full_analysis, incremental_analysis, partial_analysis
 
 _SUBCOMMANDS = {"full", "incremental", "partial"}
-
-# Distinct from 1 (generic failure) so callers/CI can branch on "fix your key".
-EXIT_AUTH_ERROR = 2
 
 
 def _build_shared_parser() -> argparse.ArgumentParser:

--- a/tests/agents/test_agent.py
+++ b/tests/agents/test_agent.py
@@ -201,6 +201,36 @@ class TestCodeBoardingAgent(unittest.TestCase):
         self.assertEqual(mock_agent_executor.invoke.call_count, 5)
 
     @patch("agents.agent.create_agent")
+    @patch("time.sleep")
+    def test_invoke_auth_error_not_retried(self, mock_sleep, mock_create_agent):
+        # A 401 is permanent: fail fast on the first attempt as a typed
+        # LLMAuthError, never retry, never return the generic fallback string.
+        from agents.llm_errors import LLMAuthError
+
+        class _AuthError(Exception):
+            status_code = 401
+
+        mock_agent_executor = Mock()
+        mock_create_agent.return_value = mock_agent_executor
+        mock_agent_executor.invoke.side_effect = _AuthError("Error code: 401 - key invalid")
+
+        agent = CodeBoardingAgent(
+            repo_dir=self.repo_dir,
+            static_analysis=self.mock_analysis,
+            system_message="Test",
+            agent_llm=self.mock_llm,
+            parsing_llm=Mock(spec=BaseChatModel),
+        )
+
+        with self.assertRaises(LLMAuthError) as ctx:
+            agent._invoke("Test prompt")
+
+        self.assertEqual(mock_agent_executor.invoke.call_count, 1)  # no retry storm
+        mock_sleep.assert_not_called()
+        self.assertEqual(ctx.exception.provider, "openai")
+        self.assertEqual(ctx.exception.key_tail, "_key")  # from OPENAI_API_KEY="test_key"
+
+    @patch("agents.agent.create_agent")
     def test_invoke_with_callbacks(self, mock_create_agent):
         # Test invocation with callbacks
         mock_agent_executor = Mock()

--- a/tests/agents/test_llm_errors.py
+++ b/tests/agents/test_llm_errors.py
@@ -1,0 +1,109 @@
+"""Tests for provider-agnostic LLM auth-error detection and typing."""
+
+import os
+from unittest.mock import patch
+
+from agents.llm_config import current_provider_key_context
+from agents.llm_errors import LLMAuthError, detect_auth_error
+
+
+class _FakeStatusError(Exception):
+    """Mimics openai/anthropic APIStatusError: carries a status_code."""
+
+    def __init__(self, message: str, status_code: int):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class _FakeGoogleError(Exception):
+    """Mimics google GoogleAPICallError: carries a numeric code."""
+
+    def __init__(self, message: str, code: int):
+        super().__init__(message)
+        self.code = code
+
+
+class TestDetectAuthError:
+    def test_openai_style_401_detected(self):
+        exc = _FakeStatusError("Error code: 401 - invalid api key", status_code=401)
+        result = detect_auth_error(exc, provider="openai", key_tail="a8dd")
+        assert isinstance(result, LLMAuthError)
+        assert result.provider == "openai"
+        assert result.key_tail == "a8dd"
+
+    def test_403_detected(self):
+        exc = _FakeStatusError("permission denied", status_code=403)
+        assert detect_auth_error(exc, provider="aws", key_tail="xxxx") is not None
+
+    def test_google_unauthenticated_code_detected(self):
+        exc = _FakeGoogleError("API key not valid", code=401)
+        assert detect_auth_error(exc, provider="google", key_tail="1234") is not None
+
+    def test_class_name_match_without_status_code(self):
+        # A bare class named AuthenticationError with no status_code still counts.
+        AuthenticationError = type("AuthenticationError", (Exception,), {})
+        exc = AuthenticationError("nope")
+        assert detect_auth_error(exc, provider="anthropic", key_tail="9999") is not None
+
+    def test_message_pattern_match(self):
+        # langchain/botocore sometimes re-wrap so only the string survives.
+        exc = RuntimeError("Error code: 401 - {'message': 'invalid x-api-key'}")
+        assert detect_auth_error(exc, provider="anthropic", key_tail="0000") is not None
+
+    def test_github_oidc_message_detected(self):
+        exc = RuntimeError("Error code: 401 - Invalid GitHub OIDC token.")
+        assert detect_auth_error(exc, provider="openrouter", key_tail="tok0") is not None
+
+    def test_non_auth_error_returns_none(self):
+        assert detect_auth_error(TimeoutError("timed out"), provider="openai", key_tail="a8dd") is None
+        assert detect_auth_error(ValueError("bad json"), provider="openai", key_tail="a8dd") is None
+        assert (
+            detect_auth_error(_FakeStatusError("not found", status_code=404), provider="openai", key_tail="x") is None
+        )
+
+    def test_existing_auth_error_passes_through_unchanged(self):
+        original = LLMAuthError("boom", provider="openai", key_tail="a8dd", telemetry_properties={"error_type": "auth"})
+        assert detect_auth_error(original, provider="ignored", key_tail="ignored") is original
+
+    def test_telemetry_properties_are_attached(self):
+        exc = _FakeStatusError("Error code: 401 - your key is invalid", status_code=401)
+        result = detect_auth_error(exc, provider="openai", key_tail="a8dd")
+        assert result is not None
+        props = result.telemetry_properties
+        assert props["error_type"] == "auth"
+        assert props["error_provider"] == "openai"
+        assert props["error_status_code"] == 401
+        assert props["error_key_tail"] == "a8dd"
+        assert "invalid" in props["error_message"]
+
+    def test_message_names_provider_and_key_tail(self):
+        exc = _FakeStatusError("401", status_code=401)
+        result = detect_auth_error(exc, provider="anthropic", key_tail="a8dd")
+        assert result is not None
+        assert "anthropic" in str(result)
+        assert "a8dd" in str(result)
+
+    def test_message_truncated_to_bound(self):
+        exc = _FakeStatusError("x" * 5000, status_code=401)
+        result = detect_auth_error(exc, provider="openai", key_tail="a8dd")
+        assert result is not None
+        assert len(result.telemetry_properties["error_message"]) <= 500
+
+
+class TestCurrentProviderKeyContext:
+    def test_masks_all_but_last_four(self):
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "sk-secret-abcd"}, clear=True):
+            name, tail = current_provider_key_context()
+        assert name == "openai"
+        assert tail == "abcd"
+
+    def test_no_provider_returns_unknown(self):
+        with patch.dict(os.environ, {}, clear=True):
+            assert current_provider_key_context() == ("unknown", "unknown")
+
+    def test_keyless_endpoint_returns_unknown_tail(self):
+        # Selected via base URL, no real key set.
+        with patch.dict(os.environ, {"OPENAI_BASE_URL": "http://127.0.0.1:8000/v1"}, clear=True):
+            name, tail = current_provider_key_context()
+        assert name == "openai"
+        assert tail == "unknown"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -533,5 +533,36 @@ class TestValidateArguments(unittest.TestCase):
         parser.error.assert_called_once()
 
 
+class TestMainAuthErrorHandler(unittest.TestCase):
+    """`_dispatch` turns a rejected key into a clean exit, not a traceback."""
+
+    @patch("main.full_analysis.run_from_args")
+    def test_auth_error_exits_with_distinct_code(self, mock_run):
+        import main
+        from agents.llm_errors import LLMAuthError
+
+        mock_run.side_effect = LLMAuthError(
+            "Your openai API key was rejected (HTTP 401). Verify the key ending in '…a8dd'.",
+            provider="openai",
+            key_tail="a8dd",
+            telemetry_properties={"error_type": "auth"},
+        )
+
+        with self.assertRaises(SystemExit) as ctx:
+            main.main(["full", "--local", "/tmp/repo"])
+
+        self.assertEqual(ctx.exception.code, main.EXIT_AUTH_ERROR)
+
+    @patch("main.full_analysis.run_from_args")
+    def test_non_auth_error_is_not_swallowed(self, mock_run):
+        import main
+
+        mock_run.side_effect = RuntimeError("something else broke")
+
+        # Only auth errors get the friendly-exit treatment; everything else propagates.
+        with self.assertRaises(RuntimeError):
+            main.main(["full", "--local", "/tmp/repo"])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

`AuthenticationError` is the **3rd most common crash** in PostHog (118 in 90d, 14 distinct users) — almost entirely bad/expired/placeholder LLM API keys, not an analysis defect. Splitting the data shows two problems: a broad first-run misconfiguration cohort (June: 10 users across vscode/oss/sync/github_action) and a narrow automation cohort (July: one `oss` user's dead key firing ~hourly for 4 days).

Today a rejected 401 is mishandled at three layers:

1. **Retried like a transient error** — `Agent._invoke`'s `classify()` only special-cases HTTP 404 and `ResourceExhausted`; a 401 falls through to the generic 5×-with-backoff path.
2. **Swallowed per-component** — the two broad `except Exception` blocks in `diagram_generator.py` catch the auth error, log it, and continue to the next component with the same dead key. The worst run emitted **47 `analysis_started` + 47 `analysis_completed` + 38 `$exception`** under one `run_id`.
3. **Raw traceback on the CLI** — `main()` had no top-level handler; the analysis call wasn't guarded (only `bootstrap_environment` was), so a mid-run 401 surfaced as an unhandled traceback + exit 1.

## Fix (Phase A — Core)

- **New `agents/llm_errors.py`** — `LLMAuthError` (typed, terminal; carries `provider`, masked `key_tail`, and `telemetry_properties`) + provider-agnostic `detect_auth_error()` recognizing 401/403 across openai/anthropic/google/AWS and message-only re-wraps (including the `Invalid GitHub OIDC token` signature).
- **`agents/agent.py`** — both `classify()` paths detect a 401 and **raise `LLMAuthError` immediately**. Kills the retry storm and bypasses the silent `"Could not get response from the agent."` fallback for auth failures.
- **`diagram_analysis/diagram_generator.py`** — the two broad `except` blocks **re-raise `LLMAuthError`**, so a dead key aborts the whole run instead of degrading component-by-component.
- **`main.py`** — `_dispatch` catches `LLMAuthError`, prints one actionable line to stderr (no traceback), and exits with a **distinct code `2`** so automation/CI can branch on "fix your key."
- **Telemetry** — props ride on the exception, so the `$exception` event (and the dashboard's structured `error` columns, previously null) now carry `error_type=auth`, provider, status, and masked key tail.
- **`agents/llm_config.py`** — `current_provider_key_context()` returns provider + masked key tail, never the secret.

## Tests

- `tests/agents/test_llm_errors.py` — detection across provider exception shapes, non-auth pass-through, existing-error pass-through, telemetry props, message truncation, provider/key-tail masking.
- `tests/agents/test_agent.py::...::test_invoke_auth_error_not_retried` — a 401 fails on the **first** attempt (call count 1, no sleep) as a typed `LLMAuthError`.
- `tests/test_main.py::TestMainAuthErrorHandler` — the CLI exits with code 2 on auth error and does **not** swallow other exceptions.

All green: `black --check` clean, `mypy` 0 errors on changed files, full agents/telemetry/diagram_analysis suites pass.

## Scope

Phase A only — Core fail-fast. Follow-ups (separate PRs): **Phase B** maps `LLMAuthError` to a dedicated JSON-RPC error code in the wrapper (so the vscode extension doesn't depend on stderr truncation) and routes auth failures to the extension's existing "Open Settings" modal. GitHub-OIDC `gha_proxy` failures are a separate proxy-token workstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Detects LLM credential rejections consistently across supported providers.
  - Authentication failures now fail fast by terminating retries during both invocation and structured parsing.
  - Diagram analysis stops immediately on rejected/auth-related LLM failures.
  - Command-line runs now exit cleanly with a dedicated code and a user-friendly message (no traceback), including provider details with masked key info.

- **Tests**
  - Added unit tests for auth-error detection, retry prevention, key masking, and top-level CLI exit behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->