### PR TITLE
fix(incremental): stop rejecting plans that re-list a component's own clusters

### DIFF
--- a/agents/incremental_agent.py
+++ b/agents/incremental_agent.py
@@ -404,7 +404,9 @@ def _log_scope_relations_summary(all_rels: list[tuple[str, list[Relation]]]) -> 
 
 
 def _operation_source_cluster_ids(scope_id: str, operation: ScopeOperation) -> list[str]:
-    local_ids = {ref.cluster_id for ref in operation.cluster_refs if ref.scope_id == scope_id}
+    # Match how the validator reads refs (cluster_ref_from_scoped_ref treats a blank scope as root),
+    # so a ref the validator counted is not silently dropped here and orphaned.
+    local_ids = {ref.cluster_id for ref in operation.cluster_refs if (ref.scope_id or ROOT_SCOPE_ID) == scope_id}
     return CodeBoardingClusterIds.qualify_local_ids(
         CodeBoardingClusterIds.from_graph_ids(local_ids),
         CodeBoardingClusterIds.prefix_for_scope(scope_id),

--- a/agents/incremental_planning_agent.py
+++ b/agents/incremental_planning_agent.py
@@ -87,14 +87,22 @@ class IncrementalPlanningAgent(CodeBoardingAgent):
             changed_files=_format_changed_files(self.toolkit.context.changes),
             structural_diff=format_structural_diff(structural_diff),
         )
+        actionable_cluster_refs = _actionable_new_cluster_refs(structural_diff)
         repair_context = ScopeOperationRepairContext(
             reference_resolver=self.reference_resolver,
             allowed_key_entity_qnames=cluster_member_qnames(cluster_results),
             component_ids_by_cluster_ref=_component_ids_by_cluster_ref(scope_id, scope.components, structural_diff),
             component_ids_by_name=_component_ids_by_name(scope.components),
+            scope_id=scope_id,
+            actionable_cluster_refs=actionable_cluster_refs,
+            owned_cluster_ids_by_component_id={
+                component.component_id: set(component.source_cluster_ids)
+                for component in scope.components
+                if component.component_id
+            },
         )
         validation_context = ScopeOperationValidationContext(
-            expected_cluster_refs=_actionable_new_cluster_refs(structural_diff),
+            expected_cluster_refs=actionable_cluster_refs,
             existing_component_ids={component.component_id for component in scope.components if component.component_id},
         )
         decision = self._invoke_repair_validate(

--- a/agents/incremental_planning_agent.py
+++ b/agents/incremental_planning_agent.py
@@ -88,10 +88,11 @@ class IncrementalPlanningAgent(CodeBoardingAgent):
             structural_diff=format_structural_diff(structural_diff),
         )
         actionable_cluster_refs = _actionable_new_cluster_refs(structural_diff)
