### PR TITLE
fix(incremental): confine child scopes to their re-partitioned parent

### DIFF
--- a/codeboarding_workflows/analysis.py
+++ b/codeboarding_workflows/analysis.py
@@ -139,6 +139,10 @@ def run_partial(
     # its subcomponents. Rebuild reads each sub's LLM relation labels, which live
     # only in memory (they aren't serialized), so it must run before the save.
     sub_analyses[component_id] = sub_analysis
+    # The baseline we loaded may predate child scopes being confined to their parent.
+    # Repair it here too: this flow only regenerates one component, so nothing else
+    # would reconcile the rest of the tree before the save asserts containment.
+    generator._rescope_child_analyses(root_analysis, sub_analyses)
     # persist_side_artifacts=False: an expansion must not rewrite file_coverage.json
     # or the static-analysis cache. The latter would drop the static_analysis.sha
     # tag (no source_sha here) and force the next incremental run to cold-start.

--- a/diagram_analysis/diagram_generator.py
+++ b/diagram_analysis/diagram_generator.py
@@ -691,9 +691,13 @@ class DiagramGenerator:
                     child_scope, cluster_results, cfg_graphs, component.component_id
                 )
             else:
-                # The parent owns no live methods, so no child may own any.
+                # The parent owns no live methods, so no child may own any. Clear the
+                # scope's own index too: ``save_analysis`` merges it into the unified
+                # ``files``/``methods_index``, and the partial flow saves without a
+                # ``_refresh_files_index`` that would otherwise drop the stale entries.
                 for child in child_scope.components:
                     child.file_methods = []
