### PR TITLE
Update project version to 0.13.1 - prepare for release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "codeboarding"
-version = "0.13.0"
+version = "0.13.1"
 description = "Interactive Diagrams for Code"
 readme = "PYPI.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -336,7 +336,7 @@ wheels = [
 
 [[package]]
 name = "codeboarding"
-version = "0.13.0"
+version = "0.13.1"
 source = { editable = "." }
 dependencies = [
     { name = "docker" },


### PR DESCRIPTION
## Summary
- Bump the CodeBoarding package version from `0.13.0` to `0.13.1`.
- Keep the project metadata and `uv.lock` package entry aligned for release.
- Include the Tree-sitter version pins merged in #412 in the patch release baseline.

## Verification
- `uv lock --check`
- `uv run pytest tests/test_pyproject_packages.py -q` (2 passed)
- `uv build`
- Built wheel metadata reports `Version: 0.13.1`
- Confirmed no existing `v0.13.1` tag or GitHub release


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package version to 0.13.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->