### PR TITLE
Update project version to 0.13.0 - prepare for release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "codeboarding"
-version = "0.12.5"
+version = "0.13.0"
 description = "Interactive Diagrams for Code"
 readme = "PYPI.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -336,7 +336,7 @@ wheels = [
 
 [[package]]
 name = "codeboarding"
-version = "0.12.5"
+version = "0.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "docker" },


### PR DESCRIPTION
Version bump to `0.13.0` in preparation for release (was `0.12.5`). `uv.lock` refreshed to match.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to 0.13.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->