+        component_ids_by_cluster_ref = _component_ids_by_cluster_ref(scope_id, scope.components, structural_diff)
         repair_context = ScopeOperationRepairContext(
             reference_resolver=self.reference_resolver,
             allowed_key_entity_qnames=cluster_member_qnames(cluster_results),
-            component_ids_by_cluster_ref=_component_ids_by_cluster_ref(scope_id, scope.components, structural_diff),
+            component_ids_by_cluster_ref=component_ids_by_cluster_ref,
             component_ids_by_name=_component_ids_by_name(scope.components),
             scope_id=scope_id,
             actionable_cluster_refs=actionable_cluster_refs,
@@ -104,6 +105,7 @@ class IncrementalPlanningAgent(CodeBoardingAgent):
         validation_context = ScopeOperationValidationContext(
             expected_cluster_refs=actionable_cluster_refs,
             existing_component_ids={component.component_id for component in scope.components if component.component_id},
+            component_ids_by_cluster_ref=component_ids_by_cluster_ref,
         )
         decision = self._invoke_repair_validate(
             prompt,

--- a/agents/repair.py
+++ b/agents/repair.py
@@ -93,11 +93,19 @@ def _drop_redundant_owned_cluster_refs(
     no-op (they are preserved when absent), so normalize the plan back to the intended
     actionable-only shape instead of failing the strict cluster_ref validator. A ref owned by a
     *different* component is left in place so genuine moves and cross-component theft still surface.
+
+    An ``update_component`` that has no changed cluster to account for is left as-is, so the
+    validator rejects it rather than trimming it to an empty update that would still apply
+    name/description to an unchanged component (``create_component`` guards the same way).
     """
     prefix = CodeBoardingClusterIds.prefix_for_scope(context.scope_id)
     trimmed = 0
     for operation in decision.operations:
         if operation.action not in EXISTING_COMPONENT_ACTIONS or operation.component_id is None:
+            continue
+        if operation.action == ScopeOperationAction.UPDATE_COMPONENT and not any(
+            cluster_ref_from_scoped_ref(ref) in context.actionable_cluster_refs for ref in operation.cluster_refs
+        ):
             continue
         owned = context.owned_cluster_ids_by_component_id.get(operation.component_id, set())
         kept: list[ScopedClusterRef] = []

--- a/agents/repair.py
+++ b/agents/repair.py
@@ -35,15 +35,6 @@ _KEY_ENTITY_METADATA_ACTIONS = frozenset(
     }
 )
 
-# Actions that change an existing component's metadata or existence (unlike noop). Trimming one of
-# these to zero cluster_refs would let it mutate or remove a component whose clusters never changed.
-_EXISTING_COMPONENT_CHANGE_ACTIONS = frozenset(
-    {
-        ScopeOperationAction.UPDATE_COMPONENT,
-        ScopeOperationAction.DELETE_COMPONENT,
-    }
-)
-
 
 class ComponentRepairTarget(Protocol):
     components: list[Component]
@@ -95,26 +86,18 @@ def _drop_redundant_owned_cluster_refs(
     decision: ScopeUpdateDecision,
     context: ScopeOperationRepairContext,
 ) -> int:
-    """Trim cluster_refs an existing-component op re-lists that it already owns and that did not change.
+    """Drop cluster_refs an operation lists that its own component already owns and that did not change.
 
-    Why: the planner echoes a touched component's full ``clusters=[...]`` display, but only
-    changed clusters are actionable. Re-listing owned-but-unchanged clusters is a downstream
-    no-op (they are preserved when absent), so normalize the plan back to the intended
-    actionable-only shape instead of failing the strict cluster_ref validator. A ref owned by a
-    *different* component is left in place so genuine moves and cross-component theft still surface.
-
-    An ``update_component`` or ``delete_component`` that has no changed cluster to account for is
-    left as-is, so the validator rejects it rather than trimming it to an empty operation that
-    would still mutate or remove an unchanged component (``create_component`` guards the same way).
+    Why: the planner copies a component's whole ``clusters=[...]`` list, but only the changed
+    (actionable) clusters need to be there. A component re-listing its own unchanged clusters changes
+    nothing, so drop those to match what the validator expects. Clusters owned by another component
+    are always kept so the validator still catches them. Only some operations are safe to trim here
+    (see ``_may_trim_owned_refs``).
     """
     prefix = CodeBoardingClusterIds.prefix_for_scope(context.scope_id)
     trimmed = 0
     for operation in decision.operations:
-        if operation.action not in EXISTING_COMPONENT_ACTIONS or operation.component_id is None:
-            continue
-        if operation.action in _EXISTING_COMPONENT_CHANGE_ACTIONS and not any(
-            cluster_ref_from_scoped_ref(ref) in context.actionable_cluster_refs for ref in operation.cluster_refs
-        ):
+        if operation.component_id is None or not _may_trim_owned_refs(operation, context):
             continue
         owned = context.owned_cluster_ids_by_component_id.get(operation.component_id, set())
         kept: list[ScopedClusterRef] = []
@@ -131,6 +114,33 @@ def _drop_redundant_owned_cluster_refs(
             kept.append(ref)
         operation.cluster_refs = kept
     return trimmed
+
+
+def _may_trim_owned_refs(operation: ScopeOperation, context: ScopeOperationRepairContext) -> bool:
+    """Whether an operation's already-owned, unchanged cluster_refs are safe to drop.
+
+    Only drop them where doing so cannot make an invalid plan look valid:
+    - noop: always - it just keeps a component unchanged.
+    - update_component: only when it edits its own component - it must list at least one changed
+      (actionable) cluster, and every changed cluster it lists must already belong to it. If one
+      belongs to another component, keep the refs so the validator still rejects the move.
+    - delete_component / create_component: never - for a delete, still-owned clusters mean the
+      component is not empty, so keep the refs and let the validator reject it.
+    """
+    if operation.action == ScopeOperationAction.NOOP:
+        return True
+    if operation.action != ScopeOperationAction.UPDATE_COMPONENT:
+        return False
+    accounts_for_own_change = False
+    for ref in operation.cluster_refs:
+        cluster_ref = cluster_ref_from_scoped_ref(ref)
+        if cluster_ref not in context.actionable_cluster_refs:
+            continue
+        proven_owner = context.component_ids_by_cluster_ref.get(cluster_ref)
+        if proven_owner is not None and proven_owner != operation.component_id:
+            return False
+        accounts_for_own_change = True
+    return accounts_for_own_change
 
 
 def _repair_unambiguous_operation_routing(

--- a/agents/repair.py
+++ b/agents/repair.py
@@ -119,19 +119,19 @@ def _drop_redundant_owned_cluster_refs(
 def _may_trim_owned_refs(operation: ScopeOperation, context: ScopeOperationRepairContext) -> bool:
     """Whether an operation's already-owned, unchanged cluster_refs are safe to drop.
 
-    Only drop them where doing so cannot make an invalid plan look valid:
-    - noop: always - it just keeps a component unchanged.
-    - update_component: only when it edits its own component - it must list at least one changed
-      (actionable) cluster, and every changed cluster it lists must already belong to it. If one
-      belongs to another component, keep the refs so the validator still rejects the move.
-    - delete_component / create_component: never - for a delete, still-owned clusters mean the
-      component is not empty, so keep the refs and let the validator reject it.
+    - noop: always. It only preserves a component; the validator separately rejects a noop that
+      claims a cluster owned by another component.
+    - update_component: only a genuine self-update - it must list at least one changed (actionable)
+      cluster, and no changed ref it lists may belong to another component. Otherwise keep the refs
+      so an empty or cross-component update is rejected instead of silently applied.
+    - delete_component / create_component: never - keep the refs so a delete of a component that
+      still owns clusters is rejected.
     """
     if operation.action == ScopeOperationAction.NOOP:
         return True
     if operation.action != ScopeOperationAction.UPDATE_COMPONENT:
         return False
-    accounts_for_own_change = False
+    lists_own_change = False
     for ref in operation.cluster_refs:
         cluster_ref = cluster_ref_from_scoped_ref(ref)
         if cluster_ref not in context.actionable_cluster_refs:
@@ -139,8 +139,8 @@ def _may_trim_owned_refs(operation: ScopeOperation, context: ScopeOperationRepai
         proven_owner = context.component_ids_by_cluster_ref.get(cluster_ref)
         if proven_owner is not None and proven_owner != operation.component_id:
             return False
-        accounts_for_own_change = True
-    return accounts_for_own_change
+        lists_own_change = True
+    return lists_own_change
 
 
 def _repair_unambiguous_operation_routing(

--- a/agents/repair.py
+++ b/agents/repair.py
@@ -35,6 +35,15 @@ _KEY_ENTITY_METADATA_ACTIONS = frozenset(
     }
 )
 
+# Actions that change an existing component's metadata or existence (unlike noop). Trimming one of
+# these to zero cluster_refs would let it mutate or remove a component whose clusters never changed.
+_EXISTING_COMPONENT_CHANGE_ACTIONS = frozenset(
+    {
+        ScopeOperationAction.UPDATE_COMPONENT,
+        ScopeOperationAction.DELETE_COMPONENT,
+    }
+)
+
 
 class ComponentRepairTarget(Protocol):
     components: list[Component]
@@ -94,16 +103,16 @@ def _drop_redundant_owned_cluster_refs(
     actionable-only shape instead of failing the strict cluster_ref validator. A ref owned by a
     *different* component is left in place so genuine moves and cross-component theft still surface.
 
-    An ``update_component`` that has no changed cluster to account for is left as-is, so the
-    validator rejects it rather than trimming it to an empty update that would still apply
-    name/description to an unchanged component (``create_component`` guards the same way).
+    An ``update_component`` or ``delete_component`` that has no changed cluster to account for is
+    left as-is, so the validator rejects it rather than trimming it to an empty operation that
+    would still mutate or remove an unchanged component (``create_component`` guards the same way).
     """
     prefix = CodeBoardingClusterIds.prefix_for_scope(context.scope_id)
     trimmed = 0
     for operation in decision.operations:
         if operation.action not in EXISTING_COMPONENT_ACTIONS or operation.component_id is None:
             continue
-        if operation.action == ScopeOperationAction.UPDATE_COMPONENT and not any(
+        if operation.action in _EXISTING_COMPONENT_CHANGE_ACTIONS and not any(
             cluster_ref_from_scoped_ref(ref) in context.actionable_cluster_refs for ref in operation.cluster_refs
         ):
             continue

--- a/agents/repair.py
+++ b/agents/repair.py
@@ -11,8 +11,11 @@ from agents.agent_responses import (
     Component,
     ScopeOperation,
     ScopeOperationAction,
+    ScopedClusterRef,
     ScopeUpdateDecision,
 )
+from agents.cluster_ids import CodeBoardingClusterIds
+from agents.scope_ids import ROOT_SCOPE_ID
 from agents.scope_operations import (
     EXISTING_COMPONENT_ACTIONS,
     cluster_member_qnames,
@@ -50,6 +53,9 @@ class ScopeOperationRepairContext:
     allowed_key_entity_qnames: set[str]
     component_ids_by_cluster_ref: dict[ClusterRef, str] = field(default_factory=dict)
     component_ids_by_name: dict[str, str] = field(default_factory=dict)
+    scope_id: str = ROOT_SCOPE_ID
+    actionable_cluster_refs: set[ClusterRef] = field(default_factory=set)
+    owned_cluster_ids_by_component_id: dict[str, set[str]] = field(default_factory=dict)
 
 
 def repair_unambiguous_routing_and_optional_key_entity_metadata(
@@ -58,19 +64,56 @@ def repair_unambiguous_routing_and_optional_key_entity_metadata(
 ) -> None:
     """Repair deterministic routing and optional key-entity metadata defects."""
     routed_operations = _repair_unambiguous_operation_routing(decision, context)
+    trimmed_refs = _drop_redundant_owned_cluster_refs(decision, context)
     canonicalized_qnames, dropped_qnames = _repair_optional_key_entity_metadata(
         decision,
         context,
     )
 
-    if routed_operations or canonicalized_qnames:
+    if routed_operations or trimmed_refs or canonicalized_qnames:
         logger.info(
-            "Repaired incremental plan: routed %d operation(s), canonicalized %d key-entity qname(s)",
+            "Repaired incremental plan: routed %d operation(s), trimmed %d redundant owned cluster ref(s), "
+            "canonicalized %d key-entity qname(s)",
             routed_operations,
+            trimmed_refs,
             canonicalized_qnames,
         )
     if dropped_qnames:
         logger.warning("Dropped unresolved optional key entities: %s", sorted(dropped_qnames))
+
+
+def _drop_redundant_owned_cluster_refs(
+    decision: ScopeUpdateDecision,
+    context: ScopeOperationRepairContext,
+) -> int:
+    """Trim cluster_refs an existing-component op re-lists that it already owns and that did not change.
+
+    Why: the planner echoes a touched component's full ``clusters=[...]`` display, but only
+    changed clusters are actionable. Re-listing owned-but-unchanged clusters is a downstream
+    no-op (they are preserved when absent), so normalize the plan back to the intended
+    actionable-only shape instead of failing the strict cluster_ref validator. A ref owned by a
+    *different* component is left in place so genuine moves and cross-component theft still surface.
+    """
+    prefix = CodeBoardingClusterIds.prefix_for_scope(context.scope_id)
+    trimmed = 0
+    for operation in decision.operations:
+        if operation.action not in EXISTING_COMPONENT_ACTIONS or operation.component_id is None:
+            continue
+        owned = context.owned_cluster_ids_by_component_id.get(operation.component_id, set())
+        kept: list[ScopedClusterRef] = []
+        for ref in operation.cluster_refs:
+            source_cluster_id = CodeBoardingClusterIds.qualify_local_id(
+                CodeBoardingClusterIds.from_graph_id(ref.cluster_id), prefix
+            )
+            redundant = source_cluster_id in owned and cluster_ref_from_scoped_ref(ref) not in (
+                context.actionable_cluster_refs
+            )
+            if redundant:
+                trimmed += 1
+                continue
+            kept.append(ref)
+        operation.cluster_refs = kept
+    return trimmed
 
 
 def _repair_unambiguous_operation_routing(

--- a/agents/validation.py
+++ b/agents/validation.py
@@ -64,6 +64,7 @@ class ValidationContext:
 class ScopeOperationValidationContext:
     expected_cluster_refs: set[ClusterRef] = field(default_factory=set)
     existing_component_ids: set[str] = field(default_factory=set)
+    component_ids_by_cluster_ref: dict[ClusterRef, str] = field(default_factory=dict)
 
 
 @dataclass
@@ -88,10 +89,26 @@ def validate_scope_update_decision(
     context: ScopeOperationValidationContext,
 ) -> ValidationResult:
     errors: list[str] = []
-    seen_refs: list[ClusterRef] = []
+    claimed_refs: list[ClusterRef] = []  # every op's refs, for the over-claim (extra) and duplicate checks
+    covered_refs: list[ClusterRef] = []  # non-delete refs only; a delete discards its clusters, so it cannot cover them
     for operation in decision.operations:
         refs = [cluster_ref_from_scoped_ref(ref) for ref in operation.cluster_refs]
-        seen_refs.extend(refs)
+        claimed_refs.extend(refs)
+        if operation.action != ScopeOperationAction.DELETE_COMPONENT:
+            covered_refs.extend(refs)
+        if operation.action == ScopeOperationAction.NOOP:
+            # A noop unions its refs into its component without removing them from the real owner,
+            # so any changed cluster it claims from another component becomes duplicate-owned.
+            foreign = {
+                ref
+                for ref in refs
+                if context.component_ids_by_cluster_ref.get(ref) not in (None, operation.component_id)
+            }
+            if foreign:
+                errors.append(
+                    f"noop for component_id={operation.component_id!r} claims clusters owned by another "
+                    f"component: {_format_cluster_ref_list(foreign)}. A noop must only preserve its own clusters."
+                )
         if operation.action in EXISTING_COMPONENT_ACTIONS:
             if operation.component_id not in context.existing_component_ids:
                 errors.append(
@@ -111,10 +128,10 @@ def validate_scope_update_decision(
         if duplicate_qnames:
             errors.append(f"Operation {operation.action} repeats key entities: {sorted(duplicate_qnames)}.")
 
-    seen_set = set(seen_refs)
-    missing = context.expected_cluster_refs - seen_set
-    extra = seen_set - context.expected_cluster_refs
-    duplicates = {ref for ref in seen_set if seen_refs.count(ref) > 1}
+    claimed_set = set(claimed_refs)
+    missing = context.expected_cluster_refs - set(covered_refs)
+    extra = claimed_set - context.expected_cluster_refs
+    duplicates = {ref for ref in claimed_set if claimed_refs.count(ref) > 1}
     if missing:
         errors.append(f"Missing cluster_refs: {_format_cluster_ref_list(missing)}")
     if extra:

--- a/agents/validation.py
+++ b/agents/validation.py
@@ -128,10 +128,15 @@ def validate_scope_update_decision(
         if duplicate_qnames:
             errors.append(f"Operation {operation.action} repeats key entities: {sorted(duplicate_qnames)}.")
 
-    claimed_set = set(claimed_refs)
+    claimed_set: set[ClusterRef] = set()
+    duplicates: set[ClusterRef] = set()
+    for ref in claimed_refs:
+        if ref in claimed_set:
+            duplicates.add(ref)
+        else:
+            claimed_set.add(ref)
     missing = context.expected_cluster_refs - set(covered_refs)
     extra = claimed_set - context.expected_cluster_refs
-    duplicates = {ref for ref in claimed_set if claimed_refs.count(ref) > 1}
     if missing:
         errors.append(f"Missing cluster_refs: {_format_cluster_ref_list(missing)}")
     if extra:

--- a/tests/agents/test_incremental_planning_agent.py
+++ b/tests/agents/test_incremental_planning_agent.py
@@ -350,6 +350,81 @@ def test_repair_scope_update_decision_repairs_full_scope_planner_output() -> Non
     assert [entity.qualified_name for entity in decision.operations[1].key_entities] == [canonical_qname]
 
 
+def test_repair_trims_redundant_owned_cluster_refs_the_planner_echoed() -> None:
+    """An update that re-lists a component's full owned set is trimmed to the changed clusters.
+
+    Why: the planner echoes the existing ``clusters=[...]`` display, but only changed
+    clusters are actionable. Re-listing owned-but-unchanged clusters used to trip the
+    strict validator and crash the sync (TS repos where components own many clusters).
+    """
+    decision = ScopeUpdateDecision(
+        operations=[
+            ScopeOperation(
+                action=ScopeOperationAction.UPDATE_COMPONENT,
+                cluster_refs=[
+                    ScopedClusterRef(scope_id="root", language="python", cluster_id=cluster_id)
+                    for cluster_id in (2, 11, 18)
+                ],
+                component_id="1",
+                rationale="A file owned by this component changed.",
+            )
+        ]
+    )
+    actionable = {ClusterRef(language="python", cluster_id=2)}
+    repair_context = ScopeOperationRepairContext(
+        reference_resolver=_reference_resolver(),
+        allowed_key_entity_qnames=set(),
+        scope_id="root",
+        actionable_cluster_refs=actionable,
+        owned_cluster_ids_by_component_id={"1": {"2", "11", "18"}},
+    )
+    validation_context = ScopeOperationValidationContext(
+        expected_cluster_refs=actionable,
+        existing_component_ids={"1"},
+    )
+
+    repair_unambiguous_routing_and_optional_key_entity_metadata(decision, repair_context)
+    result = validate_scope_update_decision(decision, validation_context)
+
+    assert result.is_valid
+    assert [ref.cluster_id for ref in decision.operations[0].cluster_refs] == [2]
+
+
+def test_repair_keeps_cross_component_owned_refs_so_theft_still_fails() -> None:
+    """A ref owned by a *different* component is not trimmed, so cross-component theft still surfaces."""
+    decision = ScopeUpdateDecision(
+        operations=[
+            ScopeOperation(
+                action=ScopeOperationAction.UPDATE_COMPONENT,
+                cluster_refs=[
+                    ScopedClusterRef(scope_id="root", language="python", cluster_id=2),
+                    ScopedClusterRef(scope_id="root", language="python", cluster_id=7),
+                ],
+                component_id="1",
+                rationale="Claims a cluster still owned by another component.",
+            )
+        ]
+    )
+    actionable = {ClusterRef(language="python", cluster_id=2)}
+    repair_context = ScopeOperationRepairContext(
+        reference_resolver=_reference_resolver(),
+        allowed_key_entity_qnames=set(),
+        scope_id="root",
+        actionable_cluster_refs=actionable,
+        owned_cluster_ids_by_component_id={"1": {"2"}, "2": {"7"}},
+    )
+    validation_context = ScopeOperationValidationContext(
+        expected_cluster_refs=actionable,
+        existing_component_ids={"1", "2"},
+    )
+
+    repair_unambiguous_routing_and_optional_key_entity_metadata(decision, repair_context)
+    result = validate_scope_update_decision(decision, validation_context)
+
+    assert not result.is_valid
+    assert "Unexpected cluster_refs: root:python:7" in "\n".join(result.feedback_messages)
+
+
 def test_validate_scope_update_decision_keeps_ownerless_update_invalid() -> None:
     ref = ClusterRef(language="python", cluster_id=7)
     decision = ScopeUpdateDecision(

--- a/tests/agents/test_incremental_planning_agent.py
+++ b/tests/agents/test_incremental_planning_agent.py
@@ -512,6 +512,86 @@ def test_repair_leaves_no_change_delete_for_validator_to_reject() -> None:
     assert "Unexpected cluster_refs" in "\n".join(result.feedback_messages)
 
 
+def test_repair_keeps_refs_when_update_moves_another_components_cluster() -> None:
+    """An update that lists a changed cluster owned by another component keeps its own owned refs.
+
+    Why: dropping them would let the validator accept moving that cluster off its real owner.
+    """
+    decision = ScopeUpdateDecision(
+        operations=[
+            ScopeOperation(
+                action=ScopeOperationAction.UPDATE_COMPONENT,
+                cluster_refs=[
+                    ScopedClusterRef(scope_id="root", language="python", cluster_id=3),  # changed, owned by comp 2
+                    ScopedClusterRef(scope_id="root", language="python", cluster_id=9),  # owned by comp 1, unchanged
+                ],
+                component_id="1",
+                rationale="Claims a changed cluster that still belongs to another component.",
+            )
+        ]
+    )
+    actionable = {ClusterRef(language="python", cluster_id=3)}
+    repair_context = ScopeOperationRepairContext(
+        reference_resolver=_reference_resolver(),
+        allowed_key_entity_qnames=set(),
+        scope_id="root",
+        actionable_cluster_refs=actionable,
+        owned_cluster_ids_by_component_id={"1": {"9"}, "2": {"3"}},
+        component_ids_by_cluster_ref={ClusterRef(language="python", cluster_id=3): "2"},
+    )
+    validation_context = ScopeOperationValidationContext(
+        expected_cluster_refs=actionable,
+        existing_component_ids={"1", "2"},
+    )
+
+    repair_unambiguous_routing_and_optional_key_entity_metadata(decision, repair_context)
+    result = validate_scope_update_decision(decision, validation_context)
+
+    assert not result.is_valid
+    assert [ref.cluster_id for ref in decision.operations[0].cluster_refs] == [3, 9]
+    assert "Unexpected cluster_refs: root:python:9" in "\n".join(result.feedback_messages)
+
+
+def test_repair_keeps_delete_refs_when_component_still_owns_clusters() -> None:
+    """A delete of a component that still owns clusters keeps its refs so the validator rejects it.
+
+    Why: dropping them would let a delete through even though the component still owns clusters.
+    """
+    decision = ScopeUpdateDecision(
+        operations=[
+            ScopeOperation(
+                action=ScopeOperationAction.DELETE_COMPONENT,
+                cluster_refs=[
+                    ScopedClusterRef(scope_id="root", language="python", cluster_id=cluster_id)
+                    for cluster_id in (2, 13, 14)
+                ],
+                component_id="5",
+                rationale="Deletes a component that still owns live clusters.",
+            )
+        ]
+    )
+    actionable = {ClusterRef(language="python", cluster_id=2)}
+    repair_context = ScopeOperationRepairContext(
+        reference_resolver=_reference_resolver(),
+        allowed_key_entity_qnames=set(),
+        scope_id="root",
+        actionable_cluster_refs=actionable,
+        owned_cluster_ids_by_component_id={"5": {"2", "13", "14"}},
+        component_ids_by_cluster_ref={ClusterRef(language="python", cluster_id=2): "5"},
+    )
+    validation_context = ScopeOperationValidationContext(
+        expected_cluster_refs=actionable,
+        existing_component_ids={"5"},
+    )
+
+    repair_unambiguous_routing_and_optional_key_entity_metadata(decision, repair_context)
+    result = validate_scope_update_decision(decision, validation_context)
+
+    assert not result.is_valid
+    assert [ref.cluster_id for ref in decision.operations[0].cluster_refs] == [2, 13, 14]
+    assert "Unexpected cluster_refs" in "\n".join(result.feedback_messages)
+
+
 def test_validate_scope_update_decision_keeps_ownerless_update_invalid() -> None:
     ref = ClusterRef(language="python", cluster_id=7)
     decision = ScopeUpdateDecision(

--- a/tests/agents/test_incremental_planning_agent.py
+++ b/tests/agents/test_incremental_planning_agent.py
@@ -467,6 +467,51 @@ def test_repair_leaves_no_change_update_for_validator_to_reject() -> None:
     assert "Unexpected cluster_refs" in "\n".join(result.feedback_messages)
 
 
+def test_repair_leaves_no_change_delete_for_validator_to_reject() -> None:
+    """A delete whose refs are all owned-unchanged (no actionable) must stay invalid.
+
+    Why: trimming it to empty would let it silently remove an untouched component.
+    """
+    decision = ScopeUpdateDecision(
+        operations=[
+            ScopeOperation(
+                action=ScopeOperationAction.UPDATE_COMPONENT,
+                cluster_refs=[ScopedClusterRef(scope_id="root", language="python", cluster_id=2)],
+                component_id="1",
+                rationale="Real change.",
+            ),
+            ScopeOperation(
+                action=ScopeOperationAction.DELETE_COMPONENT,
+                cluster_refs=[
+                    ScopedClusterRef(scope_id="root", language="python", cluster_id=cluster_id)
+                    for cluster_id in (13, 14)
+                ],
+                component_id="5",
+                rationale="Nothing here actually changed.",
+            ),
+        ]
+    )
+    actionable = {ClusterRef(language="python", cluster_id=2)}
+    repair_context = ScopeOperationRepairContext(
+        reference_resolver=_reference_resolver(),
+        allowed_key_entity_qnames=set(),
+        scope_id="root",
+        actionable_cluster_refs=actionable,
+        owned_cluster_ids_by_component_id={"1": {"2"}, "5": {"13", "14"}},
+    )
+    validation_context = ScopeOperationValidationContext(
+        expected_cluster_refs=actionable,
+        existing_component_ids={"1", "5"},
+    )
+
+    repair_unambiguous_routing_and_optional_key_entity_metadata(decision, repair_context)
+    result = validate_scope_update_decision(decision, validation_context)
+
+    assert not result.is_valid
+    assert [ref.cluster_id for ref in decision.operations[1].cluster_refs] == [13, 14]
+    assert "Unexpected cluster_refs" in "\n".join(result.feedback_messages)
+
+
 def test_validate_scope_update_decision_keeps_ownerless_update_invalid() -> None:
     ref = ClusterRef(language="python", cluster_id=7)
     decision = ScopeUpdateDecision(

--- a/tests/agents/test_incremental_planning_agent.py
+++ b/tests/agents/test_incremental_planning_agent.py
@@ -19,10 +19,12 @@ from agents.incremental_planning_agent import (
     _component_ids_by_cluster_ref,
     format_structural_diff,
 )
+from agents.incremental_agent import _operation_source_cluster_ids
 from agents.repair import (
     ScopeOperationRepairContext,
     repair_unambiguous_routing_and_optional_key_entity_metadata,
 )
+from agents.scope_ids import ROOT_SCOPE_ID
 from agents.validation import ScopeOperationValidationContext, validate_scope_update_decision
 from diagram_analysis.cluster_delta import (
     ClusterMemberDelta,
@@ -590,6 +592,115 @@ def test_repair_keeps_delete_refs_when_component_still_owns_clusters() -> None:
     assert not result.is_valid
     assert [ref.cluster_id for ref in decision.operations[0].cluster_refs] == [2, 13, 14]
     assert "Unexpected cluster_refs" in "\n".join(result.feedback_messages)
+
+
+def test_validate_rejects_noop_claiming_another_components_cluster() -> None:
+    """A noop that claims a changed cluster owned by another component is rejected (would duplicate ownership).
+
+    Why: the noop branch of update_scope unions the ref into its component without removing it from the
+    real owner, so the cluster would end up owned by two components.
+    """
+    decision = ScopeUpdateDecision(
+        operations=[
+            ScopeOperation(
+                action=ScopeOperationAction.NOOP,
+                cluster_refs=[ScopedClusterRef(scope_id="root", language="python", cluster_id=3)],  # owned by comp 1
+                component_id="2",
+                rationale="Preserves comp 2 but grabs comp 1's changed cluster.",
+            )
+        ]
+    )
+    context = ScopeOperationValidationContext(
+        expected_cluster_refs={ClusterRef(language="python", cluster_id=3)},
+        existing_component_ids={"1", "2"},
+        component_ids_by_cluster_ref={ClusterRef(language="python", cluster_id=3): "1"},
+    )
+
+    result = validate_scope_update_decision(decision, context)
+
+    assert not result.is_valid
+    assert "claims clusters owned by another component" in "\n".join(result.feedback_messages)
+
+
+def test_validate_rejects_delete_that_still_owns_an_actionable_cluster() -> None:
+    """A delete listing an actionable cluster is rejected: a delete discards its clusters, so it cannot cover one.
+
+    Why: otherwise a changed cluster "covered" only by a delete is thrown away on apply and orphaned.
+    """
+    decision = ScopeUpdateDecision(
+        operations=[
+            ScopeOperation(
+                action=ScopeOperationAction.DELETE_COMPONENT,
+                cluster_refs=[ScopedClusterRef(scope_id="root", language="python", cluster_id=5)],
+                component_id="2",
+                rationale="Deletes a component that still owns a changed cluster.",
+            )
+        ]
+    )
+    context = ScopeOperationValidationContext(
+        expected_cluster_refs={ClusterRef(language="python", cluster_id=5)},
+        existing_component_ids={"2"},
+        component_ids_by_cluster_ref={ClusterRef(language="python", cluster_id=5): "2"},
+    )
+
+    result = validate_scope_update_decision(decision, context)
+
+    assert not result.is_valid
+    assert "Missing cluster_refs: root:python:5" in "\n".join(result.feedback_messages)
+
+
+def test_repair_trims_noop_that_only_preserves_its_own_clusters() -> None:
+    """A noop listing only its own unchanged clusters is trimmed to empty and stays valid."""
+    decision = ScopeUpdateDecision(
+        operations=[
+            ScopeOperation(
+                action=ScopeOperationAction.UPDATE_COMPONENT,
+                cluster_refs=[ScopedClusterRef(scope_id="root", language="python", cluster_id=3)],
+                component_id="1",
+                rationale="Real change.",
+            ),
+            ScopeOperation(
+                action=ScopeOperationAction.NOOP,
+                cluster_refs=[
+                    ScopedClusterRef(scope_id="root", language="python", cluster_id=cluster_id) for cluster_id in (8, 9)
+                ],
+                component_id="2",
+                rationale="Preserve comp 2 unchanged.",
+            ),
+        ]
+    )
+    actionable = {ClusterRef(language="python", cluster_id=3)}
+    repair_context = ScopeOperationRepairContext(
+        reference_resolver=_reference_resolver(),
+        allowed_key_entity_qnames=set(),
+        scope_id="root",
+        actionable_cluster_refs=actionable,
+        owned_cluster_ids_by_component_id={"1": {"3"}, "2": {"8", "9"}},
+        component_ids_by_cluster_ref={ClusterRef(language="python", cluster_id=3): "1"},
+    )
+    validation_context = ScopeOperationValidationContext(
+        expected_cluster_refs=actionable,
+        existing_component_ids={"1", "2"},
+    )
+
+    repair_unambiguous_routing_and_optional_key_entity_metadata(decision, repair_context)
+    result = validate_scope_update_decision(decision, validation_context)
+
+    assert result.is_valid
+    assert decision.operations[1].cluster_refs == []
+
+
+def test_operation_source_cluster_ids_treats_blank_scope_as_root() -> None:
+    """A ref with a blank scope_id is counted for the root scope, matching the validator's normalization."""
+    operation = ScopeOperation(
+        action=ScopeOperationAction.CREATE_COMPONENT,
+        cluster_refs=[ScopedClusterRef(scope_id="", language="python", cluster_id=5)],
+        name="New Feature",
+        description="Owns a brand-new cluster.",
+        rationale="A new cluster appeared.",
+    )
+
+    assert _operation_source_cluster_ids(ROOT_SCOPE_ID, operation) == ["5"]
 
 
 def test_validate_scope_update_decision_keeps_ownerless_update_invalid() -> None:

--- a/tests/agents/test_incremental_planning_agent.py
+++ b/tests/agents/test_incremental_planning_agent.py
@@ -351,12 +351,7 @@ def test_repair_scope_update_decision_repairs_full_scope_planner_output() -> Non
 
 
 def test_repair_trims_redundant_owned_cluster_refs_the_planner_echoed() -> None:
-    """An update that re-lists a component's full owned set is trimmed to the changed clusters.
-
-    Why: the planner echoes the existing ``clusters=[...]`` display, but only changed
-    clusters are actionable. Re-listing owned-but-unchanged clusters used to trip the
-    strict validator and crash the sync (TS repos where components own many clusters).
-    """
+    """Why: the planner echoes a component's full ``clusters=[...]`` display, but only changed clusters are actionable."""
     decision = ScopeUpdateDecision(
         operations=[
             ScopeOperation(
@@ -423,6 +418,53 @@ def test_repair_keeps_cross_component_owned_refs_so_theft_still_fails() -> None:
 
     assert not result.is_valid
     assert "Unexpected cluster_refs: root:python:7" in "\n".join(result.feedback_messages)
+
+
+def test_repair_leaves_no_change_update_for_validator_to_reject() -> None:
+    """An update whose refs are all owned-unchanged (no actionable) must stay invalid.
+
+    Why: trimming it to empty would let it silently apply name/description to an untouched component.
+    """
+    decision = ScopeUpdateDecision(
+        operations=[
+            ScopeOperation(
+                action=ScopeOperationAction.UPDATE_COMPONENT,
+                cluster_refs=[ScopedClusterRef(scope_id="root", language="python", cluster_id=2)],
+                component_id="1",
+                rationale="Real change.",
+            ),
+            ScopeOperation(
+                action=ScopeOperationAction.UPDATE_COMPONENT,
+                cluster_refs=[
+                    ScopedClusterRef(scope_id="root", language="python", cluster_id=cluster_id)
+                    for cluster_id in (13, 14)
+                ],
+                component_id="5",
+                name="Hijacked",
+                description="Update of an untouched component that changed nothing.",
+                rationale="Nothing here actually changed.",
+            ),
+        ]
+    )
+    actionable = {ClusterRef(language="python", cluster_id=2)}
+    repair_context = ScopeOperationRepairContext(
+        reference_resolver=_reference_resolver(),
+        allowed_key_entity_qnames=set(),
+        scope_id="root",
+        actionable_cluster_refs=actionable,
+        owned_cluster_ids_by_component_id={"1": {"2"}, "5": {"13", "14"}},
+    )
+    validation_context = ScopeOperationValidationContext(
+        expected_cluster_refs=actionable,
+        existing_component_ids={"1", "5"},
+    )
+
+    repair_unambiguous_routing_and_optional_key_entity_metadata(decision, repair_context)
+    result = validate_scope_update_decision(decision, validation_context)
+
+    assert not result.is_valid
+    assert [ref.cluster_id for ref in decision.operations[1].cluster_refs] == [13, 14]
+    assert "Unexpected cluster_refs" in "\n".join(result.feedback_messages)
 
 
 def test_validate_scope_update_decision_keeps_ownerless_update_invalid() -> None:


### PR DESCRIPTION
## What

Incremental **sync** crashes on TypeScript repos (graph-viewer, CodeBoarding-webview) with:

```
InvalidIncrementalPlanError: Incremental plan for scope 'root' is invalid:
Unexpected cluster_refs: root:typescript:9, root:typescript:10, root:typescript:11, ... :47
```

## Root cause

`decide_scope_update` asks the planner LLM to emit one operation per touched component. The LLM echoes each component's **full** `clusters=[...]` display (its whole owned set), while `validate_scope_update_decision` only expects the clusters that actually **changed** (`_actionable_new_cluster_refs`). Every owned-but-unchanged cluster is flagged as `Unexpected`, validation fails all 3 retries, and the sync dies.

The 16 "unexpected" IDs in production decompose exactly into three components' owned-but-unchanged clusters — the planner is echoing owned sets, not hallucinating.

**Why now:** the exact-match check predates this, but the parent of #408 ended `decide_scope_update` with `logger.error(...); return decision` — it *tolerated* the mismatch and passed the plan through (harmlessly, since re-listing a component's own clusters is a downstream no-op). #408 replaced that with `raise InvalidIncrementalPlanError`, turning a previously-tolerated false positive into a hard crash.

**Why TypeScript:** TS call graphs are near-edgeless, so clustering falls to file level and each component owns 8–12 tiny clusters. A one-file edit re-lists many unchanged clusters, so `extra = owned − actionable` balloons. Python graphs cluster tightly (~1 cluster/component), `owned ≈ actionable`, and the check never trips — which is why it's TS-only.

## Fix

The plan is validated in one place (`validate_scope_update_decision`) before `update_scope` applies it, so correctness lives across the repair → validate → apply path:

**Repair (`agents/repair.py`)** — `_drop_redundant_owned_cluster_refs` normalizes the plan back to the intended actionable-only shape: it drops the cluster_refs a component re-lists that it already owns and that did not change. `_may_trim_owned_refs` only trims where it cannot hide an invalid plan — `noop` always, `update_component` only when it lists ≥1 of its own changed clusters and none belonging to another component, `delete`/`create` never.

**Validator (`agents/validation.py`)** — now enforces cluster ownership, which is `update_scope`'s only gate:
- A `noop` claiming a changed cluster owned by **another** component is rejected — the noop branch of `update_scope` unions the ref in without stripping the real owner, so it would create **duplicate ownership**.
- Refs are split into `claimed` (all ops → over-claim/duplicate) and `covered` (non-delete → coverage). A `delete` discards its clusters, so a cluster "covered" only by a delete now surfaces as **Missing** instead of being silently **orphaned**.
- Still keeps the original `missing` / `Unexpected` / `duplicate` checks; a component re-listing its own unchanged clusters is no longer flagged.

**Apply (`agents/incremental_agent.py`)** — `_operation_source_cluster_ids` normalizes a blank `scope_id` to root, matching `cluster_ref_from_scoped_ref`, so a ref the validator counted isn't dropped (and orphaned) at apply.

An `update` "moving" a cluster to another component is left as a legitimate reshape — the reassign strip guarantees single ownership, so it's self-consistent, not corruption.

The **action side is intentionally left as-is** (no full-analysis fallback added) so this class of error keeps surfacing loudly instead of being silently masked.

## How it was hardened

The last three findings (empty `update`/`delete` still applying, `noop` duplicate ownership, `delete` orphaning) came from PR review + an adversarial audit that ran the real `update_scope` apply path to separate genuine corruption from self-consistent reshapes. The takeaway that shaped the final design: the trim alone can't guarantee correctness — ownership has to be enforced in the validator.

## Testing

- Reproduced the exact production failure (same 16 IDs) against graph-viewer's real committed baseline; confirmed the fix makes it pass.
- Regression tests for every hole: over-listing accepted; empty update/delete rejected; noop-duplicate rejected; delete-orphan rejected; blank-scope ref normalized; cross-component theft, missing, and duplicate still rejected.
- Full suite green: 564 tests pass, `mypy` clean, `black` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved incremental repair/validation consistency by trimming redundant cluster references owned by the same component when they’re not actionable, while preserving references owned by other components.
  * Strengthened validation to reject NOOP decisions that claim clusters owned by another component, and treated blank scope identifiers as belonging to the root scope.
* **Tests**
  * Expanded unit test coverage for trimming correctness, non-trimming guardrails, cross-component reference protection, and root-scope handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->