### PR TITLE
Member-granular incremental change detection (CallGraph)

### DIFF
--- a/PYPI.md
+++ b/PYPI.md
@@ -81,7 +81,7 @@ generator = DiagramGenerator(
     temp_folder=output_dir,
     repo_name="my-project",
     output_dir=output_dir,
-    depth_level=1,
+    depth_level=3,  # safety-valve cap; component expansion is driven by structural separability
 )
 [analysis_path] = generator.generate_analysis()
 
@@ -139,7 +139,7 @@ codeboarding partial --local PATH --component-id ID   # update one component
 | Option | Description |
 |---|---|
 | `--local PATH` | Analyze a local repository (output: `PATH/.codeboarding/`) |
-| `--depth-level INT` | Diagram depth (default: 1) |
+| `--depth-level INT` | Safety-valve depth cap (default: 3); expansion is driven by structural separability, not this value |
 | `--force` | (full only) Force full reanalysis, skip cached static analysis |
 | `--base-ref REF` / `--target-ref REF` | (incremental only) Git refs to diff |
 | `--component-id ID` | (partial only) ID of the component to update |

--- a/README.md
+++ b/README.md
@@ -124,8 +124,9 @@ Shell environment variables such as `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GOOG
 # Analyze a local repository
 python main.py full --local ./my-project
 
-# Increase diagram depth
-python main.py full --local ./my-project --depth-level 2
+# Raise the depth ceiling (rarely needed — component expansion is driven by
+# structural separability; --depth-level is a safety-valve cap, default 3)
+python main.py full --local ./my-project --depth-level 5
 
 # Re-analyze only changed parts when possible
 python main.py incremental --local ./my-project

--- a/agents/abstraction_agent.py
+++ b/agents/abstraction_agent.py
@@ -32,6 +32,7 @@ from agents.validation import (
     validate_relations,
 )
 from monitoring import trace
+from static_analyzer import StaticAnalysisFatalError
 from static_analyzer.analysis_result import StaticAnalysisResults
 from static_analyzer.cluster_helpers import build_all_cluster_results
 from static_analyzer.graph import ClusterResult
@@ -191,6 +192,14 @@ class AbstractionAgent(ClusterMethodsMixin, CodeBoardingAgent):
 
         # Step 1: Deterministically partition leaf clusters into the top-level groups (Leiden, modularity-peak N)
         cluster_analysis = self.step_clusters_grouping(cluster_results)
+        if not cluster_analysis.cluster_components:
+            # No leaf clusters means the repo has no callable structure to abstract
+            # (unsupported/empty/no-code). Fail loudly instead of emptying the
+            # architecture and crashing downstream in populate_file_methods.
+            raise StaticAnalysisFatalError(
+                f"No component groups found for {self.project_name}: the static analysis produced "
+                "no callable structure to build an architecture from."
+            )
 
         # Step 2: Name and describe each fixed group into a component (LLM, one component per group)
         analysis = self.step_final_analysis(cluster_analysis, cluster_results)

--- a/agents/abstraction_agent.py
+++ b/agents/abstraction_agent.py
@@ -17,7 +17,6 @@ from agents.agent_responses import (
 )
 from agents.cluster_methods_mixin import ClusterMethodsMixin
 from agents.prompts import (
-    get_cluster_grouping_message,
     get_final_analysis_message,
     get_api_surfaces_message,
     get_relation_analysis_message,
@@ -28,17 +27,13 @@ from agents.relation_edges import index_relation_endpoints
 from agents.repair import ComponentRepairContext, repair_component_group_names, repair_key_entities
 from agents.validation import (
     ValidationContext,
-    validate_cluster_coverage,
     validate_group_name_coverage,
     validate_key_entities,
     validate_relations,
 )
 from monitoring import trace
 from static_analyzer.analysis_result import StaticAnalysisResults
-from static_analyzer.cluster_helpers import (
-    build_all_cluster_results,
-    get_all_cluster_ids,
-)
+from static_analyzer.cluster_helpers import build_all_cluster_results
 from static_analyzer.graph import ClusterResult
 
 logger = logging.getLogger(__name__)
@@ -61,10 +56,6 @@ class AbstractionAgent(ClusterMethodsMixin, CodeBoardingAgent):
         self.meta_context = meta_context
 
         self.prompts = {
-            "group_clusters": PromptTemplate(
-                template=get_cluster_grouping_message(),
-                input_variables=["cfg_clusters"],
-            ),
             "final_analysis": PromptTemplate(
                 template=get_final_analysis_message(),
                 input_variables=["cluster_analysis"],
@@ -88,37 +79,15 @@ class AbstractionAgent(ClusterMethodsMixin, CodeBoardingAgent):
 
     @trace
     def step_clusters_grouping(self, cluster_results: dict[str, ClusterResult]) -> ClusterAnalysis:
-        logger.info(f"[AbstractionAgent] Grouping CFG clusters for: {self.project_name}")
+        """Deterministically partition leaf clusters into the top-level component groups.
 
-        programming_langs = self.static_analysis.get_languages()
-
-        # Measure everything that wraps cfg_clusters (system message + rendered
-        # template with an empty slot) so the skip planner can back it out of
-        # the input window before budgeting the cluster string.
-        overhead_chars = len(str(self.system_message.content)) + len(
-            self.prompts["group_clusters"].format(
-                cfg_clusters="",
-            )
-        )
-        cluster_str = self._build_cluster_string(
-            programming_langs, cluster_results, prompt_overhead_chars=overhead_chars
-        )
-
-        prompt = self.prompts["group_clusters"].format(
-            cfg_clusters=cluster_str,
-        )
-
-        cluster_analysis = self._invoke_validate(
-            prompt,
-            ClusterAnalysis,
-            validators=[validate_cluster_coverage],
-            validation_context=ValidationContext(
-                cluster_results=cluster_results,
-                expected_cluster_ids=get_all_cluster_ids(cluster_results),
-            ),
-            max_validation_attempts=3,
-        )
-        return cluster_analysis
+        Resolution-tuned Leiden picks both the count (modularity peak over
+        ``[5, 8]``) and the membership, so the top-level structure is stable across
+        re-runs — the LLM no longer decides it; it only names them in the
+        final-analysis step.
+        """
+        logger.info(f"[AbstractionAgent] Super-clustering leaf clusters for: {self.project_name}")
+        return self.deterministic_cluster_grouping(cluster_results)
 
     @trace
     def step_final_analysis(
@@ -162,6 +131,7 @@ class AbstractionAgent(ClusterMethodsMixin, CodeBoardingAgent):
             validation_context=context,
             max_validation_attempts=3,
         )
+        self.assemble_one_component_per_group(architecture, llm_cluster_analysis, cluster_results)
         return AnalysisInsights(
             description=architecture.description,
             components=architecture.components,
@@ -219,10 +189,10 @@ class AbstractionAgent(ClusterMethodsMixin, CodeBoardingAgent):
         # Build full cluster results dict for all languages ONCE
         cluster_results = build_all_cluster_results(self.static_analysis)
 
-        # Step 1: Group related clusters together into logical components
+        # Step 1: Deterministically partition leaf clusters into the top-level groups (Leiden, modularity-peak N)
         cluster_analysis = self.step_clusters_grouping(cluster_results)
 
-        # Step 2: Generate abstract components from grouped clusters
+        # Step 2: Name and describe each fixed group into a component (LLM, one component per group)
         analysis = self.step_final_analysis(cluster_analysis, cluster_results)
         # Step 3: Assign hierarchical component IDs ("1", "2", "3", ...)
         assign_component_ids(analysis)

--- a/agents/cluster_methods_mixin.py
+++ b/agents/cluster_methods_mixin.py
@@ -601,7 +601,7 @@ class ClusterMethodsMixin:
                 if seeded_snapshot:
                     scoped_delta = _delta_for_language(
                         str(lang),
-                        sub_cfg.to_networkx(),
+                        sub_cfg.clustering_networkx(),
                         seeded_snapshot,
                     )
                     sub_cluster_result = scoped_delta.cluster_results
@@ -612,7 +612,9 @@ class ClusterMethodsMixin:
                 # Merge into super-clusters if too many (same limit as AbstractionAgent)
                 if len(sub_cluster_result.clusters) > MAX_LLM_CLUSTERS:
                     n_before = len(sub_cluster_result.clusters)
-                    sub_cluster_result = merge_clusters(sub_cluster_result, sub_cfg.to_networkx(), MAX_LLM_CLUSTERS)
+                    sub_cluster_result = merge_clusters(
+                        sub_cluster_result, sub_cfg.clustering_networkx(), MAX_LLM_CLUSTERS
+                    )
                     logger.info(
                         f"[DetailsAgent] Subgraph for '{component.name}': "
                         f"merged {n_before} -> {len(sub_cluster_result.clusters)} super-clusters"
@@ -624,7 +626,7 @@ class ClusterMethodsMixin:
 
         # Cross-language: enforce combined budget and unique IDs
         if len(cluster_results) > 1:
-            cfg_nx = {lang: subgraph_cfgs[lang].to_networkx() for lang in cluster_results}
+            cfg_nx = {lang: subgraph_cfgs[lang].clustering_networkx() for lang in cluster_results}
             enforce_cross_language_budget(cluster_results, cfg_nx)
 
         if source_cluster_id_prefix:

--- a/agents/cluster_methods_mixin.py
+++ b/agents/cluster_methods_mixin.py
@@ -180,7 +180,9 @@ class ClusterMethodsMixin:
         longer decides it. Each group gets a stable ``Group i`` label and a summary
         of its members; the final-analysis step only names and describes them.
         """
-        cfg_graphs = {lang: self.static_analysis.get_cfg(Language(lang)).to_networkx() for lang in cluster_results}
+        cfg_graphs = {
+            lang: self.static_analysis.get_cfg(Language(lang)).clustering_networkx() for lang in cluster_results
+        }
         groups = supercluster_leaf_ids(cluster_results, cfg_graphs, low, high)
         node_lookup, file_lookup = _leaf_cluster_lookups(cluster_results)
         cluster_components = [

--- a/agents/cluster_methods_mixin.py
+++ b/agents/cluster_methods_mixin.py
@@ -9,7 +9,9 @@ import networkx as nx
 from agents.agent_responses import (
     AnalysisInsights,
     ClusterAnalysis,
+    ClustersComponent,
     Component,
+    ComponentArchitecture,
 )
 from agents.file_index_models import FileMethodGroup, MethodEntry
 from agents.cluster_budget import ClusterPromptBudget
@@ -30,8 +32,11 @@ from static_analyzer.analysis_result import StaticAnalysisResults
 from static_analyzer.cfg_skip_planner import ContextBudgetExceededError, plan_skip_set
 from static_analyzer.cluster_helpers import (
     MAX_LLM_CLUSTERS,
+    TOP_LEVEL_COMPONENTS_MAX,
+    TOP_LEVEL_COMPONENTS_MIN,
     enforce_cross_language_budget,
     merge_clusters,
+    supercluster_leaf_ids,
 )
 from static_analyzer.cluster_relations import (
     build_component_relations,
@@ -43,6 +48,56 @@ from static_analyzer.graph import CallGraph, ClusterResult
 from static_analyzer.node import Node
 
 logger = logging.getLogger(__name__)
+
+
+def _leaf_cluster_lookups(
+    cluster_results: dict[str, ClusterResult],
+) -> tuple[dict[int, set[str]], dict[int, set[str]]]:
+    """Flatten per-language cluster results into id -> members and id -> files.
+
+    Leaf-cluster IDs are globally unique across languages, so a plain merge is safe.
+    """
+    node_lookup: dict[int, set[str]] = {}
+    file_lookup: dict[int, set[str]] = {}
+    for cr in cluster_results.values():
+        node_lookup.update(cr.clusters)
+        file_lookup.update(cr.cluster_to_files)
+    return node_lookup, file_lookup
+
+
+def _group_symbols(cluster_ids: list[int], node_lookup: dict[int, set[str]]) -> list[str]:
+    """Qualified names in a group, most top-level first (fewest name segments)."""
+    names = {qname for cid in cluster_ids for qname in node_lookup.get(cid, set())}
+    return sorted(names, key=lambda qname: (qname.count("."), qname))
+
+
+def _summarize_group(
+    group: set[int],
+    node_lookup: dict[int, set[str]],
+    file_lookup: dict[int, set[str]],
+    max_symbols: int = 12,
+    max_files: int = 8,
+) -> str:
+    """A deterministic, name-rich blurb so the LLM can name a group without re-clustering."""
+    symbols = _group_symbols(sorted(group), node_lookup)
+    files = sorted({path for cid in group for path in file_lookup.get(cid, set())})
+    file_names = [Path(path).name for path in files]
+
+    parts = [f"{len(group)} leaf clusters, {len(symbols)} symbols across {len(files)} files."]
+    if file_names:
+        shown = ", ".join(file_names[:max_files])
+        parts.append(f"Files: {shown}{', ...' if len(file_names) > max_files else ''}")
+    if symbols:
+        shown = ", ".join(symbols[:max_symbols])
+        parts.append(f"Key symbols: {shown}{', ...' if len(symbols) > max_symbols else ''}")
+    return " ".join(parts)
+
+
+def _fallback_component(group: ClustersComponent, node_lookup: dict[int, set[str]]) -> Component:
+    """Deterministic component for a group the LLM failed to name (merged/dropped it)."""
+    symbols = _group_symbols(group.cluster_ids, node_lookup)
+    name = symbols[0].split(".")[-1] if symbols else group.name
+    return Component(name=name, description=group.description, key_entities=[])
 
 
 @dataclass(frozen=True)
@@ -111,6 +166,75 @@ class ClusterMethodsMixin:
     # These attributes must be provided by the class using this mixin
     repo_dir: Path
     static_analysis: StaticAnalysisResults
+
+    def deterministic_cluster_grouping(
+        self,
+        cluster_results: dict[str, ClusterResult],
+        low: int = TOP_LEVEL_COMPONENTS_MIN,
+        high: int = TOP_LEVEL_COMPONENTS_MAX,
+    ) -> ClusterAnalysis:
+        """Partition leaf clusters into fixed component groups via resolution-tuned Leiden.
+
+        The count (modularity peak over ``[low, high]``) and membership are chosen
+        deterministically, so the structure is stable across re-runs — the LLM no
+        longer decides it. Each group gets a stable ``Group i`` label and a summary
+        of its members; the final-analysis step only names and describes them.
+        """
+        cfg_graphs = {lang: self.static_analysis.get_cfg(Language(lang)).to_networkx() for lang in cluster_results}
+        groups = supercluster_leaf_ids(cluster_results, cfg_graphs, low, high)
+        node_lookup, file_lookup = _leaf_cluster_lookups(cluster_results)
+        cluster_components = [
+            ClustersComponent(
+                name=f"Group {i}",
+                cluster_ids=sorted(group),
+                description=_summarize_group(group, node_lookup, file_lookup),
+            )
+            for i, group in enumerate(groups, start=1)
+        ]
+        logger.info(
+            f"[{type(self).__name__}] Partitioned {sum(len(g) for g in groups)} leaf clusters "
+            f"into {len(cluster_components)} deterministic groups"
+        )
+        return ClusterAnalysis(cluster_components=cluster_components)
+
+    @staticmethod
+    def assemble_one_component_per_group(
+        architecture: ComponentArchitecture,
+        cluster_analysis: ClusterAnalysis,
+        cluster_results: dict[str, ClusterResult],
+    ) -> None:
+        """Force exactly one component per fixed group — the count is Leiden's, not the LLM's.
+
+        The groups (and their membership) are decided deterministically upstream;
+        the LLM only names and describes them. Whatever the LLM returns, we pin the
+        result to one component per group: the LLM's component that claimed a group
+        keeps its name/description/key_entities; any group the LLM merged away or
+        dropped gets a deterministic fallback so the count never drifts.
+        """
+        node_lookup, _ = _leaf_cluster_lookups(cluster_results)
+        claimant: dict[str, Component] = {}
+        for comp in architecture.components:
+            for group_name in comp.source_group_names:
+                claimant.setdefault(group_name.lower(), comp)
+
+        used: set[int] = set()
+        final: list[Component] = []
+        for group in cluster_analysis.cluster_components:
+            comp = claimant.get(group.name.lower())
+            if comp is None or id(comp) in used:
+                comp = _fallback_component(group, node_lookup)
+            else:
+                used.add(id(comp))
+                comp = comp.model_copy(deep=True)
+            comp.source_group_names = [group.name]
+            final.append(comp)
+
+        if len(final) != len(architecture.components):
+            logger.info(
+                f"[ClusterMethods] Reconciled {len(architecture.components)} LLM components "
+                f"to {len(final)} (one per deterministic group)"
+            )
+        architecture.components = final
 
     def _build_cluster_string(
         self,

--- a/agents/content_hash.py
+++ b/agents/content_hash.py
@@ -68,6 +68,28 @@ def hash_whole_file(lines: list[str]) -> str:
     return hashlib.sha256("\n".join(lines).encode(SOURCE_ENCODING, errors=SOURCE_DECODE_ERRORS)).hexdigest()[:16]
 
 
+def hash_file_residual(lines: list[str], spans: list[MethodSpan]) -> str:
+    """Truncated SHA-256 of a file's *module-level* lines — everything outside ``spans``.
+
+    Why: the whole-file hash also moves when a method body changes, so it cannot
+    tell a pure method edit from a module-level (constant/import/decorator) edit. The
+    residual excises every indexed method's line range and hashes only what is left,
+    so a change here means module-level content moved even when a sibling method also
+    changed. '' when the file is empty (matches ``hash_whole_file`` so a missing
+    baseline residual degrades to "no module-level signal" rather than a false hit).
+    """
+    if not lines:
+        return ""
+    excised = [True] * len(lines)
+    for start_line, end_line in spans:
+        if start_line < 1 or end_line < start_line:
+            continue
+        for idx in range(start_line - 1, min(end_line, len(lines))):
+            excised[idx] = False
+    residual = "\n".join(line for line, keep in zip(lines, excised) if keep)
+    return hashlib.sha256(residual.encode(SOURCE_ENCODING, errors=SOURCE_DECODE_ERRORS)).hexdigest()[:16]
+
+
 def tree_hash_from_file_hashes(file_hashes: dict[str, str]) -> str:
     """SHA-256 over sorted ``path:hash`` lines. '' when no files carry a hash.
 

--- a/agents/details_agent.py
+++ b/agents/details_agent.py
@@ -18,7 +18,6 @@ from agents.agent_responses import (
 )
 from agents.prompts import (
     get_system_details_message,
-    get_cfg_details_message,
     get_details_message,
     get_api_surfaces_message,
     get_relation_analysis_message,
@@ -28,20 +27,16 @@ from agents.relation_edges import index_relation_endpoints
 from agents.repair import ComponentRepairContext, repair_component_group_names, repair_key_entities
 from agents.cluster_methods_mixin import ClusterMethodsMixin
 from caching.cache import ModelSettings
-from caching.details_cache import (
-    FinalAnalysisCache,
-    ClusterCache,
-)
+from caching.details_cache import FinalAnalysisCache
 from agents.validation import (
     ValidationContext,
-    validate_cluster_coverage,
     validate_group_name_coverage,
     validate_key_entities,
     validate_relations,
 )
 from monitoring import trace
 from static_analyzer.analysis_result import StaticAnalysisResults
-from static_analyzer.cluster_helpers import get_all_cluster_ids
+from static_analyzer.cluster_helpers import SUBCOMPONENTS_MAX, SUBCOMPONENTS_MIN
 from static_analyzer.graph import CallGraph, ClusterResult
 
 logger = logging.getLogger(__name__)
@@ -64,14 +59,9 @@ class DetailsAgent(ClusterMethodsMixin, CodeBoardingAgent):
         self.meta_context = meta_context
         self.run_id = run_id
         self._cache_model_settings = ModelSettings.from_chat_model(provider="unknown", llm=agent_llm)
-        self._cluster_cache = ClusterCache(repo_dir=repo_dir)
         self._analysis_cache = FinalAnalysisCache(repo_dir=repo_dir)
 
         self.prompts = {
-            "group_clusters": PromptTemplate(
-                template=get_cfg_details_message(),
-                input_variables=["cfg_clusters", "component"],
-            ),
             "final_analysis": PromptTemplate(
                 template=get_details_message(),
                 input_variables=["cluster_analysis", "component"],
@@ -97,56 +87,14 @@ class DetailsAgent(ClusterMethodsMixin, CodeBoardingAgent):
     def step_clusters_grouping(
         self, component: Component, subgraph_cluster_results: dict[str, ClusterResult]
     ) -> ClusterAnalysis:
+        """Deterministically partition the component's subgraph into sub-component groups.
+
+        Same resolution-tuned Leiden as the top level, but with the sub-component
+        range ``[3, 8]``: the count (modularity peak) and membership are chosen
+        deterministically from the subgraph structure, not by the LLM.
         """
-        Group clusters within the component's subgraph into logical sub-components.
-
-        Args:
-            component: The component being analyzed
-            subgraph_cluster_results: Cluster results for the subgraph (from _create_strict_component_subgraph)
-
-        Returns:
-            ClusterAnalysis with grouped clusters for this component
-        """
-        logger.info(f"[DetailsAgent] Grouping clusters for component: {component.name}")
-        programming_langs = self.static_analysis.get_languages()
-
-        overhead_chars = len(str(self.system_message.content)) + len(
-            self.prompts["group_clusters"].format(
-                cfg_clusters="",
-                component=component.llm_str(),
-            )
-        )
-        cluster_str = self._build_cluster_string(
-            programming_langs, subgraph_cluster_results, prompt_overhead_chars=overhead_chars
-        )
-
-        prompt = self.prompts["group_clusters"].format(
-            cfg_clusters=cluster_str,
-            component=component.llm_str(),
-        )
-
-        context = ValidationContext(
-            cluster_results=subgraph_cluster_results,
-            expected_cluster_ids=get_all_cluster_ids(subgraph_cluster_results),
-        )
-
-        cache_key = self._cluster_cache.build_key(prompt, self._cache_model_settings)
-
-        if (cached := self._cluster_cache.load(cache_key)) is not None:
-            return cached
-        cluster_analysis = self._invoke_validate(
-            prompt,
-            ClusterAnalysis,
-            validators=[validate_cluster_coverage],
-            validation_context=context,
-            max_validation_attempts=3,
-        )
-        self._cluster_cache.store(
-            cache_key,
-            cluster_analysis,
-            run_id=self.run_id,
-        )
-        return cluster_analysis
+        logger.info(f"[DetailsAgent] Super-clustering subgraph for component: {component.name}")
+        return self.deterministic_cluster_grouping(subgraph_cluster_results, SUBCOMPONENTS_MIN, SUBCOMPONENTS_MAX)
 
     @trace
     def step_final_analysis(
@@ -213,6 +161,7 @@ class DetailsAgent(ClusterMethodsMixin, CodeBoardingAgent):
             validation_context=context,
             max_validation_attempts=3,
         )
+        self.assemble_one_component_per_group(architecture, cluster_analysis, subgraph_cluster_results)
         result = AnalysisInsights(
             description=architecture.description,
             components=architecture.components,

--- a/agents/file_index_models.py
+++ b/agents/file_index_models.py
@@ -63,11 +63,21 @@ class FileEntry(BaseModel):
         default="",
         description="Truncated SHA-256 of the entire file's bytes; '' when source was unavailable.",
     )
+    module_hash: str = Field(
+        default="",
+        description=(
+            "Truncated SHA-256 of the file's module-level lines (everything outside indexed "
+            "method spans); '' when unavailable. Lets the incremental path attribute a "
+            "module-level edit even when a sibling method in the same file also changed."
+        ),
+    )
 
     def merge_from(self, other: FileEntry) -> FileEntry:
         """Merge another entry while retaining independent, canonical method metadata."""
         if not self.content_hash:
             self.content_hash = other.content_hash
+        if not self.module_hash:
+            self.module_hash = other.module_hash
 
         methods_by_qname: dict[str, MethodEntry] = {}
         for method in [*self.methods, *other.methods]:

--- a/agents/incremental_planning_agent.py
+++ b/agents/incremental_planning_agent.py
@@ -222,6 +222,8 @@ def _format_member_delta(delta: ClusterMemberDelta) -> str:
         parts.append(f"added={sorted(delta.added_methods)}")
     if delta.removed_methods:
         parts.append(f"removed={sorted(delta.removed_methods)}")
+    if delta.dirty_members:
+        parts.append(f"changed_members={sorted(delta.dirty_members)}")
     if delta.dirty_files:
         parts.append(f"dirty_files={sorted(delta.dirty_files)}")
     return "; ".join(parts)
@@ -253,7 +255,12 @@ def _format_reshape(reshape: ClusterReshape) -> str:
             ),
         )
     )
-    suffix = f"; dirty_files={sorted(reshape.dirty_files)}" if reshape.dirty_files else ""
+    suffix_parts: list[str] = []
+    if reshape.dirty_members:
+        suffix_parts.append(f"changed_members={sorted(reshape.dirty_members)}")
+    if reshape.dirty_files:
+        suffix_parts.append(f"dirty_files={sorted(reshape.dirty_files)}")
+    suffix = f"; {'; '.join(suffix_parts)}" if suffix_parts else ""
     return f"- old=[{old_refs}] new=[{new_refs}] overlaps=[{overlaps}]{suffix}"
 
 

--- a/agents/planner_agent.py
+++ b/agents/planner_agent.py
@@ -39,18 +39,11 @@ DEFAULT_MIN_FILES = 1  # Need at least 1 file to have content
 #   - MIN_METHODS_TO_EXPAND: below this a component is too small to sub-divide.
 #   - EXPAND_MODULARITY_THRESHOLD: peak modularity of the component's inter-cluster
 #     meta-graph; below it the internals are a cohesive blob with no natural split.
-# Chosen by sweeping the threshold over real repos and inspecting the resulting tree:
-# peak modularity is a continuous ramp ~0.02->0.48 (no clean bimodal split), so this is
-# a depth dial, not a discovered constant. 0.20 is the deepest setting where every split
-# still maps to genuine structure; below it, weakly-modular components (mod ~0.19) get
-# forced to split and produce degenerate sub-components (2-method fragments, mod~0
-# children padded only to satisfy SUBCOMPONENTS_MIN). Above Newman's ~0.30 "real
-# community structure" line trees get very shallow. Raise toward 0.25 for shallower/
-# cleaner. The 30-method floor backstops tiny leaves; at these thresholds nothing under
-# ~56 methods clears the bar, so it flips no decision on its own — it just skips the
-# re-cluster for components too small to be worth splitting.
+# Why: modularity is a continuous ramp with no bimodal split, so the threshold is a
+# depth dial — 0.20 is the deepest setting where every split still maps to genuine
+# structure; raise toward 0.25 for shallower trees.
 MIN_METHODS_TO_EXPAND = 30
-EXPAND_MODULARITY_THRESHOLD = 0.20
+EXPAND_MODULARITY_THRESHOLD = 0.15
 
 
 def component_is_separable(

--- a/agents/planner_agent.py
+++ b/agents/planner_agent.py
@@ -21,13 +21,59 @@ Example:
 """
 
 import logging
+from collections.abc import Callable
+
+import networkx as nx
 
 from agents.agent_responses import AnalysisInsights, Component
+from static_analyzer.cluster_helpers import subgraph_peak_modularity
+from static_analyzer.graph import ClusterResult
 
 logger = logging.getLogger(__name__)
 
 # Default thresholds
 DEFAULT_MIN_FILES = 1  # Need at least 1 file to have content
+
+# A component is only expanded into sub-components when its own call structure
+# actually separates. Both gates must pass:
+#   - MIN_METHODS_TO_EXPAND: below this a component is too small to sub-divide.
+#   - EXPAND_MODULARITY_THRESHOLD: peak modularity of the component's inter-cluster
+#     meta-graph; below it the internals are a cohesive blob with no natural split.
+# Calibrated on CodeBoarding / wrapper / action (29 components): peak modularity is a
+# continuous ramp 0.02->0.48 with its only natural gap at (0.242, 0.315). 0.25 sits in
+# that gap (so the decision is insensitive to the exact value) and just under Newman's
+# classic "Q>0.3 = real community structure" line, discounted for these tiny directed
+# meta-graphs. It is deliberately conservative (shallower trees); lower toward ~0.18 if
+# trees come out too shallow, but not near the 0.12 mode where decisions get unstable.
+# No component under 57 methods reached 0.25, so the 30-method floor never flips a
+# decision — it just skips the re-cluster for components too small to be worth splitting.
+MIN_METHODS_TO_EXPAND = 30
+EXPAND_MODULARITY_THRESHOLD = 0.25
+
+
+def component_is_separable(
+    cluster_results: dict[str, ClusterResult],
+    cfg_graphs: dict[str, nx.DiGraph],
+    min_modularity: float = EXPAND_MODULARITY_THRESHOLD,
+    min_methods: int = MIN_METHODS_TO_EXPAND,
+) -> bool:
+    """Whether a component's own call structure justifies splitting it into sub-components.
+
+    True only when the subgraph is big enough (>= ``min_methods`` methods) AND its
+    inter-cluster meta-graph has a genuine community split (peak modularity
+    >= ``min_modularity``). A cohesive blob (low modularity) or a small component
+    becomes a leaf instead of being force-split down to the depth cap.
+    """
+    total_methods = sum(len(members) for cr in cluster_results.values() for members in cr.clusters.values())
+    if total_methods < min_methods:
+        logger.debug(f"[Planner] subgraph too small to expand ({total_methods} < {min_methods} methods)")
+        return False
+    modularity = subgraph_peak_modularity(cluster_results, cfg_graphs)
+    separable = modularity >= min_modularity
+    logger.debug(
+        f"[Planner] subgraph peak modularity={modularity:.4f} " f"(threshold {min_modularity}) -> separable={separable}"
+    )
+    return separable
 
 
 def should_expand_component(
@@ -95,6 +141,7 @@ def get_expandable_components(
     analysis: AnalysisInsights,
     parent_had_clusters: bool = True,
     min_files: int = DEFAULT_MIN_FILES,
+    separable: Callable[[Component], bool] | None = None,
 ) -> list[Component]:
     """
     Determine which components should be expanded for deeper analysis.
@@ -106,11 +153,22 @@ def get_expandable_components(
         parent_had_clusters: Whether the parent component (that produced this analysis)
                             had source_cluster_ids. True for top-level analysis.
         min_files: Minimum files for expansion (default: 1)
+        separable: Optional predicate that also requires a component's own call
+            structure to actually split (see ``component_is_separable``). When given,
+            cohesive components are kept as leaves instead of being force-expanded to
+            the depth cap. Omitted (None) preserves the structural-only behaviour.
 
     Returns:
         List of components that should be expanded
     """
-    expandable = [c for c in analysis.components if should_expand_component(c, parent_had_clusters, min_files)]
+    expandable: list[Component] = []
+    for component in analysis.components:
+        if not should_expand_component(component, parent_had_clusters, min_files):
+            continue
+        if separable is not None and not separable(component):
+            logger.info(f"[Planner] Component '{component.name}' is cohesive (below split threshold); keeping as leaf")
+            continue
+        expandable.append(component)
 
     logger.info(f"[Planner] {len(expandable)}/{len(analysis.components)} components eligible for expansion")
 

--- a/agents/planner_agent.py
+++ b/agents/planner_agent.py
@@ -39,16 +39,18 @@ DEFAULT_MIN_FILES = 1  # Need at least 1 file to have content
 #   - MIN_METHODS_TO_EXPAND: below this a component is too small to sub-divide.
 #   - EXPAND_MODULARITY_THRESHOLD: peak modularity of the component's inter-cluster
 #     meta-graph; below it the internals are a cohesive blob with no natural split.
-# Calibrated on CodeBoarding / wrapper / action (29 components): peak modularity is a
-# continuous ramp 0.02->0.48 with its only natural gap at (0.242, 0.315). 0.25 sits in
-# that gap (so the decision is insensitive to the exact value) and just under Newman's
-# classic "Q>0.3 = real community structure" line, discounted for these tiny directed
-# meta-graphs. It is deliberately conservative (shallower trees); lower toward ~0.18 if
-# trees come out too shallow, but not near the 0.12 mode where decisions get unstable.
-# No component under 57 methods reached 0.25, so the 30-method floor never flips a
-# decision — it just skips the re-cluster for components too small to be worth splitting.
+# Chosen by sweeping the threshold over real repos and inspecting the resulting tree:
+# peak modularity is a continuous ramp ~0.02->0.48 (no clean bimodal split), so this is
+# a depth dial, not a discovered constant. 0.20 is the deepest setting where every split
+# still maps to genuine structure; below it, weakly-modular components (mod ~0.19) get
+# forced to split and produce degenerate sub-components (2-method fragments, mod~0
+# children padded only to satisfy SUBCOMPONENTS_MIN). Above Newman's ~0.30 "real
+# community structure" line trees get very shallow. Raise toward 0.25 for shallower/
+# cleaner. The 30-method floor backstops tiny leaves; at these thresholds nothing under
+# ~56 methods clears the bar, so it flips no decision on its own — it just skips the
+# re-cluster for components too small to be worth splitting.
 MIN_METHODS_TO_EXPAND = 30
-EXPAND_MODULARITY_THRESHOLD = 0.25
+EXPAND_MODULARITY_THRESHOLD = 0.20
 
 
 def component_is_separable(

--- a/agents/prompts/claude_prompts.py
+++ b/agents/prompts/claude_prompts.py
@@ -118,6 +118,8 @@ Instructions:
 Constraints:
 - Keep every group: there must be exactly as many components as groups, each backed by exactly one group.
 - Name components by architectural role (e.g. 'Authentication', 'Data Pipeline', 'Request Handling'), never 'Group N'.
+- Ground the name in the code's own vocabulary: reuse the terms that the group's own modules, classes, and packages already use, and stay close to them rather than inventing a broader abstraction.
+- Prefer a single dominant concern per name and avoid joining two concerns with '&' when possible; if a group genuinely spans two, name it after the dominant one and note the secondary concern in the description instead.
 - Components should translate well to flow diagram representation."""
 
 PLANNER_SYSTEM_MESSAGE = """You evaluate components for detailed analysis based on complexity and significance.
@@ -302,20 +304,21 @@ Focus on core subsystem functionality only. Avoid cross-cutting concerns like lo
 
 DETAILS_MESSAGE = """Create final sub-component architecture for the `{component}` subsystem optimized for flow representation.
 
+The clusters have already been partitioned into a fixed set of groups by graph community detection. Each "Group N" below is exactly one sub-component — the number of groups and their membership are already decided. Do NOT merge, split, or re-group them; only name and describe each group.
+
 Cluster Analysis:
 {cluster_analysis}
 
 Instructions:
-1. Review the named cluster groups above
-2. Decide which named groups should be merged into final sub-components
-3. For each sub-component, specify which named cluster groups it encompasses (use exact group names from the analysis above)
+1. Produce EXACTLY one sub-component per named group above (the same number of sub-components as there are groups)
+2. Set each sub-component's source_group_names to the single group it corresponds to (use the exact group name, e.g. "Group 1")
+3. Give each sub-component a descriptive architectural name (its role, not "Group N") and a one-sentence description of what it does
 4. Add 2-5 key entities (the most important classes/methods) for each sub-component, mentioning their qualified names and source files
 5. Do not define relationships yet; relationships are discovered in a later API-surface step
 6. Provide a one-paragraph description of the subsystem's main flow and purpose
 
 Guidelines:
-- Aim for 3-8 final sub-components
-- Merge related cluster groups that serve a common purpose
+- Keep every group: there must be exactly as many sub-components as groups, each backed by exactly one group
 - Each sub-component should have clear boundaries
 - Focus on component boundaries; relationships are discovered after components are finalized
 

--- a/agents/prompts/claude_prompts.py
+++ b/agents/prompts/claude_prompts.py
@@ -100,29 +100,25 @@ Focus on:
 - Clear justification for why clusters belong together
 - Describing inter-group interactions based on the inter-cluster connections"""
 
-FINAL_ANALYSIS_MESSAGE = """Create final component architecture optimized for flow representation.
+FINAL_ANALYSIS_MESSAGE = """Name and describe the final component architecture.
+
+The clusters have already been partitioned into a fixed set of groups by graph community detection. Each "Group N" below is exactly one top-level component — the number of groups and their membership are already decided. Do NOT merge, split, or re-group them; only name and describe each group.
 
 Cluster Analysis:
 {cluster_analysis}
 
 Instructions:
-1. Review the named cluster groups above
-2. Decide which named groups should be merged into final components
-3. For each component, specify which named cluster groups it encompasses (use exact group names from the analysis above)
-4. Add 2-5 key entities (the most important classes/methods) for each component, mentioning their qualified names and source files
-5. Do not define relationships yet; relationships are discovered in a later API-surface step
-6. Provide a one-paragraph description of the overall main flow and purpose
-
-Guidelines:
-- Aim for 5-8 final components
-- Merge related cluster groups that serve a common purpose
-- Each component should have clear boundaries
-- Focus on component boundaries; relationships are discovered after components are finalized
+1. Produce EXACTLY one component per named group above (the same number of components as there are groups).
+2. Set each component's source_group_names to the single group it corresponds to (use the exact group name, e.g. "Group 1").
+3. Give each component a descriptive architectural name (its role, not "Group N") and a one-sentence description of what it does.
+4. Add 2-5 key entities (the most important classes/methods) per component, using their exact qualified names and source files.
+5. Do not define relationships yet; relationships are discovered in a later API-surface step.
+6. Provide a one-paragraph description of the overall main flow and purpose.
 
 Constraints:
-- Focus on highest level architectural components
-- Exclude utility/logging components
-- Components should translate well to flow diagram representation"""
+- Keep every group: there must be exactly as many components as groups, each backed by exactly one group.
+- Name components by architectural role (e.g. 'Authentication', 'Data Pipeline', 'Request Handling'), never 'Group N'.
+- Components should translate well to flow diagram representation."""
 
 PLANNER_SYSTEM_MESSAGE = """You evaluate components for detailed analysis based on complexity and significance.
 

--- a/agents/prompts/deepseek_prompts.py
+++ b/agents/prompts/deepseek_prompts.py
@@ -96,34 +96,25 @@ The CFG has been pre-clustered into groups of related methods/functions. Each cl
 # Output format
 For each component provide a descriptive name, the list of cluster IDs it contains, and a comprehensive description with rationale and inter-group interactions."""
 
-FINAL_ANALYSIS_MESSAGE = """# Task
-Create final component architecture optimized for flow representation.
+FINAL_ANALYSIS_MESSAGE = """Name and describe the final component architecture.
 
-# Cluster Analysis
+The clusters have already been partitioned into a fixed set of groups by graph community detection. Each "Group N" below is exactly one top-level component — the number of groups and their membership are already decided. Do NOT merge, split, or re-group them; only name and describe each group.
+
+Cluster Analysis:
 {cluster_analysis}
 
-# Instructions (execute in order)
-1. Review the named cluster groups above.
-2. Decide which named groups should be merged into final components.
-3. For each component, specify which named cluster groups it encompasses via source_group_names.
-4. Add key entities (2-5 most important classes/methods) for each component, referencing the source file where they are defined.
+Instructions:
+1. Produce EXACTLY one component per named group above (the same number of components as there are groups).
+2. Set each component's source_group_names to the single group it corresponds to (use the exact group name, e.g. "Group 1").
+3. Give each component a descriptive architectural name (its role, not "Group N") and a one-sentence description of what it does.
+4. Add 2-5 key entities (the most important classes/methods) per component, using their exact qualified names and source files.
 5. Do not define relationships yet; relationships are discovered in a later API-surface step.
+6. Provide a one-paragraph description of the overall main flow and purpose.
 
-# Guidelines
-- Aim for 5-8 final components
-- Merge related cluster groups that serve a common purpose
-- Each component must have clear boundaries
-- Focus on component boundaries; relationships are discovered after components are finalized
-
-# Required outputs
-- Description: One paragraph explaining the main flow and purpose
-- Components: Each with a clear name, a description of what it does, the exact named cluster groups it encompasses, and 2-5 key entities mentioning their qualified names and source files
-
-# Constraints
-- Focus on highest level architectural components
-- Exclude utility/logging components
-- Components must translate well to flow diagram representation
-"""
+Constraints:
+- Keep every group: there must be exactly as many components as groups, each backed by exactly one group.
+- Name components by architectural role (e.g. 'Authentication', 'Data Pipeline', 'Request Handling'), never 'Group N'.
+- Components should translate well to flow diagram representation."""
 
 PLANNER_SYSTEM_MESSAGE = """You are a software architecture expert.
 

--- a/agents/prompts/deepseek_prompts.py
+++ b/agents/prompts/deepseek_prompts.py
@@ -114,6 +114,8 @@ Instructions:
 Constraints:
 - Keep every group: there must be exactly as many components as groups, each backed by exactly one group.
 - Name components by architectural role (e.g. 'Authentication', 'Data Pipeline', 'Request Handling'), never 'Group N'.
+- Ground the name in the code's own vocabulary: reuse the terms that the group's own modules, classes, and packages already use, and stay close to them rather than inventing a broader abstraction.
+- Prefer a single dominant concern per name and avoid joining two concerns with '&' when possible; if a group genuinely spans two, name it after the dominant one and note the secondary concern in the description instead.
 - Components should translate well to flow diagram representation."""
 
 PLANNER_SYSTEM_MESSAGE = """You are a software architecture expert.
@@ -307,25 +309,26 @@ For each sub-component provide a descriptive name, the list of cluster IDs it co
 DETAILS_MESSAGE = """# Task
 Create final sub-component architecture for the `{component}` subsystem optimized for flow representation.
 
+The clusters have already been partitioned into a fixed set of groups by graph community detection. Each "Group N" below is exactly one sub-component — the number of groups and their membership are already decided. Do NOT merge, split, or re-group them; only name and describe each group.
+
 # Cluster Analysis
 {cluster_analysis}
 
 # Instructions (execute in order)
-1. Review the named cluster groups above.
-2. Decide which named groups should be merged into final sub-components.
-3. For each sub-component, specify which named cluster groups it encompasses via source_group_names.
+1. Produce EXACTLY one sub-component per named group above (the same number of sub-components as there are groups).
+2. Set each sub-component's source_group_names to the single group it corresponds to (use the exact group name, e.g. "Group 1").
+3. Give each sub-component a descriptive architectural name (its role, not "Group N").
 4. Add key entities (2-5 most important classes/methods) for each sub-component, referencing the source file where they are defined.
 5. Do not define relationships yet; relationships are discovered in a later API-surface step.
 
 # Guidelines
-- Aim for 3-8 final sub-components
-- Merge related cluster groups that serve a common purpose
+- Keep every group: there must be exactly as many sub-components as groups, each backed by exactly one group
 - Each sub-component must have clear boundaries
 - Focus on component boundaries; relationships are discovered after components are finalized
 
 # Required outputs (complete all)
 - Description: One paragraph explaining the subsystem's main flow and purpose
-- Components: Each with a clear name, a description of what it does, the exact named cluster groups it encompasses, and 2-5 key entities mentioning their qualified names and source files
+- Components: Each with a clear name, a description of what it does, the single named cluster group it encompasses, and 2-5 key entities mentioning their qualified names and source files
 
 # Constraints
 - Focus on subsystem-specific functionality

--- a/agents/prompts/gemini_flash_prompts.py
+++ b/agents/prompts/gemini_flash_prompts.py
@@ -86,30 +86,25 @@ Focus on:
 - Clear justification for why clusters belong together
 - Describing inter-group interactions based on the inter-cluster connections"""
 
-FINAL_ANALYSIS_MESSAGE = """Create final component architecture optimized for flow representation.
+FINAL_ANALYSIS_MESSAGE = """Name and describe the final component architecture.
+
+The clusters have already been partitioned into a fixed set of groups by graph community detection. Each "Group N" below is exactly one top-level component — the number of groups and their membership are already decided. Do NOT merge, split, or re-group them; only name and describe each group.
 
 Cluster Analysis:
 {cluster_analysis}
 
 Instructions:
-1. Review the named cluster groups above
-2. Decide which named groups should be merged into final components
-3. For each component, specify which named cluster groups it encompasses via source_group_names
-4. Add key entities (2-5 most important classes/methods) for each component, referencing the source file where they are defined
-5. Do not define relationships yet; relationships are discovered in a later API-surface step
-
-Guidelines:
-- Aim for 5-8 final components
-- Merge related cluster groups that serve a common purpose
-- Each component should have clear boundaries
-- Focus on component boundaries; relationships are discovered after components are finalized
-
-Each component must have a clear name, a description of what it does, and reference the exact named cluster groups it encompasses (use exact group names). Include 2-5 key entities per component — the most important classes/methods — mentioning their qualified names and source files. Describe the overall architecture in one paragraph explaining the main flow and purpose. Do not define relationships yet.
+1. Produce EXACTLY one component per named group above (the same number of components as there are groups).
+2. Set each component's source_group_names to the single group it corresponds to (use the exact group name, e.g. "Group 1").
+3. Give each component a descriptive architectural name (its role, not "Group N") and a one-sentence description of what it does.
+4. Add 2-5 key entities (the most important classes/methods) per component, using their exact qualified names and source files.
+5. Do not define relationships yet; relationships are discovered in a later API-surface step.
+6. Provide a one-paragraph description of the overall main flow and purpose.
 
 Constraints:
-- Focus on highest level architectural components
-- Exclude utility/logging components
-- Components should translate well to flow diagram representation"""
+- Keep every group: there must be exactly as many components as groups, each backed by exactly one group.
+- Name components by architectural role (e.g. 'Authentication', 'Data Pipeline', 'Request Handling'), never 'Group N'.
+- Components should translate well to flow diagram representation."""
 
 PLANNER_SYSTEM_MESSAGE = """You are a software architecture expert evaluating component expansion needs.
 

--- a/agents/prompts/gemini_flash_prompts.py
+++ b/agents/prompts/gemini_flash_prompts.py
@@ -104,6 +104,8 @@ Instructions:
 Constraints:
 - Keep every group: there must be exactly as many components as groups, each backed by exactly one group.
 - Name components by architectural role (e.g. 'Authentication', 'Data Pipeline', 'Request Handling'), never 'Group N'.
+- Ground the name in the code's own vocabulary: reuse the terms that the group's own modules, classes, and packages already use, and stay close to them rather than inventing a broader abstraction.
+- Prefer a single dominant concern per name and avoid joining two concerns with '&' when possible; if a group genuinely spans two, name it after the dominant one and note the secondary concern in the description instead.
 - Components should translate well to flow diagram representation."""
 
 PLANNER_SYSTEM_MESSAGE = """You are a software architecture expert evaluating component expansion needs.
@@ -275,23 +277,24 @@ Focus on core subsystem functionality only. Avoid cross-cutting concerns like lo
 
 DETAILS_MESSAGE = """Create final sub-component architecture for the `{component}` subsystem optimized for flow representation.
 
+The clusters have already been partitioned into a fixed set of groups by graph community detection. Each "Group N" below is exactly one sub-component — the number of groups and their membership are already decided. Do NOT merge, split, or re-group them; only name and describe each group.
+
 Cluster Analysis:
 {cluster_analysis}
 
 Instructions:
-1. Review the named cluster groups above
-2. Decide which named groups should be merged into final sub-components
-3. For each sub-component, specify which named cluster groups it encompasses via source_group_names
+1. Produce EXACTLY one sub-component per named group above (the same number of sub-components as there are groups)
+2. Set each sub-component's source_group_names to the single group it corresponds to (use the exact group name, e.g. "Group 1")
+3. Give each sub-component a descriptive architectural name (its role, not "Group N")
 4. Add key entities (2-5 most important classes/methods) for each sub-component, referencing the source file where they are defined
 5. Do not define relationships yet; relationships are discovered in a later API-surface step
 
 Guidelines:
-- Aim for 3-8 final sub-components
-- Merge related cluster groups that serve a common purpose
+- Keep every group: there must be exactly as many sub-components as groups, each backed by exactly one group
 - Each sub-component should have clear boundaries
 - Focus on component boundaries; relationships are discovered after components are finalized
 
-Each sub-component must have a clear name, a description of what it does, and reference the exact named cluster groups it encompasses (use exact group names). Include 2-5 key entities per sub-component — the most important classes/methods — mentioning their qualified names and source files. Describe the subsystem's main flow and purpose in one paragraph. Do not define relationships yet.
+Each sub-component must have a clear name, a description of what it does, and reference the single named cluster group it encompasses (use the exact group name). Include 2-5 key entities per sub-component — the most important classes/methods — mentioning their qualified names and source files. Describe the subsystem's main flow and purpose in one paragraph. Do not define relationships yet.
 
 Constraints:
 - Focus on subsystem-specific functionality

--- a/agents/prompts/glm_prompts.py
+++ b/agents/prompts/glm_prompts.py
@@ -122,6 +122,8 @@ Instructions:
 Constraints:
 - Keep every group: there must be exactly as many components as groups, each backed by exactly one group.
 - Name components by architectural role (e.g. 'Authentication', 'Data Pipeline', 'Request Handling'), never 'Group N'.
+- Ground the name in the code's own vocabulary: reuse the terms that the group's own modules, classes, and packages already use, and stay close to them rather than inventing a broader abstraction.
+- Prefer a single dominant concern per name and avoid joining two concerns with '&' when possible; if a group genuinely spans two, name it after the dominant one and note the secondary concern in the description instead.
 - Components should translate well to flow diagram representation."""
 
 PLANNER_SYSTEM_MESSAGE = """You are a software architecture evaluator. STRICTLY follow these rules:
@@ -327,19 +329,20 @@ DETAILS_MESSAGE = """You are a sub-component architecture designer. STRICTLY fol
 MANDATORY TASK:
 Create final sub-component architecture for the `{component}` subsystem optimized for flow representation.
 
+The clusters have already been partitioned into a fixed set of groups by graph community detection. Each "Group N" below is exactly one sub-component — the number of groups and their membership are already decided. Do NOT merge, split, or re-group them; only name and describe each group.
+
 Cluster Analysis:
 {cluster_analysis}
 
 REQUIRED STEPS (execute in order):
-1. Review the named cluster groups above.
-2. Decide which named groups MUST be merged into final sub-components.
-3. For each sub-component, specify which named cluster groups it encompasses via source_group_names.
+1. Produce EXACTLY one sub-component per named group above (the same number of sub-components as there are groups).
+2. Set each sub-component's source_group_names to the single group it corresponds to (use the exact group name, e.g. "Group 1").
+3. Give each sub-component a descriptive architectural name (its role, not "Group N").
 4. Add key entities (2-5 most important classes/methods) for each sub-component, referencing the source file where they are defined.
 5. Do not define relationships yet; relationships are discovered in a later API-surface step.
 
 GUIDELINES (MUST follow):
-- Aim for 3-8 final sub-components
-- Merge related cluster groups that serve a common purpose
+- Keep every group: there MUST be exactly as many sub-components as groups, each backed by exactly one group
 - Each sub-component MUST have clear boundaries
 - Focus on component boundaries; relationships are discovered after components are finalized
 

--- a/agents/prompts/glm_prompts.py
+++ b/agents/prompts/glm_prompts.py
@@ -104,39 +104,25 @@ MUST return each component with a descriptive name, its cluster_ids as a list, a
 
 FINAL_ANALYSIS_MESSAGE = """You are a software architecture designer. STRICTLY follow these rules:
 
-MANDATORY TASK:
-Create final component architecture optimized for flow representation.
+Name and describe the final component architecture.
+
+The clusters have already been partitioned into a fixed set of groups by graph community detection. Each "Group N" below is exactly one top-level component — the number of groups and their membership are already decided. Do NOT merge, split, or re-group them; only name and describe each group.
 
 Cluster Analysis:
 {cluster_analysis}
 
-REQUIRED STEPS (execute in order):
-1. Review the named cluster groups above.
-2. Decide which named groups MUST be merged into final components.
-3. For each component, specify which named cluster groups it encompasses via source_group_names.
-4. Add key entities (2-5 most important classes/methods) for each component, referencing the source file where they are defined.
+Instructions:
+1. Produce EXACTLY one component per named group above (the same number of components as there are groups).
+2. Set each component's source_group_names to the single group it corresponds to (use the exact group name, e.g. "Group 1").
+3. Give each component a descriptive architectural name (its role, not "Group N") and a one-sentence description of what it does.
+4. Add 2-5 key entities (the most important classes/methods) per component, using their exact qualified names and source files.
 5. Do not define relationships yet; relationships are discovered in a later API-surface step.
+6. Provide a one-paragraph description of the overall main flow and purpose.
 
-GUIDELINES (MUST follow):
-- Aim for 5-8 final components
-- Merge related cluster groups that serve a common purpose
-- Each component MUST have clear boundaries
-- Focus on component boundaries; relationships are discovered after components are finalized
-
-REQUIRED OUTPUTS (complete all):
-- Description: One paragraph explaining the main flow and purpose
-- Components: Each MUST have:
-  * name: Clear component name
-  * description: What this component does
-  * source_group_names: Which named cluster groups from the analysis above this component encompasses (MUST use exact group names)
-  * key_entities: 2-5 most important classes/methods, mentioning their qualified names and source files
-
-
-CONSTRAINTS (MUST obey):
-- Focus on highest level architectural components
-- Exclude utility/logging components
-- Components MUST translate well to flow diagram representation
-"""
+Constraints:
+- Keep every group: there must be exactly as many components as groups, each backed by exactly one group.
+- Name components by architectural role (e.g. 'Authentication', 'Data Pipeline', 'Request Handling'), never 'Group N'.
+- Components should translate well to flow diagram representation."""
 
 PLANNER_SYSTEM_MESSAGE = """You are a software architecture evaluator. STRICTLY follow these rules:
 

--- a/agents/prompts/gpt_prompts.py
+++ b/agents/prompts/gpt_prompts.py
@@ -90,6 +90,8 @@ Instructions:
 Constraints:
 - Keep every group: there must be exactly as many components as groups, each backed by exactly one group.
 - Name components by architectural role (e.g. 'Authentication', 'Data Pipeline', 'Request Handling'), never 'Group N'.
+- Ground the name in the code's own vocabulary: reuse the terms that the group's own modules, classes, and packages already use, and stay close to them rather than inventing a broader abstraction.
+- Prefer a single dominant concern per name and avoid joining two concerns with '&' when possible; if a group genuinely spans two, name it after the dominant one and note the secondary concern in the description instead.
 - Components should translate well to flow diagram representation."""
 
 PLANNER_SYSTEM_MESSAGE = """You are an architectural planning expert for software documentation.
@@ -361,23 +363,24 @@ Focus on core subsystem functionality only. Avoid cross-cutting concerns like lo
 
 DETAILS_MESSAGE = """Create final sub-component architecture for the `{component}` subsystem optimized for flow representation.
 
+The clusters have already been partitioned into a fixed set of groups by graph community detection. Each "Group N" below is exactly one sub-component — the number of groups and their membership are already decided. Do NOT merge, split, or re-group them; only name and describe each group.
+
 Cluster Analysis:
 {cluster_analysis}
 
 Instructions:
-1. Review the named cluster groups above
-2. Decide which named groups should be merged into final sub-components
-3. For each sub-component, specify which named cluster groups it encompasses via source_group_names
+1. Produce EXACTLY one sub-component per named group above (the same number of sub-components as there are groups)
+2. Set each sub-component's source_group_names to the single group it corresponds to (use the exact group name, e.g. "Group 1")
+3. Give each sub-component a descriptive architectural name (its role, not "Group N")
 4. Add key entities (2-5 most important classes/methods) for each sub-component, referencing the source file where they are defined
 5. Do not define relationships yet; relationships are discovered in a later API-surface step
 
 Guidelines:
-- Aim for 3-8 final sub-components
-- Merge related cluster groups that serve a common purpose
+- Keep every group: there must be exactly as many sub-components as groups, each backed by exactly one group
 - Each sub-component should have clear boundaries
 - Focus on component boundaries; relationships are discovered after components are finalized
 
-For each sub-component provide: a clear name, a description of what it does, the exact named cluster group names it encompasses, and 2-5 key entities (mentioning their qualified names and source files). Provide one paragraph describing the subsystem's main flow and purpose. Do not define relationships yet.
+For each sub-component provide: a clear name, a description of what it does, the single named cluster group it encompasses, and 2-5 key entities (mentioning their qualified names and source files). Provide one paragraph describing the subsystem's main flow and purpose. Do not define relationships yet.
 
 Constraints:
 - Focus on subsystem-specific functionality

--- a/agents/prompts/gpt_prompts.py
+++ b/agents/prompts/gpt_prompts.py
@@ -72,30 +72,25 @@ Focus on:
 - Clear justification for why clusters belong together
 - Describing inter-group interactions based on the inter-cluster connections"""
 
-FINAL_ANALYSIS_MESSAGE = """Create final component architecture optimized for flow representation.
+FINAL_ANALYSIS_MESSAGE = """Name and describe the final component architecture.
+
+The clusters have already been partitioned into a fixed set of groups by graph community detection. Each "Group N" below is exactly one top-level component — the number of groups and their membership are already decided. Do NOT merge, split, or re-group them; only name and describe each group.
 
 Cluster Analysis:
 {cluster_analysis}
 
 Instructions:
-1. Review the named cluster groups above
-2. Decide which named groups should be merged into final components
-3. For each component, specify which named cluster groups it encompasses via source_group_names
-4. Add key entities (2-5 most important classes/methods) for each component, referencing the source file where they are defined
-5. Do not define relationships yet; relationships are discovered in a later API-surface step
-
-Guidelines:
-- Aim for 5-8 final components
-- Merge related cluster groups that serve a common purpose
-- Each component should have clear boundaries
-- Focus on component boundaries; relationships are discovered after components are finalized
-
-For each component provide: a clear name, a description of what it does, the exact named cluster group names it encompasses, and 2-5 key entities (mentioning their qualified names and source files). Provide one paragraph describing the overall main flow and purpose. Do not define relationships yet.
+1. Produce EXACTLY one component per named group above (the same number of components as there are groups).
+2. Set each component's source_group_names to the single group it corresponds to (use the exact group name, e.g. "Group 1").
+3. Give each component a descriptive architectural name (its role, not "Group N") and a one-sentence description of what it does.
+4. Add 2-5 key entities (the most important classes/methods) per component, using their exact qualified names and source files.
+5. Do not define relationships yet; relationships are discovered in a later API-surface step.
+6. Provide a one-paragraph description of the overall main flow and purpose.
 
 Constraints:
-- Focus on highest level architectural components
-- Exclude utility/logging components
-- Components should translate well to flow diagram representation"""
+- Keep every group: there must be exactly as many components as groups, each backed by exactly one group.
+- Name components by architectural role (e.g. 'Authentication', 'Data Pipeline', 'Request Handling'), never 'Group N'.
+- Components should translate well to flow diagram representation."""
 
 PLANNER_SYSTEM_MESSAGE = """You are an architectural planning expert for software documentation.
 

--- a/agents/prompts/kimi_prompts.py
+++ b/agents/prompts/kimi_prompts.py
@@ -108,6 +108,8 @@ Instructions:
 Constraints:
 - Keep every group: there must be exactly as many components as groups, each backed by exactly one group.
 - Name components by architectural role (e.g. 'Authentication', 'Data Pipeline', 'Request Handling'), never 'Group N'.
+- Ground the name in the code's own vocabulary: reuse the terms that the group's own modules, classes, and packages already use, and stay close to them rather than inventing a broader abstraction.
+- Prefer a single dominant concern per name and avoid joining two concerns with '&' when possible; if a group genuinely spans two, name it after the dominant one and note the secondary concern in the description instead.
 - Components should translate well to flow diagram representation."""
 
 PLANNER_SYSTEM_MESSAGE = """You are Kimi, an AI assistant created by Moonshot AI.
@@ -314,21 +316,22 @@ Cluster Analysis:
 
 Task: Create final sub-component architecture for the `{component}` subsystem optimized for flow representation.
 
+The clusters have already been partitioned into a fixed set of groups by graph community detection. Each "Group N" above is exactly one sub-component — the number of groups and their membership are already decided. Do NOT merge, split, or re-group them; only name and describe each group.
+
 Think aloud first (reasoning), then synthesize:
 
-1. Review the named cluster groups above.
-2. Decide which named groups should be merged into final sub-components.
-3. For each sub-component, specify which named cluster groups it encompasses via source_group_names.
+1. Produce EXACTLY one sub-component per named group above (the same number of sub-components as there are groups).
+2. Set each sub-component's source_group_names to the single group it corresponds to (use the exact group name, e.g. "Group 1").
+3. Give each sub-component a descriptive architectural name (its role, not "Group N").
 4. For each sub-component, list the 2-5 most important classes/methods, referencing their qualified names and source files.
 5. Do not define relationships yet; relationships are discovered in a later API-surface step.
 
 Guidelines:
-- Aim for 3-8 final sub-components
-- Merge related cluster groups that serve a common purpose
+- Keep every group: there must be exactly as many sub-components as groups, each backed by exactly one group
 - Each sub-component should have clear boundaries
 - Focus on component boundaries; relationships are discovered after components are finalized
 
-For each sub-component provide a clear name, a description of what it does, the exact named cluster group names it encompasses, and the 2-5 most important classes/methods with their qualified names and source files. Also provide one paragraph explaining the subsystem's overall main flow and purpose. Do not define relationships yet.
+For each sub-component provide a clear name, a description of what it does, the single named cluster group it encompasses, and the 2-5 most important classes/methods with their qualified names and source files. Also provide one paragraph explaining the subsystem's overall main flow and purpose. Do not define relationships yet.
 
 Constraints:
 - Focus on subsystem-specific functionality

--- a/agents/prompts/kimi_prompts.py
+++ b/agents/prompts/kimi_prompts.py
@@ -90,31 +90,25 @@ Return each grouped component with a descriptive name, its cluster_ids list, and
 
 FINAL_ANALYSIS_MESSAGE = """You are Kimi, an AI assistant created by Moonshot AI.
 
+Name and describe the final component architecture.
+
+The clusters have already been partitioned into a fixed set of groups by graph community detection. Each "Group N" below is exactly one top-level component — the number of groups and their membership are already decided. Do NOT merge, split, or re-group them; only name and describe each group.
+
 Cluster Analysis:
 {cluster_analysis}
 
-Task: Create final component architecture optimized for flow representation.
-
-Reason step-by-step. Decompose this into subtasks:
-
-1. Review the named cluster groups above.
-2. Decide which named groups should be merged into final components.
-3. For each component, specify which named cluster groups it encompasses via source_group_names.
-4. For each component, list the 2-5 most important classes/methods, referencing their qualified names and source files.
+Instructions:
+1. Produce EXACTLY one component per named group above (the same number of components as there are groups).
+2. Set each component's source_group_names to the single group it corresponds to (use the exact group name, e.g. "Group 1").
+3. Give each component a descriptive architectural name (its role, not "Group N") and a one-sentence description of what it does.
+4. Add 2-5 key entities (the most important classes/methods) per component, using their exact qualified names and source files.
 5. Do not define relationships yet; relationships are discovered in a later API-surface step.
-
-Guidelines:
-- Aim for 5-8 final components
-- Merge related cluster groups that serve a common purpose
-- Each component should have clear boundaries
-- Focus on component boundaries; relationships are discovered after components are finalized
-
-For each component provide a clear name, a description of what it does, the exact named cluster group names it encompasses, and the 2-5 most important classes/methods with their qualified names and source files. Also provide one paragraph explaining the overall main flow and purpose. Do not define relationships yet.
+6. Provide a one-paragraph description of the overall main flow and purpose.
 
 Constraints:
-- Focus on highest level architectural components
-- Exclude utility/logging components
-- Components should translate well to flow diagram representation"""
+- Keep every group: there must be exactly as many components as groups, each backed by exactly one group.
+- Name components by architectural role (e.g. 'Authentication', 'Data Pipeline', 'Request Handling'), never 'Group N'.
+- Components should translate well to flow diagram representation."""
 
 PLANNER_SYSTEM_MESSAGE = """You are Kimi, an AI assistant created by Moonshot AI.
 

--- a/codeboarding_cli/commands/full_analysis.py
+++ b/codeboarding_cli/commands/full_analysis.py
@@ -11,7 +11,7 @@ from codeboarding_workflows.analysis import run_full
 from codeboarding_workflows.orchestration import run_analysis_pipeline
 from codeboarding_workflows.rendering import render_docs
 from codeboarding_workflows.sources import SourceContext, local_source, remote_source
-from diagram_analysis import RunContext, RunPaths
+from diagram_analysis import DEFAULT_DEPTH_LEVEL, RunContext, RunPaths
 from monitoring import monitor_execution
 from monitoring.paths import get_monitoring_run_dir
 from repo_utils import get_branch, store_token
@@ -46,8 +46,12 @@ def add_arguments(subparsers: argparse._SubParsersAction, parents: list[argparse
     parser.add_argument(
         "--depth-level",
         type=int,
-        default=1,
-        help="Depth level for diagram generation (default: 1)",
+        default=DEFAULT_DEPTH_LEVEL,
+        help=(
+            "Safety-valve ceiling on component-hierarchy depth (default: "
+            f"{DEFAULT_DEPTH_LEVEL}). Expansion is driven by structural separability, "
+            "not this cap; raise it only if a large repo's diagram is being cut short."
+        ),
     )
 
 

--- a/codeboarding_workflows/analysis.py
+++ b/codeboarding_workflows/analysis.py
@@ -142,7 +142,7 @@ def run_partial(
     # The baseline we loaded may predate child scopes being confined to their parent.
     # Repair it here too: this flow only regenerates one component, so nothing else
     # would reconcile the rest of the tree before the save asserts containment.
-    generator._rescope_child_analyses(root_analysis, sub_analyses)
+    generator._rescope_child_analyses(root_analysis, sub_analyses, set())
     # persist_side_artifacts=False: an expansion must not rewrite file_coverage.json
     # or the static-analysis cache. The latter would drop the static_analysis.sha
     # tag (no source_sha here) and force the next incremental run to cold-start.

--- a/codeboarding_workflows/analysis.py
+++ b/codeboarding_workflows/analysis.py
@@ -89,11 +89,8 @@ def run_partial(
         f"Running PARTIAL analysis workflow for project '{run_paths.project_name}', component '{component_id}'."
     )
 
-    # Depth comes from the existing analysis.json's configured cap
-    # (metadata.depth_cap), not the realized depth_level — a run that stopped
-    # short of its cap (separability-gated) must not leave future runs capped
-    # at that shallower depth. Legacy baselines predate depth_cap, so fall
-    # back to depth_level for those.
+    # Depth is the baseline's configured cap (metadata.depth_cap), with a
+    # legacy depth_level fallback — not the realized depth.
     metadata = load_analysis_metadata(run_paths.output_dir)
     if metadata is None:
         raise BaselineUnavailableError(

--- a/codeboarding_workflows/analysis.py
+++ b/codeboarding_workflows/analysis.py
@@ -15,7 +15,7 @@ from pathlib import Path
 
 from diagram_analysis import DiagramGenerator
 from diagram_analysis.io_utils import load_analysis_metadata, load_full_analysis
-from diagram_analysis.run_context import RunContext, RunPaths
+from diagram_analysis.run_context import DEFAULT_DEPTH_LEVEL, RunContext, RunPaths
 from repo_utils.fingerprint_diff import BaselineUnavailableError, detect_changes_from_fingerprint
 from telemetry.events import track_analysis
 
@@ -49,7 +49,7 @@ def build_generator(
 def run_full(
     run_paths: RunPaths,
     run_context: RunContext,
-    depth_level: int = 1,
+    depth_level: int = DEFAULT_DEPTH_LEVEL,
     monitoring_enabled: bool = False,
     force_full: bool = False,
     static_analyzer=None,
@@ -96,7 +96,7 @@ def run_partial(
             f"No baseline analysis.json found in '{run_paths.output_dir}'. Run a full analysis first."
         )
 
-    depth_level = int(metadata.get("depth_level", 1))
+    depth_level = int(metadata.get("depth_level", DEFAULT_DEPTH_LEVEL))
     generator = build_generator(run_paths, run_context, depth_level=depth_level)
     generator.pre_analysis()
 
@@ -175,7 +175,7 @@ def run_incremental(
         raise BaselineUnavailableError(
             f"No baseline analysis.json found in '{run_paths.output_dir}'. Run a full analysis first."
         )
-    depth_level = int(metadata.get("depth_level", 1))
+    depth_level = int(metadata.get("depth_level", DEFAULT_DEPTH_LEVEL))
 
     changes = detect_changes_from_fingerprint(run_paths.repo_path, run_paths.output_dir)
     logger.info(

--- a/codeboarding_workflows/analysis.py
+++ b/codeboarding_workflows/analysis.py
@@ -139,6 +139,10 @@ def run_partial(
     # its subcomponents. Rebuild reads each sub's LLM relation labels, which live
     # only in memory (they aren't serialized), so it must run before the save.
     sub_analyses[component_id] = sub_analysis
+    # The baseline we loaded may predate child scopes being confined to their parent.
+    # Repair it here too: this flow only regenerates one component, so nothing else
+    # would reconcile the rest of the tree before the save asserts containment.
+    generator._rescope_child_analyses(root_analysis, sub_analyses)
     # persist_side_artifacts=False: an expansion must not rewrite file_coverage.json
     # or the static-analysis cache. The latter would drop the static_analysis.sha
     # tag (no source_sha here) and force the next incremental run to cold-start.

--- a/codeboarding_workflows/analysis.py
+++ b/codeboarding_workflows/analysis.py
@@ -89,14 +89,18 @@ def run_partial(
         f"Running PARTIAL analysis workflow for project '{run_paths.project_name}', component '{component_id}'."
     )
 
-    # Depth comes from the existing analysis.json (metadata.depth_level).
+    # Depth comes from the existing analysis.json's configured cap
+    # (metadata.depth_cap), not the realized depth_level — a run that stopped
+    # short of its cap (separability-gated) must not leave future runs capped
+    # at that shallower depth. Legacy baselines predate depth_cap, so fall
+    # back to depth_level for those.
     metadata = load_analysis_metadata(run_paths.output_dir)
     if metadata is None:
         raise BaselineUnavailableError(
             f"No baseline analysis.json found in '{run_paths.output_dir}'. Run a full analysis first."
         )
 
-    depth_level = int(metadata.get("depth_level", DEFAULT_DEPTH_LEVEL))
+    depth_level = int(metadata.get("depth_cap", metadata.get("depth_level", DEFAULT_DEPTH_LEVEL)))
     generator = build_generator(run_paths, run_context, depth_level=depth_level)
     generator.pre_analysis()
 
@@ -167,15 +171,19 @@ def run_incremental(
     should surface a "run full analysis" prompt rather than silently degrading to
     an unscoped run.
     """
-    # Depth comes from the existing analysis.json (metadata.depth_level).
-    # Fail fast on cold-start: ``_generate_subcomponents`` requires the prior
-    # depth to re-detail changed components.
+    # Depth comes from the existing analysis.json's configured cap
+    # (metadata.depth_cap, falling back to depth_level for legacy baselines
+    # that predate it) — not the realized depth_level, so a run that stopped
+    # short of its cap doesn't leave incremental permanently capped shallower
+    # than what was actually configured. Fail fast on cold-start:
+    # ``_generate_subcomponents`` requires the prior depth to re-detail
+    # changed components.
     metadata = load_analysis_metadata(run_paths.output_dir)
     if metadata is None:
         raise BaselineUnavailableError(
             f"No baseline analysis.json found in '{run_paths.output_dir}'. Run a full analysis first."
         )
-    depth_level = int(metadata.get("depth_level", DEFAULT_DEPTH_LEVEL))
+    depth_level = int(metadata.get("depth_cap", metadata.get("depth_level", DEFAULT_DEPTH_LEVEL)))
 
     changes = detect_changes_from_fingerprint(run_paths.repo_path, run_paths.output_dir)
     logger.info(

--- a/diagram_analysis/__init__.py
+++ b/diagram_analysis/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-__all__ = ["DiagramGenerator", "RunContext", "RunPaths", "configure_models"]
+__all__ = ["DiagramGenerator", "RunContext", "RunPaths", "DEFAULT_DEPTH_LEVEL", "configure_models"]
 
 
 def __getattr__(name: str):
@@ -19,6 +19,10 @@ def __getattr__(name: str):
         from .run_context import RunPaths
 
         return RunPaths
+    if name == "DEFAULT_DEPTH_LEVEL":
+        from .run_context import DEFAULT_DEPTH_LEVEL
+
+        return DEFAULT_DEPTH_LEVEL
     if name == "configure_models":
         from agents.llm_config import configure_models
 

--- a/diagram_analysis/analysis_json.py
+++ b/diagram_analysis/analysis_json.py
@@ -99,7 +99,12 @@ class AnalysisMetadata(BaseModel):
         description="SHA-256 over the sorted per-file content hashes; the source-state version key.",
     )
     repo_name: str = Field(description="Name of the analyzed repository.")
-    depth_level: int = Field(description="Maximum depth level of the analysis.")
+    depth_level: int = Field(description="Maximum depth level actually reached by this analysis.")
+    depth_cap: int = Field(
+        description="Safety-valve depth ceiling the run was configured with (see --depth-level); "
+        "may exceed depth_level when separability stopped expansion before the cap. "
+        "The value future incremental/partial runs reuse as their own cap."
+    )
     file_coverage_summary: FileCoverageSummary = Field(
         default_factory=lambda: FileCoverageSummary(
             total_files=0, analyzed=0, not_analyzed=0, not_analyzed_by_reason={}
@@ -428,6 +433,7 @@ def build_unified_analysis_json(
     repo_name: str,
     repo_dir: Path,
     source_tree_hash: str,
+    depth_cap: int,
     sub_analyses: dict[str, tuple[AnalysisInsights, list[Component]]] | None = None,
     file_coverage_summary: FileCoverageSummary | None = None,
 ) -> str:
@@ -435,8 +441,11 @@ def build_unified_analysis_json(
 
     ``repo_dir`` relativizes relation-edge file paths into ``methods_index`` keys.
     ``source_tree_hash`` is the precomputed whole-tree version key (the caller
-    fingerprints the tree once and reuses it across saves). The depth_level
-    metadata is computed automatically from the sub_analyses structure.
+    fingerprints the tree once and reuses it across saves). ``depth_level``
+    (realized depth) is computed automatically from the sub_analyses structure;
+    ``depth_cap`` is the run's configured ceiling, persisted separately so a run
+    that stopped short of the cap (separability-gated) doesn't leave a future
+    incremental/partial run capped at the shallower realized depth.
     """
     components_json = [
         from_component_to_json_component(c, expandable_components, repo_dir, sub_analyses) for c in analysis.components
@@ -460,6 +469,7 @@ def build_unified_analysis_json(
             source_tree_hash=source_tree_hash,
             repo_name=repo_name,
             depth_level=_compute_depth_level(sub_analyses),
+            depth_cap=depth_cap,
             file_coverage_summary=summary,
         ),
         description=analysis.description,

--- a/diagram_analysis/analysis_json.py
+++ b/diagram_analysis/analysis_json.py
@@ -142,6 +142,10 @@ class FileEntryJson(BaseModel):
         default="",
         description="Truncated SHA-256 of the entire file's bytes; '' when unknown.",
     )
+    module_hash: str = Field(
+        default="",
+        description="Truncated SHA-256 of the file's module-level lines (outside method spans); '' when unknown.",
+    )
 
 
 class UnifiedAnalysisJson(BaseModel):
@@ -243,6 +247,7 @@ def _build_file_entry_json_from_files(files_index: dict[str, FileEntry]) -> dict
         file_path: FileEntryJson(
             method_keys=[_method_key(file_path, m.qualified_name) for m in entry.methods],
             content_hash=entry.content_hash,
+            module_hash=entry.module_hash,
         )
         for file_path, entry in files_index.items()
         if file_path
@@ -502,7 +507,10 @@ def _reconstruct_files_index(
     """Rebuild in-memory ``FileEntry`` objects from persisted ``method_keys``."""
     files_index: dict[str, FileEntry] = {}
     for file_path, entry_raw in files_raw.items():
-        entry = FileEntry(content_hash=entry_raw.get("content_hash", ""))
+        entry = FileEntry(
+            content_hash=entry_raw.get("content_hash", ""),
+            module_hash=entry_raw.get("module_hash", ""),
+        )
         indexed_methods: list[MethodEntry] = []
         for key in entry_raw["method_keys"]:
             indexed = methods_index.get(key)

--- a/diagram_analysis/cluster_delta.py
+++ b/diagram_analysis/cluster_delta.py
@@ -131,6 +131,10 @@ class ChangedMembers:
     them so such edits are never silently missed.
     """
 
+    # Bare qnames, not (file, qname): downstream dirty/restore checks match on qname alone, which
+    # assumes a qname is unique per file (module-path-prefixed qnames guarantee this). A cross-file
+    # bare-qname collision would let one file's edit dirty the other's cluster — accepted as a
+    # redundant re-detail, never a missed change.
     members: set[str] = field(default_factory=set)
     unattributed_files: set[str] = field(default_factory=set)
 

--- a/diagram_analysis/cluster_delta.py
+++ b/diagram_analysis/cluster_delta.py
@@ -18,6 +18,8 @@ from pathlib import Path
 
 import networkx as nx
 
+from agents.content_hash import SourceCache, hash_method_body, hash_whole_file, read_source_lines
+from agents.file_index_models import FileEntry
 from agents.scope_ids import ROOT_SCOPE_ID
 from diagram_analysis.cluster_snapshot import ClusterSnapshot, ClusterSnapshotEntry
 from diagram_analysis.io_utils import normalize_repo_path
@@ -68,6 +70,11 @@ class ClusterMemberDelta:
     unchanged_methods: set[str] = field(default_factory=set)
     added_methods: set[str] = field(default_factory=set)
     removed_methods: set[str] = field(default_factory=set)
+    # Members (qnames) this cluster owns whose body content changed — the
+    # member-granular signal that drives the modified decision. ``dirty_files``
+    # is the narrow file-level fallback (module-level / unhashable edits) plus
+    # display context; see ``_dirty_signal``.
+    dirty_members: set[str] = field(default_factory=set)
     dirty_files: set[str] = field(default_factory=set)
 
 
@@ -76,6 +83,7 @@ class ClusterReshape:
     old_clusters: list[ClusterRef] = field(default_factory=list)
     new_clusters: list[ClusterRef] = field(default_factory=list)
     overlap_counts: dict[tuple[ClusterRef, ClusterRef], int] = field(default_factory=dict)
+    dirty_members: set[str] = field(default_factory=set)
     dirty_files: set[str] = field(default_factory=set)
 
 
@@ -101,6 +109,109 @@ class StructuralClusterDiff:
     @property
     def has_changes(self) -> bool:
         return any(diff.has_changes for diff in self.by_language.values())
+
+
+@dataclass
+class ChangedMembers:
+    """Member-granular content-change signal from per-method content hashes.
+
+    ``members`` are qualified names (the identity clusters store, so they join
+    directly against cluster members) whose method body content changed — or
+    that were added/removed — inside the change set's added/modified files.
+    ``unattributed_files`` are changed files whose edit no hashed member
+    represents (module-level statements, data/config files, or source with no
+    indexed methods); the narrow file-level fallback dirties clusters owning
+    them so such edits are never silently missed.
+    """
+
+    members: set[str] = field(default_factory=set)
+    unattributed_files: set[str] = field(default_factory=set)
+
+
+def compute_changed_members(
+    baseline_files: dict[str, FileEntry],
+    new_static: StaticAnalysisResults,
+    changes: ChangeSet,
+    repo_dir: Path,
+    source_cache: SourceCache | None = None,
+) -> ChangedMembers:
+    """Diff per-method content hashes to find genuinely-changed cluster members.
+
+    ``baseline_files`` is the prior ``analysis.json`` file index (its methods
+    carry the previously-persisted ``content_hash``); the new hashes are
+    recomputed from live source at the current CFG spans with the same helper,
+    so an unchanged method below an edit — whose line span shifts but whose body
+    text is identical — hashes equal and does not light up. Scoped to the change
+    set's added/modified files, so drift in untouched files cannot leak in.
+
+    A changed file that produces no changed member (and whose whole-file hash
+    still differs) is recorded in ``unattributed_files`` for the file-level
+    fallback. When the baseline predates content hashing (all hashes ``''``),
+    every method in a changed file differs and the signal degrades gracefully to
+    the old file-granular behavior rather than missing the change.
+    """
+    file_cache: SourceCache = source_cache if source_cache is not None else {}
+    changed_paths = {normalize_repo_path(fc.file_path, repo_dir) for fc in changes.files if fc.is_content_change()}
+    if not changed_paths:
+        return ChangedMembers()
+
+    new_member_hashes = _live_member_hashes(new_static, repo_dir, changed_paths, file_cache)
+
+    result = ChangedMembers()
+    for path in changed_paths:
+        baseline_entry = baseline_files.get(path)
+        baseline_members = (
+            {method.qualified_name: method.content_hash for method in baseline_entry.methods}
+            if baseline_entry is not None
+            else {}
+        )
+        new_members = new_member_hashes.get(path, {})
+
+        file_changed: set[str] = set()
+        for qname in set(baseline_members) | set(new_members):
+            in_baseline = qname in baseline_members
+            in_new = qname in new_members
+            if in_baseline and in_new:
+                if baseline_members[qname] != new_members[qname]:
+                    file_changed.add(qname)
+            else:
+                # Present in exactly one index: a method was added or removed.
+                file_changed.add(qname)
+
+        if file_changed:
+            result.members |= file_changed
+            continue
+
+        # No hashed member represents this file's edit — fall back to file level,
+        # but only if the whole-file content actually differs (a fingerprint
+        # false positive or metadata-only change must not dirty the cluster).
+        baseline_file_hash = baseline_entry.content_hash if baseline_entry is not None else ""
+        new_file_hash = hash_whole_file(read_source_lines(repo_dir, path, file_cache))
+        if new_file_hash != baseline_file_hash:
+            result.unattributed_files.add(path)
+    return result
+
+
+def _live_member_hashes(
+    new_static: StaticAnalysisResults,
+    repo_dir: Path,
+    changed_paths: set[str],
+    file_cache: SourceCache,
+) -> dict[str, dict[str, str]]:
+    """``{file_path -> {qname -> body_hash}}`` for CFG nodes in changed files."""
+    hashes: dict[str, dict[str, str]] = {}
+    for language in new_static.get_languages():
+        try:
+            cfg = new_static.get_cfg(language)
+        except (KeyError, ValueError):
+            continue
+        for qname, node in cfg.nodes.items():
+            path = normalize_repo_path(node.file_path, repo_dir)
+            if path not in changed_paths:
+                continue
+            source_lines = read_source_lines(repo_dir, path, file_cache)
+            hashes.setdefault(path, {})[qname] = hash_method_body(source_lines, node.line_start, node.line_end)
+    return hashes
 
 
 def compute_cluster_delta(
@@ -139,8 +250,17 @@ def structural_diff_from_delta(
     changes: ChangeSet | None = None,
     repo_dir: Path | None = None,
     scope_id: str = ROOT_SCOPE_ID,
+    changed: ChangedMembers | None = None,
 ) -> StructuralClusterDiff:
-    """Classify seeded cluster output into scope-local structural facts."""
+    """Classify seeded cluster output into scope-local structural facts.
+
+    ``changed`` (from ``compute_changed_members``) makes the modified decision
+    member-granular: a carried-over cluster is modified only when its own
+    members changed. Without it, the decision falls back to the legacy
+    file-level dirty signal (a cluster is modified if any of its member files is
+    in the diff), which over-reports because a file's methods disperse across
+    clusters.
+    """
     diff_files = _changeset_to_path_set(changes) if changes is not None else set()
     structural = StructuralClusterDiff()
     languages = set(old_snapshot.by_language) | set(delta.by_language)
@@ -155,6 +275,7 @@ def structural_diff_from_delta(
             diff_files,
             repo_dir,
             scope_id,
+            changed,
         )
     return structural
 
@@ -176,6 +297,7 @@ def _structural_diff_for_language(
     diff_files: set[str],
     repo_dir: Path | None,
     scope_id: str,
+    changed: ChangedMembers | None,
 ) -> LanguageStructuralDiff:
     result = LanguageStructuralDiff(language=language)
     old_to_new: dict[int, set[int]] = {}
@@ -233,13 +355,19 @@ def _structural_diff_for_language(
                 diff_files,
                 repo_dir,
                 scope_id,
+                changed,
             )
-            if member_delta.added_methods or member_delta.removed_methods or member_delta.dirty_files:
+            if _member_delta_has_change(member_delta):
                 result.modified.append(member_delta)
             else:
                 result.unchanged.append(member_delta)
             continue
 
+        # A reshape (many-to-many cluster remap) is itself a structural change:
+        # the partition boundary moved, so components must be re-derived even when
+        # no member body changed. It always surfaces — unlike the member-delta
+        # path, it was never the file-granular over-report source. ``dirty_members``
+        # is computed for display context only.
         result.reshaped.append(
             _build_reshape(
                 language,
@@ -251,6 +379,7 @@ def _structural_diff_for_language(
                 diff_files,
                 repo_dir,
                 scope_id,
+                changed,
             )
         )
 
@@ -267,9 +396,40 @@ def _structural_diff_for_language(
                 diff_files,
                 repo_dir,
                 scope_id,
+                changed,
             )
         )
     return result
+
+
+def _member_delta_has_change(delta: ClusterMemberDelta) -> bool:
+    """A carried-over cluster is modified when its own members (or a fallback
+    dirty file) changed — never merely because some unrelated method in a shared
+    file changed."""
+    return bool(delta.added_methods or delta.removed_methods or delta.dirty_members or delta.dirty_files)
+
+
+def _dirty_signal(
+    cluster_members: set[str],
+    cluster_files: set[str],
+    diff_files: set[str],
+    changed: ChangedMembers | None,
+) -> tuple[set[str], set[str]]:
+    """Return ``(dirty_members, dirty_files)`` for a cluster.
+
+    Member-granular when ``changed`` is provided: ``dirty_members`` are the
+    cluster's own changed members and ``dirty_files`` is the narrow fallback —
+    changed files the cluster owns whose edit no hashed member represents. Without
+    ``changed`` there is no member signal, so it degrades to the legacy file-level
+    dirty (any owned file in the diff), which over-reports.
+    """
+    if changed is None:
+        return set(), (cluster_files & diff_files)
+    return (cluster_members & changed.members), (cluster_files & changed.unattributed_files)
+
+
+def _normalize_files(paths: set[str], repo_dir: Path | None) -> set[str]:
+    return {normalize_repo_path(file_path, repo_dir) for file_path in paths if file_path}
 
 
 def _build_new_cluster_delta(
@@ -279,16 +439,17 @@ def _build_new_cluster_delta(
     diff_files: set[str],
     repo_dir: Path | None,
     scope_id: str,
+    changed: ChangedMembers | None,
 ) -> ClusterMemberDelta:
     members = set(new_result.clusters.get(new_id, set()))
-    files = {normalize_repo_path(file_path, repo_dir) for file_path in new_result.cluster_to_files.get(new_id, set())}
-    if diff_files:
-        files &= diff_files
+    cluster_files = _normalize_files(set(new_result.cluster_to_files.get(new_id, set())), repo_dir)
+    dirty_members, dirty_files = _dirty_signal(members, cluster_files, diff_files, changed)
     return ClusterMemberDelta(
         old_cluster=ClusterRef(language=language, cluster_id=new_id, scope_id=scope_id),
         new_cluster=ClusterRef(language=language, cluster_id=new_id, scope_id=scope_id),
         added_methods=members,
-        dirty_files=files,
+        dirty_members=dirty_members,
+        dirty_files=dirty_files,
     )
 
 
@@ -301,15 +462,25 @@ def _build_member_delta(
     diff_files: set[str],
     repo_dir: Path | None,
     scope_id: str,
+    changed: ChangedMembers | None,
 ) -> ClusterMemberDelta:
     new_members = new_result.clusters.get(new_id, set())
+    cluster_members = old_entry.members | new_members
+    cluster_files = _normalize_files(
+        set(old_entry.files)
+        | set(old_entry.member_files.values())
+        | set(new_result.cluster_to_files.get(new_id, set())),
+        repo_dir,
+    )
+    dirty_members, dirty_files = _dirty_signal(cluster_members, cluster_files, diff_files, changed)
     return ClusterMemberDelta(
         old_cluster=ClusterRef(language=language, cluster_id=old_id, scope_id=scope_id),
         new_cluster=ClusterRef(language=language, cluster_id=new_id, scope_id=scope_id),
         unchanged_methods=old_entry.members & new_members,
         added_methods=new_members - old_entry.members,
         removed_methods=old_entry.members - new_members,
-        dirty_files=_dirty_files(old_entry, new_result, new_id, diff_files, repo_dir),
+        dirty_members=dirty_members,
+        dirty_files=dirty_files,
     )
 
 
@@ -323,6 +494,7 @@ def _build_reshape(
     diff_files: set[str],
     repo_dir: Path | None,
     scope_id: str,
+    changed: ChangedMembers | None,
 ) -> ClusterReshape:
     old_refs = [ClusterRef(language=language, cluster_id=old_id, scope_id=scope_id) for old_id in sorted(old_ids)]
     new_refs = [ClusterRef(language=language, cluster_id=new_id, scope_id=scope_id) for new_id in sorted(new_ids)]
@@ -333,34 +505,25 @@ def _build_reshape(
         if old_id in old_ids and new_id in new_ids:
             ref_overlaps[(ref_by_old_id[old_id], ref_by_new_id[new_id])] = overlap_counts[(old_id, new_id)]
 
-    dirty_files: set[str] = set()
+    cluster_members: set[str] = set()
+    cluster_files_raw: set[str] = set()
     for old_id in old_ids:
-        for new_id in new_ids:
-            dirty_files |= _dirty_files(old_clusters[old_id], new_result, new_id, diff_files, repo_dir)
+        entry = old_clusters[old_id]
+        cluster_members |= entry.members
+        cluster_files_raw |= set(entry.files) | set(entry.member_files.values())
+    for new_id in new_ids:
+        cluster_members |= new_result.clusters.get(new_id, set())
+        cluster_files_raw |= set(new_result.cluster_to_files.get(new_id, set()))
+    dirty_members, dirty_files = _dirty_signal(
+        cluster_members, _normalize_files(cluster_files_raw, repo_dir), diff_files, changed
+    )
     return ClusterReshape(
         old_clusters=old_refs,
         new_clusters=new_refs,
         overlap_counts=ref_overlaps,
+        dirty_members=dirty_members,
         dirty_files=dirty_files,
     )
-
-
-def _dirty_files(
-    old_entry: ClusterSnapshotEntry,
-    new_result: ClusterResult,
-    new_id: int,
-    diff_files: set[str],
-    repo_dir: Path | None,
-) -> set[str]:
-    if not diff_files:
-        return set()
-    cluster_files = (
-        set(old_entry.files)
-        | set(old_entry.member_files.values())
-        | set(new_result.cluster_to_files.get(new_id, set()))
-    )
-    normalized = {normalize_repo_path(file_path, repo_dir) for file_path in cluster_files if file_path}
-    return normalized & diff_files
 
 
 def _delta_for_language(

--- a/diagram_analysis/cluster_delta.py
+++ b/diagram_analysis/cluster_delta.py
@@ -18,7 +18,14 @@ from pathlib import Path
 
 import networkx as nx
 
-from agents.content_hash import SourceCache, hash_method_body, hash_whole_file, read_source_lines
+from agents.content_hash import (
+    MethodSpan,
+    SourceCache,
+    hash_file_residual,
+    hash_method_body,
+    hash_whole_file,
+    read_source_lines,
+)
 from agents.file_index_models import FileEntry
 from agents.scope_ids import ROOT_SCOPE_ID
 from diagram_analysis.cluster_snapshot import ClusterSnapshot, ClusterSnapshotEntry
@@ -155,7 +162,7 @@ def compute_changed_members(
     if not changed_paths:
         return ChangedMembers()
 
-    new_member_hashes = _live_member_hashes(new_static, repo_dir, changed_paths, file_cache)
+    new_member_hashes, new_member_spans = _live_member_hashes(new_static, repo_dir, changed_paths, file_cache)
 
     result = ChangedMembers()
     for path in changed_paths:
@@ -178,8 +185,24 @@ def compute_changed_members(
                 # Present in exactly one index: a method was added or removed.
                 file_changed.add(qname)
 
+        result.members |= file_changed
+
+        # Module-level (non-method) content is not covered by any member hash, so a
+        # constant/import/decorator edit must be caught separately — even when a sibling
+        # method in the same file also changed (a "mixed" edit). Compare the residual of
+        # everything outside the live method spans against the baseline residual; only a
+        # real module-level difference dirties the file, so a pure member edit never does.
+        baseline_module_hash = baseline_entry.module_hash if baseline_entry is not None else ""
+        new_module_hash = hash_file_residual(
+            read_source_lines(repo_dir, path, file_cache), new_member_spans.get(path, [])
+        )
+        module_changed = new_module_hash != baseline_module_hash
+
         if file_changed:
-            result.members |= file_changed
+            if module_changed and baseline_module_hash:
+                # Only trust the residual when the baseline actually carried one; a legacy
+                # baseline (no module_hash) would otherwise dirty the file on every mixed edit.
+                result.unattributed_files.add(path)
             continue
 
         # No hashed member represents this file's edit — fall back to file level,
@@ -197,9 +220,10 @@ def _live_member_hashes(
     repo_dir: Path,
     changed_paths: set[str],
     file_cache: SourceCache,
-) -> dict[str, dict[str, str]]:
-    """``{file_path -> {qname -> body_hash}}`` for CFG nodes in changed files."""
+) -> tuple[dict[str, dict[str, str]], dict[str, list[MethodSpan]]]:
+    """``({file_path -> {qname -> body_hash}}, {file_path -> [method spans]})`` for changed files."""
     hashes: dict[str, dict[str, str]] = {}
+    spans: dict[str, list[MethodSpan]] = {}
     for language in new_static.get_languages():
         try:
             cfg = new_static.get_cfg(language)
@@ -211,7 +235,8 @@ def _live_member_hashes(
                 continue
             source_lines = read_source_lines(repo_dir, path, file_cache)
             hashes.setdefault(path, {})[qname] = hash_method_body(source_lines, node.line_start, node.line_end)
-    return hashes
+            spans.setdefault(path, []).append(MethodSpan(node.line_start, node.line_end))
+    return hashes, spans
 
 
 def compute_cluster_delta(
@@ -232,7 +257,9 @@ def compute_cluster_delta(
     diff_files = _changeset_to_path_set(changes) if changes is not None else None
     for language in new_static.get_languages():
         cfg = new_static.get_cfg(language)
-        nx_graph = cfg.to_networkx()
+        # Cluster the same reference-augmented graph the full run uses; a call-only graph would
+        # re-cluster type-coupled methods differently and drift from what a full analysis produces.
+        nx_graph = cfg.clustering_networkx()
         old_clusters = old_snapshot.get_language(language)
         delta.by_language[language] = _delta_for_language(
             language,

--- a/diagram_analysis/diagram_generator.py
+++ b/diagram_analysis/diagram_generator.py
@@ -34,7 +34,7 @@ from agents.file_index_models import FileEntry, FileMethodGroup, MethodEntry
 from agents.llm_config import initialize_llms
 from agents.llm_errors import LLMAuthError
 from agents.meta_agent import MetaAgent
-from agents.planner_agent import get_expandable_components
+from agents.planner_agent import component_is_separable, get_expandable_components
 from agents.relation_edges import index_relation_endpoints
 from agents.scope_ids import ROOT_SCOPE_ID
 from agents.content_hash import SourceCache, hash_repo_source_files, tree_hash_from_file_hashes
@@ -537,6 +537,27 @@ class DiagramGenerator:
     ) -> tuple[str, AnalysisInsights, list[Component]] | tuple[None, None, list]:
         return self._process_component(component)
 
+    def _component_separable(self, component: Component) -> bool:
+        """Deterministic gate: does this component's own call structure actually split?
+
+        Builds the component's subgraph (no side effects — empty scope prefix) and
+        asks whether its inter-cluster meta-graph has a genuine community split.
+        Cohesive components stay leaves instead of being force-expanded to the cap.
+        If the subgraph can't be built (e.g. a legacy static-analysis baseline whose
+        pickled edges predate the current schema), fall back to the structural
+        default of expanding rather than aborting the run.
+        """
+        assert self.details_agent is not None
+        try:
+            _str, cluster_results, subgraph_cfgs = self.details_agent._create_strict_component_subgraph(component)
+        except Exception:
+            logger.exception("Separability check failed for '%s'; defaulting to expandable", component.name)
+            return True
+        if not cluster_results:
+            return False
+        cfg_graphs = {lang: cfg.to_networkx() for lang, cfg in subgraph_cfgs.items()}
+        return component_is_separable(cluster_results, cfg_graphs)
+
     def _process_component(
         self, component: Component
     ) -> tuple[str, AnalysisInsights, list[Component]] | tuple[None, None, list]:
@@ -549,8 +570,11 @@ class DiagramGenerator:
             # Track whether parent had clusters for expansion decision
             parent_had_clusters = bool(component.source_cluster_ids)
 
-            # Get new components to analyze (deterministic, no LLM)
-            new_components = get_expandable_components(analysis, parent_had_clusters=parent_had_clusters)
+            # Get new components to analyze (deterministic, no LLM). The separability
+            # gate keeps cohesive sub-components as leaves rather than splitting them.
+            new_components = get_expandable_components(
+                analysis, parent_had_clusters=parent_had_clusters, separable=self._component_separable
+            )
 
             return component.component_id, analysis, new_components
         except LLMAuthError:
@@ -955,8 +979,9 @@ class DiagramGenerator:
             assert self.abstraction_agent is not None
 
             analysis, cluster_results = self.abstraction_agent.run()
-            # Get the initial components to analyze (deterministic, no LLM)
-            root_components = get_expandable_components(analysis)
+            # Get the initial components to analyze (deterministic, no LLM). The
+            # separability gate keeps cohesive top-level components as leaves.
+            root_components = get_expandable_components(analysis, separable=self._component_separable)
             logger.info(f"Found {len(root_components)} components to analyze at level 1")
 
             # Process components using a frontier queue: submit children as soon as parent finishes.

--- a/diagram_analysis/diagram_generator.py
+++ b/diagram_analysis/diagram_generator.py
@@ -20,6 +20,7 @@ from agents.agent_responses import (
     MetaAnalysisInsights,
     Relation,
     SourceCodeReference,
+    index_components_by_id,
 )
 from agents.cluster_methods_mixin import scoped_snapshot_from_lineage
 from agents.details_agent import DetailsAgent
@@ -597,7 +598,10 @@ class DiagramGenerator:
             return True
         if not cluster_results:
             return False
-        cfg_graphs = {lang: cfg.to_networkx() for lang, cfg in subgraph_cfgs.items()}
+        # Reference-augmented graph, matching the production split (deterministic_cluster_grouping ->
+        # supercluster_by_modularity_peak): a component separable only via CONTAINS/INHERITS edges
+        # must not be judged cohesive on a call-only graph.
+        cfg_graphs = {lang: cfg.clustering_networkx() for lang, cfg in subgraph_cfgs.items()}
         return component_is_separable(cluster_results, cfg_graphs)
 
     def _process_component(
@@ -1119,12 +1123,28 @@ class DiagramGenerator:
         # Only when the details agent is live (the analysis flows); a bare re-save without it keeps
         # the deterministic default (``None`` -> structural computation) rather than risk a crash.
         expandable_component_ids: list[str] | None = None
+        sub_expandable_ids: dict[str, list[str]] | None = None
         if self.details_agent is not None:
             expandable_component_ids = [
                 component.component_id
                 for component in get_expandable_components(root_analysis, separable=self._component_separable)
                 if component.component_id
             ]
+            # Same separability-respecting decision for each nested scope, so a cohesive
+            # sub-component kept as a leaf isn't advertised as expandable by the save-time
+            # structural recompute either.
+            component_lookup = index_components_by_id(root_analysis, sub_analyses)
+            sub_expandable_ids = {}
+            for cid, sub in sub_analyses.items():
+                parent = component_lookup.get(cid)
+                parent_had_clusters = bool(parent.source_cluster_ids) if parent else True
+                sub_expandable_ids[cid] = [
+                    component.component_id
+                    for component in get_expandable_components(
+                        sub, parent_had_clusters=parent_had_clusters, separable=self._component_separable
+                    )
+                    if component.component_id
+                ]
         analysis_path = save_analysis(
             analysis=root_analysis,
             output_dir=Path(self.output_dir),
@@ -1134,6 +1154,7 @@ class DiagramGenerator:
             repo_dir=self.repo_location,
             source_tree_hash=source_tree_hash,
             expandable_component_ids=expandable_component_ids,
+            sub_expandable_ids=sub_expandable_ids,
         ).resolve()
         if seed_delta is not None:
             self._seed_incremental_cluster_cache(seed_delta)

--- a/diagram_analysis/diagram_generator.py
+++ b/diagram_analysis/diagram_generator.py
@@ -19,6 +19,7 @@ from agents.agent_responses import (
     Component,
     MetaAnalysisInsights,
     Relation,
+    RelationEdge,
     SourceCodeReference,
 )
 from agents.cluster_methods_mixin import scoped_snapshot_from_lineage
@@ -434,28 +435,86 @@ def _incremental_changed_component_ids(
     return changed
 
 
+def _merge_edges_method_granular(
+    fresh: Relation,
+    base: Relation | None,
+    re_extracted_methods: set[str],
+    deleted_methods: set[str],
+    live_methods: set[str],
+) -> Relation | None:
+    """Rebuild a changed pair's edges at method granularity.
+
+    The static call-edge extraction is non-deterministic: re-analysing a file yields a
+    different edge set each run even when its code is byte-identical, so taking the fresh
+    rebuild wholesale churns edges for methods that did not change. Here an edge survives
+    from the fresh rebuild only when its *source method* was actually re-extracted this run
+    — body-changed or newly added. Every other edge is taken from the baseline, so an
+    unchanged method keeps exactly the edges it had. Edges whose source or target method was
+    deleted (or is otherwise gone from the live tree) are dropped, which is how a removal
+    retracts its relations without inventing new ones. Returns ``None`` when nothing
+    survives, so an emptied relation is dropped rather than left as a shell.
+    """
+
+    def live_edge(edge: RelationEdge) -> bool:
+        src = edge.source.qualified_name
+        dst = edge.target.qualified_name
+        return src not in deleted_methods and dst not in deleted_methods and src in live_methods and dst in live_methods
+
+    def collect(fresh_edges: list[RelationEdge], base_edges: list[RelationEdge]) -> list[RelationEdge]:
+        merged = [e for e in fresh_edges if e.source.qualified_name in re_extracted_methods and live_edge(e)]
+        seen = {(e.source.qualified_name, e.target.qualified_name) for e in merged}
+        for e in base_edges:
+            key = (e.source.qualified_name, e.target.qualified_name)
+            if e.source.qualified_name not in re_extracted_methods and live_edge(e) and key not in seen:
+                merged.append(e)
+                seen.add(key)
+        return merged
+
+    all_edges = collect(fresh.all_edges, base.all_edges if base is not None else [])
+    key_edges = collect(fresh.key_edges, base.key_edges if base is not None else [])
+    if not all_edges:
+        return None
+    return fresh.model_copy(update={"all_edges": all_edges, "key_edges": key_edges})
+
+
 def _preserve_unchanged_global_relations(
     rebuilt_relations: list[Relation],
     baseline_by_pair: dict[tuple[str, str], Relation],
     changed_component_ids: set[str],
     live_ids: set[str],
+    re_extracted_methods: set[str],
+    deleted_methods: set[str],
+    live_methods: set[str],
 ) -> list[Relation]:
     """Carry a global relation over from the baseline when neither endpoint changed.
 
     The save-time rebuild re-derives every relation at the deepest granularity, re-labelling
     even edges between two untouched components. For each pair whose endpoints are both
-    unchanged we drop the rebuilt edge and take the baseline verbatim; edges touching a
-    changed component keep the fresh rebuild. A baseline relation between two unchanged,
-    still-live components that the rebuild dropped is restored, and a spurious rebuilt edge
-    between two unchanged components is discarded — so both relabel and structural drift
-    against untouched components is eliminated. Relations are keyed by ``(src_id, dst_id)``,
-    the stable component identity; the rebuild always populates both ids.
+    unchanged we drop the rebuilt edge and take the baseline verbatim. For a pair that DOES
+    touch a changed component we no longer take the fresh rebuild wholesale — that would
+    churn the edges of the pair's unchanged methods, because extraction is non-deterministic
+    — but merge it against the baseline at method granularity (see
+    ``_merge_edges_method_granular``): only a body-changed or newly-added method contributes
+    fresh edges; unchanged methods keep their baseline edges; deleted methods' edges are
+    dropped. Relations are keyed by ``(src_id, dst_id)``, the stable component identity.
     """
 
     def touches_change(src_id: str, dst_id: str) -> bool:
         return src_id in changed_component_ids or dst_id in changed_component_ids
 
-    kept = [rel for rel in rebuilt_relations if touches_change(rel.src_id, rel.dst_id)]
+    kept: list[Relation] = []
+    for rel in rebuilt_relations:
+        if not touches_change(rel.src_id, rel.dst_id):
+            continue
+        merged = _merge_edges_method_granular(
+            rel,
+            baseline_by_pair.get((rel.src_id, rel.dst_id)),
+            re_extracted_methods,
+            deleted_methods,
+            live_methods,
+        )
+        if merged is not None:
+            kept.append(merged)
     for (src_id, dst_id), relation in baseline_by_pair.items():
         if touches_change(src_id, dst_id) or src_id not in live_ids or dst_id not in live_ids:
             continue
@@ -997,8 +1056,26 @@ class DiagramGenerator:
                 for component in analysis.components
                 if component.component_id
             }
+            live_methods = {
+                method.qualified_name
+                for _scope_id, analysis in _iter_incremental_scopes(root_analysis, sub_analyses)
+                for component in analysis.components
+                for group in component.file_methods
+                for method in group.methods
+            }
+            base_methods = {qname for keys in self._baseline_member_keys.values() for _file, qname in keys}
+            deleted_methods = base_methods - live_methods
+            # Only a body-changed or newly-added method has its edges re-extracted from the
+            # (non-deterministic) fresh CFG; every unchanged method keeps its baseline edges.
+            re_extracted_methods = self._changed_members | (live_methods - base_methods)
             global_relations = _preserve_unchanged_global_relations(
-                global_relations, self._baseline_global_relations, changed_ids, live_ids
+                global_relations,
+                self._baseline_global_relations,
+                changed_ids,
+                live_ids,
+                re_extracted_methods,
+                deleted_methods,
+                live_methods,
             )
         root_analysis.components_relations = global_relations
         return global_relations
@@ -1207,6 +1284,19 @@ class DiagramGenerator:
             for relation in root_analysis.components_relations
             if relation.src_id and relation.dst_id
         }
+        # Per-component baseline member keys, captured pre-mutation so the save-time relation
+        # rebuild sees the true before-state on BOTH the re-cluster path and the empty-delta
+        # path (a body-only edit). Deleted methods are still present here, which is how a
+        # removal becomes visible to the rebuild; an empty-delta run left this unset before,
+        # so every component read as changed and its non-deterministic fresh edges were kept.
+        self._baseline_member_keys = {
+            component.component_id: frozenset(
+                (group.file_path, method.qualified_name) for group in component.file_methods for method in group.methods
+            )
+            for _scope_id, analysis in _iter_incremental_scopes(root_analysis, sub_analyses)
+            for component in analysis.components
+            if component.component_id
+        }
 
         monitor = self.stats_writer if self.stats_writer else nullcontext()
         with monitor:
@@ -1282,10 +1372,6 @@ class DiagramGenerator:
             )
             protected_empty_ids = _cluster_backed_empty_component_ids(root_analysis, sub_analyses)
             baseline_membership = _capture_membership_baseline(root_analysis, sub_analyses)
-            # Feed the per-component baseline member keys to the save-time global relation
-            # rebuild so a component that only gained/lost a member (no body-hash change) is
-            # still treated as changed and its edges are re-derived, not carried over stale.
-            self._baseline_member_keys = {cid: meta.member_keys for cid, meta in baseline_membership.meta_by_id.items()}
             apply_result = self._apply_incremental_scope_recursively(
                 ROOT_SCOPE_ID,
                 root_analysis,

--- a/diagram_analysis/diagram_generator.py
+++ b/diagram_analysis/diagram_generator.py
@@ -693,9 +693,13 @@ class DiagramGenerator:
                     child_scope, cluster_results, cfg_graphs, component.component_id
                 )
             else:
-                # The parent owns no live methods, so no child may own any.
+                # The parent owns no live methods, so no child may own any. Clear the
+                # scope's own index too: ``save_analysis`` merges it into the unified
+                # ``files``/``methods_index``, and the partial flow saves without a
+                # ``_refresh_files_index`` that would otherwise drop the stale entries.
                 for child in child_scope.components:
                     child.file_methods = []
+                child_scope.files = {}
             self._rescope_child_analyses(child_scope, sub_analyses)
 
     def _apply_incremental_scope_recursively(

--- a/diagram_analysis/diagram_generator.py
+++ b/diagram_analysis/diagram_generator.py
@@ -2,8 +2,11 @@ import json
 import logging
 import os
 import time
+from collections import Counter, defaultdict
+from collections.abc import Iterable, Iterator
 from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
 from contextlib import nullcontext
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -15,6 +18,8 @@ from agents.agent_responses import (
     AnalysisInsights,
     Component,
     MetaAnalysisInsights,
+    Relation,
+    SourceCodeReference,
 )
 from agents.cluster_methods_mixin import scoped_snapshot_from_lineage
 from agents.details_agent import DetailsAgent
@@ -25,7 +30,7 @@ from agents.incremental_agent import (
 )
 from agents.incremental_planning_agent import IncrementalPlanningAgent
 from agents.incremental_results import RecursiveScopeUpdateResult
-from agents.file_index_models import FileEntry
+from agents.file_index_models import FileEntry, FileMethodGroup, MethodEntry
 from agents.llm_config import initialize_llms
 from agents.llm_errors import LLMAuthError
 from agents.meta_agent import MetaAgent
@@ -90,6 +95,374 @@ def _component_expansion_seeds(components: list[Component], max_depth: int) -> l
     ]
 
 
+def _owned_method_keys(components: Iterable[Component]) -> set[tuple[str, str]]:
+    """The ``(file_path, qualified_name)`` set the given components collectively own."""
+    return {
+        (group.file_path, method.qualified_name)
+        for component in components
+        for group in component.file_methods
+        for method in group.methods
+    }
+
+
+def _reconcile_child_scope(
+    parent: Component,
+    child_scope: AnalysisInsights,
+    parent_keys: set[tuple[str, str]],
+    child_keys: set[tuple[str, str]],
+    repo_dir: Path,
+) -> None:
+    """Bring a child scope's membership up to its parent's, preserving unchanged placements.
+
+    ``update_scope`` may shift a handful of methods into or out of a parent. Re-clustering
+    the whole subtree to absorb that would renumber sub-components nothing touched, so
+    instead drop only the departed methods — the double-ownership fix — and graft each
+    entered method onto the child component with the strongest same-file affinity, leaving
+    every method that stayed exactly where it was.
+    """
+    departed = child_keys - parent_keys
+    entered = parent_keys - child_keys
+    if departed:
+        for child in child_scope.components:
+            for group in child.file_methods:
+                group.methods = [m for m in group.methods if (group.file_path, m.qualified_name) not in departed]
+            child.file_methods = [group for group in child.file_methods if group.methods]
+    if entered:
+        parent_methods = {
+            (group.file_path, method.qualified_name): method
+            for group in parent.file_methods
+            for method in group.methods
+        }
+        _graft_entered_methods(child_scope, entered, parent_methods)
+    child_scope.files = build_files_index(child_scope, repo_dir)
+
+
+def _graft_entered_methods(
+    child_scope: AnalysisInsights,
+    entered: set[tuple[str, str]],
+    parent_methods: dict[tuple[str, str], MethodEntry],
+) -> None:
+    """Place each entered method on the child component that already owns most of its file."""
+    file_owner_counts: defaultdict[str, Counter[str]] = defaultdict(Counter)
+    child_by_id: dict[str, Component] = {}
+    for child in child_scope.components:
+        child_by_id[child.component_id] = child
+        for group in child.file_methods:
+            file_owner_counts[group.file_path][child.component_id] += len(group.methods)
+    # Deterministic home for a method whose file no child owns yet.
+    fallback = max(
+        child_scope.components,
+        key=lambda c: (sum(len(g.methods) for g in c.file_methods), c.component_id),
+    )
+    for file_path, qualified_name in sorted(entered):
+        counts = file_owner_counts.get(file_path)
+        target = child_by_id[max(counts, key=lambda cid: (counts[cid], cid))] if counts else fallback
+        _append_method(target, file_path, parent_methods[(file_path, qualified_name)])
+        file_owner_counts[file_path][target.component_id] += 1
+
+
+def _append_method(component: Component, file_path: str, method: MethodEntry) -> None:
+    for group in component.file_methods:
+        if group.file_path == file_path:
+            if all(existing.qualified_name != method.qualified_name for existing in group.methods):
+                group.methods.append(method)
+            return
+    component.file_methods.append(FileMethodGroup(file_path=file_path, methods=[method]))
+
+
+@dataclass
+class _ComponentBaseline:
+    """One component's pre-update metadata and membership, for verbatim restoration."""
+
+    name: str
+    description: str
+    key_entities: list[SourceCodeReference]
+    source_group_names: list[str]
+    source_cluster_ids: list[str]
+    member_keys: frozenset[tuple[str, str]]
+    member_qnames: frozenset[str]
+
+
+@dataclass
+class _MembershipBaseline:
+    """Pre-update snapshot the incremental restores unchanged components from."""
+
+    # scope_id -> (file_path, qname) -> owning component_id
+    owner_by_scope: dict[str, dict[tuple[str, str], str]] = field(default_factory=dict)
+    # scope_id -> (file_path, qname) -> the baseline method entry (restored verbatim)
+    entry_by_scope: dict[str, dict[tuple[str, str], MethodEntry]] = field(default_factory=dict)
+    meta_by_id: dict[str, _ComponentBaseline] = field(default_factory=dict)
+    # sub-scope_id -> a verbatim deep copy of the child-scope analysis, so a component with
+    # no changed member anywhere in its subtree can have its whole sub-component structure
+    # (which method sits in which child) restored, not just its top-level ownership.
+    scope_by_id: dict[str, AnalysisInsights] = field(default_factory=dict)
+
+
+def _iter_incremental_scopes(
+    root_analysis: AnalysisInsights,
+    sub_analyses: dict[str, AnalysisInsights],
+) -> Iterator[tuple[str, AnalysisInsights]]:
+    """Yield ``(scope_id, analysis)`` for the root and every expanded sub-scope."""
+    yield ROOT_SCOPE_ID, root_analysis
+    for scope_id, sub in sub_analyses.items():
+        yield scope_id, sub
+
+
+def _capture_membership_baseline(
+    root_analysis: AnalysisInsights,
+    sub_analyses: dict[str, AnalysisInsights],
+) -> _MembershipBaseline:
+    """Snapshot per-scope method ownership and per-component metadata before the update.
+
+    The incremental re-partitions clusters, which can shuffle unchanged methods between
+    components. This snapshot lets a later pass pin every unchanged method back to the
+    component that owned it and restore the metadata of components that end up identical.
+    """
+    baseline = _MembershipBaseline()
+    for scope_id, analysis in _iter_incremental_scopes(root_analysis, sub_analyses):
+        if scope_id != ROOT_SCOPE_ID:
+            baseline.scope_by_id[scope_id] = analysis.model_copy(deep=True)
+        owner = baseline.owner_by_scope.setdefault(scope_id, {})
+        entries = baseline.entry_by_scope.setdefault(scope_id, {})
+        for component in analysis.components:
+            if not component.component_id:
+                continue
+            keys: set[tuple[str, str]] = set()
+            qnames: set[str] = set()
+            for group in component.file_methods:
+                for method in group.methods:
+                    key = (group.file_path, method.qualified_name)
+                    owner[key] = component.component_id
+                    entries[key] = method.model_copy(deep=True)
+                    keys.add(key)
+                    qnames.add(method.qualified_name)
+            baseline.meta_by_id[component.component_id] = _ComponentBaseline(
+                name=component.name,
+                description=component.description,
+                key_entities=[entity.model_copy(deep=True) for entity in component.key_entities],
+                source_group_names=list(component.source_group_names),
+                source_cluster_ids=list(component.source_cluster_ids),
+                member_keys=frozenset(keys),
+                member_qnames=frozenset(qnames),
+            )
+    return baseline
+
+
+def _restore_unchanged_membership(
+    root_analysis: AnalysisInsights,
+    sub_analyses: dict[str, AnalysisInsights],
+    baseline: _MembershipBaseline,
+    changed_members: set[str],
+    protected_ids: set[str],
+) -> None:
+    """Pin every unchanged method back to the component that owned it in the baseline.
+
+    A method whose body did not change (absent from ``changed_members``) and whose baseline
+    owner still exists is returned to that owner, overriding wherever the re-partition placed
+    it — this is what stops an untouched top-level component from silently gaining or losing
+    methods. Body-changed methods, added methods, methods whose owner was removed, and every
+    method inside a freshly created component (``protected_ids``) keep the re-partition's
+    placement, so a genuinely changed component still re-clusters. Each live method resolves
+    to exactly one owner, so nothing is dropped or duplicated.
+    """
+    for scope_id, analysis in _iter_incremental_scopes(root_analysis, sub_analyses):
+        owner = baseline.owner_by_scope.get(scope_id, {})
+        entries = baseline.entry_by_scope.get(scope_id, {})
+        live_ids = {component.component_id for component in analysis.components if component.component_id}
+        assigned: dict[str, dict[str, list[MethodEntry]]] = defaultdict(lambda: defaultdict(list))
+        for component in analysis.components:
+            protected = component.component_id in protected_ids
+            for group in component.file_methods:
+                for method in group.methods:
+                    key = (group.file_path, method.qualified_name)
+                    base_owner = owner.get(key)
+                    if not protected and method.qualified_name not in changed_members and base_owner in live_ids:
+                        assigned[base_owner][group.file_path].append(entries.get(key, method))
+                    else:
+                        assigned[component.component_id][group.file_path].append(method)
+        for component in analysis.components:
+            by_file = assigned.get(component.component_id, {})
+            component.file_methods = [
+                FileMethodGroup(
+                    file_path=file_path,
+                    methods=sorted(methods, key=lambda m: (m.start_line, m.end_line, m.qualified_name)),
+                )
+                for file_path, methods in sorted(by_file.items())
+            ]
+
+
+def _restore_unchanged_metadata(
+    root_analysis: AnalysisInsights,
+    sub_analyses: dict[str, AnalysisInsights],
+    baseline: _MembershipBaseline,
+    changed_members: set[str],
+) -> set[str]:
+    """Restore name/description/key_entities of components identical to their baseline.
+
+    A component with the same membership as the baseline and no body-changed member did not
+    genuinely change; the planner may still have reworded it. Restoring its metadata and
+    returning its id lets the caller drop it from the refresh set, so its relations to other
+    unchanged components are carried over verbatim rather than re-derived.
+    """
+    unchanged_ids: set[str] = set()
+    for _scope_id, analysis in _iter_incremental_scopes(root_analysis, sub_analyses):
+        for component in analysis.components:
+            meta = baseline.meta_by_id.get(component.component_id)
+            if meta is None:
+                continue
+            final_keys = frozenset(
+                (group.file_path, method.qualified_name) for group in component.file_methods for method in group.methods
+            )
+            if final_keys != meta.member_keys or (meta.member_qnames & changed_members):
+                continue
+            component.name = meta.name
+            component.description = meta.description
+            component.key_entities = [entity.model_copy(deep=True) for entity in meta.key_entities]
+            component.source_group_names = list(meta.source_group_names)
+            # Restore the paired cluster ids too: membership is baseline-identical here, so the
+            # repartition's ids would leave the component claiming clusters it no longer owns and
+            # misroute the next incremental's changes for them.
+            component.source_cluster_ids = list(meta.source_cluster_ids)
+            unchanged_ids.add(component.component_id)
+    return unchanged_ids
+
+
+def _fully_unchanged_component_ids(
+    root_analysis: AnalysisInsights,
+    sub_analyses: dict[str, AnalysisInsights],
+    baseline: _MembershipBaseline,
+    changed_members: set[str],
+    protected_ids: set[str],
+) -> set[str]:
+    """Ids of components whose entire subtree is byte-identical to the baseline.
+
+    A component qualifies when, at every depth, no member changed and it neither gained nor
+    lost one. Containment (parent is a superset of every descendant) means a component's own top-level
+    member set already spans its whole subtree, so testing that set is enough: no member
+    qname is in ``changed_members`` and the live keys equal the baseline. A subtree holding
+    a freshly created component is excluded — restoring it verbatim would delete that
+    component, and new components are never restored.
+    """
+    fully_unchanged: set[str] = set()
+    for _scope_id, analysis in _iter_incremental_scopes(root_analysis, sub_analyses):
+        for component in analysis.components:
+            cid = component.component_id
+            meta = baseline.meta_by_id.get(cid)
+            if meta is None or meta.member_qnames & changed_members:
+                continue
+            if any(is_self_or_descendant(protected_id, cid) for protected_id in protected_ids):
+                continue
+            live_keys = frozenset(
+                (group.file_path, method.qualified_name) for group in component.file_methods for method in group.methods
+            )
+            if live_keys == meta.member_keys:
+                fully_unchanged.add(cid)
+    return fully_unchanged
+
+
+def _restore_unchanged_subtrees(
+    root_analysis: AnalysisInsights,
+    sub_analyses: dict[str, AnalysisInsights],
+    baseline: _MembershipBaseline,
+    changed_members: set[str],
+    protected_ids: set[str],
+) -> set[str]:
+    """Restore the whole child-scope subtree of every fully-unchanged component, verbatim.
+
+    ``_restore_unchanged_membership`` pins top-level ownership, but a component's child
+    sub-components live in separate scopes that the re-partition — or the later
+    ``_rescope_child_analyses`` reconcile — can still reshuffle, moving a method from one
+    child to a sibling. That shifts the node->deepest-component map and churns the
+    deepest-granularity relations even though nothing in the component changed. For every
+    component whose subtree has no changed member, replace each descendant scope with its
+    baseline deep copy so which method sits in which child is identical to the baseline.
+
+    Returns the full set of preserved ids so the caller can skip them in the reconcile pass;
+    the restore itself only rewrites each maximal subtree once (restoring a root already
+    covers its descendants).
+    """
+    fully_unchanged = _fully_unchanged_component_ids(
+        root_analysis, sub_analyses, baseline, changed_members, protected_ids
+    )
+    for scope_id, analysis in _iter_incremental_scopes(root_analysis, sub_analyses):
+        # A component whose parent scope is also fully unchanged is restored by that parent.
+        if scope_id != ROOT_SCOPE_ID and scope_id in fully_unchanged:
+            continue
+        for component in analysis.components:
+            cid = component.component_id
+            if cid not in fully_unchanged:
+                continue
+            for descendant_id, baseline_scope in baseline.scope_by_id.items():
+                if is_self_or_descendant(descendant_id, cid):
+                    sub_analyses[descendant_id] = baseline_scope.model_copy(deep=True)
+    return fully_unchanged
+
+
+def _incremental_changed_component_ids(
+    root_analysis: AnalysisInsights,
+    sub_analyses: dict[str, AnalysisInsights],
+    baseline_component_ids: set[str],
+    baseline_member_keys: dict[str, frozenset[tuple[str, str]]],
+    changed_members: set[str],
+) -> set[str]:
+    """Component ids whose global relations may legitimately differ from the baseline.
+
+    A live component counts as changed when it is absent from the baseline (freshly
+    created), owns a body-changed member, or its live member-key set differs from the
+    baseline — it gained or lost a member. Membership churn alone (a new caller of another
+    component, or the last caller removed) relabels the edges between the two components
+    even with no surviving body-hash change, so it must be treated as changed or the
+    genuinely-new edge is dropped / the stale baseline edge restored. Because every ancestor
+    scope lists a method in its own ``file_methods``, the owner of a change and all of its
+    ancestors are captured together. Everything else is preserved verbatim.
+    """
+    changed: set[str] = set()
+    for _scope_id, analysis in _iter_incremental_scopes(root_analysis, sub_analyses):
+        for component in analysis.components:
+            component_id = component.component_id
+            if not component_id:
+                continue
+            live_keys = frozenset(
+                (group.file_path, method.qualified_name) for group in component.file_methods for method in group.methods
+            )
+            body_changed = any(
+                method.qualified_name in changed_members for group in component.file_methods for method in group.methods
+            )
+            membership_changed = live_keys != baseline_member_keys.get(component_id, frozenset())
+            if component_id not in baseline_component_ids or body_changed or membership_changed:
+                changed.add(component_id)
+    return changed
+
+
+def _preserve_unchanged_global_relations(
+    rebuilt_relations: list[Relation],
+    baseline_by_pair: dict[tuple[str, str], Relation],
+    changed_component_ids: set[str],
+    live_ids: set[str],
+) -> list[Relation]:
+    """Carry a global relation over from the baseline when neither endpoint changed.
+
+    The save-time rebuild re-derives every relation at the deepest granularity, re-labelling
+    even edges between two untouched components. For each pair whose endpoints are both
+    unchanged we drop the rebuilt edge and take the baseline verbatim; edges touching a
+    changed component keep the fresh rebuild. A baseline relation between two unchanged,
+    still-live components that the rebuild dropped is restored, and a spurious rebuilt edge
+    between two unchanged components is discarded — so both relabel and structural drift
+    against untouched components is eliminated. Relations are keyed by ``(src_id, dst_id)``,
+    the stable component identity; the rebuild always populates both ids.
+    """
+
+    def touches_change(src_id: str, dst_id: str) -> bool:
+        return src_id in changed_component_ids or dst_id in changed_component_ids
+
+    kept = [rel for rel in rebuilt_relations if touches_change(rel.src_id, rel.dst_id)]
+    for (src_id, dst_id), relation in baseline_by_pair.items():
+        if touches_change(src_id, dst_id) or src_id not in live_ids or dst_id not in live_ids:
+            continue
+        kept.append(relation)
+    return sorted(kept, key=lambda rel: (rel.src_id, rel.dst_id))
+
+
 class DiagramGenerator:
     def __init__(
         self,
@@ -120,6 +493,22 @@ class DiagramGenerator:
         # the prior analysis (see ``compute_cluster_delta``). ``None`` runs
         # unscoped (no drift filtering).
         self.changes: ChangeSet | None = changes
+        # Qnames whose method body changed vs the baseline, derived once per incremental run
+        # from the member-granular change signal. Drives copy-forward: an unchanged method is
+        # pinned back to its baseline owner, and the save-time global relation rebuild treats a
+        # component owning one of these as changed.
+        self._changed_members: set[str] = set()
+        # Incremental-only baseline captured at the top of ``generate_analysis_incremental``,
+        # so the save-time global relation rebuild can carry an edge between two unchanged
+        # components over verbatim instead of re-deriving (and re-labelling) it.
+        # ``None`` => full analysis: rebuild every relation. Keyed by ``(src_id, dst_id)``.
+        self._baseline_global_relations: dict[tuple[str, str], Relation] | None = None
+        self._baseline_component_ids: set[str] = set()
+        # Per-component baseline member-key set, captured with the membership baseline. A
+        # component whose live member keys differ from these gained or lost a member (without
+        # necessarily a body-hash change), so its relations may legitimately relabel — the
+        # save-time global rebuild must treat it as changed.
+        self._baseline_member_keys: dict[str, frozenset[tuple[str, str]]] = {}
         # Whole-tree content hash, stamped into the pkl's sibling .sha file as the
         # diff base for the next warm-start (NOT a cache gate). ``pre_analysis``
         # fills it from the live tree when unset; ``None`` is a tag-less save.
@@ -592,6 +981,25 @@ class DiagramGenerator:
             return []
         cfg_graphs = {str(lang): self.static_analysis.get_cfg(lang) for lang in self.static_analysis.get_languages()}
         global_relations = build_global_relations(root_analysis, sub_analyses, cfg_graphs)
+        if self._baseline_global_relations is not None:
+            # Incremental: the wholesale rebuild would relabel edges between two untouched
+            # components, so carry those over verbatim from the baseline.
+            changed_ids = _incremental_changed_component_ids(
+                root_analysis,
+                sub_analyses,
+                self._baseline_component_ids,
+                self._baseline_member_keys,
+                self._changed_members,
+            )
+            live_ids = {
+                component.component_id
+                for _scope_id, analysis in _iter_incremental_scopes(root_analysis, sub_analyses)
+                for component in analysis.components
+                if component.component_id
+            }
+            global_relations = _preserve_unchanged_global_relations(
+                global_relations, self._baseline_global_relations, changed_ids, live_ids
+            )
         root_analysis.components_relations = global_relations
         return global_relations
 
@@ -672,35 +1080,37 @@ class DiagramGenerator:
         self,
         scope: AnalysisInsights,
         sub_analyses: dict[str, AnalysisInsights],
+        preserved_ids: set[str],
     ) -> None:
-        """Re-partition every child scope over its parent's current ``file_methods``.
+        """Reconcile each child scope whose membership diverges from its parent's, surgically.
 
         Why: ``update_scope`` re-partitions a parent against the live clustering, but a
         child scope is a separate ``AnalysisInsights`` that no patch touches — a method
         that moved to another component would otherwise stay in the old owner's subtree
         and appear under two components.
+
+        Only reconcile a scope whose parent's live method set differs from what its
+        children currently reflect; an agreeing scope is left byte-for-byte, so a small
+        change stops rippling into subtrees nothing touched. The reconcile itself is
+        surgical (drop departed, graft entered) rather than a fresh re-cluster, so even a
+        genuinely-changed component keeps its unchanged methods where they already were.
+        Recurse into every scope so a deeper boundary that shifted is still caught.
+
+        ``preserved_ids`` are components whose subtree was already restored verbatim from
+        the baseline; reconciling them would graft the parent's undistributed methods into
+        children and re-drift the very structure the restore froze, so skip them entirely.
         """
-        assert self.incremental_agent is not None
         for component in scope.components:
+            if component.component_id in preserved_ids:
+                continue
             child_scope = sub_analyses.get(component.component_id)
             if child_scope is None or not child_scope.components:
                 continue
-            _subgraph_str, cluster_results, cfg_graphs = self.incremental_agent._create_strict_component_subgraph(
-                component, source_cluster_id_prefix=component.component_id
-            )
-            if cluster_results:
-                self.incremental_agent.populate_file_methods(
-                    child_scope, cluster_results, cfg_graphs, component.component_id
-                )
-            else:
-                # The parent owns no live methods, so no child may own any. Clear the
-                # scope's own index too: ``save_analysis`` merges it into the unified
-                # ``files``/``methods_index``, and the partial flow saves without a
-                # ``_refresh_files_index`` that would otherwise drop the stale entries.
-                for child in child_scope.components:
-                    child.file_methods = []
-                child_scope.files = {}
-            self._rescope_child_analyses(child_scope, sub_analyses)
+            parent_keys = _owned_method_keys([component])
+            child_keys = _owned_method_keys(child_scope.components)
+            if parent_keys != child_keys:
+                _reconcile_child_scope(component, child_scope, parent_keys, child_keys, self.repo_location)
+            self._rescope_child_analyses(child_scope, sub_analyses, preserved_ids)
 
     def _apply_incremental_scope_recursively(
         self,
@@ -782,6 +1192,22 @@ class DiagramGenerator:
         assert self.incremental_planning_agent is not None
         assert self.incremental_agent is not None
 
+        # Snapshot the loaded baseline before any mutation: its global relations (deepest
+        # granularity, keyed by component id) are carried over verbatim at save time for any
+        # edge between two components that did not change. This is what marks the run as
+        # incremental for ``rebuild_global_relations``; a full run leaves it ``None``.
+        self._baseline_component_ids = {
+            component.component_id
+            for _scope_id, analysis in _iter_incremental_scopes(root_analysis, sub_analyses)
+            for component in analysis.components
+            if component.component_id
+        }
+        self._baseline_global_relations = {
+            (relation.src_id, relation.dst_id): relation.model_copy(deep=True)
+            for relation in root_analysis.components_relations
+            if relation.src_id and relation.dst_id
+        }
+
         monitor = self.stats_writer if self.stats_writer else nullcontext()
         with monitor:
             # Scrub before cluster math: orphan-routed files never appear in
@@ -812,6 +1238,8 @@ class DiagramGenerator:
                 if self.changes is not None
                 else None
             )
+            # Body-changed qnames drive copy-forward and the save-time relation preservation.
+            self._changed_members = changed_members.members if changed_members is not None else set()
 
             snapshot_source = self.static_analysis.incremental_base_results or self.static_analysis
             old_snapshot = snapshot_from_static_analysis(snapshot_source)
@@ -841,7 +1269,7 @@ class DiagramGenerator:
                 # go stale (relations are already the global set here).
                 # Re-scope anyway: a baseline written before child scopes were
                 # confined to their parent stays drifted until something repairs it.
-                self._rescope_child_analyses(root_analysis, sub_analyses)
+                self._rescope_child_analyses(root_analysis, sub_analyses, set())
                 self._refresh_files_index(root_analysis, sub_analyses)
                 return self.finalize_and_save(root_analysis, sub_analyses)
 
@@ -853,6 +1281,11 @@ class DiagramGenerator:
                 changed=changed_members,
             )
             protected_empty_ids = _cluster_backed_empty_component_ids(root_analysis, sub_analyses)
+            baseline_membership = _capture_membership_baseline(root_analysis, sub_analyses)
+            # Feed the per-component baseline member keys to the save-time global relation
+            # rebuild so a component that only gained/lost a member (no body-hash change) is
+            # still treated as changed and its edges are re-derived, not carried over stale.
+            self._baseline_member_keys = {cid: meta.member_keys for cid, meta in baseline_membership.meta_by_id.items()}
             apply_result = self._apply_incremental_scope_recursively(
                 ROOT_SCOPE_ID,
                 root_analysis,
@@ -861,7 +1294,31 @@ class DiagramGenerator:
                 sub_analyses,
                 changed_members,
             )
-            self._rescope_child_analyses(root_analysis, sub_analyses)
+            # Pin unchanged methods back to their baseline owner so the re-partition only
+            # moves what genuinely changed, then freeze the whole subtree of any component
+            # with no changed member so its sub-component boundaries can't drift, and finally
+            # reconcile the child scopes that genuinely moved.
+            _restore_unchanged_membership(
+                root_analysis,
+                sub_analyses,
+                baseline_membership,
+                self._changed_members,
+                apply_result.new_component_ids,
+            )
+            preserved_ids = _restore_unchanged_subtrees(
+                root_analysis,
+                sub_analyses,
+                baseline_membership,
+                self._changed_members,
+                apply_result.new_component_ids,
+            )
+            self._rescope_child_analyses(root_analysis, sub_analyses, preserved_ids)
+            # A component identical to its baseline did not change: restore any metadata the
+            # planner reworded and drop it from the refresh set so its relations carry over.
+            unchanged_ids = _restore_unchanged_metadata(
+                root_analysis, sub_analyses, baseline_membership, self._changed_members
+            )
+            apply_result.refresh_ids -= unchanged_ids
 
             removed_ids = prune_empty_components(root_analysis, sub_analyses, protected_empty_ids)
             if removed_ids:

--- a/diagram_analysis/diagram_generator.py
+++ b/diagram_analysis/diagram_generator.py
@@ -1571,11 +1571,22 @@ def _child_scope_needs_recursive_update(
         for method in group.methods
         if method.qualified_name
     }
+    # A module-level edit no member represents surfaces only as dirty_files, so match on the
+    # child's owned files too — otherwise a pure import/constant edit in a file this expanded
+    # child owns refreshes the parent but leaves the child's descriptions/relations stale.
+    owned_files = {
+        normalize_repo_path(group.file_path)
+        for component in child_scope.components
+        for group in component.file_methods
+        if group.file_path
+    }
     changed_qnames: set[str] = set()
+    dirty_files: set[str] = set()
     for diff in structural_diff.by_language.values():
         for member_delta in [*diff.modified, *diff.new_details]:
             changed_qnames.update(member_delta.removed_methods, member_delta.added_methods, member_delta.dirty_members)
-    return bool(changed_qnames.intersection(owned_qnames))
+            dirty_files.update(normalize_repo_path(path) for path in member_delta.dirty_files)
+    return bool(changed_qnames & owned_qnames) or bool(dirty_files & owned_files)
 
 
 def _build_scope_incremental_inputs(

--- a/diagram_analysis/diagram_generator.py
+++ b/diagram_analysis/diagram_generator.py
@@ -39,9 +39,11 @@ from diagram_analysis.analysis_json import (
     NotAnalyzedFile,
 )
 from diagram_analysis.cluster_delta import (
+    ChangedMembers,
     ClusterDelta,
     LanguageDelta,
     StructuralClusterDiff,
+    compute_changed_members,
     compute_cluster_delta,
     structural_diff_from_delta,
 )
@@ -672,6 +674,7 @@ class DiagramGenerator:
         structural_diff: StructuralClusterDiff,
         cluster_results: dict[str, ClusterResult],
         sub_analyses: dict[str, AnalysisInsights],
+        changed_members: ChangedMembers | None,
     ) -> RecursiveScopeUpdateResult:
         assert self.incremental_planning_agent is not None
         assert self.incremental_agent is not None
@@ -705,6 +708,7 @@ class DiagramGenerator:
                 self.incremental_agent,
                 self.changes,
                 self.repo_location,
+                changed_members,
             )
             if not child_diff.has_changes:
                 continue
@@ -716,6 +720,7 @@ class DiagramGenerator:
                 child_diff,
                 child_cluster_results,
                 sub_analyses,
+                changed_members,
             )
             result.refresh_ids |= child_result.refresh_ids
             result.new_component_ids |= child_result.new_component_ids
@@ -757,6 +762,22 @@ class DiagramGenerator:
                         live_files.add(normalize_repo_path(node.file_path, self.repo_location))
             remove_deleted_files(root_analysis, sub_analyses, live_files)
 
+            # Member-granular change signal from per-method content hashes,
+            # captured from the baseline analysis.json *before* the files index
+            # is refreshed (which would overwrite the prior hashes). Drives the
+            # modified decision so a body-only edit lights up only the clusters
+            # whose own members changed, not every cluster sharing the file.
+            changed_members = (
+                compute_changed_members(
+                    root_analysis.files,
+                    self.static_analysis,
+                    self.changes,
+                    self.repo_location,
+                )
+                if self.changes is not None
+                else None
+            )
+
             snapshot_source = self.static_analysis.incremental_base_results or self.static_analysis
             old_snapshot = snapshot_from_static_analysis(snapshot_source)
             if not old_snapshot.all_cluster_ids():
@@ -791,6 +812,7 @@ class DiagramGenerator:
                 delta,
                 changes=self.changes,
                 repo_dir=self.repo_location,
+                changed=changed_members,
             )
             protected_empty_ids = _cluster_backed_empty_component_ids(root_analysis, sub_analyses)
             apply_result = self._apply_incremental_scope_recursively(
@@ -799,6 +821,7 @@ class DiagramGenerator:
                 structural_diff,
                 delta.cluster_results(),
                 sub_analyses,
+                changed_members,
             )
 
             removed_ids = prune_empty_components(root_analysis, sub_analyses, protected_empty_ids)
@@ -922,6 +945,7 @@ def _build_scope_incremental_inputs(
     incremental_agent: IncrementalAgent,
     changes: ChangeSet | None,
     repo_dir: Path,
+    changed_members: ChangedMembers | None,
 ) -> tuple[dict[str, ClusterResult], StructuralClusterDiff]:
     old_snapshot = scoped_snapshot_for_component(component, scope_id, incremental_agent)
     if not old_snapshot.all_cluster_ids():
@@ -943,6 +967,7 @@ def _build_scope_incremental_inputs(
         changes=changes,
         repo_dir=repo_dir,
         scope_id=scope_id,
+        changed=changed_members,
     )
     return cluster_results, structural_diff
 

--- a/diagram_analysis/diagram_generator.py
+++ b/diagram_analysis/diagram_generator.py
@@ -979,6 +979,7 @@ class DiagramGenerator:
                                 repo_name=self.repo_name,
                                 repo_dir=self.repo_location,
                                 source_tree_hash=self._source_tree_hash(),
+                                depth_cap=self.depth_level,
                             )
 
                         if new_components and level + 1 < self.depth_level:
@@ -1155,6 +1156,7 @@ class DiagramGenerator:
             source_tree_hash=source_tree_hash,
             expandable_component_ids=expandable_component_ids,
             sub_expandable_ids=sub_expandable_ids,
+            depth_cap=self.depth_level,
         ).resolve()
         if seed_delta is not None:
             self._seed_incremental_cluster_cache(seed_delta)

--- a/diagram_analysis/diagram_generator.py
+++ b/diagram_analysis/diagram_generator.py
@@ -19,7 +19,6 @@ from agents.agent_responses import (
     Component,
     MetaAnalysisInsights,
     Relation,
-    RelationEdge,
     SourceCodeReference,
 )
 from agents.cluster_methods_mixin import scoped_snapshot_from_lineage
@@ -435,86 +434,28 @@ def _incremental_changed_component_ids(
     return changed
 
 
-def _merge_edges_method_granular(
-    fresh: Relation,
-    base: Relation | None,
-    re_extracted_methods: set[str],
-    deleted_methods: set[str],
-    live_methods: set[str],
-) -> Relation | None:
-    """Rebuild a changed pair's edges at method granularity.
-
-    The static call-edge extraction is non-deterministic: re-analysing a file yields a
-    different edge set each run even when its code is byte-identical, so taking the fresh
-    rebuild wholesale churns edges for methods that did not change. Here an edge survives
-    from the fresh rebuild only when its *source method* was actually re-extracted this run
-    — body-changed or newly added. Every other edge is taken from the baseline, so an
-    unchanged method keeps exactly the edges it had. Edges whose source or target method was
-    deleted (or is otherwise gone from the live tree) are dropped, which is how a removal
-    retracts its relations without inventing new ones. Returns ``None`` when nothing
-    survives, so an emptied relation is dropped rather than left as a shell.
-    """
-
-    def live_edge(edge: RelationEdge) -> bool:
-        src = edge.source.qualified_name
-        dst = edge.target.qualified_name
-        return src not in deleted_methods and dst not in deleted_methods and src in live_methods and dst in live_methods
-
-    def collect(fresh_edges: list[RelationEdge], base_edges: list[RelationEdge]) -> list[RelationEdge]:
-        merged = [e for e in fresh_edges if e.source.qualified_name in re_extracted_methods and live_edge(e)]
-        seen = {(e.source.qualified_name, e.target.qualified_name) for e in merged}
-        for e in base_edges:
-            key = (e.source.qualified_name, e.target.qualified_name)
-            if e.source.qualified_name not in re_extracted_methods and live_edge(e) and key not in seen:
-                merged.append(e)
-                seen.add(key)
-        return merged
-
-    all_edges = collect(fresh.all_edges, base.all_edges if base is not None else [])
-    key_edges = collect(fresh.key_edges, base.key_edges if base is not None else [])
-    if not all_edges:
-        return None
-    return fresh.model_copy(update={"all_edges": all_edges, "key_edges": key_edges})
-
-
 def _preserve_unchanged_global_relations(
     rebuilt_relations: list[Relation],
     baseline_by_pair: dict[tuple[str, str], Relation],
     changed_component_ids: set[str],
     live_ids: set[str],
-    re_extracted_methods: set[str],
-    deleted_methods: set[str],
-    live_methods: set[str],
 ) -> list[Relation]:
     """Carry a global relation over from the baseline when neither endpoint changed.
 
     The save-time rebuild re-derives every relation at the deepest granularity, re-labelling
     even edges between two untouched components. For each pair whose endpoints are both
-    unchanged we drop the rebuilt edge and take the baseline verbatim. For a pair that DOES
-    touch a changed component we no longer take the fresh rebuild wholesale — that would
-    churn the edges of the pair's unchanged methods, because extraction is non-deterministic
-    — but merge it against the baseline at method granularity (see
-    ``_merge_edges_method_granular``): only a body-changed or newly-added method contributes
-    fresh edges; unchanged methods keep their baseline edges; deleted methods' edges are
-    dropped. Relations are keyed by ``(src_id, dst_id)``, the stable component identity.
+    unchanged we drop the rebuilt edge and take the baseline verbatim; edges touching a
+    changed component keep the fresh rebuild. A baseline relation between two unchanged,
+    still-live components that the rebuild dropped is restored, and a spurious rebuilt edge
+    between two unchanged components is discarded — so both relabel and structural drift
+    against untouched components is eliminated. Relations are keyed by ``(src_id, dst_id)``,
+    the stable component identity; the rebuild always populates both ids.
     """
 
     def touches_change(src_id: str, dst_id: str) -> bool:
         return src_id in changed_component_ids or dst_id in changed_component_ids
 
-    kept: list[Relation] = []
-    for rel in rebuilt_relations:
-        if not touches_change(rel.src_id, rel.dst_id):
-            continue
-        merged = _merge_edges_method_granular(
-            rel,
-            baseline_by_pair.get((rel.src_id, rel.dst_id)),
-            re_extracted_methods,
-            deleted_methods,
-            live_methods,
-        )
-        if merged is not None:
-            kept.append(merged)
+    kept = [rel for rel in rebuilt_relations if touches_change(rel.src_id, rel.dst_id)]
     for (src_id, dst_id), relation in baseline_by_pair.items():
         if touches_change(src_id, dst_id) or src_id not in live_ids or dst_id not in live_ids:
             continue
@@ -1056,26 +997,8 @@ class DiagramGenerator:
                 for component in analysis.components
                 if component.component_id
             }
-            live_methods = {
-                method.qualified_name
-                for _scope_id, analysis in _iter_incremental_scopes(root_analysis, sub_analyses)
-                for component in analysis.components
-                for group in component.file_methods
-                for method in group.methods
-            }
-            base_methods = {qname for keys in self._baseline_member_keys.values() for _file, qname in keys}
-            deleted_methods = base_methods - live_methods
-            # Only a body-changed or newly-added method has its edges re-extracted from the
-            # (non-deterministic) fresh CFG; every unchanged method keeps its baseline edges.
-            re_extracted_methods = self._changed_members | (live_methods - base_methods)
             global_relations = _preserve_unchanged_global_relations(
-                global_relations,
-                self._baseline_global_relations,
-                changed_ids,
-                live_ids,
-                re_extracted_methods,
-                deleted_methods,
-                live_methods,
+                global_relations, self._baseline_global_relations, changed_ids, live_ids
             )
         root_analysis.components_relations = global_relations
         return global_relations
@@ -1284,19 +1207,6 @@ class DiagramGenerator:
             for relation in root_analysis.components_relations
             if relation.src_id and relation.dst_id
         }
-        # Per-component baseline member keys, captured pre-mutation so the save-time relation
-        # rebuild sees the true before-state on BOTH the re-cluster path and the empty-delta
-        # path (a body-only edit). Deleted methods are still present here, which is how a
-        # removal becomes visible to the rebuild; an empty-delta run left this unset before,
-        # so every component read as changed and its non-deterministic fresh edges were kept.
-        self._baseline_member_keys = {
-            component.component_id: frozenset(
-                (group.file_path, method.qualified_name) for group in component.file_methods for method in group.methods
-            )
-            for _scope_id, analysis in _iter_incremental_scopes(root_analysis, sub_analyses)
-            for component in analysis.components
-            if component.component_id
-        }
 
         monitor = self.stats_writer if self.stats_writer else nullcontext()
         with monitor:
@@ -1372,6 +1282,10 @@ class DiagramGenerator:
             )
             protected_empty_ids = _cluster_backed_empty_component_ids(root_analysis, sub_analyses)
             baseline_membership = _capture_membership_baseline(root_analysis, sub_analyses)
+            # Feed the per-component baseline member keys to the save-time global relation
+            # rebuild so a component that only gained/lost a member (no body-hash change) is
+            # still treated as changed and its edges are re-derived, not carried over stale.
+            self._baseline_member_keys = {cid: meta.member_keys for cid, meta in baseline_membership.meta_by_id.items()}
             apply_result = self._apply_incremental_scope_recursively(
                 ROOT_SCOPE_ID,
                 root_analysis,

--- a/diagram_analysis/diagram_generator.py
+++ b/diagram_analysis/diagram_generator.py
@@ -51,7 +51,7 @@ from diagram_analysis.cluster_snapshot import (
     ClusterSnapshot,
     snapshot_from_static_analysis,
 )
-from diagram_analysis.exceptions import IncrementalCacheMissingError
+from diagram_analysis.exceptions import IncrementalCacheMissingError, ScopeContainmentError
 from diagram_analysis.file_coverage import FileCoverage
 from diagram_analysis.file_index import build_files_index, refresh_method_spans_from_cfg
 from diagram_analysis.io_utils import load_analysis_metadata, normalize_repo_path, save_analysis, write_fingerprint
@@ -608,6 +608,7 @@ class DiagramGenerator:
         """
         self.rebuild_global_relations(root_analysis, sub_analyses)
         self._strip_ignored(root_analysis, sub_analyses)
+        assert_scope_containment(root_analysis, sub_analyses)
 
     def finalize_and_save(
         self,
@@ -666,6 +667,36 @@ class DiagramGenerator:
             not_analyzed=summary["not_analyzed"],
             not_analyzed_by_reason=summary["not_analyzed_by_reason"],
         )
+
+    def _rescope_child_analyses(
+        self,
+        scope: AnalysisInsights,
+        sub_analyses: dict[str, AnalysisInsights],
+    ) -> None:
+        """Re-partition every child scope over its parent's current ``file_methods``.
+
+        Why: ``update_scope`` re-partitions a parent against the live clustering, but a
+        child scope is a separate ``AnalysisInsights`` that no patch touches — a method
+        that moved to another component would otherwise stay in the old owner's subtree
+        and appear under two components.
+        """
+        assert self.incremental_agent is not None
+        for component in scope.components:
+            child_scope = sub_analyses.get(component.component_id)
+            if child_scope is None or not child_scope.components:
+                continue
+            _subgraph_str, cluster_results, cfg_graphs = self.incremental_agent._create_strict_component_subgraph(
+                component, source_cluster_id_prefix=component.component_id
+            )
+            if cluster_results:
+                self.incremental_agent.populate_file_methods(
+                    child_scope, cluster_results, cfg_graphs, component.component_id
+                )
+            else:
+                # The parent owns no live methods, so no child may own any.
+                for child in child_scope.components:
+                    child.file_methods = []
+            self._rescope_child_analyses(child_scope, sub_analyses)
 
     def _apply_incremental_scope_recursively(
         self,
@@ -804,6 +835,9 @@ class DiagramGenerator:
                 # No structural change, but a body-only edit still moves content
                 # hashes — refresh the files index from live source so they don't
                 # go stale (relations are already the global set here).
+                # Re-scope anyway: a baseline written before child scopes were
+                # confined to their parent stays drifted until something repairs it.
+                self._rescope_child_analyses(root_analysis, sub_analyses)
                 self._refresh_files_index(root_analysis, sub_analyses)
                 return self.finalize_and_save(root_analysis, sub_analyses)
 
@@ -823,6 +857,7 @@ class DiagramGenerator:
                 sub_analyses,
                 changed_members,
             )
+            self._rescope_child_analyses(root_analysis, sub_analyses)
 
             removed_ids = prune_empty_components(root_analysis, sub_analyses, protected_empty_ids)
             if removed_ids:
@@ -877,6 +912,35 @@ class DiagramGenerator:
             for fp, entry in analysis.files.items():
                 unified_files.setdefault(fp, FileEntry()).merge_from(entry)
         root_analysis.files = unified_files
+
+
+def assert_scope_containment(
+    root_analysis: AnalysisInsights,
+    sub_analyses: dict[str, AnalysisInsights],
+) -> None:
+    """Raise ``ScopeContainmentError`` if any child scope owns methods its parent does not."""
+    components_by_id = {
+        component.component_id: component
+        for analysis in [root_analysis, *sub_analyses.values()]
+        for component in analysis.components
+        if component.component_id
+    }
+    violations: list[str] = []
+    for component_id, child_scope in sorted(sub_analyses.items()):
+        parent = components_by_id.get(component_id)
+        if parent is None:
+            continue
+        owned = {(group.file_path, method.qualified_name) for group in parent.file_methods for method in group.methods}
+        for child in child_scope.components:
+            escaped = {
+                (group.file_path, method.qualified_name) for group in child.file_methods for method in group.methods
+            } - owned
+            if escaped:
+                violations.append(
+                    f"{child.component_id or child.name} holds {len(escaped)} method(s) outside parent {component_id}"
+                )
+    if violations:
+        raise ScopeContainmentError(violations)
 
 
 def _collect_components_by_id(

--- a/diagram_analysis/diagram_generator.py
+++ b/diagram_analysis/diagram_generator.py
@@ -134,6 +134,11 @@ def _reconcile_child_scope(
             for method in group.methods
         }
         _graft_entered_methods(child_scope, entered, parent_methods)
+    if departed or entered:
+        # Membership moved, so the scoped LLM relations may reference a method that just left
+        # this scope. They are consumed as authoritative by ``build_global_relations``; clear
+        # them so the deterministic rebuild re-derives edges for the reconciled membership.
+        child_scope.components_relations = []
     child_scope.files = build_files_index(child_scope, repo_dir)
 
 
@@ -206,6 +211,28 @@ def _iter_incremental_scopes(
     yield ROOT_SCOPE_ID, root_analysis
     for scope_id, sub in sub_analyses.items():
         yield scope_id, sub
+
+
+def _capture_baseline_member_keys(
+    root_analysis: AnalysisInsights,
+    sub_analyses: dict[str, AnalysisInsights],
+) -> dict[str, frozenset[tuple[str, str]]]:
+    """Per-component ``{id -> frozenset((file, qname))}`` — the member-key half of the baseline.
+
+    Captured before ``remove_deleted_files`` so a deleted method still shows as a membership
+    change at save-time relation preservation. Deliberately lighter than
+    ``_capture_membership_baseline`` (no deep copies of scopes/metadata), which the restore
+    passes need captured *after* the scrub so they don't re-inject a deleted method.
+    """
+    keys: dict[str, frozenset[tuple[str, str]]] = {}
+    for _scope_id, analysis in _iter_incremental_scopes(root_analysis, sub_analyses):
+        for component in analysis.components:
+            if not component.component_id:
+                continue
+            keys[component.component_id] = frozenset(
+                (group.file_path, method.qualified_name) for group in component.file_methods for method in group.methods
+            )
+    return keys
 
 
 def _capture_membership_baseline(
@@ -296,13 +323,15 @@ def _restore_unchanged_metadata(
     sub_analyses: dict[str, AnalysisInsights],
     baseline: _MembershipBaseline,
     changed_members: set[str],
+    changed_files: set[str],
 ) -> set[str]:
     """Restore name/description/key_entities of components identical to their baseline.
 
-    A component with the same membership as the baseline and no body-changed member did not
-    genuinely change; the planner may still have reworded it. Restoring its metadata and
-    returning its id lets the caller drop it from the refresh set, so its relations to other
-    unchanged components are carried over verbatim rather than re-derived.
+    A component with the same membership as the baseline, no body-changed member, and no
+    module-level edit in a file it owns did not genuinely change; the planner may still have
+    reworded it. Restoring its metadata and returning its id lets the caller drop it from the
+    refresh set, so its relations to other unchanged components are carried over verbatim
+    rather than re-derived.
     """
     unchanged_ids: set[str] = set()
     for _scope_id, analysis in _iter_incremental_scopes(root_analysis, sub_analyses):
@@ -313,7 +342,8 @@ def _restore_unchanged_metadata(
             final_keys = frozenset(
                 (group.file_path, method.qualified_name) for group in component.file_methods for method in group.methods
             )
-            if final_keys != meta.member_keys or (meta.member_qnames & changed_members):
+            owns_changed_file = any(group.file_path in changed_files for group in component.file_methods)
+            if final_keys != meta.member_keys or (meta.member_qnames & changed_members) or owns_changed_file:
                 continue
             component.name = meta.name
             component.description = meta.description
@@ -332,15 +362,17 @@ def _fully_unchanged_component_ids(
     sub_analyses: dict[str, AnalysisInsights],
     baseline: _MembershipBaseline,
     changed_members: set[str],
+    changed_files: set[str],
     protected_ids: set[str],
 ) -> set[str]:
     """Ids of components whose entire subtree is byte-identical to the baseline.
 
-    A component qualifies when, at every depth, no member changed and it neither gained nor
-    lost one. Containment (parent is a superset of every descendant) means a component's own top-level
-    member set already spans its whole subtree, so testing that set is enough: no member
-    qname is in ``changed_members`` and the live keys equal the baseline. A subtree holding
-    a freshly created component is excluded — restoring it verbatim would delete that
+    A component qualifies when, at every depth, no member changed, no file it owns had a
+    module-level edit, and it neither gained nor lost a member. Containment (parent is a
+    superset of every descendant) means a component's own top-level member set already spans
+    its whole subtree, so testing that set is enough: no member qname is in ``changed_members``,
+    no owned file is in ``changed_files``, and the live keys equal the baseline. A subtree
+    holding a freshly created component is excluded — restoring it verbatim would delete that
     component, and new components are never restored.
     """
     fully_unchanged: set[str] = set()
@@ -349,6 +381,8 @@ def _fully_unchanged_component_ids(
             cid = component.component_id
             meta = baseline.meta_by_id.get(cid)
             if meta is None or meta.member_qnames & changed_members:
+                continue
+            if any(group.file_path in changed_files for group in component.file_methods):
                 continue
             if any(is_self_or_descendant(protected_id, cid) for protected_id in protected_ids):
                 continue
@@ -365,6 +399,7 @@ def _restore_unchanged_subtrees(
     sub_analyses: dict[str, AnalysisInsights],
     baseline: _MembershipBaseline,
     changed_members: set[str],
+    changed_files: set[str],
     protected_ids: set[str],
 ) -> set[str]:
     """Restore the whole child-scope subtree of every fully-unchanged component, verbatim.
@@ -382,7 +417,7 @@ def _restore_unchanged_subtrees(
     covers its descendants).
     """
     fully_unchanged = _fully_unchanged_component_ids(
-        root_analysis, sub_analyses, baseline, changed_members, protected_ids
+        root_analysis, sub_analyses, baseline, changed_members, changed_files, protected_ids
     )
     for scope_id, analysis in _iter_incremental_scopes(root_analysis, sub_analyses):
         # A component whose parent scope is also fully unchanged is restored by that parent.
@@ -404,17 +439,19 @@ def _incremental_changed_component_ids(
     baseline_component_ids: set[str],
     baseline_member_keys: dict[str, frozenset[tuple[str, str]]],
     changed_members: set[str],
+    changed_files: set[str],
 ) -> set[str]:
     """Component ids whose global relations may legitimately differ from the baseline.
 
     A live component counts as changed when it is absent from the baseline (freshly
-    created), owns a body-changed member, or its live member-key set differs from the
-    baseline — it gained or lost a member. Membership churn alone (a new caller of another
-    component, or the last caller removed) relabels the edges between the two components
-    even with no surviving body-hash change, so it must be treated as changed or the
-    genuinely-new edge is dropped / the stale baseline edge restored. Because every ancestor
-    scope lists a method in its own ``file_methods``, the owner of a change and all of its
-    ancestors are captured together. Everything else is preserved verbatim.
+    created), owns a body-changed member, owns a file with a module-level edit no member
+    represents (``changed_files``), or its live member-key set differs from the baseline —
+    it gained or lost a member. Membership churn alone (a new caller of another component,
+    or the last caller removed) relabels the edges between the two components even with no
+    surviving body-hash change, so it must be treated as changed or the genuinely-new edge
+    is dropped / the stale baseline edge restored. Because every ancestor scope lists a
+    method in its own ``file_methods``, the owner of a change and all of its ancestors are
+    captured together. Everything else is preserved verbatim.
     """
     changed: set[str] = set()
     for _scope_id, analysis in _iter_incremental_scopes(root_analysis, sub_analyses):
@@ -428,8 +465,9 @@ def _incremental_changed_component_ids(
             body_changed = any(
                 method.qualified_name in changed_members for group in component.file_methods for method in group.methods
             )
+            file_changed = any(group.file_path in changed_files for group in component.file_methods)
             membership_changed = live_keys != baseline_member_keys.get(component_id, frozenset())
-            if component_id not in baseline_component_ids or body_changed or membership_changed:
+            if component_id not in baseline_component_ids or body_changed or file_changed or membership_changed:
                 changed.add(component_id)
     return changed
 
@@ -498,6 +536,10 @@ class DiagramGenerator:
         # pinned back to its baseline owner, and the save-time global relation rebuild treats a
         # component owning one of these as changed.
         self._changed_members: set[str] = set()
+        # Changed files whose edit no hashed member represents (module-level/config content).
+        # A component owning one of these counts as changed even with no body-hash or membership
+        # change, so its metadata and global relations are re-derived, not carried over stale.
+        self._changed_unattributed_files: set[str] = set()
         # Incremental-only baseline captured at the top of ``generate_analysis_incremental``,
         # so the save-time global relation rebuild can carry an edge between two unchanged
         # components over verbatim instead of re-deriving (and re-labelling) it.
@@ -1015,6 +1057,7 @@ class DiagramGenerator:
                 self._baseline_component_ids,
                 self._baseline_member_keys,
                 self._changed_members,
+                self._changed_unattributed_files,
             )
             live_ids = {
                 component.component_id
@@ -1071,6 +1114,17 @@ class DiagramGenerator:
             # Partial: keep the prior hash so metadata matches the unrewritten sidecar.
             prior_metadata = load_analysis_metadata(Path(self.output_dir)) or {}
             source_tree_hash = prior_metadata.get("source_tree_hash", "") or self._source_tree_hash()
+        # Persist the separability-respecting expandable set so a cohesive component the run kept
+        # as a leaf isn't advertised as expandable by the save-time recompute (which is structural-only).
+        # Only when the details agent is live (the analysis flows); a bare re-save without it keeps
+        # the deterministic default (``None`` -> structural computation) rather than risk a crash.
+        expandable_component_ids: list[str] | None = None
+        if self.details_agent is not None:
+            expandable_component_ids = [
+                component.component_id
+                for component in get_expandable_components(root_analysis, separable=self._component_separable)
+                if component.component_id
+            ]
         analysis_path = save_analysis(
             analysis=root_analysis,
             output_dir=Path(self.output_dir),
@@ -1079,6 +1133,7 @@ class DiagramGenerator:
             file_coverage_summary=self._build_file_coverage_summary(),
             repo_dir=self.repo_location,
             source_tree_hash=source_tree_hash,
+            expandable_component_ids=expandable_component_ids,
         ).resolve()
         if seed_delta is not None:
             self._seed_incremental_cluster_cache(seed_delta)
@@ -1232,6 +1287,12 @@ class DiagramGenerator:
             for relation in root_analysis.components_relations
             if relation.src_id and relation.dst_id
         }
+        # Capture per-component member keys BEFORE remove_deleted_files scrubs ownership: a deleted
+        # method must still register as a membership change so its component isn't treated as
+        # unchanged and its stale baseline relations restored. Kept separate from the full
+        # membership baseline (captured post-scrub below) so the restore passes never re-inject a
+        # deleted method. Also drives the empty-delta path, which returns before that capture.
+        self._baseline_member_keys = _capture_baseline_member_keys(root_analysis, sub_analyses)
 
         monitor = self.stats_writer if self.stats_writer else nullcontext()
         with monitor:
@@ -1265,6 +1326,10 @@ class DiagramGenerator:
             )
             # Body-changed qnames drive copy-forward and the save-time relation preservation.
             self._changed_members = changed_members.members if changed_members is not None else set()
+            # Module-level edits no member represents dirty the owning component too.
+            self._changed_unattributed_files = (
+                changed_members.unattributed_files if changed_members is not None else set()
+            )
 
             snapshot_source = self.static_analysis.incremental_base_results or self.static_analysis
             old_snapshot = snapshot_from_static_analysis(snapshot_source)
@@ -1306,11 +1371,9 @@ class DiagramGenerator:
                 changed=changed_members,
             )
             protected_empty_ids = _cluster_backed_empty_component_ids(root_analysis, sub_analyses)
+            # Full membership baseline for the restore/rescope passes, captured AFTER the deletion
+            # scrub so a deleted method is never re-injected from the baseline into a live scope.
             baseline_membership = _capture_membership_baseline(root_analysis, sub_analyses)
-            # Feed the per-component baseline member keys to the save-time global relation
-            # rebuild so a component that only gained/lost a member (no body-hash change) is
-            # still treated as changed and its edges are re-derived, not carried over stale.
-            self._baseline_member_keys = {cid: meta.member_keys for cid, meta in baseline_membership.meta_by_id.items()}
             apply_result = self._apply_incremental_scope_recursively(
                 ROOT_SCOPE_ID,
                 root_analysis,
@@ -1335,13 +1398,18 @@ class DiagramGenerator:
                 sub_analyses,
                 baseline_membership,
                 self._changed_members,
+                self._changed_unattributed_files,
                 apply_result.new_component_ids,
             )
             self._rescope_child_analyses(root_analysis, sub_analyses, preserved_ids)
             # A component identical to its baseline did not change: restore any metadata the
             # planner reworded and drop it from the refresh set so its relations carry over.
             unchanged_ids = _restore_unchanged_metadata(
-                root_analysis, sub_analyses, baseline_membership, self._changed_members
+                root_analysis,
+                sub_analyses,
+                baseline_membership,
+                self._changed_members,
+                self._changed_unattributed_files,
             )
             apply_result.refresh_ids -= unchanged_ids
 
@@ -1482,11 +1550,11 @@ def _child_scope_needs_recursive_update(
         for method in group.methods
         if method.qualified_name
     }
-    removed_qnames: set[str] = set()
+    changed_qnames: set[str] = set()
     for diff in structural_diff.by_language.values():
         for member_delta in [*diff.modified, *diff.new_details]:
-            removed_qnames.update(member_delta.removed_methods)
-    return bool(removed_qnames.intersection(owned_qnames))
+            changed_qnames.update(member_delta.removed_methods, member_delta.added_methods, member_delta.dirty_members)
+    return bool(changed_qnames.intersection(owned_qnames))
 
 
 def _build_scope_incremental_inputs(

--- a/diagram_analysis/exceptions.py
+++ b/diagram_analysis/exceptions.py
@@ -51,3 +51,18 @@ class InvalidIncrementalPlanError(RuntimeError):
         super().__init__(f"Incremental plan for scope {scope_id!r} is invalid: {issue_summary}")
         self.scope_id = scope_id
         self.issues = issues
+
+
+class ScopeContainmentError(RuntimeError):
+    """Raised when a child scope owns methods its parent component does not.
+
+    Every method must belong to exactly one component per tree level. Because a
+    child scope is a separate ``AnalysisInsights``, containment is the one half of
+    that invariant no single populate/patch pass can enforce — so it is checked
+    once before the save. A violation means the same method renders under two
+    components, which is worse to ship than a failed run.
+    """
+
+    def __init__(self, violations: list[str]):
+        super().__init__("Child scopes own methods outside their parent component: " + "; ".join(violations))
+        self.violations = violations

--- a/diagram_analysis/file_index.py
+++ b/diagram_analysis/file_index.py
@@ -7,6 +7,7 @@ from agents.content_hash import (
     MethodRef,
     MethodSpan,
     SourceCache,
+    hash_file_residual,
     hash_method_body,
     hash_whole_file,
     read_source_lines,
@@ -44,6 +45,13 @@ def build_files_index(
                     content_hash=hash_whole_file(source_lines),
                 )
             )
+    # module_hash excises *all* of a file's method spans, so it must be computed once the
+    # file's methods are gathered across every component — a file split across components
+    # would otherwise count a sibling component's methods as module-level.
+    for file_path, entry in files.items():
+        source_lines = read_source_lines(repo_dir, file_path, file_cache)
+        spans = [MethodSpan(method.start_line, method.end_line) for method in entry.methods]
+        entry.module_hash = hash_file_residual(source_lines, spans)
     return files
 
 

--- a/diagram_analysis/io_utils.py
+++ b/diagram_analysis/io_utils.py
@@ -197,11 +197,17 @@ class _AnalysisFileStore:
         file_coverage_summary: FileCoverageSummary | None = None,
     ) -> Path:
         """Write ``analysis.json`` — caller must already hold ``self._lock``."""
-        # Keep caller-provided expandables, but also preserve deterministic planner eligibility.
-        expandable_ids = set(expandable_component_ids or [])
-        expandable_ids.update(
-            c.component_id for c in self._compute_expandable_components(analysis, parent_had_clusters=True)
-        )
+        # A caller-provided set is authoritative: it already reflects the run's expansion
+        # decision (including the separability gate that keeps cohesive components as leaves),
+        # so unioning in the unconditional ``should_expand_component`` set would re-mark those
+        # suppressed components expandable. Only fall back to the deterministic computation when
+        # the caller supplied nothing.
+        if expandable_component_ids is not None:
+            expandable_ids = set(expandable_component_ids)
+        else:
+            expandable_ids = {
+                c.component_id for c in self._compute_expandable_components(analysis, parent_had_clusters=True)
+            }
         expandable = [c for c in analysis.components if c.component_id in expandable_ids]
 
         # Preserve existing metadata fields from disk when not explicitly provided

--- a/diagram_analysis/io_utils.py
+++ b/diagram_analysis/io_utils.py
@@ -119,6 +119,7 @@ class _AnalysisFileStore:
         sub_analyses: dict[str, AnalysisInsights] | None = None,
         repo_name: str = "",
         file_coverage_summary: FileCoverageSummary | None = None,
+        sub_expandable_ids: dict[str, list[str]] | None = None,
     ) -> Path:
         """Write the full analysis to ``analysis.json`` with file locking.
 
@@ -134,6 +135,7 @@ class _AnalysisFileStore:
                 sub_analyses,
                 repo_name,
                 file_coverage_summary,
+                sub_expandable_ids,
             )
 
     def write_sub(
@@ -195,6 +197,7 @@ class _AnalysisFileStore:
         sub_analyses: dict[str, AnalysisInsights] | None = None,
         repo_name: str = "",
         file_coverage_summary: FileCoverageSummary | None = None,
+        sub_expandable_ids: dict[str, list[str]] | None = None,
     ) -> Path:
         """Write ``analysis.json`` — caller must already hold ``self._lock``."""
         # A caller-provided set is authoritative: it already reflects the run's expansion
@@ -236,9 +239,15 @@ class _AnalysisFileStore:
             component_lookup = index_components_by_id(analysis, sub_analyses)
             sub_analyses_tuples = {}
             for cid, sub in sub_analyses.items():
-                parent_component = component_lookup.get(cid)
-                parent_had_clusters = bool(parent_component.source_cluster_ids) if parent_component else True
-                sub_expandable = self._compute_expandable_components(sub, parent_had_clusters=parent_had_clusters)
+                if sub_expandable_ids is not None and cid in sub_expandable_ids:
+                    # Authoritative per-sub set from the run's separability gate; same
+                    # rationale as the root list above (don't re-mark suppressed leaves).
+                    ids = set(sub_expandable_ids[cid])
+                    sub_expandable = [c for c in sub.components if c.component_id in ids]
+                else:
+                    parent_component = component_lookup.get(cid)
+                    parent_had_clusters = bool(parent_component.source_cluster_ids) if parent_component else True
+                    sub_expandable = self._compute_expandable_components(sub, parent_had_clusters=parent_had_clusters)
                 sub_analyses_tuples[cid] = (sub, sub_expandable)
 
         # Atomic write: build the JSON in a sibling temp file, then rename
@@ -356,6 +365,7 @@ def save_analysis(
     sub_analyses: dict[str, AnalysisInsights] | None = None,
     repo_name: str = "",
     file_coverage_summary: FileCoverageSummary | None = None,
+    sub_expandable_ids: dict[str, list[str]] | None = None,
 ) -> Path:
     """Save the analysis to a unified analysis.json file with file locking.
 
@@ -370,6 +380,7 @@ def save_analysis(
         sub_analyses,
         repo_name,
         file_coverage_summary,
+        sub_expandable_ids,
     )
 
 

--- a/diagram_analysis/io_utils.py
+++ b/diagram_analysis/io_utils.py
@@ -29,6 +29,7 @@ from diagram_analysis.analysis_json import (
     build_unified_analysis_json,
     parse_unified_analysis,
 )
+from diagram_analysis.run_context import DEFAULT_DEPTH_LEVEL
 from repo_utils.path_utils import normalize_repo_path
 from utils import ANALYSIS_FILENAME, CODEBOARDING_DIR_NAME, FINGERPRINT_FILENAME, RUN_OUTPUT_DIR_NAME
 
@@ -120,11 +121,14 @@ class _AnalysisFileStore:
         repo_name: str = "",
         file_coverage_summary: FileCoverageSummary | None = None,
         sub_expandable_ids: dict[str, list[str]] | None = None,
+        depth_cap: int | None = None,
     ) -> Path:
         """Write the full analysis to ``analysis.json`` with file locking.
 
         If *sub_analyses* is not provided, existing sub-analyses on disk are
-        preserved.
+        preserved. ``depth_cap`` is the run's configured depth ceiling; when
+        omitted, the existing on-disk value is preserved (see
+        ``_write_with_lock_held``).
         """
         with self._lock:
             return self._write_with_lock_held(
@@ -136,6 +140,7 @@ class _AnalysisFileStore:
                 repo_name,
                 file_coverage_summary,
                 sub_expandable_ids,
+                depth_cap,
             )
 
     def write_sub(
@@ -198,6 +203,7 @@ class _AnalysisFileStore:
         repo_name: str = "",
         file_coverage_summary: FileCoverageSummary | None = None,
         sub_expandable_ids: dict[str, list[str]] | None = None,
+        depth_cap: int | None = None,
     ) -> Path:
         """Write ``analysis.json`` — caller must already hold ``self._lock``."""
         # A caller-provided set is authoritative: it already reflects the run's expansion
@@ -214,7 +220,7 @@ class _AnalysisFileStore:
         expandable = [c for c in analysis.components if c.component_id in expandable_ids]
 
         # Preserve existing metadata fields from disk when not explicitly provided
-        if sub_analyses is None or file_coverage_summary is None or not repo_name:
+        if sub_analyses is None or file_coverage_summary is None or not repo_name or depth_cap is None:
             existing = self.read()
             if existing:
                 _, existing_subs, existing_data = existing
@@ -232,6 +238,13 @@ class _AnalysisFileStore:
                             not_analyzed=raw_summary.get("not_analyzed", 0),
                             not_analyzed_by_reason=raw_summary.get("not_analyzed_by_reason", {}),
                         )
+                if depth_cap is None:
+                    # Legacy baselines predate depth_cap: their depth_level was the
+                    # cap at the time (pre-separability-gate semantics), so it's the
+                    # closest available approximation.
+                    depth_cap = metadata.get("depth_cap", metadata.get("depth_level"))
+        if depth_cap is None:
+            depth_cap = DEFAULT_DEPTH_LEVEL
 
         # Convert sub_analyses dict to the format expected by build_unified_analysis_json
         sub_analyses_tuples: dict[str, tuple[AnalysisInsights, list[Component]]] | None = None
@@ -259,6 +272,7 @@ class _AnalysisFileStore:
             repo_name=repo_name,
             repo_dir=repo_dir,
             source_tree_hash=source_tree_hash,
+            depth_cap=depth_cap,
             sub_analyses=sub_analyses_tuples,
             file_coverage_summary=file_coverage_summary,
         )
@@ -366,11 +380,14 @@ def save_analysis(
     repo_name: str = "",
     file_coverage_summary: FileCoverageSummary | None = None,
     sub_expandable_ids: dict[str, list[str]] | None = None,
+    depth_cap: int | None = None,
 ) -> Path:
     """Save the analysis to a unified analysis.json file with file locking.
 
     ``repo_dir`` relativizes paths; ``source_tree_hash`` is the precomputed
     whole-tree version key (reproducible by consumers that fingerprint the tree).
+    ``depth_cap`` is the run's configured depth ceiling; omit to preserve the
+    existing on-disk value (e.g. for an intermediate save mid-run).
     """
     return _get_store(output_dir).write(
         analysis,
@@ -381,6 +398,7 @@ def save_analysis(
         repo_name,
         file_coverage_summary,
         sub_expandable_ids,
+        depth_cap,
     )
 
 

--- a/diagram_analysis/io_utils.py
+++ b/diagram_analysis/io_utils.py
@@ -26,6 +26,7 @@ from agents.agent_responses import AnalysisInsights, Component, index_components
 from agents.planner_agent import should_expand_component
 from diagram_analysis.analysis_json import (
     FileCoverageSummary,
+    _compute_depth_level,
     build_unified_analysis_json,
     parse_unified_analysis,
 )
@@ -262,6 +263,12 @@ class _AnalysisFileStore:
                     parent_had_clusters = bool(parent_component.source_cluster_ids) if parent_component else True
                     sub_expandable = self._compute_expandable_components(sub, parent_had_clusters=parent_had_clusters)
                 sub_analyses_tuples[cid] = (sub, sub_expandable)
+
+        # A cap below the tree's own realized depth would silently freeze future
+        # incremental/partial runs at that shallower depth (e.g. a partial run
+        # against a depth-1 baseline that grafts on a new depth-2 subtree must not
+        # save depth_cap=1 — the realized tree already exceeds it).
+        depth_cap = max(depth_cap, _compute_depth_level(sub_analyses_tuples))
 
         # Atomic write: build the JSON in a sibling temp file, then rename
         # over the destination.  A crashed process leaves either the prior

--- a/diagram_analysis/run_context.py
+++ b/diagram_analysis/run_context.py
@@ -8,6 +8,12 @@ from utils import generate_run_id
 
 logger = logging.getLogger(__name__)
 
+# Safety-valve ceiling on component-hierarchy depth, not a target: expansion is
+# driven by structural separability (agents.planner_agent.component_is_separable),
+# which stops cohesive components from over-expanding on its own. This cap only
+# guards against pathological recursion on a repo whose structure never bottoms out.
+DEFAULT_DEPTH_LEVEL = 3
+
 
 @dataclass(frozen=True, slots=True)
 class RunPaths:

--- a/diagram_analysis/run_context.py
+++ b/diagram_analysis/run_context.py
@@ -8,10 +8,7 @@ from utils import generate_run_id
 
 logger = logging.getLogger(__name__)
 
-# Safety-valve ceiling on component-hierarchy depth, not a target: expansion is
-# driven by structural separability (agents.planner_agent.component_is_separable),
-# which stops cohesive components from over-expanding on its own. This cap only
-# guards against pathological recursion on a repo whose structure never bottoms out.
+# Safety-valve depth cap, not a target — see --depth-level help / README for why.
 DEFAULT_DEPTH_LEVEL = 3
 
 

--- a/github_action.py
+++ b/github_action.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from codeboarding_workflows.analysis import run_incremental_workflow
 from codeboarding_workflows.rendering import render_docs
-from diagram_analysis import DiagramGenerator, RunContext
+from diagram_analysis import DEFAULT_DEPTH_LEVEL, DiagramGenerator, RunContext
 from repo_utils import checkout_repo, clone_repository
 from utils import ANALYSIS_FILENAME, CODEBOARDING_DIR_NAME, create_temp_repo_folder
 
@@ -109,7 +109,7 @@ def generate_analysis(
         temp_folder=temp_repo_folder,
         repo_name=repo_name,
         output_dir=temp_repo_folder,
-        depth_level=int(os.getenv("DIAGRAM_DEPTH_LEVEL", "1")),
+        depth_level=int(os.getenv("DIAGRAM_DEPTH_LEVEL", str(DEFAULT_DEPTH_LEVEL))),
         run_id=run_context.run_id,
         log_path=run_context.log_path,
     )

--- a/github_action.py
+++ b/github_action.py
@@ -86,15 +86,7 @@ def _seed_existing_analysis(existing_analysis_dir: Path, temp_repo_folder: Path)
 
 
 def _resolve_depth_level(temp_repo_folder: Path) -> int:
-    """Depth cap for this run: explicit env var, else the seeded baseline's own
-    configured cap, else the shared default.
-
-    Mirrors ``run_incremental``'s baseline-depth recovery — without this, an
-    incremental over a seeded baseline would silently re-cap it at whatever
-    ``DEFAULT_DEPTH_LEVEL`` happens to be instead of the depth the baseline
-    was actually built at (e.g. a committed depth-4 analysis re-capped at 3,
-    or a depth-1 baseline unexpectedly re-detailed to 3).
-    """
+    """Depth cap: explicit env var, else the seeded baseline's own depth_cap, else the default."""
     env_depth = os.getenv("DIAGRAM_DEPTH_LEVEL")
     if env_depth is not None:
         return int(env_depth)

--- a/github_action.py
+++ b/github_action.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from codeboarding_workflows.analysis import run_incremental_workflow
 from codeboarding_workflows.rendering import render_docs
 from diagram_analysis import DEFAULT_DEPTH_LEVEL, DiagramGenerator, RunContext
+from diagram_analysis.io_utils import load_analysis_metadata
 from repo_utils import checkout_repo, clone_repository
 from utils import ANALYSIS_FILENAME, CODEBOARDING_DIR_NAME, create_temp_repo_folder
 
@@ -84,6 +85,25 @@ def _seed_existing_analysis(existing_analysis_dir: Path, temp_repo_folder: Path)
             logger.info(f"Seeded existing {filename} for incremental analysis")
 
 
+def _resolve_depth_level(temp_repo_folder: Path) -> int:
+    """Depth cap for this run: explicit env var, else the seeded baseline's own
+    configured cap, else the shared default.
+
+    Mirrors ``run_incremental``'s baseline-depth recovery — without this, an
+    incremental over a seeded baseline would silently re-cap it at whatever
+    ``DEFAULT_DEPTH_LEVEL`` happens to be instead of the depth the baseline
+    was actually built at (e.g. a committed depth-4 analysis re-capped at 3,
+    or a depth-1 baseline unexpectedly re-detailed to 3).
+    """
+    env_depth = os.getenv("DIAGRAM_DEPTH_LEVEL")
+    if env_depth is not None:
+        return int(env_depth)
+    metadata = load_analysis_metadata(temp_repo_folder)
+    if metadata is not None:
+        return int(metadata.get("depth_cap", metadata.get("depth_level", DEFAULT_DEPTH_LEVEL)))
+    return DEFAULT_DEPTH_LEVEL
+
+
 def generate_analysis(
     repo_url: str,
     source_branch: str,
@@ -109,7 +129,7 @@ def generate_analysis(
         temp_folder=temp_repo_folder,
         repo_name=repo_name,
         output_dir=temp_repo_folder,
-        depth_level=int(os.getenv("DIAGRAM_DEPTH_LEVEL", str(DEFAULT_DEPTH_LEVEL))),
+        depth_level=_resolve_depth_level(temp_repo_folder),
         run_id=run_context.run_id,
         log_path=run_context.log_path,
     )

--- a/main.py
+++ b/main.py
@@ -36,8 +36,9 @@ Examples:
   # Local full analysis (output to <repo>/.codeboarding/); `full` is implied
   codeboarding --local /path/to/repo
 
-  # Local full analysis with custom depth level
-  codeboarding --local /path/to/repo --depth-level 2
+  # Local full analysis with a higher depth ceiling (rarely needed — expansion
+  # is driven by structural separability, this only raises the safety-valve cap)
+  codeboarding --local /path/to/repo --depth-level 5
 
   # Incremental update on a local repository (explicit subcommand required)
   codeboarding incremental --local /path/to/repo

--- a/repo_utils/__init__.py
+++ b/repo_utils/__init__.py
@@ -249,7 +249,14 @@ def normalize_path(path: str | Path, root: str | Path | None = None) -> Path:
         try:
             path_obj = path_obj.relative_to(root_obj)
         except (ValueError, TypeError):
-            pass
+            try:
+                # Reconcile symlinked roots (e.g. macOS /var -> /private/var) that make a
+                # plain relative_to fail even though the file really is under root. Without
+                # this the path stays absolute and never matches the relative all-files set,
+                # so file-coverage counts it as not-analyzed (totals then fail to add up).
+                path_obj = path_obj.resolve().relative_to(root_obj.resolve())
+            except (ValueError, TypeError):
+                pass
 
     return Path(normalize_repo_path(path_obj))
 

--- a/static_analyzer/analysis_cache.py
+++ b/static_analyzer/analysis_cache.py
@@ -30,7 +30,7 @@ from typing import TYPE_CHECKING, Any
 from filelock import FileLock
 
 from static_analyzer.analysis_result import AnalysisData, InvalidatedAnalysis, InvalidatedEdge
-from static_analyzer.graph import Edge
+from static_analyzer.graph import CallGraph, Edge, EdgeKind
 from static_analyzer.lsp_client.diagnostics import FileDiagnosticsMap
 from static_analyzer.node import Node
 from repo_utils.path_utils import to_absolute_path, to_relative_path
@@ -413,9 +413,17 @@ def merge_results(
     }
     merged_diagnostics.update(new_diagnostics)
 
+    merged_call_graph = cached_result.call_graph.union(new.call_graph)
+    merged_class_hierarchies = {**cached_result.class_hierarchies, **new.class_hierarchies}
+    # A warm-start re-LSPs only changed files, so a changed subclass whose superclass lives in
+    # an unchanged file emits no INHERITS edge during conversion (the superclass wasn't in that
+    # partial graph). Re-derive INHERITS from the merged hierarchy against the merged node set so
+    # the cross-file link is restored — otherwise incremental clustering loses class cohesion.
+    _rederive_inherits_edges(merged_call_graph, merged_class_hierarchies)
+
     merged = AnalysisData(
-        call_graph=cached_result.call_graph.union(new.call_graph),
-        class_hierarchies={**cached_result.class_hierarchies, **new.class_hierarchies},
+        call_graph=merged_call_graph,
+        class_hierarchies=merged_class_hierarchies,
         package_relations={**cached_result.package_relations, **new.package_relations},
         references=[ref for ref in cached_result.references if ref.file_path not in new_file_paths] + new.references,
         source_files=[path for path in cached_result.source_files if str(path) not in new_file_paths]
@@ -423,6 +431,20 @@ def merge_results(
         diagnostics=merged_diagnostics or None,
     )
     return merged
+
+
+def _rederive_inherits_edges(call_graph: CallGraph, class_hierarchies: dict[str, Any]) -> None:
+    """Add any missing INHERITS edge from the merged hierarchy, endpoints permitting.
+
+    ``add_reference_edge`` only records an edge when both endpoints are live nodes, so a
+    cross-file superclass now present in the merged graph gets its link; existing edges are
+    skipped to avoid duplicates.
+    """
+    existing = {(s, d) for s, d, k in call_graph.reference_edges if k == str(EdgeKind.INHERITS)}
+    for child, info in class_hierarchies.items():
+        for superclass in info.get("superclasses", []):
+            if (child, superclass) not in existing:
+                call_graph.add_reference_edge(child, superclass, EdgeKind.INHERITS)
 
 
 def _collect_invalidated_edge(

--- a/static_analyzer/cluster_helpers.py
+++ b/static_analyzer/cluster_helpers.py
@@ -18,9 +18,11 @@ distance) do we fall back to **file overlap** as a proxy for relatedness.
 """
 
 import logging
+import os
 from collections import defaultdict
 
 import networkx as nx
+import networkx.algorithms.community as nx_comm
 
 from static_analyzer.analysis_result import StaticAnalysisResults
 from static_analyzer.constants import ClusteringConfig, Language
@@ -32,6 +34,24 @@ logger = logging.getLogger(__name__)
 # more clusters than this, merge_clusters() collapses them into super-clusters
 # using community detection on the inter-cluster connectivity graph.
 MAX_LLM_CLUSTERS = 50
+
+# Range for the number of top-level architecture components. The exact count N
+# inside this range is chosen deterministically by the modularity peak of a
+# resolution-tuned Leiden partition (see ``supercluster_leaf_ids``), not by the
+# LLM — so the component structure is stable across re-runs.
+TOP_LEVEL_COMPONENTS_MIN = 5
+TOP_LEVEL_COMPONENTS_MAX = 8
+
+# Same idea for a component's sub-components (one level down); a component is
+# usually smaller than the whole repo, so the floor is lower.
+SUBCOMPONENTS_MIN = 3
+SUBCOMPONENTS_MAX = 8
+
+# Resolution ladder swept to steer Leiden toward a target community count.
+# Ascending: higher resolution -> more, finer communities. Reaches well past 1.0
+# so a graph with a large connected core can still be over-segmented to any N in
+# the target range before absorbing leftovers back down.
+_RESOLUTION_LADDER = (0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 2.0, 2.5, 3.0, 4.0, 5.0, 7.0, 10.0)
 
 
 def build_cluster_results_for_languages(
@@ -470,6 +490,263 @@ def merge_clusters(
     )
 
     return _build_merged_cluster_result(communities, cluster_result, cfg_graph)
+
+
+# ---------------------------------------------------------------------------
+# Top-level component grouping (resolution-tuned Leiden, modularity-peak N)
+# ---------------------------------------------------------------------------
+
+
+def _combine_cluster_results(cluster_results: dict[str, ClusterResult]) -> ClusterResult:
+    """Union per-language ClusterResults into one.
+
+    Cluster IDs are already globally unique across languages (``build_all_cluster_results``
+    re-indexes them), so a plain union is safe and lets us super-cluster every
+    language's leaf clusters against a single meta-graph.
+    """
+    clusters: dict[int, set[str]] = {}
+    cluster_to_files: dict[int, set[str]] = {}
+    file_to_clusters: dict[str, set[int]] = defaultdict(set)
+    for cr in cluster_results.values():
+        clusters.update(cr.clusters)
+        cluster_to_files.update(cr.cluster_to_files)
+        for file_path, cids in cr.file_to_clusters.items():
+            file_to_clusters[file_path].update(cids)
+    return ClusterResult(
+        clusters=clusters,
+        cluster_to_files=cluster_to_files,
+        file_to_clusters=dict(file_to_clusters),
+        strategy="combined",
+    )
+
+
+def _pick_peak_partition(
+    meta_graph: nx.DiGraph,
+    low: int,
+    high: int,
+    seed: int,
+) -> list[set[int]]:
+    """Sweep the resolution ladder and return the partition at the modularity peak in ``[low, high]``.
+
+    "N" counts *non-singleton* communities (size >= 2 leaf clusters) — the
+    connected structure Leiden actually resolves — because real call graphs
+    carry a long tail of isolated leaf clusters that would otherwise pin the raw
+    community count far above ``high`` at every resolution. Among partitions
+    whose non-singleton count lands in range, the highest-modularity one wins.
+    Falls back to the partition whose count is closest to the range when none
+    lands inside it (or to all-singletons on an edgeless graph).
+    """
+    if meta_graph.number_of_edges() == 0:
+        return [{cid} for cid in meta_graph.nodes]
+
+    candidates: list[tuple[int, float, list[set[int]]]] = []
+    for resolution in _RESOLUTION_LADDER:
+        try:
+            communities: list[set[int]] = detect_communities(
+                meta_graph, weight="weight", resolution=resolution, seed=seed
+            )
+        except Exception as e:  # noqa: BLE001 - a bad resolution shouldn't abort the sweep
+            logger.debug(f"[SuperCluster] resolution={resolution} failed: {e}")
+            continue
+        n_real = sum(1 for community in communities if len(community) >= 2)
+        modularity = nx_comm.modularity(meta_graph, communities, weight="weight")
+        candidates.append((n_real, modularity, communities))
+        logger.debug(f"[SuperCluster] resolution={resolution}: n_real={n_real} modularity={modularity:.4f}")
+
+    if not candidates:
+        return [{cid} for cid in meta_graph.nodes]
+
+    in_range = [c for c in candidates if low <= c[0] <= high]
+    if in_range:
+        n_real, modularity, communities = max(in_range, key=lambda c: c[1])
+        logger.info(f"[SuperCluster] modularity peak at N={n_real} (modularity={modularity:.4f}) over [{low},{high}]")
+        return communities
+
+    def range_distance(n_real: int) -> int:
+        return 0 if low <= n_real <= high else min(abs(n_real - low), abs(n_real - high))
+
+    n_real, _, communities = min(candidates, key=lambda c: (range_distance(c[0]), -c[1]))
+    logger.info(f"[SuperCluster] no partition with N in [{low},{high}]; using closest (N={n_real})")
+    return communities
+
+
+def _seeds_from_partition(
+    communities: list[set[int]],
+    method_count: dict[int, int],
+    low: int,
+    high: int,
+) -> tuple[list[set[int]], list[int]]:
+    """Split a partition into top-level *seed* communities and leftover leaf clusters.
+
+    Seeds are the non-singleton communities (ranked by total method count),
+    capped at ``high``. When there are fewer than ``low`` seeds, the largest
+    leftover leaf clusters are promoted to their own seed so a genuinely big but
+    call-isolated module (e.g. a data-model file nothing calls) still becomes a
+    component instead of being folded into another. Everything else is a
+    leftover to be absorbed.
+    """
+    reals = sorted(
+        (set(c) for c in communities if len(c) >= 2),
+        key=lambda community: (sum(method_count.get(cid, 0) for cid in community), -min(community)),
+        reverse=True,
+    )
+    leftovers = [cid for c in communities if len(c) == 1 for cid in c]
+
+    if len(reals) > high:
+        leftovers.extend(cid for community in reals[high:] for cid in community)
+        reals = reals[:high]
+
+    # Absorption grows seed packages as it goes (order matters), so order leftovers
+    # deterministically — biggest clusters first (they anchor packages), tie-broken
+    # by id — rather than relying on set/community iteration order.
+    leftovers.sort(key=lambda cid: (-method_count.get(cid, 0), cid))
+
+    seeds = reals
+    if len(seeds) < low:
+        while len(seeds) < low and leftovers:
+            seeds.append({leftovers.pop(0)})
+
+    return seeds, leftovers
+
+
+def _nearest_seed_index(
+    cid: int,
+    seeds: list[set[int]],
+    undirected_meta: nx.Graph,
+    seed_packages: list[set[str]],
+    cluster_result: ClusterResult,
+    method_count: dict[int, int],
+) -> int:
+    """Pick the seed a leftover leaf cluster belongs to: call proximity, then package, then size.
+
+    1. Shortest meta-graph path to any seed member (call coupling).
+    2. Directory/package overlap — the right signal for call-isolated clusters,
+       which have no meta-graph path at all.
+    3. The largest seed by method count, so nothing is dropped.
+    """
+    best_idx, best_dist = None, float("inf")
+    for idx, seed in enumerate(seeds):
+        for member in seed:
+            try:
+                dist = nx.shortest_path_length(undirected_meta, cid, member)
+            except (nx.NetworkXNoPath, nx.NodeNotFound):
+                continue
+            if dist < best_dist:
+                best_dist, best_idx = dist, idx
+    if best_idx is not None:
+        return best_idx
+
+    packages = _cluster_packages(cid, cluster_result)
+    best_idx, best_overlap = None, 0
+    for idx, seed_pkgs in enumerate(seed_packages):
+        overlap = len(packages & seed_pkgs)
+        if overlap > best_overlap:
+            best_overlap, best_idx = overlap, idx
+    if best_idx is not None:
+        return best_idx
+
+    return max(range(len(seeds)), key=lambda idx: sum(method_count.get(cid, 0) for cid in seeds[idx]))
+
+
+def _cluster_packages(cid: int, cluster_result: ClusterResult) -> set[str]:
+    """Directories of the files a leaf cluster touches (its 'package')."""
+    return {os.path.dirname(path) for path in cluster_result.cluster_to_files.get(cid, set())}
+
+
+def supercluster_by_modularity_peak(
+    cluster_result: ClusterResult,
+    cfg_graph: nx.DiGraph,
+    low: int = TOP_LEVEL_COMPONENTS_MIN,
+    high: int = TOP_LEVEL_COMPONENTS_MAX,
+    seed: int = ClusteringConfig.CLUSTERING_SEED,
+) -> list[set[int]]:
+    """Group leaf clusters into N top-level components via resolution-tuned Leiden.
+
+    Resolution tuning steers Leiden over the weighted inter-cluster meta-graph;
+    N (the number of top-level components) is the modularity peak among
+    partitions with ``[low, high]`` non-singleton communities. Those communities
+    become seeds and every remaining leaf cluster is absorbed into the nearest
+    seed (call proximity, then package, then size). Returns the partition as a
+    list of leaf-cluster-id sets — a complete, disjoint cover.
+
+    Unlike ``merge_clusters`` (which targets a preset count and absorbs down to
+    it by size), N here is data-driven: the sweep + modularity peak pick both the
+    partition and its size, and absorption is seed-directed rather than
+    smallest-first.
+    """
+    meta_graph = _build_meta_graph(cluster_result, cfg_graph)
+    n_leaf = meta_graph.number_of_nodes()
+    if n_leaf == 0:
+        return []
+    if n_leaf <= low:
+        # Fewer leaf clusters than the floor — each is its own component.
+        return [{cid} for cid in meta_graph.nodes]
+
+    method_count = {cid: len(members) for cid, members in cluster_result.clusters.items()}
+    communities = _pick_peak_partition(meta_graph, low, min(high, n_leaf), seed)
+    seeds, leftovers = _seeds_from_partition(communities, method_count, low, min(high, n_leaf))
+
+    if seeds:
+        undirected_meta = meta_graph.to_undirected(as_view=True) if meta_graph.is_directed() else meta_graph
+        seed_packages = [{pkg for cid in seed for pkg in _cluster_packages(cid, cluster_result)} for seed in seeds]
+        for cid in leftovers:
+            idx = _nearest_seed_index(cid, seeds, undirected_meta, seed_packages, cluster_result, method_count)
+            seeds[idx].add(cid)
+            seed_packages[idx].update(_cluster_packages(cid, cluster_result))
+
+    logger.info(
+        f"[SuperCluster] {n_leaf} leaf clusters -> {len(seeds)} components "
+        f"(sizes {sorted((len(s) for s in seeds), reverse=True)})"
+    )
+    return seeds
+
+
+def supercluster_leaf_ids(
+    cluster_results: dict[str, ClusterResult],
+    cfg_graphs: dict[str, nx.DiGraph],
+    low: int = TOP_LEVEL_COMPONENTS_MIN,
+    high: int = TOP_LEVEL_COMPONENTS_MAX,
+    seed: int = ClusteringConfig.CLUSTERING_SEED,
+) -> list[set[int]]:
+    """Partition all languages' leaf clusters into N top-level component groups.
+
+    Builds one combined meta-graph across languages (leaf-cluster IDs are already
+    globally unique) so the returned groups sum to a single top-level count in
+    ``[low, high]``. Each group is a set of leaf-cluster IDs; the LLM later only
+    names and describes these fixed groups.
+    """
+    combined = _combine_cluster_results(cluster_results)
+    combined_cfg: nx.DiGraph = nx.compose_all(list(cfg_graphs.values())) if cfg_graphs else nx.DiGraph()
+    return supercluster_by_modularity_peak(combined, combined_cfg, low, high, seed)
+
+
+def subgraph_peak_modularity(
+    cluster_results: dict[str, ClusterResult],
+    cfg_graphs: dict[str, nx.DiGraph],
+    low: int = SUBCOMPONENTS_MIN,
+    high: int = SUBCOMPONENTS_MAX,
+    seed: int = ClusteringConfig.CLUSTERING_SEED,
+) -> float:
+    """Modularity of the sub-component split we would produce for this component — its separability.
+
+    This is the Newman modularity of the exact ``[low, high]`` partition
+    ``supercluster_by_modularity_peak`` would build (via ``_pick_peak_partition``),
+    so the score is the quality of the real split, not an abstract graph metric. A
+    high value means the internals separate cleanly (worth expanding); near-zero
+    means a cohesive blob (a leaf). Returns 0.0 when there are fewer than two leaf
+    clusters or no inter-cluster edges (``nx`` modularity is undefined on an
+    edgeless graph, and a single cluster cannot split).
+    """
+    combined = _combine_cluster_results(cluster_results)
+    n_clusters = len(combined.clusters)
+    if n_clusters < 2:
+        return 0.0
+    combined_cfg: nx.DiGraph = nx.compose_all(list(cfg_graphs.values())) if cfg_graphs else nx.DiGraph()
+    meta_graph = _build_meta_graph(combined, combined_cfg)
+    if meta_graph.number_of_edges() == 0:
+        return 0.0
+    communities = _pick_peak_partition(meta_graph, low, min(high, n_clusters), seed)
+    return nx_comm.modularity(meta_graph, communities, weight="weight")
 
 
 # ---------------------------------------------------------------------------

--- a/static_analyzer/cluster_helpers.py
+++ b/static_analyzer/cluster_helpers.py
@@ -99,7 +99,7 @@ def build_all_cluster_results(static_analysis: StaticAnalysisResults) -> dict[st
                 f"[SuperCluster] {lang}: {n_clusters} clusters exceeds limit of {MAX_LLM_CLUSTERS}, "
                 f"merging into super-clusters"
             )
-            cluster_results[lang] = merge_clusters(cr, cfg.to_networkx(), MAX_LLM_CLUSTERS)
+            cluster_results[lang] = merge_clusters(cr, cfg.clustering_networkx(), MAX_LLM_CLUSTERS)
             new_count = len(cluster_results[lang].clusters)
             logger.info(f"[SuperCluster] {lang}: merged {n_clusters} -> {new_count} super-clusters")
 
@@ -107,7 +107,7 @@ def build_all_cluster_results(static_analysis: StaticAnalysisResults) -> dict[st
     # within MAX_LLM_CLUSTERS by proportionally reducing per-language counts,
     # then re-index IDs so they don't overlap across languages.
     if len(cluster_results) > 1:
-        cfg_graphs = {lang: static_analysis.get_cfg(Language(lang)).to_networkx() for lang in cluster_results}
+        cfg_graphs = {lang: static_analysis.get_cfg(Language(lang)).clustering_networkx() for lang in cluster_results}
         enforce_cross_language_budget(cluster_results, cfg_graphs)
 
     _sync_cluster_cache(static_analysis, cluster_results)

--- a/static_analyzer/constants.py
+++ b/static_analyzer/constants.py
@@ -82,6 +82,14 @@ class ClusteringConfig:
     # Deterministic seed for clustering algorithms
     CLUSTERING_SEED = 42
 
+    # Which reference-edge kinds (beyond call edges) to fold into the graph used
+    # for clustering. The static call graph misses ~a fifth of symbols (isolated
+    # constructors, dunders, DI/interface methods), so completing it with these
+    # relationships avoids grab-bag components. Values are ``graph.EdgeKind`` string
+    # values. IMPORT is emitted but excluded by default — it over-merges (coarse,
+    # dense, file-level). Change this tuple to analyze a different subset.
+    CLUSTERING_EDGE_KINDS = ("contains", "inherits", "typeref")
+
 
 class NodeType(IntEnum):
     """LSP SymbolKind constants as an IntEnum.

--- a/static_analyzer/engine/call_graph_builder.py
+++ b/static_analyzer/engine/call_graph_builder.py
@@ -41,13 +41,14 @@ class CallGraphBuilder:
         """Public access to the symbol table for result conversion."""
         return self._symbol_table
 
-    def build(self, source_files: list[Path], skip_hierarchy: bool = True) -> LanguageAnalysisResult:
+    def build(self, source_files: list[Path], skip_hierarchy: bool = False) -> LanguageAnalysisResult:
         """Run the full analysis pipeline and return results.
 
         Args:
             source_files: List of source files to analyze.
-            skip_hierarchy: If True (default), skip Phase 3 (class hierarchy).
-                Hierarchy is currently not consumed by the LLM agents.
+            skip_hierarchy: If True, skip Phase 3 (class hierarchy). Default False:
+                the hierarchy now feeds INHERITS reference edges that complete the
+                graph for clustering (see ``EdgeKind``).
         """
         t_pipeline = time.monotonic()
 

--- a/static_analyzer/engine/models.py
+++ b/static_analyzer/engine/models.py
@@ -96,6 +96,11 @@ class LanguageAnalysisResult:
     cfg: CallFlowGraph = field(default_factory=CallFlowGraph)
     package_dependencies: dict[str, dict] = field(default_factory=dict)
     source_files: list[str] = field(default_factory=list)
+    # Non-call relationship edges completing the graph for clustering. Each entry
+    # is (source_qname, target_qname). type_references: code names a type (param,
+    # return, annotation, cast); import_edges: module A imports symbol/module B.
+    type_references: list[tuple[str, str]] = field(default_factory=list)
+    import_edges: list[tuple[str, str]] = field(default_factory=list)
 
 
 class AnalysisResults:

--- a/static_analyzer/engine/result_converter.py
+++ b/static_analyzer/engine/result_converter.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 import logging
 
-from static_analyzer.constants import GRAPH_NODE_TYPES, NodeType
+from collections import Counter
+
+from static_analyzer.constants import CLASS_TYPES, GRAPH_NODE_TYPES, NodeType
 from static_analyzer.engine.language_adapter import LanguageAdapter
 from static_analyzer.engine.models import LanguageAnalysisResult
 from static_analyzer.engine.symbol_table import SymbolTable
-from static_analyzer.graph import CallGraph
+from static_analyzer.graph import CallGraph, EdgeKind
 from static_analyzer.node import Node
 
 logger = logging.getLogger(__name__)
@@ -95,6 +97,15 @@ def convert_to_codeboarding_format(
         language,
     )
 
+    _add_reference_edges(call_graph, result)
+
+    logger.info(
+        "Reference edges for %s: %d (%s)",
+        language,
+        len(call_graph.reference_edges),
+        dict(_count_by_kind(call_graph.reference_edges)),
+    )
+
     # Build references list from primary symbols only (excludes dual-registration
     # aliases and local variables/parameters that are implementation noise).
     primary_qnames: set[str] = set()
@@ -135,6 +146,42 @@ def convert_to_codeboarding_format(
         "source_files": result.source_files,
         "diagnostics": {},
     }
+
+
+def _add_reference_edges(call_graph: CallGraph, result: LanguageAnalysisResult) -> None:
+    """Complete the graph with non-call relationship edges (see ``EdgeKind``).
+
+    CONTAINS and INHERITS need no extra LSP work — they come from the qualified-name
+    hierarchy and the already-computed class hierarchy. TYPEREF and IMPORT are read
+    from the engine result when the analyzer populated them.
+    """
+    class_qnames = {qname for qname, node in call_graph.nodes.items() if node.type in CLASS_TYPES}
+
+    # CONTAINS: each method / nested symbol -> its innermost enclosing class node.
+    for qname in call_graph.nodes:
+        if qname in class_qnames:
+            continue
+        parts = qname.split(".")
+        for i in range(len(parts) - 1, 0, -1):
+            parent = ".".join(parts[:i])
+            if parent in class_qnames:
+                call_graph.add_reference_edge(qname, parent, EdgeKind.CONTAINS)
+                break
+
+    # INHERITS: child class -> each superclass (already computed by HierarchyBuilder).
+    for child, info in (result.hierarchy or {}).items():
+        for superclass in info.get("superclasses", []):
+            call_graph.add_reference_edge(child, superclass, EdgeKind.INHERITS)
+
+    # TYPEREF / IMPORT: emitted by the analyzer when available (see engine models).
+    for src, dst in getattr(result, "type_references", None) or ():
+        call_graph.add_reference_edge(src, dst, EdgeKind.TYPEREF)
+    for src, dst in getattr(result, "import_edges", None) or ():
+        call_graph.add_reference_edge(src, dst, EdgeKind.IMPORT)
+
+
+def _count_by_kind(reference_edges: list[tuple[str, str, str]]) -> Counter:
+    return Counter(kind for _, _, kind in reference_edges)
 
 
 def _map_symbol_kind(kind: int) -> NodeType:

--- a/static_analyzer/graph.py
+++ b/static_analyzer/graph.py
@@ -262,9 +262,13 @@ class CallGraph:
         carried: list[tuple[str, str, str]] = []
         for source in (self, *extra_sources):
             for s, d, k in getattr(source, "reference_edges", ()):
-                if s in out.nodes and d in out.nodes and (s, d, k) not in seen:
-                    seen.add((s, d, k))
-                    carried.append((s, d, k))
+                # Resolve through the SOURCE's alias map: an endpoint stored under a short
+                # alias must map to the canonical name ``out`` promoted it to, or a call edge
+                # (which add_edge resolves) survives while its reference edge is silently dropped.
+                rs, rd = source._resolve_name(s), source._resolve_name(d)
+                if rs in out.nodes and rd in out.nodes and rs != rd and (rs, rd, k) not in seen:
+                    seen.add((rs, rd, k))
+                    carried.append((rs, rd, k))
         out.reference_edges = carried
 
     def filter(
@@ -398,9 +402,12 @@ class CallGraph:
         kinds = set(ClusteringConfig.CLUSTERING_EDGE_KINDS if reference_kinds is None else reference_kinds)
         nx_graph = self.to_networkx()
         # getattr: baselines pickled before reference edges existed lack the attribute.
+        # Resolve endpoints through the alias map so an edge stored under a short alias still
+        # lands on the canonical node (matching how add_edge resolves call edges).
         for src, dst, kind in getattr(self, "reference_edges", ()):
-            if kind in kinds and src in self.nodes and dst in self.nodes:
-                nx_graph.add_edge(src, dst)
+            rsrc, rdst = self._resolve_name(src), self._resolve_name(dst)
+            if kind in kinds and rsrc in self.nodes and rdst in self.nodes:
+                nx_graph.add_edge(rsrc, rdst)
         return nx_graph
 
     def cluster(

--- a/static_analyzer/graph.py
+++ b/static_analyzer/graph.py
@@ -2,6 +2,7 @@ import logging
 from collections import defaultdict
 from collections.abc import Callable, Collection, Hashable, Mapping, Sequence
 from dataclasses import dataclass, field
+from enum import StrEnum
 from types import MappingProxyType
 
 import networkx as nx
@@ -35,6 +36,25 @@ def detect_communities[T](
     the dependency surface is contained to ``leiden_utils``.
     """
     return _leiden_find_partition(graph, weight=weight, resolution=resolution, seed=seed)
+
+
+class EdgeKind(StrEnum):
+    """Kind of relationship an edge represents.
+
+    ``CALL`` edges live in ``CallGraph.edges`` and drive component *relations*.
+    The rest are *reference edges* (``CallGraph.reference_edges``): structural
+    relationships the pure call graph misses — a method belongs to its class
+    (CONTAINS), a class extends another (INHERITS), code names a type (TYPEREF),
+    a module imports another (IMPORT). They complete the graph for *clustering*
+    (so constructors/dunders/DI/interface methods aren't graph-isolated) without
+    polluting the call-relation semantics.
+    """
+
+    CALL = "call"
+    CONTAINS = "contains"
+    INHERITS = "inherits"
+    TYPEREF = "typeref"
+    IMPORT = "import"
 
 
 @dataclass(frozen=True)
@@ -149,6 +169,11 @@ class CallGraph:
         # ``add_edge`` can transparently resolve references to dropped aliases.
         self._location_index: dict[LocationKey, str] = {}
         self._alias_to_canonical: dict[str, str] = {}
+        # Non-call relationship edges (CONTAINS/INHERITS/TYPEREF/IMPORT), kept off
+        # ``self.edges`` so relations and ``methods_called_by_me`` stay call-only.
+        # Merged into the graph only for clustering (``clustering_networkx``).
+        # Each entry: (src_qname, dst_qname, EdgeKind value).
+        self.reference_edges: list[tuple[str, str, str]] = []
 
     def add_node(self, node: Node) -> None:
         loc_key = LocationKey(node.file_path, node.line_start, node.line_end, node.type.value, node.col_start)
@@ -215,6 +240,23 @@ class CallGraph:
 
         self.nodes[src_name].added_method_called_by_me(self.nodes[dst_name])
 
+    def add_reference_edge(self, src_name: str, dst_name: str, kind: EdgeKind) -> None:
+        """Record a non-call relationship edge (CONTAINS/INHERITS/TYPEREF/IMPORT).
+
+        Stored separately from call edges; used only to complete the graph for
+        clustering. Silently ignores endpoints that aren't nodes or self-loops.
+        """
+        src_name = self._resolve_name(src_name)
+        dst_name = self._resolve_name(dst_name)
+        if src_name in self.nodes and dst_name in self.nodes and src_name != dst_name:
+            self.reference_edges.append((src_name, dst_name, str(kind)))
+
+    def _carry_reference_edges(self, out: "CallGraph") -> None:
+        """Copy reference edges whose both endpoints survive into a derived subgraph."""
+        out.reference_edges = [
+            (s, d, k) for s, d, k in getattr(self, "reference_edges", ()) if s in out.nodes and d in out.nodes
+        ]
+
     def filter(
         self,
         keep_node: Callable[[Node], bool],
@@ -242,6 +284,7 @@ class CallGraph:
                 on_dropped_edge(edge)
         out._cluster_cache = self._prune_cluster_cache(out.nodes)
         out.method_cluster_paths = self._prune_method_cluster_paths(out.nodes)
+        self._carry_reference_edges(out)
         return out
 
     def union(self, other: "CallGraph") -> "CallGraph":
@@ -269,6 +312,7 @@ class CallGraph:
                 pass
         out._cluster_cache = self._prune_cluster_cache(out.nodes)
         out.method_cluster_paths = self._prune_method_cluster_paths(out.nodes)
+        self._carry_reference_edges(out)
         return out
 
     def _prune_cluster_cache(self, surviving_nodes: dict[str, Node]) -> "ClusterResult | None":
@@ -330,6 +374,23 @@ class CallGraph:
             nx_graph.add_edge(edge.get_source(), edge.get_destination())
         return nx_graph
 
+    def clustering_networkx(self, reference_kinds: Collection[str] | None = None) -> nx.DiGraph:
+        """Graph used for clustering: call edges plus configured reference-edge kinds.
+
+        Reference edges (CONTAINS/INHERITS/TYPEREF/IMPORT) complete the graph so
+        constructors, dunders, DI/reflection-invoked, and interface methods aren't
+        graph-isolated. ``reference_kinds`` defaults to
+        ``ClusteringConfig.CLUSTERING_EDGE_KINDS``; pass an explicit set to analyze
+        a different subset. Call edges are always included.
+        """
+        kinds = set(ClusteringConfig.CLUSTERING_EDGE_KINDS if reference_kinds is None else reference_kinds)
+        nx_graph = self.to_networkx()
+        # getattr: baselines pickled before reference edges existed lack the attribute.
+        for src, dst, kind in getattr(self, "reference_edges", ()):
+            if kind in kinds and src in self.nodes and dst in self.nodes:
+                nx_graph.add_edge(src, dst)
+        return nx_graph
+
     def cluster(
         self,
         target_clusters: int = ClusteringConfig.DEFAULT_TARGET_CLUSTERS,
@@ -344,7 +405,7 @@ class CallGraph:
         if self._cluster_cache is not None:
             return self._cluster_cache
 
-        nx_graph = self.to_networkx()
+        nx_graph = self.clustering_networkx()
         if nx_graph.number_of_nodes() == 0:
             logger.warning("No nodes available for clustering.")
             self._cluster_cache = ClusterResult(strategy="empty")
@@ -419,6 +480,7 @@ class CallGraph:
         # Create new graph, preserving the source language
         sub_graph = CallGraph(nodes=relevant_nodes, edges=filtered_edges, language=self.language)
         sub_graph.method_cluster_paths = self._prune_method_cluster_paths(relevant_nodes)
+        self._carry_reference_edges(sub_graph)
 
         return sub_graph
 

--- a/static_analyzer/graph.py
+++ b/static_analyzer/graph.py
@@ -251,11 +251,21 @@ class CallGraph:
         if src_name in self.nodes and dst_name in self.nodes and src_name != dst_name:
             self.reference_edges.append((src_name, dst_name, str(kind)))
 
-    def _carry_reference_edges(self, out: "CallGraph") -> None:
-        """Copy reference edges whose both endpoints survive into a derived subgraph."""
-        out.reference_edges = [
-            (s, d, k) for s, d, k in getattr(self, "reference_edges", ()) if s in out.nodes and d in out.nodes
-        ]
+    def _carry_reference_edges(self, out: "CallGraph", *extra_sources: "CallGraph") -> None:
+        """Copy reference edges whose both endpoints survive into a derived graph.
+
+        Includes ``self`` and any ``extra_sources`` (e.g. the ``other`` side of a union), so
+        reference edges freshly computed for changed/added files are not dropped when both
+        endpoints survive. Deduped, keeping only edges whose endpoints are both in ``out``.
+        """
+        seen: set[tuple[str, str, str]] = set()
+        carried: list[tuple[str, str, str]] = []
+        for source in (self, *extra_sources):
+            for s, d, k in getattr(source, "reference_edges", ()):
+                if s in out.nodes and d in out.nodes and (s, d, k) not in seen:
+                    seen.add((s, d, k))
+                    carried.append((s, d, k))
+        out.reference_edges = carried
 
     def filter(
         self,
@@ -312,7 +322,9 @@ class CallGraph:
                 pass
         out._cluster_cache = self._prune_cluster_cache(out.nodes)
         out.method_cluster_paths = self._prune_method_cluster_paths(out.nodes)
-        self._carry_reference_edges(out)
+        # Carry reference edges from BOTH sides: ``other`` holds the fresh reference edges for
+        # changed/added files, which would otherwise be lost and revert those files to call-only.
+        self._carry_reference_edges(out, other)
         return out
 
     def _prune_cluster_cache(self, surviving_nodes: dict[str, Node]) -> "ClusterResult | None":
@@ -504,6 +516,7 @@ class CallGraph:
 
         sub_graph = CallGraph(nodes=relevant_nodes, edges=filtered_edges, language=self.language)
         sub_graph.method_cluster_paths = self._prune_method_cluster_paths(relevant_nodes)
+        self._carry_reference_edges(sub_graph)
         return sub_graph
 
     def to_cluster_string(

--- a/static_analyzer/incremental_orchestrator.py
+++ b/static_analyzer/incremental_orchestrator.py
@@ -379,10 +379,13 @@ def _filter_to_live_files(merged_analysis: AnalysisData) -> AnalysisData:
         on_dropped_edge=lambda _edge: None,
     )
 
+    # Hierarchy entries are keyed by class qname and carry no file_path, so filter by whether the
+    # class still exists as a live call-graph node (already filtered above) — the old
+    # ``info.get("file_path")`` check was always None and dropped every hierarchy, which then
+    # starved the warm-start INHERITS re-derivation of its source on the next run.
+    live_class_names = set(merged_analysis.call_graph.nodes.keys())
     merged_analysis.class_hierarchies = {
-        name: info
-        for name, info in merged_analysis.class_hierarchies.items()
-        if info.get("file_path") in existing_file_strs
+        name: info for name, info in merged_analysis.class_hierarchies.items() if name in live_class_names
     }
 
     filtered_packages: dict[str, Any] = {}

--- a/static_analyzer/language_results.py
+++ b/static_analyzer/language_results.py
@@ -53,7 +53,7 @@ class ControlFlowGraph:
         # Carry the other graph's reference edges (CONTAINS/INHERITS/TYPEREF/IMPORT) so a
         # same-language sub-project's completed graph isn't reduced to call-only after merge.
         # Re-added via the API so alias-resolution and node-existence guards apply post-merge.
-        for src, dst, kind in other.reference_edges:
+        for src, dst, kind in getattr(other, "reference_edges", ()):
             self.graph.add_reference_edge(src, dst, EdgeKind(kind))
         self.graph.method_cluster_paths.merge(other.method_cluster_paths)
 

--- a/static_analyzer/language_results.py
+++ b/static_analyzer/language_results.py
@@ -11,7 +11,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 import logging
 
-from static_analyzer.graph import CallGraph
+from static_analyzer.graph import CallGraph, EdgeKind
 from static_analyzer.node import Node
 
 logger = logging.getLogger(__name__)
@@ -50,6 +50,11 @@ class ControlFlowGraph:
                     exc_info=True,
                 )
                 self.graph.add_edge(edge.get_source(), edge.get_destination())
+        # Carry the other graph's reference edges (CONTAINS/INHERITS/TYPEREF/IMPORT) so a
+        # same-language sub-project's completed graph isn't reduced to call-only after merge.
+        # Re-added via the API so alias-resolution and node-existence guards apply post-merge.
+        for src, dst, kind in other.reference_edges:
+            self.graph.add_reference_edge(src, dst, EdgeKind(kind))
         self.graph.method_cluster_paths.merge(other.method_cluster_paths)
 
     def visit_paths(self, fn: Callable[[str], str]) -> None:

--- a/tests/agents/test_abstraction_agent.py
+++ b/tests/agents/test_abstraction_agent.py
@@ -3,13 +3,16 @@ import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import networkx as nx
+
 from agents.abstraction_agent import AbstractionAgent
 from agents.agent_responses import (
     AnalysisInsights,
     ClusterAnalysis,
+    ClustersComponent,
     Component,
+    ComponentArchitecture,
     MetaAnalysisInsights,
-    SourceCodeReference,
 )
 from static_analyzer.analysis_result import StaticAnalysisResults
 from static_analyzer.graph import ClusterResult
@@ -66,95 +69,93 @@ class TestAbstractionAgent(unittest.TestCase):
 
         self.assertEqual(agent.project_name, self.project_name)
         self.assertEqual(agent.meta_context, self.mock_meta_context)
-        self.assertIn("group_clusters", agent.prompts)
         self.assertIn("final_analysis", agent.prompts)
 
-    @patch("agents.abstraction_agent.AbstractionAgent._invoke_validate")
-    def test_step_clusters_grouping_single_language(self, mock_invoke_validate):
-        # Test step_clusters_grouping with single language
-        mock_llm = MagicMock()
-        mock_parsing_llm = MagicMock()
-        agent = AbstractionAgent(
+    def _make_agent(self):
+        return AbstractionAgent(
             repo_dir=self.repo_dir,
             static_analysis=self.mock_static_analysis,
             project_name=self.project_name,
             meta_context=self.mock_meta_context,
-            agent_llm=mock_llm,
-            parsing_llm=mock_parsing_llm,
+            agent_llm=MagicMock(),
+            parsing_llm=MagicMock(),
         )
 
-        mock_response = ClusterAnalysis(
-            cluster_components=[],
+    @staticmethod
+    def _clustered_graph(cluster_ids):
+        """A ClusterResult + matching nx graph: one chained pair of nodes per cluster id."""
+        clusters, cluster_to_files, file_to_clusters = {}, {}, {}
+        graph = nx.DiGraph()
+        for cid in cluster_ids:
+            nodes = [f"pkg.mod{cid}.a", f"pkg.mod{cid}.b"]
+            clusters[cid] = set(nodes)
+            path = f"/repo/mod{cid}.py"
+            cluster_to_files[cid] = {path}
+            file_to_clusters[path] = {cid}
+            for node in nodes:
+                graph.add_node(node, file_path=path)
+            graph.add_edge(nodes[0], nodes[1])
+        # Chain consecutive clusters so the meta-graph is connected.
+        ids = list(cluster_ids)
+        for prev, cur in zip(ids, ids[1:]):
+            graph.add_edge(f"pkg.mod{prev}.b", f"pkg.mod{cur}.a")
+        cr = ClusterResult(
+            clusters=clusters, cluster_to_files=cluster_to_files, file_to_clusters=file_to_clusters, strategy="test"
         )
-        mock_invoke_validate.return_value = mock_response
+        return cr, graph
 
-        mock_cluster_result = ClusterResult(clusters={1: {"node1"}})
-        cluster_results = {"python": mock_cluster_result}
+    def _assert_partition(self, result, expected_ids):
+        self.assertIsInstance(result, ClusterAnalysis)
+        self.assertGreaterEqual(len(result.cluster_components), 1)
+        # Names are the deterministic Group-1..N labels.
+        self.assertEqual(
+            [cc.name for cc in result.cluster_components],
+            [f"Group {i}" for i in range(1, len(result.cluster_components) + 1)],
+        )
+        # Every leaf cluster is owned by exactly one group (a true partition).
+        assigned = [cid for cc in result.cluster_components for cid in cc.cluster_ids]
+        self.assertEqual(sorted(assigned), sorted(expected_ids))
+        self.assertEqual(len(assigned), len(set(assigned)))
+
+    def test_step_clusters_grouping_single_language(self):
+        agent = self._make_agent()
+        cr, graph = self._clustered_graph(range(1, 13))
+        self.mock_static_analysis.get_cfg.return_value.to_networkx.return_value = graph
+        cluster_results = {"python": cr}
 
         result = agent.step_clusters_grouping(cluster_results)
+        result_again = agent.step_clusters_grouping(cluster_results)
 
-        self.assertEqual(result, mock_response)
-        mock_invoke_validate.assert_called_once()
+        self._assert_partition(result, list(range(1, 13)))
+        # Deterministic: same membership on a re-run.
+        self.assertEqual(
+            [sorted(cc.cluster_ids) for cc in result.cluster_components],
+            [sorted(cc.cluster_ids) for cc in result_again.cluster_components],
+        )
 
-    @patch("agents.abstraction_agent.AbstractionAgent._invoke_validate")
-    def test_step_clusters_grouping_multiple_languages(self, mock_invoke_validate):
-        # Test step_clusters_grouping with multiple languages
+    def test_step_clusters_grouping_multiple_languages(self):
         self.mock_static_analysis.get_languages.return_value = ["python", "javascript"]
-
-        mock_llm = MagicMock()
-        mock_parsing_llm = MagicMock()
-        agent = AbstractionAgent(
-            repo_dir=self.repo_dir,
-            static_analysis=self.mock_static_analysis,
-            project_name=self.project_name,
-            meta_context=self.mock_meta_context,
-            agent_llm=mock_llm,
-            parsing_llm=mock_parsing_llm,
-        )
-
-        mock_response = ClusterAnalysis(
-            cluster_components=[],
-        )
-        mock_invoke_validate.return_value = mock_response
-
-        # Create mock cluster_results for both languages
-        from static_analyzer.graph import ClusterResult
-
-        mock_cluster_result = ClusterResult(clusters={1: {"node1"}})
-        cluster_results = {"python": mock_cluster_result, "javascript": mock_cluster_result}
+        agent = self._make_agent()
+        # Globally-unique cluster ids across languages, sharing one combined graph.
+        _, graph = self._clustered_graph(range(1, 13))
+        py_cr, _ = self._clustered_graph(range(1, 7))
+        js_cr, _ = self._clustered_graph(range(7, 13))
+        self.mock_static_analysis.get_cfg.return_value.to_networkx.return_value = graph
+        cluster_results = {"python": py_cr, "javascript": js_cr}
 
         result = agent.step_clusters_grouping(cluster_results)
 
-        self.assertEqual(result, mock_response)
+        self._assert_partition(result, list(range(1, 13)))
         self.mock_static_analysis.get_cfg.assert_called()
 
-    @patch("agents.abstraction_agent.AbstractionAgent._invoke_validate")
-    def test_step_clusters_grouping_no_languages(self, mock_invoke_validate):
-        # Test step_clusters_grouping with no languages detected
+    def test_step_clusters_grouping_no_languages(self):
         self.mock_static_analysis.get_languages.return_value = []
+        agent = self._make_agent()
 
-        mock_llm = MagicMock()
-        mock_parsing_llm = MagicMock()
-        agent = AbstractionAgent(
-            repo_dir=self.repo_dir,
-            static_analysis=self.mock_static_analysis,
-            project_name=self.project_name,
-            meta_context=self.mock_meta_context,
-            agent_llm=mock_llm,
-            parsing_llm=mock_parsing_llm,
-        )
+        result = agent.step_clusters_grouping({})
 
-        mock_response = ClusterAnalysis(
-            cluster_components=[],
-        )
-        mock_invoke_validate.return_value = mock_response
-
-        # Empty cluster_results for no languages
-        cluster_results: dict = {}
-
-        result = agent.step_clusters_grouping(cluster_results)
-
-        self.assertEqual(result, mock_response)
+        self.assertIsInstance(result, ClusterAnalysis)
+        self.assertEqual(result.cluster_components, [])
 
     @patch("agents.abstraction_agent.AbstractionAgent._invoke_repair_validate")
     def test_step_final_analysis(self, mock_invoke_repair_validate):
@@ -190,6 +191,43 @@ class TestAbstractionAgent(unittest.TestCase):
         result = agent.step_final_analysis(cluster_analysis, cluster_results)
 
         self.assertEqual(result, mock_response)
+
+    @patch("agents.abstraction_agent.AbstractionAgent._invoke_repair_validate")
+    def test_step_final_analysis_pins_one_component_per_group(self, mock_invoke_repair_validate):
+        """Even when the LLM merges/drops groups, the result has exactly one component per group."""
+        agent = self._make_agent()
+
+        cluster_analysis = ClusterAnalysis(
+            cluster_components=[
+                ClustersComponent(name="Group 1", cluster_ids=[1, 2], description="g1"),
+                ClustersComponent(name="Group 2", cluster_ids=[3], description="g2"),
+                ClustersComponent(name="Group 3", cluster_ids=[4, 5], description="g3"),
+            ]
+        )
+        # LLM output: keeps Group 1, merges Group 2 + 3 into one component (drops a slot).
+        mock_invoke_repair_validate.return_value = ComponentArchitecture(
+            description="arch",
+            components=[
+                Component(name="Auth", description="auth", key_entities=[], source_group_names=["Group 1"]),
+                Component(name="Data", description="data", key_entities=[], source_group_names=["Group 2", "Group 3"]),
+            ],
+        )
+
+        cluster_results = {
+            "python": ClusterResult(
+                clusters={1: {"a"}, 2: {"b"}, 3: {"c"}, 4: {"pkg.Widget"}, 5: {"e"}},
+            )
+        }
+
+        result = agent.step_final_analysis(cluster_analysis, cluster_results)
+
+        # Exactly one component per group, each backed by exactly one group.
+        self.assertEqual(len(result.components), 3)
+        self.assertEqual([c.source_group_names for c in result.components], [["Group 1"], ["Group 2"], ["Group 3"]])
+        # The claimed groups keep the LLM's names; the dropped one gets a deterministic fallback.
+        self.assertEqual(result.components[0].name, "Auth")
+        self.assertEqual(result.components[1].name, "Data")
+        self.assertTrue(result.components[2].name)  # fallback derived from the group's symbols
 
 
 if __name__ == "__main__":

--- a/tests/agents/test_abstraction_agent.py
+++ b/tests/agents/test_abstraction_agent.py
@@ -121,6 +121,7 @@ class TestAbstractionAgent(unittest.TestCase):
         agent = self._make_agent()
         cr, graph = self._clustered_graph(range(1, 13))
         self.mock_static_analysis.get_cfg.return_value.to_networkx.return_value = graph
+        self.mock_static_analysis.get_cfg.return_value.clustering_networkx.return_value = graph
         cluster_results = {"python": cr}
 
         result = agent.step_clusters_grouping(cluster_results)
@@ -141,6 +142,7 @@ class TestAbstractionAgent(unittest.TestCase):
         py_cr, _ = self._clustered_graph(range(1, 7))
         js_cr, _ = self._clustered_graph(range(7, 13))
         self.mock_static_analysis.get_cfg.return_value.to_networkx.return_value = graph
+        self.mock_static_analysis.get_cfg.return_value.clustering_networkx.return_value = graph
         cluster_results = {"python": py_cr, "javascript": js_cr}
 
         result = agent.step_clusters_grouping(cluster_results)

--- a/tests/agents/test_details_agent.py
+++ b/tests/agents/test_details_agent.py
@@ -1,7 +1,9 @@
 import shutil
 import unittest
 from pathlib import Path
-from unittest.mock import ANY, MagicMock, call, patch
+from unittest.mock import ANY, MagicMock, patch
+
+import networkx as nx
 
 from agents.details_agent import DetailsAgent
 from agents.agent_responses import (
@@ -78,6 +80,53 @@ class TestDetailsAgent(unittest.TestCase):
         if hasattr(self, "temp_dir"):
             shutil.rmtree(self.temp_dir, ignore_errors=True)
 
+    def _make_agent(self):
+        return DetailsAgent(
+            repo_dir=self.repo_dir,
+            static_analysis=self.mock_static_analysis,
+            project_name=self.project_name,
+            meta_context=self.mock_meta_context,
+            agent_llm=MagicMock(),
+            parsing_llm=MagicMock(),
+            run_id="test-run-id",
+        )
+
+    @staticmethod
+    def _clustered_graph(cluster_ids):
+        """A ClusterResult + matching nx graph: one chained pair of nodes per cluster id."""
+        clusters, cluster_to_files, file_to_clusters = {}, {}, {}
+        graph = nx.DiGraph()
+        for cid in cluster_ids:
+            nodes = [f"pkg.mod{cid}.a", f"pkg.mod{cid}.b"]
+            clusters[cid] = set(nodes)
+            path = f"/repo/mod{cid}.py"
+            cluster_to_files[cid] = {path}
+            file_to_clusters[path] = {cid}
+            for node in nodes:
+                graph.add_node(node, file_path=path)
+            graph.add_edge(nodes[0], nodes[1])
+        # Chain consecutive clusters so the meta-graph is connected.
+        ids = list(cluster_ids)
+        for prev, cur in zip(ids, ids[1:]):
+            graph.add_edge(f"pkg.mod{prev}.b", f"pkg.mod{cur}.a")
+        cr = ClusterResult(
+            clusters=clusters, cluster_to_files=cluster_to_files, file_to_clusters=file_to_clusters, strategy="test"
+        )
+        return cr, graph
+
+    def _assert_partition(self, result, expected_ids):
+        self.assertIsInstance(result, ClusterAnalysis)
+        self.assertGreaterEqual(len(result.cluster_components), 1)
+        # Names are the deterministic Group-1..N labels.
+        self.assertEqual(
+            [cc.name for cc in result.cluster_components],
+            [f"Group {i}" for i in range(1, len(result.cluster_components) + 1)],
+        )
+        # Every leaf cluster is owned by exactly one group (a true, disjoint partition).
+        assigned = [cid for cc in result.cluster_components for cid in cc.cluster_ids]
+        self.assertEqual(sorted(assigned), sorted(expected_ids))
+        self.assertEqual(len(assigned), len(set(assigned)))
+
     def test_init(self):
         # Test initialization
         mock_llm = MagicMock()
@@ -94,7 +143,6 @@ class TestDetailsAgent(unittest.TestCase):
 
         self.assertEqual(agent.project_name, self.project_name)
         self.assertEqual(agent.meta_context, self.mock_meta_context)
-        self.assertIn("group_clusters", agent.prompts)
         self.assertIn("final_analysis", agent.prompts)
 
     def test_create_strict_component_subgraph(self):
@@ -149,35 +197,23 @@ class TestDetailsAgent(unittest.TestCase):
         mock_cfg.filter_by_nodes.assert_called_with(expected_qnames)
         mock_subgraph.cluster.assert_called_once()
 
-    @patch("agents.details_agent.DetailsAgent._invoke_validate")
-    def test_step_clusters_grouping(self, mock_invoke_validate):
-        # Test step_clusters_grouping
-        mock_llm = MagicMock()
-        mock_parsing_llm = MagicMock()
-        agent = DetailsAgent(
-            repo_dir=self.repo_dir,
-            static_analysis=self.mock_static_analysis,
-            project_name=self.project_name,
-            meta_context=self.mock_meta_context,
-            agent_llm=mock_llm,
-            parsing_llm=mock_parsing_llm,
-            run_id="test-run-id",
-        )
-        mock_response = ClusterAnalysis(cluster_components=[])
-        mock_invoke_validate.return_value = mock_response
-
-        # Mock CFG to return a proper cluster string
-        mock_cfg = MagicMock()
-        mock_cfg.to_cluster_string.return_value = "Cluster 1: method_a, method_b"
-        self.mock_static_analysis.get_cfg.return_value = mock_cfg
-
-        mock_cluster_result = MagicMock()
-        subgraph_cluster_results = {"python": mock_cluster_result}
+    def test_step_clusters_grouping(self):
+        # Grouping is deterministic (resolution-tuned Leiden on the subgraph), no LLM call.
+        agent = self._make_agent()
+        cr, graph = self._clustered_graph(range(1, 11))
+        self.mock_static_analysis.get_cfg.return_value.to_networkx.return_value = graph
+        subgraph_cluster_results = {"python": cr}
 
         result = agent.step_clusters_grouping(self.test_component, subgraph_cluster_results)
+        result_again = agent.step_clusters_grouping(self.test_component, subgraph_cluster_results)
 
-        self.assertEqual(result, mock_response)
-        mock_invoke_validate.assert_called_once()
+        # A complete, disjoint partition of the leaf clusters into "Group i" components.
+        self._assert_partition(result, list(range(1, 11)))
+        # Deterministic: same membership on a re-run.
+        self.assertEqual(
+            [sorted(cc.cluster_ids) for cc in result.cluster_components],
+            [sorted(cc.cluster_ids) for cc in result_again.cluster_components],
+        )
 
     @patch("agents.details_agent.DetailsAgent._invoke_repair_validate")
     def test_step_final_analysis(self, mock_invoke_repair_validate):
@@ -346,7 +382,8 @@ class TestDetailsAgent(unittest.TestCase):
         mock_cluster_result.get_cluster_ids.return_value = {1}
         mock_cluster_result.get_files_for_cluster.return_value = abs_assigned
 
-        mock_sub_cluster_result = MagicMock()
+        # Real subgraph cluster result + graph so deterministic grouping has structure.
+        sub_cluster_result, subgraph_graph = self._clustered_graph(range(1, 7))
 
         mock_node = MagicMock()
         mock_node.file_path = str(self.repo_dir / "src" / "main.py")
@@ -357,20 +394,23 @@ class TestDetailsAgent(unittest.TestCase):
 
         mock_subgraph = MagicMock()
         mock_subgraph.nodes = {"n1": mock_node}
-        mock_subgraph.cluster.return_value = mock_sub_cluster_result
+        mock_subgraph.cluster.return_value = sub_cluster_result
         mock_subgraph.to_cluster_string.return_value = "Component CFG String"
+        mock_subgraph.to_networkx.return_value = subgraph_graph
 
         mock_cfg = MagicMock()
         mock_cfg.cluster.return_value = mock_cluster_result
         mock_cfg.filter_by_nodes.return_value = mock_subgraph
         # _build_cluster_string calls cfg.to_cluster_string on the original cfg
         mock_cfg.to_cluster_string.return_value = "Cluster 1: method_a, method_b"
+        # deterministic_cluster_grouping reads the (super-)graph via get_cfg(...).to_networkx()
+        mock_cfg.to_networkx.return_value = subgraph_graph
 
         self.mock_static_analysis.get_languages.return_value = ["python"]
         self.mock_static_analysis.get_cfg.return_value = mock_cfg
 
-        # Mock responses for grouping and final analysis
-        cluster_response = ClusterAnalysis(cluster_components=[])
+        # Mock responses for final analysis. Grouping is now deterministic, so the
+        # only _invoke_validate call in the pipeline is for relations.
         final_component = Component(
             name="SubComp",
             description="A sub-component",
@@ -385,7 +425,7 @@ class TestDetailsAgent(unittest.TestCase):
 
         api_response = ComponentApiSurfaces(api_surfaces=[])
         relation_response = ComponentRelations(components_relations=[])
-        mock_invoke_validate.side_effect = [cluster_response, relation_response]
+        mock_invoke_validate.side_effect = [relation_response]
         mock_invoke_repair_validate.return_value = final_response
         mock_parse_invoke.return_value = api_response
         mock_fix_ref.return_value = final_response
@@ -393,23 +433,12 @@ class TestDetailsAgent(unittest.TestCase):
         analysis, _subgraph_results = agent.run(self.test_component)
 
         self.assertEqual(analysis, final_response)
-        mock_invoke_validate.assert_has_calls(
-            [
-                call(
-                    ANY,
-                    ClusterAnalysis,
-                    validators=ANY,
-                    validation_context=ANY,
-                    max_validation_attempts=3,
-                ),
-                call(
-                    ANY,
-                    ComponentRelations,
-                    validators=ANY,
-                    validation_context=ANY,
-                    max_validation_attempts=3,
-                ),
-            ]
+        mock_invoke_validate.assert_called_once_with(
+            ANY,
+            ComponentRelations,
+            validators=ANY,
+            validation_context=ANY,
+            max_validation_attempts=3,
         )
         mock_invoke_repair_validate.assert_called_once()
         mock_parse_invoke.assert_called_once_with(ANY, ComponentApiSurfaces)

--- a/tests/agents/test_method_uniqueness.py
+++ b/tests/agents/test_method_uniqueness.py
@@ -34,7 +34,7 @@ from agents.agent_responses import (
     SourceCodeReference,
 )
 from agents.cluster_methods_mixin import ClusterMethodsMixin
-from agents.file_index_models import FileMethodGroup, MethodEntry
+from agents.file_index_models import FileEntry, FileMethodGroup, MethodEntry
 from diagram_analysis.diagram_generator import DiagramGenerator, assert_scope_containment
 from diagram_analysis.exceptions import ScopeContainmentError
 from static_analyzer.constants import Language, NodeType
@@ -424,11 +424,8 @@ class TestMethodUniquenessNoAliases(unittest.TestCase):
 class TestScopeContainment(unittest.TestCase):
     """A child scope must only own methods its parent component still owns.
 
-    Reproduces the CodeBoarding-webview drift: an incremental run re-partitions the
-    root components against the live clustering, moving methods from component 1 to
-    component 2, but sub_analyses["1"] is a separate object no patch touches. Its
-    children keep the moved methods, so each one renders under component 2 *and*
-    under component 1's subtree.
+    Why: a child scope is a separate ``AnalysisInsights``, so re-partitioning a
+    parent cannot evict the moved methods from its children.
     """
 
     def setUp(self):
@@ -543,11 +540,15 @@ class TestScopeContainment(unittest.TestCase):
     def test_rescope_empties_children_when_parent_owns_nothing(self):
         root, sub_analyses, static_analysis = self._build_tree()
         root.components[0].file_methods = []
+        sub_analyses["1"].files = {"shared.ts": FileEntry()}
         gen = self._generator(static_analysis)
 
         gen._rescope_child_analyses(root, sub_analyses)
 
         self.assertEqual([m for c in sub_analyses["1"].components for g in c.file_methods for m in g.methods], [])
+        # save_analysis merges every scope's index into the unified files/methods_index,
+        # so a scope with no owned methods must not keep one.
+        self.assertEqual(sub_analyses["1"].files, {})
         assert_scope_containment(root, sub_analyses)
 
 

--- a/tests/agents/test_method_uniqueness.py
+++ b/tests/agents/test_method_uniqueness.py
@@ -522,7 +522,7 @@ class TestScopeContainment(unittest.TestCase):
         root, sub_analyses, static_analysis = self._build_tree()
         gen = self._generator(static_analysis)
 
-        gen._rescope_child_analyses(root, sub_analyses)
+        gen._rescope_child_analyses(root, sub_analyses, set())
 
         parent_owned = {m.qualified_name for g in root.components[0].file_methods for m in g.methods}
         child_owned = {
@@ -543,7 +543,7 @@ class TestScopeContainment(unittest.TestCase):
         sub_analyses["1"].files = {"shared.ts": FileEntry()}
         gen = self._generator(static_analysis)
 
-        gen._rescope_child_analyses(root, sub_analyses)
+        gen._rescope_child_analyses(root, sub_analyses, set())
 
         self.assertEqual([m for c in sub_analyses["1"].components for g in c.file_methods for m in g.methods], [])
         # save_analysis merges every scope's index into the unified files/methods_index,

--- a/tests/agents/test_method_uniqueness.py
+++ b/tests/agents/test_method_uniqueness.py
@@ -12,11 +12,17 @@ one component. However, `_build_file_methods_from_nodes` deduplicates by
 (start_line, end_line, type, short_name) — so both aliases produce the same MethodEntry
 in the output. Result: the same deduplicated method appears in BOTH components.
 
-The invariant: at the same tree level, a method (identified by its deduplicated key:
-start_line + end_line + type + short_name) must appear in at most ONE component's
-file_methods.
+The invariant has two halves:
+1. Within a tree level, a method (by its deduplicated key: start_line + end_line +
+   type + short_name) appears in at most ONE component's file_methods.
+2. Across levels, a child scope only owns methods its parent component owns. A child
+   scope is a separate ``AnalysisInsights`` in ``sub_analyses`` — ``Component`` has no
+   ``.components`` field, nesting is stitched at serialization — so no single populate
+   pass sees both halves. ``TestScopeContainment`` covers this one.
 """
 
+import shutil
+import tempfile
 import unittest
 from collections import defaultdict
 from pathlib import Path
@@ -28,7 +34,10 @@ from agents.agent_responses import (
     SourceCodeReference,
 )
 from agents.cluster_methods_mixin import ClusterMethodsMixin
-from static_analyzer.constants import NodeType
+from agents.file_index_models import FileMethodGroup, MethodEntry
+from diagram_analysis.diagram_generator import DiagramGenerator, assert_scope_containment
+from diagram_analysis.exceptions import ScopeContainmentError
+from static_analyzer.constants import Language, NodeType
 from static_analyzer.graph import CallGraph, ClusterResult
 from static_analyzer.node import Node
 
@@ -410,6 +419,136 @@ class TestMethodUniquenessNoAliases(unittest.TestCase):
         # All 6 methods should be assigned
         total = sum(len(m.methods) for c in analysis.components for m in c.file_methods)
         self.assertEqual(total, 6)
+
+
+class TestScopeContainment(unittest.TestCase):
+    """A child scope must only own methods its parent component still owns.
+
+    Reproduces the CodeBoarding-webview drift: an incremental run re-partitions the
+    root components against the live clustering, moving methods from component 1 to
+    component 2, but sub_analyses["1"] is a separate object no patch touches. Its
+    children keep the moved methods, so each one renders under component 2 *and*
+    under component 1's subtree.
+    """
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.repo_location = Path(self.temp_dir) / "repo"
+        self.repo_location.mkdir(parents=True)
+        self.output_dir = Path(self.temp_dir) / "out"
+        self.output_dir.mkdir(parents=True)
+        self.temp_folder = Path(self.temp_dir) / "tmp"
+        self.temp_folder.mkdir(parents=True)
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def _method(self, qname: str, start: int) -> MethodEntry:
+        return MethodEntry(
+            qualified_name=qname, start_line=start, end_line=start + 8, node_type="FUNCTION", content_hash="h"
+        )
+
+    def _build_tree(self):
+        """Root owns 6 methods in shared.ts, split 3/3 between components 1 and 2.
+
+        sub_analyses["1"] still covers all 6 — the state left behind after an
+        incremental run moved 3 of them from component 1 to component 2.
+        """
+        cfg = CallGraph(language="typescript")
+        shared = str(self.repo_location / "shared.ts")
+        for i in range(6):
+            cfg.add_node(Node(f"shared.func{i}", NodeType.FUNCTION, shared, i * 10 + 1, i * 10 + 9))
+        for i in range(5):
+            cfg.add_edge(f"shared.func{i}", f"shared.func{i + 1}")
+
+        keeps = [self._method(f"shared.func{i}", i * 10 + 1) for i in range(3)]
+        moved = [self._method(f"shared.func{i}", i * 10 + 1) for i in range(3, 6)]
+
+        comp_one = Component(
+            name="One",
+            description="parent that lost methods",
+            component_id="1",
+            key_entities=[SourceCodeReference(qualified_name="shared.func0")],
+            source_cluster_ids=["0"],
+            file_methods=[FileMethodGroup(file_path="shared.ts", methods=keeps)],
+        )
+        comp_two = Component(
+            name="Two",
+            description="component that gained them",
+            component_id="2",
+            key_entities=[SourceCodeReference(qualified_name="shared.func3")],
+            source_cluster_ids=["1"],
+            file_methods=[FileMethodGroup(file_path="shared.ts", methods=moved)],
+        )
+        root = AnalysisInsights(description="root", components=[comp_one, comp_two], components_relations=[])
+
+        # Child of component 1, still detailed against the pre-move boundary.
+        child = Component(
+            name="One-child",
+            description="stale subtree",
+            component_id="1.1",
+            key_entities=[SourceCodeReference(qualified_name="shared.func0")],
+            source_cluster_ids=["1.0"],
+            file_methods=[FileMethodGroup(file_path="shared.ts", methods=keeps + moved)],
+        )
+        sub_analyses = {"1": AnalysisInsights(description="sub of 1", components=[child], components_relations=[])}
+
+        static_analysis = MagicMock()
+        static_analysis.get_cfg.return_value = cfg
+        static_analysis.get_languages.return_value = [Language.TYPESCRIPT]
+        return root, sub_analyses, static_analysis
+
+    def _generator(self, static_analysis) -> DiagramGenerator:
+        gen = DiagramGenerator(
+            repo_location=self.repo_location,
+            temp_folder=self.temp_folder,
+            repo_name="repo",
+            output_dir=self.output_dir,
+            depth_level=2,
+            run_id="test-run",
+            log_path="repo/test-run",
+        )
+        # _rescope_child_analyses only needs the mixin half of IncrementalAgent.
+        gen.incremental_agent = MockMixin(repo_dir=self.repo_location, static_analysis=static_analysis)  # type: ignore[assignment]
+        return gen
+
+    def test_stale_child_scope_is_detected(self):
+        """The guard must reject a child holding methods its parent no longer owns."""
+        root, sub_analyses, _ = self._build_tree()
+
+        with self.assertRaises(ScopeContainmentError) as ctx:
+            assert_scope_containment(root, sub_analyses)
+        self.assertIn("1.1", str(ctx.exception))
+
+    def test_rescope_confines_children_to_parent(self):
+        """Re-scoping must drop the moved methods from component 1's subtree."""
+        root, sub_analyses, static_analysis = self._build_tree()
+        gen = self._generator(static_analysis)
+
+        gen._rescope_child_analyses(root, sub_analyses)
+
+        parent_owned = {m.qualified_name for g in root.components[0].file_methods for m in g.methods}
+        child_owned = {
+            m.qualified_name for c in sub_analyses["1"].components for g in c.file_methods for m in g.methods
+        }
+        self.assertEqual(child_owned - parent_owned, set(), "child escaped its parent's scope")
+        self.assertEqual(child_owned, parent_owned, "children must partition the parent exactly")
+
+        # The moved methods now belong to component 2 alone.
+        two_owned = {m.qualified_name for g in root.components[1].file_methods for m in g.methods}
+        self.assertEqual(child_owned & two_owned, set(), "method still rendered under two components")
+
+        assert_scope_containment(root, sub_analyses)
+
+    def test_rescope_empties_children_when_parent_owns_nothing(self):
+        root, sub_analyses, static_analysis = self._build_tree()
+        root.components[0].file_methods = []
+        gen = self._generator(static_analysis)
+
+        gen._rescope_child_analyses(root, sub_analyses)
+
+        self.assertEqual([m for c in sub_analyses["1"].components for g in c.file_methods for m in g.methods], [])
+        assert_scope_containment(root, sub_analyses)
 
 
 if __name__ == "__main__":

--- a/tests/agents/test_planner_agent.py
+++ b/tests/agents/test_planner_agent.py
@@ -12,13 +12,20 @@ Expansion Rules:
 
 import unittest
 
-from agents.planner_agent import should_expand_component, get_expandable_components
+import networkx as nx
+
+from agents.planner_agent import (
+    component_is_separable,
+    get_expandable_components,
+    should_expand_component,
+)
 from agents.agent_responses import (
     AnalysisInsights,
     Component,
     SourceCodeReference,
 )
 from agents.file_index_models import FileMethodGroup, MethodEntry
+from static_analyzer.graph import ClusterResult
 
 
 class TestShouldExpandComponent(unittest.TestCase):
@@ -310,6 +317,90 @@ class TestPlanAnalysis(unittest.TestCase):
         parent_had_clusters = bool(details_agent.source_cluster_ids)
         level2_expandable = get_expandable_components(level2_analysis, parent_had_clusters=parent_had_clusters)
         self.assertEqual(len(level2_expandable), 0)  # Should NOT expand - we're at leaf
+
+
+class TestComponentIsSeparable(unittest.TestCase):
+    """The modularity + method-count gate deciding whether a component splits further."""
+
+    @staticmethod
+    def _subgraph(n_blocks, clusters_per_block, methods_per_cluster, cohesive=False):
+        """Build (cluster_results, cfg_graphs) for a component subgraph.
+
+        Non-cohesive: clusters chained within a block, blocks weakly bridged (clean split).
+        Cohesive: every cluster wired to every other (one blob, no boundary).
+        """
+        n = n_blocks * clusters_per_block
+        clusters, cluster_to_files, file_to_clusters = {}, {}, {}
+        graph = nx.DiGraph()
+        for cid in range(1, n + 1):
+            members = {f"n{cid}_{j}" for j in range(methods_per_cluster)}
+            clusters[cid] = members
+            cluster_to_files[cid] = {f"/repo/c{cid}.py"}
+            file_to_clusters[f"/repo/c{cid}.py"] = {cid}
+            for m in members:
+                graph.add_node(m, file_path=f"/repo/c{cid}.py")
+        if cohesive:
+            for a in range(1, n + 1):
+                for b in range(1, n + 1):
+                    if a != b:
+                        graph.add_edge(f"n{a}_0", f"n{b}_1")
+        else:
+            for cid in range(1, n + 1):
+                block = (cid - 1) // clusters_per_block
+                for other in range(1, n + 1):
+                    if other != cid and (other - 1) // clusters_per_block == block:
+                        graph.add_edge(f"n{cid}_0", f"n{other}_1")
+            for block in range(n_blocks - 1):
+                graph.add_edge(f"n{block * clusters_per_block + 1}_0", f"n{(block + 1) * clusters_per_block + 1}_1")
+        cr = ClusterResult(
+            clusters=clusters, cluster_to_files=cluster_to_files, file_to_clusters=file_to_clusters, strategy="t"
+        )
+        return {"python": cr}, {"python": graph}
+
+    def test_large_separable_component_expands(self):
+        crs, cfgs = self._subgraph(n_blocks=3, clusters_per_block=3, methods_per_cluster=4)  # 36 methods
+        self.assertTrue(component_is_separable(crs, cfgs))
+
+    def test_large_cohesive_component_is_leaf(self):
+        crs, cfgs = self._subgraph(n_blocks=1, clusters_per_block=6, methods_per_cluster=6, cohesive=True)  # 36 methods
+        self.assertFalse(component_is_separable(crs, cfgs))
+
+    def test_small_component_is_leaf_regardless_of_structure(self):
+        # Strong structure but only 9 methods — below the min-method gate.
+        crs, cfgs = self._subgraph(n_blocks=3, clusters_per_block=1, methods_per_cluster=3)  # 9 methods
+        self.assertFalse(component_is_separable(crs, cfgs))
+
+
+class TestSeparablePredicate(unittest.TestCase):
+    """get_expandable_components honours the optional separability predicate."""
+
+    @staticmethod
+    def _expandable_component(name: str) -> Component:
+        methods = [MethodEntry(qualified_name=f"{name}.m", start_line=1, end_line=9, node_type="METHOD")]
+        return Component(
+            name=name,
+            description=name,
+            key_entities=[],
+            source_cluster_ids=["1"],
+            file_methods=[FileMethodGroup(file_path=f"{name}.py", methods=methods)],
+        )
+
+    def test_predicate_filters_cohesive_components(self):
+        analysis = AnalysisInsights(
+            description="d",
+            components=[self._expandable_component("Keep"), self._expandable_component("Drop")],
+            components_relations=[],
+        )
+        result = get_expandable_components(analysis, separable=lambda c: c.name == "Keep")
+        self.assertEqual([c.name for c in result], ["Keep"])
+
+    def test_no_predicate_preserves_structural_behavior(self):
+        analysis = AnalysisInsights(
+            description="d",
+            components=[self._expandable_component("A"), self._expandable_component("B")],
+            components_relations=[],
+        )
+        self.assertEqual(len(get_expandable_components(analysis)), 2)
 
 
 if __name__ == "__main__":

--- a/tests/diagram_analysis/test_cluster_delta.py
+++ b/tests/diagram_analysis/test_cluster_delta.py
@@ -1,14 +1,18 @@
 """Tests for ``diagram_analysis.cluster_delta`` (seeded Leiden, no fallback)."""
 
+import tempfile
 import unittest
 from pathlib import Path
 
+from agents.content_hash import hash_method_body, hash_whole_file, read_source_lines
+from agents.file_index_models import FileEntry, MethodEntry
 from diagram_analysis.cluster_delta import (
     ClusterRef,
     ClusterDelta,
     LanguageDelta,
     _affected_frontier,
     _flavor_b_seeded,
+    compute_changed_members,
     compute_cluster_delta,
     structural_diff_from_delta,
 )
@@ -564,6 +568,176 @@ class TestSeededLockGuarantee(unittest.TestCase):
         # must reach the frontier via the 1-hop expansion.
         self.assertIn("added.x", frontier)
         self.assertIn("callee.x", frontier)
+
+
+class TestMemberGranularDirty(unittest.TestCase):
+    """A body-only edit to a file whose methods span two clusters marks only the owning cluster."""
+
+    def _fixture(self, tmp: str) -> tuple[dict[str, FileEntry], StaticAnalysisResults, ChangeSet, Path]:
+        repo = Path(tmp)
+        # shared.py: m1 (cluster 1) and m2 (cluster 2) live in the same file.
+        original = "def m1():\n    return 1\n\ndef m2():\n    return 2\n"
+        (repo / "shared.py").write_text(original, encoding="utf-8")
+        orig_lines = read_source_lines(repo, "shared.py", {})
+        baseline_files = {
+            "shared.py": FileEntry(
+                content_hash=hash_whole_file(orig_lines),
+                methods=[
+                    MethodEntry(
+                        qualified_name="pkg.m1",
+                        start_line=1,
+                        end_line=2,
+                        node_type="FUNCTION",
+                        content_hash=hash_method_body(orig_lines, 1, 2),
+                    ),
+                    MethodEntry(
+                        qualified_name="pkg.m2",
+                        start_line=4,
+                        end_line=5,
+                        node_type="FUNCTION",
+                        content_hash=hash_method_body(orig_lines, 4, 5),
+                    ),
+                ],
+            )
+        }
+
+        # Edit m1's body only; an inserted line shifts m2 down. m2's body text is
+        # byte-for-byte identical, so its content hash must not change.
+        edited = "def m1():\n    x = 5\n    return 1\n\ndef m2():\n    return 2\n"
+        (repo / "shared.py").write_text(edited, encoding="utf-8")
+
+        graph = CallGraph(language="python")
+        graph.add_node(
+            Node(
+                fully_qualified_name="pkg.m1",
+                node_type=NodeType.FUNCTION,
+                file_path=str(repo / "shared.py"),
+                line_start=1,
+                line_end=3,
+            )
+        )
+        graph.add_node(
+            Node(
+                fully_qualified_name="pkg.m2",
+                node_type=NodeType.FUNCTION,
+                file_path=str(repo / "shared.py"),
+                line_start=5,
+                line_end=6,
+            )
+        )
+        static = StaticAnalysisResults()
+        static.add_cfg(Language.PYTHON, graph)
+        changes = ChangeSet(files=[FileChange(status_code="M", file_path="shared.py")])
+        return baseline_files, static, changes, repo
+
+    def _snapshot_and_delta(self) -> tuple[ClusterSnapshot, ClusterDelta]:
+        old_snapshot = ClusterSnapshot(
+            by_language={
+                "python": {
+                    1: ClusterSnapshotEntry(
+                        members={"pkg.m1"}, files={"shared.py"}, member_files={"pkg.m1": "shared.py"}
+                    ),
+                    2: ClusterSnapshotEntry(
+                        members={"pkg.m2"}, files={"shared.py"}, member_files={"pkg.m2": "shared.py"}
+                    ),
+                }
+            }
+        )
+        delta = ClusterDelta(
+            by_language={
+                "python": LanguageDelta(
+                    language="python",
+                    cluster_results=ClusterResult(
+                        clusters={1: {"pkg.m1"}, 2: {"pkg.m2"}},
+                        cluster_to_files={1: {"shared.py"}, 2: {"shared.py"}},
+                    ),
+                )
+            }
+        )
+        return old_snapshot, delta
+
+    def test_changed_members_pins_edit_to_its_method(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            baseline_files, static, changes, repo = self._fixture(tmp)
+
+            changed = compute_changed_members(baseline_files, static, changes, repo)
+
+            # m1's body changed; m2's body is unchanged despite its line shift.
+            self.assertEqual(changed.members, {"pkg.m1"})
+            self.assertEqual(changed.unattributed_files, set())
+
+    def test_only_owning_cluster_is_modified(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            baseline_files, static, changes, repo = self._fixture(tmp)
+            changed = compute_changed_members(baseline_files, static, changes, repo)
+            old_snapshot, delta = self._snapshot_and_delta()
+
+            structural = structural_diff_from_delta(
+                old_snapshot, delta, changes=changes, repo_dir=repo, changed=changed
+            )
+            lang = structural.by_language["python"]
+
+            self.assertEqual({d.old_cluster.cluster_id for d in lang.modified}, {1})
+            self.assertEqual({d.old_cluster.cluster_id for d in lang.unchanged}, {2})
+            self.assertEqual(lang.modified[0].dirty_members, {"pkg.m1"})
+            # A hashed body edit needs no file-level fallback.
+            self.assertEqual(lang.modified[0].dirty_files, set())
+
+    def test_without_member_signal_file_granular_over_reports(self) -> None:
+        # Contrast: the legacy path (no ``changed``) marks *both* clusters modified
+        # because both own the changed file — the bug this fix removes.
+        with tempfile.TemporaryDirectory() as tmp:
+            _baseline_files, _static, changes, repo = self._fixture(tmp)
+            old_snapshot, delta = self._snapshot_and_delta()
+
+            structural = structural_diff_from_delta(old_snapshot, delta, changes=changes, repo_dir=repo)
+            lang = structural.by_language["python"]
+
+            self.assertEqual({d.old_cluster.cluster_id for d in lang.modified}, {1, 2})
+
+    def test_module_level_edit_falls_back_to_file_level(self) -> None:
+        # An edit outside any hashed method (module scope) cannot be pinned to a
+        # member, so the narrow file-level fallback dirties clusters owning the file.
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            original = "CONST = 1\n\ndef m1():\n    return 1\n"
+            (repo / "shared.py").write_text(original, encoding="utf-8")
+            orig_lines = read_source_lines(repo, "shared.py", {})
+            baseline_files = {
+                "shared.py": FileEntry(
+                    content_hash=hash_whole_file(orig_lines),
+                    methods=[
+                        MethodEntry(
+                            qualified_name="pkg.m1",
+                            start_line=3,
+                            end_line=4,
+                            node_type="FUNCTION",
+                            content_hash=hash_method_body(orig_lines, 3, 4),
+                        )
+                    ],
+                )
+            }
+            # Change only the module-level constant; m1's body is untouched.
+            (repo / "shared.py").write_text("CONST = 999\n\ndef m1():\n    return 1\n", encoding="utf-8")
+
+            graph = CallGraph(language="python")
+            graph.add_node(
+                Node(
+                    fully_qualified_name="pkg.m1",
+                    node_type=NodeType.FUNCTION,
+                    file_path=str(repo / "shared.py"),
+                    line_start=3,
+                    line_end=4,
+                )
+            )
+            static = StaticAnalysisResults()
+            static.add_cfg(Language.PYTHON, graph)
+            changes = ChangeSet(files=[FileChange(status_code="M", file_path="shared.py")])
+
+            changed = compute_changed_members(baseline_files, static, changes, repo)
+
+            self.assertEqual(changed.members, set())
+            self.assertEqual(changed.unattributed_files, {"shared.py"})
 
 
 class TestDisconnectedAdditions(unittest.TestCase):

--- a/tests/diagram_analysis/test_diagram_analysis.py
+++ b/tests/diagram_analysis/test_diagram_analysis.py
@@ -1193,6 +1193,7 @@ class TestDiagramGenerator(unittest.TestCase):
             StructuralClusterDiff(),
             {},
             {},
+            None,
         )
 
         self.assertEqual(result.relation_contexts, {"root": relation_context})
@@ -1264,6 +1265,7 @@ class TestDiagramGenerator(unittest.TestCase):
             StructuralClusterDiff(),
             {},
             {"1": child},
+            None,
         )
 
         self.assertEqual(result.relation_contexts, {"root": root_context, "1": child_context})
@@ -1408,6 +1410,7 @@ class TestDiagramGenerator(unittest.TestCase):
             _mock_incremental_agent.return_value,
             gen.changes,
             gen.repo_location,
+            None,
         )
         gen._generate_subcomponents.assert_not_called()
         self.assertEqual(sub_analyses["1"].components[0].name, "Stable Child")

--- a/tests/diagram_analysis/test_diagram_analysis.py
+++ b/tests/diagram_analysis/test_diagram_analysis.py
@@ -41,6 +41,7 @@ from diagram_analysis.diagram_generator import (
     _component_expansion_seeds,
 )
 from diagram_analysis.exceptions import IncrementalCacheMissingError
+from diagram_analysis.io_utils import load_analysis_metadata, save_analysis
 from repo_utils.change_detector import ChangeSet
 from static_analyzer.analysis_cache import StaticAnalysisCache
 from static_analyzer.analysis_result import StaticAnalysisResults
@@ -751,8 +752,6 @@ class TestDepthCapPersistence(unittest.TestCase):
         return AnalysisInsights(description="Test", components=[comp], components_relations=[])
 
     def test_save_clamps_depth_cap_to_realized_depth(self):
-        from diagram_analysis.io_utils import load_analysis_metadata, save_analysis
-
         # A depth-1 baseline (no sub-analyses) with a low configured cap.
         save_analysis(
             analysis=self._make_root(),
@@ -786,8 +785,6 @@ class TestDepthCapPersistence(unittest.TestCase):
         self.assertEqual(metadata["depth_cap"], 2)
 
     def test_save_preserves_higher_cap_than_realized_depth(self):
-        from diagram_analysis.io_utils import load_analysis_metadata, save_analysis
-
         # A shallow realized tree with a cap that's already deeper (separability
         # decided there was nothing more to split) must keep the higher cap.
         save_analysis(

--- a/tests/diagram_analysis/test_diagram_analysis.py
+++ b/tests/diagram_analysis/test_diagram_analysis.py
@@ -120,7 +120,9 @@ class TestUnifiedAnalysisJson(unittest.TestCase):
         rel = RelationJson(src_name="Comp1", dst_name="Comp2", relation="uses")
 
         analysis = UnifiedAnalysisJson(
-            metadata=AnalysisMetadata(generated_at="2026-01-01T00:00:00Z", repo_name="test", depth_level=1),
+            metadata=AnalysisMetadata(
+                generated_at="2026-01-01T00:00:00Z", repo_name="test", depth_level=1, depth_cap=1
+            ),
             description="Test analysis",
             components=[comp1, comp2],
             components_relations=[rel],
@@ -142,7 +144,9 @@ class TestUnifiedAnalysisJson(unittest.TestCase):
             key_entities=[],
         )
         analysis = UnifiedAnalysisJson(
-            metadata=AnalysisMetadata(generated_at="2026-01-01T00:00:00Z", repo_name="test", depth_level=1),
+            metadata=AnalysisMetadata(
+                generated_at="2026-01-01T00:00:00Z", repo_name="test", depth_level=1, depth_cap=1
+            ),
             description="Test",
             components=[comp],
             components_relations=[],
@@ -424,7 +428,9 @@ class TestAnalysisJsonConversion(unittest.TestCase):
         ]
 
         data = json.loads(
-            build_unified_analysis_json(self.analysis, [], "repo", repo_dir=self.repo_dir, source_tree_hash="")
+            build_unified_analysis_json(
+                self.analysis, [], "repo", repo_dir=self.repo_dir, source_tree_hash="", depth_cap=1
+            )
         )
         parsed, _ = parse_unified_analysis(data)
 
@@ -467,7 +473,9 @@ class TestAnalysisJsonConversion(unittest.TestCase):
         ]
 
         data = json.loads(
-            build_unified_analysis_json(self.analysis, [], "repo", repo_dir=self.repo_dir, source_tree_hash="")
+            build_unified_analysis_json(
+                self.analysis, [], "repo", repo_dir=self.repo_dir, source_tree_hash="", depth_cap=1
+            )
         )
         parsed, _ = parse_unified_analysis(data)
 
@@ -481,7 +489,9 @@ class TestAnalysisJsonConversion(unittest.TestCase):
 
     def test_unified_analysis_parse_recovers_edges_missing_from_methods_index(self):
         data = json.loads(
-            build_unified_analysis_json(self.analysis, [], "repo", repo_dir=self.repo_dir, source_tree_hash="")
+            build_unified_analysis_json(
+                self.analysis, [], "repo", repo_dir=self.repo_dir, source_tree_hash="", depth_cap=1
+            )
         )
         data["components_relations"] = [
             {
@@ -535,7 +545,9 @@ class TestAnalysisJsonConversion(unittest.TestCase):
         index_relation_endpoints(self.analysis, self.repo_dir)
 
         data = json.loads(
-            build_unified_analysis_json(self.analysis, [], "repo", repo_dir=self.repo_dir, source_tree_hash="")
+            build_unified_analysis_json(
+                self.analysis, [], "repo", repo_dir=self.repo_dir, source_tree_hash="", depth_cap=1
+            )
         )
 
         self.assertNotIn("|importlib.metadata.entry_points", data["methods_index"])
@@ -553,7 +565,9 @@ class TestAnalysisJsonConversion(unittest.TestCase):
         # builder no longer re-walks the tree to recompute it.
         precomputed = "a1b2c3d4e5f60718"
         data = json.loads(
-            build_unified_analysis_json(self.analysis, [], "repo", repo_dir=self.repo_dir, source_tree_hash=precomputed)
+            build_unified_analysis_json(
+                self.analysis, [], "repo", repo_dir=self.repo_dir, source_tree_hash=precomputed, depth_cap=1
+            )
         )
         self.assertEqual(data["metadata"]["source_tree_hash"], precomputed)
 
@@ -1012,6 +1026,7 @@ class TestDiagramGenerator(unittest.TestCase):
             repo_name,
             repo_dir,
             source_tree_hash,
+            depth_cap,
             sub_analyses,
             file_coverage_summary,
         ):

--- a/tests/diagram_analysis/test_diagram_analysis.py
+++ b/tests/diagram_analysis/test_diagram_analysis.py
@@ -34,7 +34,12 @@ from diagram_analysis.analysis_json import (
     parse_unified_analysis,
 )
 from diagram_analysis.cluster_delta import ClusterMemberDelta, ClusterRef, LanguageStructuralDiff, StructuralClusterDiff
-from diagram_analysis.diagram_generator import DiagramGenerator, _component_depth, _component_expansion_seeds
+from diagram_analysis.diagram_generator import (
+    DiagramGenerator,
+    _child_scope_needs_recursive_update,
+    _component_depth,
+    _component_expansion_seeds,
+)
 from diagram_analysis.exceptions import IncrementalCacheMissingError
 from repo_utils.change_detector import ChangeSet
 from static_analyzer.analysis_cache import StaticAnalysisCache
@@ -1199,6 +1204,60 @@ class TestDiagramGenerator(unittest.TestCase):
         )
 
         self.assertEqual(result.relation_contexts, {"root": relation_context})
+
+    def test_child_scope_recurses_on_owned_dirty_file(self):
+        # A module-level edit surfaces only as dirty_files (no qname signal); a child that owns
+        # that file must still be recursed into so its descriptions/relations don't go stale.
+        child_scope = AnalysisInsights(
+            description="child",
+            components=[
+                Component(
+                    name="Child",
+                    description="",
+                    key_entities=[],
+                    component_id="1.1",
+                    file_methods=[
+                        FileMethodGroup(
+                            file_path="pkg/module.py",
+                            methods=[MethodEntry(qualified_name="pkg.m", start_line=1, end_line=5, node_type="METHOD")],
+                        )
+                    ],
+                )
+            ],
+            components_relations=[],
+        )
+        dirty_only = StructuralClusterDiff(
+            by_language={
+                "python": LanguageStructuralDiff(
+                    language="python",
+                    modified=[
+                        ClusterMemberDelta(
+                            old_cluster=ClusterRef(language="python", cluster_id=1),
+                            new_cluster=ClusterRef(language="python", cluster_id=1),
+                            dirty_files={"pkg/module.py"},
+                        )
+                    ],
+                )
+            }
+        )
+        self.assertTrue(_child_scope_needs_recursive_update(child_scope, dirty_only))
+
+        # A dirty file the child does not own must not trigger a recursive update.
+        other_file = StructuralClusterDiff(
+            by_language={
+                "python": LanguageStructuralDiff(
+                    language="python",
+                    modified=[
+                        ClusterMemberDelta(
+                            old_cluster=ClusterRef(language="python", cluster_id=1),
+                            new_cluster=ClusterRef(language="python", cluster_id=1),
+                            dirty_files={"other/elsewhere.py"},
+                        )
+                    ],
+                )
+            }
+        )
+        self.assertFalse(_child_scope_needs_recursive_update(child_scope, other_file))
 
     @patch("diagram_analysis.diagram_generator._build_scope_incremental_inputs")
     def test_recursive_scope_update_aggregates_relation_contexts(self, mock_build_scope_inputs):

--- a/tests/diagram_analysis/test_diagram_analysis.py
+++ b/tests/diagram_analysis/test_diagram_analysis.py
@@ -1390,6 +1390,7 @@ class TestDiagramGenerator(unittest.TestCase):
                 new_component_ids=set(),
             ),
         ]
+        _mock_incremental_agent.return_value._create_strict_component_subgraph.return_value = ("", {}, {})
         mock_save_analysis.return_value = self.output_dir / "analysis.json"
 
         gen.generate_analysis_incremental(root_analysis, sub_analyses)
@@ -1509,6 +1510,7 @@ class TestDiagramGenerator(unittest.TestCase):
         gen.details_agent = Mock()
         gen.incremental_planning_agent = Mock()
         gen.incremental_agent = Mock()
+        gen.incremental_agent._create_strict_component_subgraph.return_value = ("", {}, {})
         gen.static_analysis = Mock()
         gen.static_analysis.get_languages.return_value = []
         gen.static_analysis.incremental_base_results = Mock()

--- a/tests/diagram_analysis/test_diagram_analysis.py
+++ b/tests/diagram_analysis/test_diagram_analysis.py
@@ -726,6 +726,84 @@ class TestAnalysisJsonConversion(unittest.TestCase):
         self.assertIn("  ", json_str)  # 2-space indentation
 
 
+class TestDepthCapPersistence(unittest.TestCase):
+    """depth_cap must never be saved lower than the tree's own realized depth —
+    a partial run against a shallow baseline that grafts on a deeper subtree
+    would otherwise permanently freeze future incremental/partial runs at the
+    old, shallower cap even though the tree has already gone deeper."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.output_dir = Path(self.temp_dir)
+        self.repo_dir = Path(".")
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def _make_root(self) -> AnalysisInsights:
+        comp = Component(
+            name="Root",
+            component_id="1",
+            description="Root component",
+            key_entities=[],
+            file_methods=[FileMethodGroup(file_path="file1.py")],
+        )
+        return AnalysisInsights(description="Test", components=[comp], components_relations=[])
+
+    def test_save_clamps_depth_cap_to_realized_depth(self):
+        from diagram_analysis.io_utils import load_analysis_metadata, save_analysis
+
+        # A depth-1 baseline (no sub-analyses) with a low configured cap.
+        save_analysis(
+            analysis=self._make_root(),
+            output_dir=self.output_dir,
+            repo_dir=self.repo_dir,
+            source_tree_hash="hash1",
+            repo_name="test",
+            depth_cap=1,
+        )
+        baseline_metadata = load_analysis_metadata(self.output_dir)
+        assert baseline_metadata is not None
+        self.assertEqual(baseline_metadata["depth_cap"], 1)
+
+        # Partial run grafts a depth-2 subtree onto the root (component "1" now
+        # has sub_analyses["1"]), but is still constructed with the old cap (1)
+        # — saving must not persist depth_cap=1 now that the realized tree is
+        # 2 levels deep.
+        child_analysis = AnalysisInsights(description="Child", components=[], components_relations=[])
+        save_analysis(
+            analysis=self._make_root(),
+            output_dir=self.output_dir,
+            repo_dir=self.repo_dir,
+            source_tree_hash="hash2",
+            repo_name="test",
+            sub_analyses={"1": child_analysis},
+            depth_cap=1,
+        )
+        metadata = load_analysis_metadata(self.output_dir)
+        assert metadata is not None
+        self.assertEqual(metadata["depth_level"], 2)
+        self.assertEqual(metadata["depth_cap"], 2)
+
+    def test_save_preserves_higher_cap_than_realized_depth(self):
+        from diagram_analysis.io_utils import load_analysis_metadata, save_analysis
+
+        # A shallow realized tree with a cap that's already deeper (separability
+        # decided there was nothing more to split) must keep the higher cap.
+        save_analysis(
+            analysis=self._make_root(),
+            output_dir=self.output_dir,
+            repo_dir=self.repo_dir,
+            source_tree_hash="hash1",
+            repo_name="test",
+            depth_cap=3,
+        )
+        metadata = load_analysis_metadata(self.output_dir)
+        assert metadata is not None
+        self.assertEqual(metadata["depth_level"], 1)
+        self.assertEqual(metadata["depth_cap"], 3)
+
+
 class TestDiagramGenerator(unittest.TestCase):
     def setUp(self):
         # Create temporary directories for testing

--- a/tests/diagram_analysis/test_diagram_analysis.py
+++ b/tests/diagram_analysis/test_diagram_analysis.py
@@ -1020,10 +1020,12 @@ class TestDiagramGenerator(unittest.TestCase):
             ):
                 gen.generate_analysis()
 
-        # Both components have files, so both should be expandable (io_utils merges caller-provided with computed)
+        # The run's separability-respecting expandable set is authoritative: only the planned
+        # component ("1") is advertised as expandable. Component "2" was kept as a leaf and must
+        # NOT be re-added by the save-time structural recompute.
         self.assertEqual(
             sorted([c.component_id for c in captured["expandable_components"]]),
-            sorted([c.component_id for c in analysis.components]),
+            [comp1.component_id],
         )
 
     @patch("diagram_analysis.diagram_generator.get_expandable_components")

--- a/tests/static_analyzer/test_cluster_helpers.py
+++ b/tests/static_analyzer/test_cluster_helpers.py
@@ -40,8 +40,8 @@ class TestClusterHelpers(unittest.TestCase):
 
         python_cfg.cluster.return_value = self._make_cluster_result("py", 40)
         typescript_cfg.cluster.return_value = self._make_cluster_result("ts", 40)
-        python_cfg.to_networkx.return_value = object()
-        typescript_cfg.to_networkx.return_value = object()
+        python_cfg.clustering_networkx.return_value = object()
+        typescript_cfg.clustering_networkx.return_value = object()
 
         analysis.get_cfg.side_effect = lambda language: {
             "python": python_cfg,

--- a/tests/static_analyzer/test_cluster_helpers.py
+++ b/tests/static_analyzer/test_cluster_helpers.py
@@ -8,7 +8,12 @@ from static_analyzer.cluster_helpers import (
     build_all_cluster_results,
     enforce_cross_language_budget,
     reindex_cluster_result,
+    subgraph_peak_modularity,
+    supercluster_by_modularity_peak,
+    supercluster_leaf_ids,
     MAX_LLM_CLUSTERS,
+    TOP_LEVEL_COMPONENTS_MAX,
+    TOP_LEVEL_COMPONENTS_MIN,
 )
 from static_analyzer.graph import ClusterResult
 
@@ -127,6 +132,152 @@ class TestClusterHelpers(unittest.TestCase):
 
         self.assertIs(cluster_results["python"], cr)
         self.assertEqual(set(cr.clusters.keys()), set(range(1, 11)))
+
+
+class TestSuperClusterModularityPeak(unittest.TestCase):
+    @staticmethod
+    def _blocks(n_blocks: int, per_block: int, weak_bridges: bool = True):
+        """A ClusterResult + meta-friendly cfg with ``n_blocks`` tight blocks of leaf clusters."""
+        clusters, cluster_to_files, file_to_clusters = {}, {}, {}
+        graph = nx.DiGraph()
+        n = n_blocks * per_block
+        for cid in range(1, n + 1):
+            block = (cid - 1) // per_block
+            nodes = [f"n{cid}_{j}" for j in range(3)]
+            clusters[cid] = set(nodes)
+            path = f"/repo/block{block}/c{cid}.py"
+            cluster_to_files[cid] = {path}
+            file_to_clusters[path] = {cid}
+            for node in nodes:
+                graph.add_node(node, file_path=path)
+        # Dense calls within a block, so each block is a tight community.
+        for cid in range(1, n + 1):
+            block = (cid - 1) // per_block
+            for other in range(1, n + 1):
+                if other != cid and (other - 1) // per_block == block:
+                    graph.add_edge(f"n{cid}_0", f"n{other}_1")
+        if weak_bridges:
+            for block in range(n_blocks - 1):
+                graph.add_edge(f"n{block * per_block + 1}_0", f"n{(block + 1) * per_block + 1}_1")
+        cr = ClusterResult(
+            clusters=clusters, cluster_to_files=cluster_to_files, file_to_clusters=file_to_clusters, strategy="t"
+        )
+        return cr, graph
+
+    def _assert_partition(self, groups, expected_ids):
+        assigned = [cid for group in groups for cid in group]
+        self.assertEqual(sorted(assigned), sorted(expected_ids))
+        self.assertEqual(len(assigned), len(set(assigned)), "clusters must be partitioned, not shared")
+
+    def test_recovers_natural_block_count_within_range(self):
+        cr, graph = self._blocks(n_blocks=6, per_block=5)
+        groups = supercluster_by_modularity_peak(cr, graph)
+        self.assertEqual(len(groups), 6)
+        self._assert_partition(groups, range(1, 31))
+
+    def test_count_is_clamped_to_range(self):
+        # 10 natural blocks, but the count must not exceed the max.
+        cr, graph = self._blocks(n_blocks=10, per_block=4)
+        groups = supercluster_by_modularity_peak(cr, graph)
+        self.assertTrue(TOP_LEVEL_COMPONENTS_MIN <= len(groups) <= TOP_LEVEL_COMPONENTS_MAX)
+        self._assert_partition(groups, range(1, 41))
+
+    def test_deterministic_across_runs(self):
+        cr, graph = self._blocks(n_blocks=7, per_block=4)
+        first = supercluster_by_modularity_peak(cr, graph)
+        second = supercluster_by_modularity_peak(cr, graph)
+        self.assertEqual(sorted(map(sorted, first)), sorted(map(sorted, second)))
+
+    def test_fewer_clusters_than_floor_returns_singletons(self):
+        cr, graph = self._blocks(n_blocks=1, per_block=3, weak_bridges=False)
+        groups = supercluster_by_modularity_peak(cr, graph)
+        self.assertEqual(len(groups), 3)
+        self._assert_partition(groups, range(1, 4))
+
+    def test_isolated_clusters_absorbed_by_file_overlap(self):
+        # No inter-cluster edges at all; absorption falls back to file overlap.
+        clusters = {cid: {f"n{cid}"} for cid in range(1, 21)}
+        # Four clusters share each of five files, so overlap can regroup them.
+        cluster_to_files = {cid: {f"/repo/dir{(cid - 1) // 4}.py"} for cid in range(1, 21)}
+        file_to_clusters: dict[str, set[int]] = {}
+        for cid, files in cluster_to_files.items():
+            for f in files:
+                file_to_clusters.setdefault(f, set()).add(cid)
+        cr = ClusterResult(
+            clusters=clusters, cluster_to_files=cluster_to_files, file_to_clusters=file_to_clusters, strategy="t"
+        )
+        graph = nx.DiGraph()
+        for cid in range(1, 21):
+            graph.add_node(f"n{cid}", file_path=next(iter(cluster_to_files[cid])))
+        groups = supercluster_by_modularity_peak(cr, graph)
+        self.assertEqual(len(groups), TOP_LEVEL_COMPONENTS_MIN)
+        self._assert_partition(groups, range(1, 21))
+
+    def test_large_isolated_cluster_becomes_its_own_component(self):
+        # A connected core plus one big, call-isolated module (e.g. a data-model
+        # file nothing calls). The big module must stay its own component, not be
+        # folded into a seed.
+        cr, graph = self._blocks(n_blocks=4, per_block=3)
+        big_id = 999
+        cr.clusters[big_id] = {f"models.Model{i}" for i in range(60)}  # 60 methods, no call edges
+        cr.cluster_to_files[big_id] = {"/repo/models/schema.py"}
+        cr.file_to_clusters["/repo/models/schema.py"] = {big_id}
+        graph.add_node("models.Model0", file_path="/repo/models/schema.py")
+
+        groups = supercluster_by_modularity_peak(cr, graph)
+        owner = next(group for group in groups if big_id in group)
+        # It seeded its own group rather than being absorbed into a larger one.
+        self.assertEqual(owner, {big_id})
+
+    def test_leaf_ids_combines_languages_into_single_budget(self):
+        cr_py, graph = self._blocks(n_blocks=6, per_block=5)
+        # Split the same clusters/graph across two languages by cluster id.
+        py_clusters = {cid: cr_py.clusters[cid] for cid in range(1, 16)}
+        js_clusters = {cid: cr_py.clusters[cid] for cid in range(16, 31)}
+        py = ClusterResult(clusters=py_clusters, cluster_to_files=cr_py.cluster_to_files, strategy="t")
+        js = ClusterResult(clusters=js_clusters, cluster_to_files=cr_py.cluster_to_files, strategy="t")
+        groups = supercluster_leaf_ids({"python": py, "javascript": js}, {"python": graph, "javascript": graph})
+        self.assertTrue(TOP_LEVEL_COMPONENTS_MIN <= len(groups) <= TOP_LEVEL_COMPONENTS_MAX)
+        self._assert_partition(groups, range(1, 31))
+
+
+class TestSubgraphPeakModularity(unittest.TestCase):
+    @staticmethod
+    def _cr_and_graph(clusters, edges):
+        """A ClusterResult (one node per leaf cluster) + a DiGraph with the given cluster-id edges."""
+        cluster_map = {cid: {f"n{cid}"} for cid in clusters}
+        cluster_to_files = {cid: {f"/repo/c{cid}.py"} for cid in clusters}
+        file_to_clusters = {f"/repo/c{cid}.py": {cid} for cid in clusters}
+        graph = nx.DiGraph()
+        for cid in clusters:
+            graph.add_node(f"n{cid}", file_path=f"/repo/c{cid}.py")
+        for s, d in edges:
+            graph.add_edge(f"n{s}", f"n{d}")
+        cr = ClusterResult(
+            clusters=cluster_map, cluster_to_files=cluster_to_files, file_to_clusters=file_to_clusters, strategy="t"
+        )
+        return {"python": cr}, {"python": graph}
+
+    def test_separable_structure_scores_high(self):
+        # Three tight triangles, weakly bridged -> clean community split -> high modularity.
+        edges = [(1, 2), (2, 3), (3, 1), (4, 5), (5, 6), (6, 4), (7, 8), (8, 9), (9, 7), (1, 4), (4, 7)]
+        crs, cfgs = self._cr_and_graph(range(1, 10), edges)
+        self.assertGreater(subgraph_peak_modularity(crs, cfgs), 0.25)
+
+    def test_cohesive_blob_scores_low(self):
+        # A single fully-connected clique has no internal boundary -> ~0 modularity.
+        ids = range(1, 7)
+        edges = [(s, d) for s in ids for d in ids if s != d]
+        crs, cfgs = self._cr_and_graph(ids, edges)
+        self.assertLess(subgraph_peak_modularity(crs, cfgs), 0.25)
+
+    def test_no_edges_scores_zero(self):
+        crs, cfgs = self._cr_and_graph(range(1, 6), [])
+        self.assertEqual(subgraph_peak_modularity(crs, cfgs), 0.0)
+
+    def test_single_cluster_scores_zero(self):
+        crs, cfgs = self._cr_and_graph([1], [])
+        self.assertEqual(subgraph_peak_modularity(crs, cfgs), 0.0)
 
 
 if __name__ == "__main__":

--- a/tests/static_analyzer/test_result_converter.py
+++ b/tests/static_analyzer/test_result_converter.py
@@ -590,3 +590,77 @@ class TestOutputStructure:
         assert "diagnostics" in out
         assert out["diagnostics"] == {}
         assert out["source_files"] == ["/root/mod.py"]
+
+
+# ---------------------------------------------------------------------------
+# Reference edges (CONTAINS / INHERITS / TYPEREF / IMPORT)
+# ---------------------------------------------------------------------------
+
+
+def test_add_reference_edges_contains_and_inherits():
+    """CONTAINS from the qualified-name hierarchy; INHERITS from the class hierarchy."""
+    from static_analyzer.engine.result_converter import _add_reference_edges
+    from static_analyzer.graph import CallGraph, EdgeKind
+    from static_analyzer.node import Node
+
+    cg = CallGraph(language="python")
+    for i, (qname, kind) in enumerate(
+        [
+            ("mod.Base", NodeType.CLASS),
+            ("mod.Widget", NodeType.CLASS),
+            ("mod.Widget.render", NodeType.METHOD),
+            ("mod.Widget.__init__", NodeType.METHOD),
+            ("mod.helper", NodeType.FUNCTION),
+        ]
+    ):
+        cg.add_node(
+            Node(
+                fully_qualified_name=qname,
+                node_type=kind,
+                file_path="mod.py",
+                line_start=i * 10 + 1,
+                line_end=i * 10 + 5,
+            )
+        )
+
+    result = LanguageAnalysisResult(
+        hierarchy={"mod.Widget": {"superclasses": ["mod.Base"], "subclasses": []}},
+        type_references=[("mod.helper", "mod.Widget")],
+        import_edges=[("mod.helper", "mod.Base")],
+    )
+    _add_reference_edges(cg, result)
+
+    got = {(s, d, k) for s, d, k in cg.reference_edges}
+    # methods -> their class
+    assert ("mod.Widget.render", "mod.Widget", str(EdgeKind.CONTAINS)) in got
+    assert ("mod.Widget.__init__", "mod.Widget", str(EdgeKind.CONTAINS)) in got
+    # subclass -> superclass
+    assert ("mod.Widget", "mod.Base", str(EdgeKind.INHERITS)) in got
+    # engine-supplied typeref / import
+    assert ("mod.helper", "mod.Widget", str(EdgeKind.TYPEREF)) in got
+    assert ("mod.helper", "mod.Base", str(EdgeKind.IMPORT)) in got
+    # top-level function is not "contained" by any class
+    assert not any(s == "mod.helper" and k == str(EdgeKind.CONTAINS) for s, d, k in cg.reference_edges)
+
+
+def test_clustering_networkx_includes_configured_reference_kinds():
+    from static_analyzer.graph import CallGraph, EdgeKind
+    from static_analyzer.node import Node
+
+    cg = CallGraph(language="python")
+    for i, qname in enumerate(("mod.A", "mod.B")):
+        cg.add_node(
+            Node(
+                fully_qualified_name=qname,
+                node_type=NodeType.CLASS,
+                file_path="mod.py",
+                line_start=i * 10 + 1,
+                line_end=i * 10 + 5,
+            )
+        )
+    cg.add_reference_edge("mod.A", "mod.B", EdgeKind.CONTAINS)
+
+    # default kinds include contains -> edge present
+    assert cg.clustering_networkx().has_edge("mod.A", "mod.B")
+    # restricting to a kind that isn't present -> edge absent (call graph had no edges)
+    assert not cg.clustering_networkx(reference_kinds={"import"}).has_edge("mod.A", "mod.B")

--- a/tests/test_github_action.py
+++ b/tests/test_github_action.py
@@ -5,7 +5,9 @@ import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+from diagram_analysis import DEFAULT_DEPTH_LEVEL
 from github_action import (
+    _resolve_depth_level,
     generate_analysis,
     generate_html,
     generate_markdown,
@@ -424,6 +426,47 @@ class TestGenerateAnalysis(unittest.TestCase):
             mock_checkout.assert_called_once()
             args = mock_checkout.call_args[0]
             self.assertEqual(args[1], "feature-branch")
+
+
+class TestResolveDepthLevel(unittest.TestCase):
+    """An action incremental over a seeded baseline must reuse the baseline's
+    own configured cap, not silently re-cap it at the current default."""
+
+    @patch.dict(os.environ, {"DIAGRAM_DEPTH_LEVEL": "5"}, clear=True)
+    def test_env_var_takes_priority_over_seeded_baseline(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            _write_analysis_file(temp_path / "analysis.json")
+            self.assertEqual(_resolve_depth_level(temp_path), 5)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_seeded_baseline_depth_cap_used_when_env_var_unset(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            metadata: dict[str, object] = {
+                "generated_at": "2024-01-01T00:00:00Z",
+                "repo_name": "test",
+                "depth_level": 1,
+                "depth_cap": 4,
+            }
+            analysis = {**UNIFIED_ANALYSIS_JSON, "metadata": metadata}
+            with open(temp_path / "analysis.json", "w") as f:
+                json.dump(analysis, f)
+
+            self.assertEqual(_resolve_depth_level(temp_path), 4)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_legacy_baseline_falls_back_to_depth_level(self):
+        """Baselines written before depth_cap existed only have depth_level."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            _write_analysis_file(temp_path / "analysis.json")  # depth_level=1, no depth_cap
+            self.assertEqual(_resolve_depth_level(temp_path), 1)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_no_baseline_falls_back_to_default(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            self.assertEqual(_resolve_depth_level(Path(temp_dir)), DEFAULT_DEPTH_LEVEL)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What this does

Makes an **incremental** re-analysis (re-running after a code change) update **only the parts of the architecture diagram that actually changed**, instead of reshuffling the whole thing. Brings the CallGraph engine in line with the ProgramGraph work in #422.

## The problem, in plain terms

When you edit a few lines and re-run, you want the diagram to touch only what you changed. It didn't — a small edit could light up most of the high-level components and move unchanged code around. Three separate things caused that, and this PR fixes each.

## The four fixes

**1. Only flag a component as changed when *its own* code changed** (member-granular detection)
Before, a component was marked "changed" if it merely shared a *file* with an edit — even if none of its own methods were touched. Because one file's methods can belong to several components, one small edit lit up many of them. Now we compare a hash of each method's body against the saved one and flag a component only when a method it actually owns changed.

**2. Put unchanged code back where it was** (this is what "copy-forward" means)
The step that groups methods into components isn't perfectly stable: re-running it can shuffle *unchanged* methods between components. "Copy-forward" is the fix: after re-grouping, we put every unchanged method back on its original shelf and keep each unchanged component's name, description, and connections exactly as they were. Only the genuinely-changed parts move or get rewritten. This is what takes method-owner stability on a large change from **44% to 98%**.

**3. Keep every method under exactly one component** (containment, from #416)
On a big change, a heavy re-grouping could leave the same method showing up under *two* different components at once — we measured **253** such cases on the large benchmark. #416 confines each child scope to its parent, so a method belongs to exactly one place. Now: **0**.

**4. Fix the file-coverage count** (bookkeeping)
The "how many files did we analyze vs. skip" summary didn't add up (it reported *every* file as not-analyzed on top of the analyzed ones: 182 analyzed + 455 not-analyzed on a repo of 455 files). Cause: analyzed-file paths came back resolved through a macOS `/var → /private/var` symlink while the repo root didn't, so they never matched and none were subtracted. Fixed so the paths reconcile and the totals add up (182 + 273 = 455).

## Results (all against the same CallGraph baselines main uses)

| Benchmark | before these fixes | after |
|---|---|---|
| CodeBoarding **small** (5-file edit) | 2/6 modified, **74%** method stability | ~1/6*, **~100%** |
| CodeBoarding **large** (102-file restructure) | 6/6, **44%** stability, **253** methods double-owned | 6/6, **98%**, **0** double-owned |
| **markitdown** (real converter edit) | — | 1/5, 100%, correctly detects the change |

*small "modified count" varies 0–2/6 across runs because the LLM decides how many descriptions to refresh; method-owner stability stays ~100% throughout.

This matches the ProgramGraph approach (#422) on CodeBoarding and is actually more robust on markitdown, where #422's copy-forward misses the change (0/7) but this branch detects it (1/5). Validation runs are recorded in the evals repo (`eval-results/incremental-clustering-study`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Incremental updates now attribute edits at method granularity, marking only the owning component as modified.
  * Structural-diff output now reports member-level changes (“changed members”) in addition to file-level fallbacks.
  * Top-level component grouping/expansion is more deterministic via modularity-peak partitioning and a separability gate, including “one component per group” assembly.
* **Bug Fixes**
  * Partial refresh now repairs child-scope containment before saving.
  * Added strict scope-containment enforcement to prevent cross-scope method drift; relation preservation is improved for unchanged endpoints.
  * Improved relative-path normalization for symlinked roots.
* **Tests**
  * Added/updated tests for member-granular dirtying, stale child-scope detection, separability filtering, and deterministic clustering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Update — method-granular edge preservation (`a5b43052`)

**What it adds.** The incremental save re-derives every component's call edges from the call graph, so a change that touched a component re-derived *all* of that component's edges — including edges belonging to methods that did **not** change — which churned them. This commit rebuilds a changed component's edges at **method granularity**: keep the baseline edge for any method whose body did not change, take a fresh edge only from a body-changed or newly-added method, and drop edges whose source or target method was deleted.

**Measured on the benchmark probes (E1 null control, E8 symbol removal):**

| | E1 — body edit, must be silent | E8 — symbol removal |
|---|---|---|
| before | `EDGE_ADDED 3`, `EDGE_EVIDENCE_CHANGED 44` | `EDGE_ADDED 9`, `MEMBERSHIP_MOVED 1` |
| after | `EDGE_ADDED 1`, `EDGE_EVIDENCE_CHANGED 2` | `EDGE_ADDED 2`, `MEMBERSHIP_MOVED 1` |

E1's edge churn drops ~93% (47 edge ops → 3); E8's spurious additions fall 9 → 2.

**What it does not fix, and why.** Investigation established that the underlying LSP call-edge **extraction is deterministic** — 687 raw call-graph edges, 100% identical across six independent runs (standalone and from two full-pipeline pkls). The residual churn is **clustering non-determinism**: the same deterministic edges get attributed to different component pairs run-to-run because membership assignment varies (e.g. an unchanged method's component id renumbers `3.1.5→3.1.4`). That is a separate membership-stability problem, and an extraction-layer "retry timed-out queries" experiment confirmed it changed nothing (extraction was already 100% stable).
