### PR TITLE
Stop incremental churn on content-only changes (benchmark hardening on top of #423)

### DIFF
--- a/diagram_analysis/diagram_generator.py
+++ b/diagram_analysis/diagram_generator.py
@@ -408,13 +408,17 @@ def _incremental_changed_component_ids(
     """Component ids whose global relations may legitimately differ from the baseline.
 
     A live component counts as changed when it is absent from the baseline (freshly
-    created), owns a body-changed member, or its live member-key set differs from the
-    baseline — it gained or lost a member. Membership churn alone (a new caller of another
-    component, or the last caller removed) relabels the edges between the two components
-    even with no surviving body-hash change, so it must be treated as changed or the
-    genuinely-new edge is dropped / the stale baseline edge restored. Because every ancestor
-    scope lists a method in its own ``file_methods``, the owner of a change and all of its
-    ancestors are captured together. Everything else is preserved verbatim.
+    created) or its live member-key set differs from the baseline — it gained, lost or
+    handed over a member. Membership churn (a new caller of another component, the last
+    caller removed, or a moved method) relabels the edges between the two components, so it
+    must be treated as changed or the genuinely-new edge is dropped / the stale baseline
+    edge restored. A body-only edit is deliberately NOT enough on its own: it changes a
+    method's content but not which methods call which, so the component's edges are
+    identical to the baseline and re-deriving them only introduces re-analysis churn
+    (relabelled evidence, occasional spurious edges). The description still refreshes via
+    the refresh set; only the edges are preserved. Because every ancestor scope lists a
+    method in its own ``file_methods``, the owner of a change and all of its ancestors are
+    captured together. Everything else is preserved verbatim.
     """
     changed: set[str] = set()
     for _scope_id, analysis in _iter_incremental_scopes(root_analysis, sub_analyses):
@@ -425,11 +429,8 @@ def _incremental_changed_component_ids(
             live_keys = frozenset(
                 (group.file_path, method.qualified_name) for group in component.file_methods for method in group.methods
             )
-            body_changed = any(
-                method.qualified_name in changed_members for group in component.file_methods for method in group.methods
-            )
             membership_changed = live_keys != baseline_member_keys.get(component_id, frozenset())
-            if component_id not in baseline_component_ids or body_changed or membership_changed:
+            if component_id not in baseline_component_ids or membership_changed:
                 changed.add(component_id)
     return changed
 
@@ -1207,6 +1208,18 @@ class DiagramGenerator:
             for relation in root_analysis.components_relations
             if relation.src_id and relation.dst_id
         }
+        # Per-component baseline member keys, captured pre-mutation so the save-time relation
+        # preservation works on BOTH the re-cluster path and the empty-delta path (a body-only
+        # edit). Without it the empty-delta path sees no baseline and treats every component as
+        # changed, re-deriving all edges and churning them for a change that moved nothing.
+        self._baseline_member_keys = {
+            component.component_id: frozenset(
+                (group.file_path, method.qualified_name) for group in component.file_methods for method in group.methods
+            )
+            for _scope_id, analysis in _iter_incremental_scopes(root_analysis, sub_analyses)
+            for component in analysis.components
+            if component.component_id
+        }
 
         monitor = self.stats_writer if self.stats_writer else nullcontext()
         with monitor:
@@ -1282,10 +1295,6 @@ class DiagramGenerator:
             )
             protected_empty_ids = _cluster_backed_empty_component_ids(root_analysis, sub_analyses)
             baseline_membership = _capture_membership_baseline(root_analysis, sub_analyses)
-            # Feed the per-component baseline member keys to the save-time global relation
-            # rebuild so a component that only gained/lost a member (no body-hash change) is
-            # still treated as changed and its edges are re-derived, not carried over stale.
-            self._baseline_member_keys = {cid: meta.member_keys for cid, meta in baseline_membership.meta_by_id.items()}
             apply_result = self._apply_incremental_scope_recursively(
                 ROOT_SCOPE_ID,
                 root_analysis,


### PR DESCRIPTION
# Stop the incremental engine from churning the graph when nothing structural changed

Builds on #423. Two small change-detection fixes that remove spurious churn, plus an
honest, evidence-checked map of everything the new 12-entry benchmark surfaced — what
these fixes close, what they don't, and where the benchmark itself is wrong.

## The problem in one sentence

When you edit one line inside one method, the incremental analysis was inventing new
edges in the architecture graph — even though the edit changed *no* call from any method
to any other. The benchmark's null control caught it: a one-line body edit produced 47
spurious structural operations where the right answer is "nothing happened."

## What we changed (≈25 lines, one function + its baseline capture)

**Fix 1 — a body edit is not a structural change.** A component used to be re-analysed if
any method *body* inside it was touched. But a body edit changes a method's *contents*,
not *which methods it calls*, so re-deriving its edges can only add noise. We now
re-derive a component's edges only when its **membership** changes — it gained, lost or
handed off a method. A pure body edit refreshes the prose description and leaves the
edges exactly as they were.

**Fix 2 — take the "before" snapshot before we start deleting.** Change-detection compares
each component's current members against a baseline snapshot. That snapshot was taken
*after* the step that scrubs deleted files — so a deleted file's methods were already
gone from the "baseline," and the deletion became invisible (stale edges carried
forward). We now snapshot *before* any mutation. This also makes Fix 1 fire on the
null-control path, which takes an early "nothing to re-cluster" branch that never had a
baseline.

## What it fixes — verified, on the identical base commit

Measured against `backfill-pr423` (PR #423 at this branch's exact base, pre-fix), **three
entries flip from violated to met**:

| entry | change | before → after |
|---|---|---|
| **E1** — one-line body edit | null control | `EDGE_ADDED 3`, `EDGE_EVIDENCE_CHANGED 44` → **0 structural ops** |
| **E4** — new cross-boundary call | Java | `MEMBERSHIP_MOVED 1` → **0 moves** |
| **E7** — new `health/` subsystem | Python | `MEMBERSHIP_MOVED 7` → **0 moves** |

All three were the same disease — the engine re-clustering code the commit never touched.
E7 is the clearest: adding a new package used to move 7 methods inside the untouched
`agents/` package; now it moves none. These aren't lucky passes — each was re-checked by
re-running the grader over the stored analyses and against the source commit (E4's one
gained method is genuinely new; E7's untouched packages show zero changed methods).

Fix 2 also makes deletions visible to edge retraction: on the whole-module-deletion entry
(E9), `EDGE_REMOVED` now fires where **both** engines previously never retracted a single
edge on deletion.

## What it does *not* fix — and why we're not pretending otherwise

The task was explicitly not to chase a green score. The full run is **4 of 12 met, 83% of
expectations**. Every remaining failure was traced to a specific cause, and the causes are
**seven distinct engine weaknesses in seven distinct subsystems** — not one thing a
change-detection tweak could close. Each has a located fix direction (full detail and
evidence in `docs/benchmark-results.md`, Round 3):

1. **E2 — the planner can crash with no recovery.** An invalid LLM plan raises
   `InvalidIncrementalPlanError`, which is caught nowhere, so the run aborts instead of
   degrading to the achievable no-op. Fix: extend the repair pass to drop plan operations
   referencing unknown components and trim stray cluster refs.
2. **E5 — the base static graph is incomplete** (a real forwarding call is missing from
   it, so the head "discovers" it). An LSP/extraction gap.
3. **E8 — deletion renumbers an unchanged component**, and copy-forward pins methods back
   *by id*, so the pin misses and a method reads as "moved." Needs id stability across
   re-clustering.
4. **E9 — deleted code leaves an empty-shell component and duplicated edges.** Fix 2 makes
   the removal visible but clean-up needs empty-component pruning + cross-scope edge
   de-duplication.
5. **E10 — re-analysing a changed file invents/drops edges** between unchanged code.
6. **E11 — a rename is half-applied**: the add half lands, the delete half doesn't, so the
   old files linger as ghosts.
7. **E12 — the incremental head is stale** for a modified file (keeps methods that moved
   out of it).

## Where the benchmark is wrong (we checked, rather than overfitting)

Three failures are the benchmark asking for the wrong thing, each verified against the
actual analysis or the source commit:

- **E6** — the entry forbids an edge-evidence change and doesn't list `Gson.java` in its
  blast radius, but the commit *does* modify `Gson.java` (confirmed via the GitHub API),
  so a correct engine fails. The entry's file list is incomplete.
- **E9** — one of its three edge-evidence changes is a relation that genuinely straddles
  the deletion boundary (backed by surviving *and* deleted calls), so losing the deleted
  calls is correct — the entry's "nothing survives can change" rule overlooks straddling
  relations. (The other two are the real duplicate-edge bug above, so this is a *minor*
  flaw on a real weakness.)
- **E12** — it *requires* a "membership moved" op that is **unsatisfiable by construction**
  (the grader keys methods by file path, so a method that moves to a different file can
  never be scored as a move) and *forbids* new members the commit genuinely adds.

## One more measured finding: op sets aren't stable across reruns

The benchmark grades on "structural operation sets are stable; only counts move." That
holds for the null control but **not** for change-bearing entries: E11's move set is 6 in
one run and 1 (different endpoints) in another; E10 flips met↔violated on identical code.
So single-run verdicts on E8–E12 aren't reliable — the deterministic cores (ghost files,
empty shells, the E8 move) are the signal; the move/edge counts on top are not.

## Bottom line

A clean, focused, verified fix: it kills spurious churn when structure is unchanged (E1,
E4, E7 → met; null control → zero) and makes deletions visible to edge retraction. It
doesn't reach 9-of-12, because the rest are seven separate engine weaknesses and three
benchmark flaws — each documented with a fix direction for its own follow-up, rather than
papered over by tuning to the score.
