### PR TITLE
Update project version to 0.13.3 - prepare for release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "codeboarding"
-version = "0.13.2"
+version = "0.13.3"
 description = "Interactive Diagrams for Code"
 readme = "PYPI.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -336,7 +336,7 @@ wheels = [
 
 [[package]]
 name = "codeboarding"
-version = "0.13.2"
+version = "0.13.3"
 source = { editable = "." }
 dependencies = [
     { name = "docker" },


### PR DESCRIPTION
Version bump to `0.13.3` in preparation for release. Manifest (`pyproject.toml`) + `uv.lock` only.

Ships the work merged to `main` since 0.13.2 — incremental static-analysis fixes and the depth-as-limit / member-granular incremental changes (#427, #429, #423) — plus the private-integration-suite move. No functional code changes in this PR itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the package version to **0.13.3**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->