+                child_scope.files = {}
             self._rescope_child_analyses(child_scope, sub_analyses)
 
     def _apply_incremental_scope_recursively(

--- a/diagram_analysis/diagram_generator.py
+++ b/diagram_analysis/diagram_generator.py
@@ -49,7 +49,7 @@ from diagram_analysis.cluster_snapshot import (
     ClusterSnapshot,
     snapshot_from_static_analysis,
 )
-from diagram_analysis.exceptions import IncrementalCacheMissingError
+from diagram_analysis.exceptions import IncrementalCacheMissingError, ScopeContainmentError
 from diagram_analysis.file_coverage import FileCoverage
 from diagram_analysis.file_index import build_files_index, refresh_method_spans_from_cfg
 from diagram_analysis.io_utils import load_analysis_metadata, normalize_repo_path, save_analysis, write_fingerprint
@@ -606,6 +606,7 @@ class DiagramGenerator:
         """
         self.rebuild_global_relations(root_analysis, sub_analyses)
         self._strip_ignored(root_analysis, sub_analyses)
+        assert_scope_containment(root_analysis, sub_analyses)
 
     def finalize_and_save(
         self,
@@ -664,6 +665,36 @@ class DiagramGenerator:
             not_analyzed=summary["not_analyzed"],
             not_analyzed_by_reason=summary["not_analyzed_by_reason"],
         )
+
+    def _rescope_child_analyses(
+        self,
+        scope: AnalysisInsights,
+        sub_analyses: dict[str, AnalysisInsights],
+    ) -> None:
+        """Re-partition every child scope over its parent's current ``file_methods``.
+
+        Why: ``update_scope`` re-partitions a parent against the live clustering, but a
+        child scope is a separate ``AnalysisInsights`` that no patch touches — a method
+        that moved to another component would otherwise stay in the old owner's subtree
+        and appear under two components.
+        """
+        assert self.incremental_agent is not None
+        for component in scope.components:
+            child_scope = sub_analyses.get(component.component_id)
+            if child_scope is None or not child_scope.components:
+                continue
+            _subgraph_str, cluster_results, cfg_graphs = self.incremental_agent._create_strict_component_subgraph(
+                component, source_cluster_id_prefix=component.component_id
+            )
+            if cluster_results:
+                self.incremental_agent.populate_file_methods(
+                    child_scope, cluster_results, cfg_graphs, component.component_id
+                )
+            else:
+                # The parent owns no live methods, so no child may own any.
+                for child in child_scope.components:
+                    child.file_methods = []
+            self._rescope_child_analyses(child_scope, sub_analyses)
 
     def _apply_incremental_scope_recursively(
         self,
@@ -783,6 +814,9 @@ class DiagramGenerator:
                 # No structural change, but a body-only edit still moves content
                 # hashes — refresh the files index from live source so they don't
                 # go stale (relations are already the global set here).
+                # Re-scope anyway: a baseline written before child scopes were
+                # confined to their parent stays drifted until something repairs it.
+                self._rescope_child_analyses(root_analysis, sub_analyses)
                 self._refresh_files_index(root_analysis, sub_analyses)
                 return self.finalize_and_save(root_analysis, sub_analyses)
 
@@ -800,6 +834,7 @@ class DiagramGenerator:
                 delta.cluster_results(),
                 sub_analyses,
             )
+            self._rescope_child_analyses(root_analysis, sub_analyses)
 
             removed_ids = prune_empty_components(root_analysis, sub_analyses, protected_empty_ids)
             if removed_ids:
@@ -854,6 +889,35 @@ class DiagramGenerator:
             for fp, entry in analysis.files.items():
                 unified_files.setdefault(fp, FileEntry()).merge_from(entry)
         root_analysis.files = unified_files
+
+
+def assert_scope_containment(
+    root_analysis: AnalysisInsights,
+    sub_analyses: dict[str, AnalysisInsights],
+) -> None:
+    """Raise ``ScopeContainmentError`` if any child scope owns methods its parent does not."""
+    components_by_id = {
+        component.component_id: component
+        for analysis in [root_analysis, *sub_analyses.values()]
+        for component in analysis.components
+        if component.component_id
+    }
+    violations: list[str] = []
+    for component_id, child_scope in sorted(sub_analyses.items()):
+        parent = components_by_id.get(component_id)
+        if parent is None:
+            continue
+        owned = {(group.file_path, method.qualified_name) for group in parent.file_methods for method in group.methods}
+        for child in child_scope.components:
+            escaped = {
+                (group.file_path, method.qualified_name) for group in child.file_methods for method in group.methods
+            } - owned
+            if escaped:
+                violations.append(
+                    f"{child.component_id or child.name} holds {len(escaped)} method(s) outside parent {component_id}"
+                )
+    if violations:
+        raise ScopeContainmentError(violations)
 
 
 def _collect_components_by_id(

--- a/diagram_analysis/exceptions.py
+++ b/diagram_analysis/exceptions.py
@@ -51,3 +51,18 @@ class InvalidIncrementalPlanError(RuntimeError):
         super().__init__(f"Incremental plan for scope {scope_id!r} is invalid: {issue_summary}")
         self.scope_id = scope_id
         self.issues = issues
+
+
+class ScopeContainmentError(RuntimeError):
+    """Raised when a child scope owns methods its parent component does not.
+
+    Every method must belong to exactly one component per tree level. Because a
+    child scope is a separate ``AnalysisInsights``, containment is the one half of
+    that invariant no single populate/patch pass can enforce — so it is checked
+    once before the save. A violation means the same method renders under two
+    components, which is worse to ship than a failed run.
+    """
+
+    def __init__(self, violations: list[str]):
+        super().__init__("Child scopes own methods outside their parent component: " + "; ".join(violations))
+        self.violations = violations

--- a/tests/agents/test_method_uniqueness.py
+++ b/tests/agents/test_method_uniqueness.py
@@ -34,7 +34,7 @@ from agents.agent_responses import (
     SourceCodeReference,
 )
 from agents.cluster_methods_mixin import ClusterMethodsMixin
-from agents.file_index_models import FileMethodGroup, MethodEntry
+from agents.file_index_models import FileEntry, FileMethodGroup, MethodEntry
 from diagram_analysis.diagram_generator import DiagramGenerator, assert_scope_containment
 from diagram_analysis.exceptions import ScopeContainmentError
 from static_analyzer.constants import Language, NodeType
@@ -424,11 +424,8 @@ class TestMethodUniquenessNoAliases(unittest.TestCase):
 class TestScopeContainment(unittest.TestCase):
     """A child scope must only own methods its parent component still owns.
 
-    Reproduces the CodeBoarding-webview drift: an incremental run re-partitions the
-    root components against the live clustering, moving methods from component 1 to
-    component 2, but sub_analyses["1"] is a separate object no patch touches. Its
-    children keep the moved methods, so each one renders under component 2 *and*
-    under component 1's subtree.
+    Why: a child scope is a separate ``AnalysisInsights``, so re-partitioning a
+    parent cannot evict the moved methods from its children.
     """
 
     def setUp(self):
@@ -543,11 +540,15 @@ class TestScopeContainment(unittest.TestCase):
     def test_rescope_empties_children_when_parent_owns_nothing(self):
         root, sub_analyses, static_analysis = self._build_tree()
         root.components[0].file_methods = []
+        sub_analyses["1"].files = {"shared.ts": FileEntry()}
         gen = self._generator(static_analysis)
 
         gen._rescope_child_analyses(root, sub_analyses)
 
         self.assertEqual([m for c in sub_analyses["1"].components for g in c.file_methods for m in g.methods], [])
+        # save_analysis merges every scope's index into the unified files/methods_index,
+        # so a scope with no owned methods must not keep one.
+        self.assertEqual(sub_analyses["1"].files, {})
         assert_scope_containment(root, sub_analyses)
 
 

--- a/tests/agents/test_method_uniqueness.py
+++ b/tests/agents/test_method_uniqueness.py
@@ -12,11 +12,17 @@ one component. However, `_build_file_methods_from_nodes` deduplicates by
 (start_line, end_line, type, short_name) — so both aliases produce the same MethodEntry
 in the output. Result: the same deduplicated method appears in BOTH components.
 
-The invariant: at the same tree level, a method (identified by its deduplicated key:
-start_line + end_line + type + short_name) must appear in at most ONE component's
-file_methods.
+The invariant has two halves:
+1. Within a tree level, a method (by its deduplicated key: start_line + end_line +
+   type + short_name) appears in at most ONE component's file_methods.
+2. Across levels, a child scope only owns methods its parent component owns. A child
+   scope is a separate ``AnalysisInsights`` in ``sub_analyses`` — ``Component`` has no
+   ``.components`` field, nesting is stitched at serialization — so no single populate
+   pass sees both halves. ``TestScopeContainment`` covers this one.
 """
 
+import shutil
+import tempfile
 import unittest
 from collections import defaultdict
 from pathlib import Path
@@ -28,7 +34,10 @@ from agents.agent_responses import (
     SourceCodeReference,
 )
 from agents.cluster_methods_mixin import ClusterMethodsMixin
-from static_analyzer.constants import NodeType
+from agents.file_index_models import FileMethodGroup, MethodEntry
+from diagram_analysis.diagram_generator import DiagramGenerator, assert_scope_containment
+from diagram_analysis.exceptions import ScopeContainmentError
+from static_analyzer.constants import Language, NodeType
 from static_analyzer.graph import CallGraph, ClusterResult
 from static_analyzer.node import Node
 
@@ -410,6 +419,136 @@ class TestMethodUniquenessNoAliases(unittest.TestCase):
         # All 6 methods should be assigned
         total = sum(len(m.methods) for c in analysis.components for m in c.file_methods)
         self.assertEqual(total, 6)
+
+
+class TestScopeContainment(unittest.TestCase):
+    """A child scope must only own methods its parent component still owns.
+
+    Reproduces the CodeBoarding-webview drift: an incremental run re-partitions the
+    root components against the live clustering, moving methods from component 1 to
+    component 2, but sub_analyses["1"] is a separate object no patch touches. Its
+    children keep the moved methods, so each one renders under component 2 *and*
+    under component 1's subtree.
+    """
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.repo_location = Path(self.temp_dir) / "repo"
+        self.repo_location.mkdir(parents=True)
+        self.output_dir = Path(self.temp_dir) / "out"
+        self.output_dir.mkdir(parents=True)
+        self.temp_folder = Path(self.temp_dir) / "tmp"
+        self.temp_folder.mkdir(parents=True)
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def _method(self, qname: str, start: int) -> MethodEntry:
+        return MethodEntry(
+            qualified_name=qname, start_line=start, end_line=start + 8, node_type="FUNCTION", content_hash="h"
+        )
+
+    def _build_tree(self):
+        """Root owns 6 methods in shared.ts, split 3/3 between components 1 and 2.
+
+        sub_analyses["1"] still covers all 6 — the state left behind after an
+        incremental run moved 3 of them from component 1 to component 2.
+        """
+        cfg = CallGraph(language="typescript")
+        shared = str(self.repo_location / "shared.ts")
+        for i in range(6):
+            cfg.add_node(Node(f"shared.func{i}", NodeType.FUNCTION, shared, i * 10 + 1, i * 10 + 9))
+        for i in range(5):
+            cfg.add_edge(f"shared.func{i}", f"shared.func{i + 1}")
+
+        keeps = [self._method(f"shared.func{i}", i * 10 + 1) for i in range(3)]
+        moved = [self._method(f"shared.func{i}", i * 10 + 1) for i in range(3, 6)]
+
+        comp_one = Component(
+            name="One",
+            description="parent that lost methods",
+            component_id="1",
+            key_entities=[SourceCodeReference(qualified_name="shared.func0")],
+            source_cluster_ids=["0"],
+            file_methods=[FileMethodGroup(file_path="shared.ts", methods=keeps)],
+        )
+        comp_two = Component(
+            name="Two",
+            description="component that gained them",
+            component_id="2",
+            key_entities=[SourceCodeReference(qualified_name="shared.func3")],
+            source_cluster_ids=["1"],
+            file_methods=[FileMethodGroup(file_path="shared.ts", methods=moved)],
+        )
+        root = AnalysisInsights(description="root", components=[comp_one, comp_two], components_relations=[])
+
+        # Child of component 1, still detailed against the pre-move boundary.
+        child = Component(
+            name="One-child",
+            description="stale subtree",
+            component_id="1.1",
+            key_entities=[SourceCodeReference(qualified_name="shared.func0")],
+            source_cluster_ids=["1.0"],
+            file_methods=[FileMethodGroup(file_path="shared.ts", methods=keeps + moved)],
+        )
+        sub_analyses = {"1": AnalysisInsights(description="sub of 1", components=[child], components_relations=[])}
+
+        static_analysis = MagicMock()
+        static_analysis.get_cfg.return_value = cfg
+        static_analysis.get_languages.return_value = [Language.TYPESCRIPT]
+        return root, sub_analyses, static_analysis
+
+    def _generator(self, static_analysis) -> DiagramGenerator:
+        gen = DiagramGenerator(
+            repo_location=self.repo_location,
+            temp_folder=self.temp_folder,
+            repo_name="repo",
+            output_dir=self.output_dir,
+            depth_level=2,
+            run_id="test-run",
+            log_path="repo/test-run",
+        )
+        # _rescope_child_analyses only needs the mixin half of IncrementalAgent.
+        gen.incremental_agent = MockMixin(repo_dir=self.repo_location, static_analysis=static_analysis)  # type: ignore[assignment]
+        return gen
+
+    def test_stale_child_scope_is_detected(self):
+        """The guard must reject a child holding methods its parent no longer owns."""
+        root, sub_analyses, _ = self._build_tree()
+
+        with self.assertRaises(ScopeContainmentError) as ctx:
+            assert_scope_containment(root, sub_analyses)
+        self.assertIn("1.1", str(ctx.exception))
+
+    def test_rescope_confines_children_to_parent(self):
+        """Re-scoping must drop the moved methods from component 1's subtree."""
+        root, sub_analyses, static_analysis = self._build_tree()
+        gen = self._generator(static_analysis)
+
+        gen._rescope_child_analyses(root, sub_analyses)
+
+        parent_owned = {m.qualified_name for g in root.components[0].file_methods for m in g.methods}
+        child_owned = {
+            m.qualified_name for c in sub_analyses["1"].components for g in c.file_methods for m in g.methods
+        }
+        self.assertEqual(child_owned - parent_owned, set(), "child escaped its parent's scope")
+        self.assertEqual(child_owned, parent_owned, "children must partition the parent exactly")
+
+        # The moved methods now belong to component 2 alone.
+        two_owned = {m.qualified_name for g in root.components[1].file_methods for m in g.methods}
+        self.assertEqual(child_owned & two_owned, set(), "method still rendered under two components")
+
+        assert_scope_containment(root, sub_analyses)
+
+    def test_rescope_empties_children_when_parent_owns_nothing(self):
+        root, sub_analyses, static_analysis = self._build_tree()
+        root.components[0].file_methods = []
+        gen = self._generator(static_analysis)
+
+        gen._rescope_child_analyses(root, sub_analyses)
+
+        self.assertEqual([m for c in sub_analyses["1"].components for g in c.file_methods for m in g.methods], [])
+        assert_scope_containment(root, sub_analyses)
 
 
 if __name__ == "__main__":

--- a/tests/diagram_analysis/test_diagram_analysis.py
+++ b/tests/diagram_analysis/test_diagram_analysis.py
@@ -1388,6 +1388,7 @@ class TestDiagramGenerator(unittest.TestCase):
                 new_component_ids=set(),
             ),
         ]
+        _mock_incremental_agent.return_value._create_strict_component_subgraph.return_value = ("", {}, {})
         mock_save_analysis.return_value = self.output_dir / "analysis.json"
 
         gen.generate_analysis_incremental(root_analysis, sub_analyses)
@@ -1506,6 +1507,7 @@ class TestDiagramGenerator(unittest.TestCase):
         gen.details_agent = Mock()
         gen.incremental_planning_agent = Mock()
         gen.incremental_agent = Mock()
+        gen.incremental_agent._create_strict_component_subgraph.return_value = ("", {}, {})
         gen.static_analysis = Mock()
         gen.static_analysis.get_languages.return_value = []
         gen.static_analysis.incremental_base_results = Mock()


### PR DESCRIPTION
Reported off [CodeBoarding-webview#17](https://github.com/CodeBoarding/CodeBoarding-webview/pull/17) ([diagram](https://app.codeboarding.org/CodeBoarding/CodeBoarding-webview/pull/17?run=29457724097)): the same method/class shows up under several components. In that artifact **1419 of 2263 methods** appear in more than one top-level component — e.g. `ReviewPanel` under both `State Management & UI Shell` and `GitHub Integration Layer > GitHub API Proxy & Client`.

## It is not sibling overlap

At **every** level of the tree, methods are perfectly disjoint (0 duplicates at level 1, 0 among level-2 siblings). All of it is **parent↔child**: a child holds methods its parent no longer owns, while a *different* top-level component now owns them. Measuring sibling overlap shows nothing here — the invariant that breaks is `union(children) == parent.own`.

## Root cause — incremental only

The analysis is two levels living in **separate objects**: root components in `analysis.json`, children in `sub_analyses`. `Component` has no `.components` field; nesting is stitched together only at serialization. So parent↔child containment spans two objects no single pass ever sees together.

A **full run** does two steps in order:
1. assign every method in the repo to a root component;
2. for each root component, split **only its methods** among its children.

Step 2 reads the parent's set, so children cannot escape it.

An **incremental run** does step 1 and skips step 2. `_patch_file_methods` strips represented qnames from *every* component in the scope (no `touched_ids` guard), fully re-partitioning the root against the live clustering — methods legitimately move between components. Nothing tells the children.

Bisected on the webview baselines (same Core version either side — the difference is the run mode):

| | full run (Jul 15 10:01) | next incremental (19:31) |
|---|---|---|
| GitHub Integration Layer **owns** | 1892 | **206** |
| its children **hold** | 1892 ✓ | **1734** ← untouched |
| State Management **owns** | 6 | **1570** ← gained them |

`ReviewPanel`'s methods moved to State Management at root level; `GitHub API Proxy & Client` was never told and still lists them, so it renders under both.

## The fix — reuse the full path's missing step

`_rescope_child_analyses` is DetailsAgent's **step 1 + step 6**, called verbatim:

```python
_str, cluster_results, cfg_graphs = agent._create_strict_component_subgraph(component, prefix=component_id)
agent.populate_file_methods(child_scope, cluster_results, cfg_graphs, component_id)
```

No new assignment logic — it re-derives each child scope from its parent's current `file_methods`. It deliberately skips DetailsAgent's LLM half (steps 2–5), which would re-name and re-ID every child on each run and defeat the point of incremental. It runs before relations are built, on every path that **loads** a baseline: the main incremental path, the `not delta.has_changes` early return, and partial expansion. Full runs are correct by construction and are left alone.

`assert_scope_containment` guards the save. Because every path either builds the tree correctly or repairs it first, a violation can now only mean the repair didn't converge — a real bug, where shipping a diagram with one method under two components is worse than failing loudly (AGENTS.md §5).

> Note on validation/retry: this can't live in `agents/validation.py`. Those validators score **LLM output** to drive re-prompts, and `file_methods` is `exclude=True` — never sent to or returned by the LLM, populated deterministically. A retry would be bit-identical. The deterministic analogue of a retry is the repair above, which is why it runs on every affected path instead of just failing.

## Validation — replayed the real regression

Using the webview's clean baseline `10be343f`, its **committed** `static_analysis.pkl`, and the real source change `5efe4d3`:

| run | leak |
|---|---|
| pre-fix (drift reproduced) | **1561** (production saw 1562, per-component within 1) |
| post-fix, same inputs | **0**, with `own == kids` for every component |

- Methods in more than one top-level component: **1419 → 0**.
- The shipped corrupt baseline `713f4a6a` (leak=1565) **self-heals to 0 in one run** — no full re-analysis needed. Verified for both the incremental no-change path and partial expansion (the latter would otherwise have hard-failed on the new guard).
- It also fixes the mirror defect: State Management's subtree went from covering 6 of its ~1500 methods to all of them.

## Tests

`TestScopeContainment` covers the axis nothing tested before — containment across `(root, sub_analyses)`. The existing `test_method_uniqueness.py` asserts the one axis that isn't broken (sibling overlap = 0 here) on the one path that can't break it (`populate_file_methods`); adding recursion wouldn't help since `Component` has no children to recurse into. Verified the new tests **fail without the fix**. Full suite green (1833 passed), mypy + black clean.

## Known, out of scope

Incremental runs also leave **duplicate cluster ownership** at level 1 — two root components both claiming a cluster in `source_cluster_ids` (21 contested clusters even after this fix). It doesn't duplicate methods, because `_build_cluster_to_component_map` is a dict and silently resolves last-writer-wins by list order, but the metadata is wrong and the winner is arbitrary — plausibly what drives the violent migration above. `_update_component_from_operation` unions cluster ids into the baseline's and never removes, so #415's validator check (which inspects the plan, not the post-merge state) doesn't catch it. Worth a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured incremental diagram analysis keeps child components consistent with their parent’s current method ownership.
  * Added a pre-save validation that detects and blocks invalid cross-scope method ownership, raising a clear error when violations occur.
  * Automatically re-scopes child components to repair method ownership boundaries before results are saved.
* **Tests**
  * Added scenarios covering stale child ownership detection, automatic re-scoping behavior, and empty parent-scope handling.
  * Updated incremental-analysis tests to stub a consistent strict-component subgraph structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->