### PR TITLE
fix(relations): ground relation edges in symbols and gate churn on changed methods

### DIFF
--- a/agents/incremental_agent.py
+++ b/agents/incremental_agent.py
@@ -40,6 +40,11 @@ from agents.prompts import (
     get_system_message,
 )
 from agents.relation_edges import index_relation_endpoints, preserve_unchanged_relations
+from static_analyzer.cluster_relations import (
+    build_node_to_component_map,
+    build_owner_index,
+    prune_ungrounded_edges,
+)
 from agents.scope_ids import ROOT_SCOPE_ID
 from agents.validation import ValidationContext, validate_relations
 from diagram_analysis.file_index import build_files_index
@@ -138,11 +143,17 @@ class IncrementalAgent(ClusterMethodsMixin, CodeBoardingAgent):
             if operation.action == ScopeOperationAction.NOOP:
                 component = components_by_id.get(operation.component_id or "")
                 if component is not None:
-                    component.source_cluster_ids = CodeBoardingClusterIds.sort(
+                    merged = CodeBoardingClusterIds.sort(
                         set(component.source_cluster_ids) | set(_operation_source_cluster_ids(scope_id, operation))
                     )
-                    if component.component_id:
-                        refresh_ids.add(component.component_id)
+                    # NOOP means the planner asked for nothing. Only a cluster set that actually
+                    # moved is a reason to refresh; marking every NOOP component refreshed put
+                    # untouched siblings into `changed_ids`, which is what let their relations
+                    # be added and removed for a commit that never reached them.
+                    if merged != component.source_cluster_ids:
+                        component.source_cluster_ids = merged
+                        if component.component_id:
+                            refresh_ids.add(component.component_id)
                 continue
 
             component = components_by_id.get(operation.component_id or "")
@@ -383,6 +394,17 @@ class IncrementalAgent(ClusterMethodsMixin, CodeBoardingAgent):
             for relation in scope.components_relations
             if relation.src_id and relation.dst_id
         }
+        # Also keyed by NAME. Ids are assigned per run by `assign_relation_ids`, so a
+        # re-partition can hand the same two components different numbers; the id lookup then
+        # misses and the pair is treated as brand new, which re-rolls its wording. Measured on
+        # `referenced-symbol-deleted`: 9 statically-backed relations whose call set was
+        # byte-identical came back re-worded for exactly this reason. Names survive
+        # renumbering, so they are the fallback identity.
+        baseline_by_names = {
+            (relation.src_name, relation.dst_name): relation.model_copy(deep=True)
+            for relation in scope.components_relations
+            if relation.src_name and relation.dst_name
+        }
 
         if context.changed_ids:
             cluster_analysis = _cluster_analysis_for_scope(scope, scope_name, context.cluster_results)
@@ -404,19 +426,48 @@ class IncrementalAgent(ClusterMethodsMixin, CodeBoardingAgent):
 
         if baseline_by_pair:
             live_ids = {component.component_id for component in scope.components if component.component_id}
+            # A relation is ADDED or REMOVED because code changed, not because a partitioner
+            # moved untouched methods around. `context.changed_ids` carries both — it is the
+            # right scope to re-derive, and the wrong reason to change the edge set — so the
+            # preservation gate sees only components the COMMIT reached. Components that are
+            # new or gone keep their ids here: they are changes the commit does account for.
+            commit_changed = {
+                component.component_id
+                for component in scope.components
+                if component.component_id
+                and any(
+                    method.qualified_name in (changed_members or set())
+                    for group in component.file_methods
+                    for method in group.methods
+                )
+            } | (set(context.changed_ids) - live_ids)
             live_qnames = {
                 qualified_name
                 for cluster_result in context.cluster_results.values()
                 for members in cluster_result.clusters.values()
                 for qualified_name in members
             }
+            for relation in scope.components_relations:
+                pair = (relation.src_id, relation.dst_id)
+                if pair not in baseline_by_pair:
+                    by_name = baseline_by_names.get((relation.src_name, relation.dst_name))
+                    if by_name is not None:
+                        baseline_by_pair[pair] = by_name
             scope.components_relations = preserve_unchanged_relations(
                 scope.components_relations,
                 baseline_by_pair,
-                set(context.changed_ids),
+                commit_changed,
                 live_ids,
                 live_qnames,
                 changed_members,
+            )
+            # Preservation runs after the grounding filters and re-injects baseline edges, so
+            # the assembled list is filtered once more — otherwise a baseline's invented or
+            # mis-attributed edges survive every update that leaves their methods alone.
+            scope.components_relations = prune_ungrounded_edges(
+                scope.components_relations,
+                build_owner_index(build_node_to_component_map(scope)),
+                self.reference_resolver.keep_relation_edge,
             )
             rels = scope.components_relations
         return rels

--- a/agents/incremental_agent.py
+++ b/agents/incremental_agent.py
@@ -142,18 +142,9 @@ class IncrementalAgent(ClusterMethodsMixin, CodeBoardingAgent):
                 continue
             if operation.action == ScopeOperationAction.NOOP:
                 component = components_by_id.get(operation.component_id or "")
-                if component is not None:
-                    merged = CodeBoardingClusterIds.sort(
-                        set(component.source_cluster_ids) | set(_operation_source_cluster_ids(scope_id, operation))
-                    )
-                    # NOOP means the planner asked for nothing. Only a cluster set that actually
-                    # moved is a reason to refresh; marking every NOOP component refreshed put
-                    # untouched siblings into `changed_ids`, which is what let their relations
-                    # be added and removed for a commit that never reached them.
-                    if merged != component.source_cluster_ids:
-                        component.source_cluster_ids = merged
-                        if component.component_id:
-                            refresh_ids.add(component.component_id)
+                if component is None:
+                    continue
+                self._sync_noop_component_cluster_ids(scope_id, component, operation, refresh_ids)
                 continue
 
             component = components_by_id.get(operation.component_id or "")
@@ -219,6 +210,20 @@ class IncrementalAgent(ClusterMethodsMixin, CodeBoardingAgent):
             refresh_ids.add(component.component_id)
             new_component_ids.add(component.component_id)
             components_by_id[component.component_id] = component
+
+    def _sync_noop_component_cluster_ids(
+        self,
+        scope_id: str,
+        component: Component,
+        operation: ScopeOperation,
+        refresh_ids: set[str],
+    ) -> None:
+        merged_cluster_ids = CodeBoardingClusterIds.sort(
+            set(component.source_cluster_ids) | set(_operation_source_cluster_ids(scope_id, operation))
+        )
+        if merged_cluster_ids != component.source_cluster_ids and component.component_id:
+            refresh_ids.add(component.component_id)
+        component.source_cluster_ids = merged_cluster_ids
 
     @trace
     def detail_new_components(self, components: list[Component]) -> None:
@@ -431,7 +436,7 @@ class IncrementalAgent(ClusterMethodsMixin, CodeBoardingAgent):
             # right scope to re-derive, and the wrong reason to change the edge set — so the
             # preservation gate sees only components the COMMIT reached. Components that are
             # new or gone keep their ids here: they are changes the commit does account for.
-            commit_changed = {
+            changed_component_ids = {
                 component.component_id
                 for component in scope.components
                 if component.component_id
@@ -440,7 +445,8 @@ class IncrementalAgent(ClusterMethodsMixin, CodeBoardingAgent):
                     for group in component.file_methods
                     for method in group.methods
                 )
-            } | (set(context.changed_ids) - live_ids)
+            }
+            commit_changed = changed_component_ids | (set(context.changed_ids) - live_ids)
             live_qnames = {
                 qualified_name
                 for cluster_result in context.cluster_results.values()
@@ -448,6 +454,7 @@ class IncrementalAgent(ClusterMethodsMixin, CodeBoardingAgent):
                 for qualified_name in members
             }
             for relation in scope.components_relations:
+                # Carry the baseline forward when regenerated component ids changed but names did not.
                 pair = (relation.src_id, relation.dst_id)
                 if pair not in baseline_by_pair:
                     by_name = baseline_by_names.get((relation.src_name, relation.dst_name))

--- a/agents/relation_edges.py
+++ b/agents/relation_edges.py
@@ -55,7 +55,8 @@ def index_relation_endpoints(analysis: AnalysisInsights, repo_dir: Path) -> None
 def _is_internal_self_relation(relation: Relation) -> bool:
     """A component related to itself by concrete intra-component calls.
 
-    The backing edges are real CFG calls whose endpoints currently fall in the same
+    Its supporting calls — the concrete method-to-method calls stored under the relation —
+    are real CFG calls whose endpoints currently fall in the same
     component, so at this granularity there is no cross-component connection to draw — the
     loop is the residue of a rollup that collapsed a cross-child edge onto its shared parent.
     The CFG still holds every such edge, so expanding the component re-materialises it across
@@ -76,7 +77,7 @@ def drop_internal_self_relations(relations: list[Relation]) -> list[Relation]:
 def _relation_backing_survives(relation: Relation, live_qnames: set[str]) -> bool:
     """Whether a baseline relation's static backing still exists in live code.
 
-    A relation restored verbatim keeps its call edges. If the only edges connecting the two
+    A relation is supported by concrete method-to-method calls; restoring it verbatim keeps them. If the only edges connecting the two
     components pointed at a symbol since deleted, restoring the relation resurrects an edge
     citing code that is gone — a phantom. A relation with no static edge at all is a
     runtime/config relation with nothing to invalidate, so it is left alone.
@@ -90,6 +91,7 @@ def _relation_backing_survives(relation: Relation, live_qnames: set[str]) -> boo
 
 
 def _backing_edge_pairs(relation: Relation) -> set[tuple[str, str]]:
+    """The (source, target) method pairs supporting this relation — the calls under the arrow."""
     edges = relation.all_edges or relation.key_edges
     return {(edge.source.qualified_name, edge.target.qualified_name) for edge in edges}
 
@@ -107,7 +109,70 @@ def _relation_edges_unmoved(rebuilt: Relation, previous: Relation) -> bool:
 
 
 def _edge_touches_changed_method(edge: RelationEdge, changed_members: set[str]) -> bool:
-    return edge.source.qualified_name in changed_members or edge.target.qualified_name in changed_members
+    """Whether a code change can account for this call appearing or disappearing.
+
+    A call is written inside its SOURCE method's body, so the source is the only end whose
+    change can create or remove it. An untouched caller calls exactly what it called before,
+    whatever happened inside the callee — editing a function's body does not change who calls
+    it, and neither does adding one.
+
+    So this asks about the source alone. Accepting either end (the previous rule) let every
+    rebuilt edge whose *callee* happened to be edited pass as code-backed, which is how a
+    one-function commit re-worded relations whose call set was byte-identical.
+
+    Not "both ends", which would be too strict the other way: editing a caller to call an
+    existing, untouched function is the commonest way a real dependency appears, and its callee
+    never changes. A deleted callee needs no special case — the caller must be edited to stop
+    calling it, so the source is in ``changed_members`` anyway.
+    """
+    return edge.source.qualified_name in changed_members
+
+
+def _restore_baseline_orientation(relation: Relation, baseline_by_pair: dict) -> Relation:
+    """Put an ungrounded relation back the way round the reader last saw it.
+
+    Why only ungrounded ones: a statically-backed relation takes its direction from real CFG
+    edges, so the arrow means something and must not be touched. A runtime/config relation has
+    no call to fix it, so the model picks an orientation afresh each run — and a swap keyed on
+    the ordered pair reads as one relation deleted and another added. On the reported case
+    (CodeBoarding-action#65) two of the five changed edges were exactly that: the same two
+    component pairs with their arrows reversed and relabelled.
+
+    Applied only when the fresh relation carries no backing edges at all, because an edge is
+    what would make the direction a claim rather than a phrasing — flipping a relation that has
+    one would point its edges the wrong way.
+    """
+    if relation.is_static or relation.all_edges or relation.key_edges:
+        return relation
+    flipped = baseline_by_pair.get((relation.dst_id, relation.src_id))
+    if flipped is None or flipped.is_static or flipped.all_edges or flipped.key_edges:
+        return relation
+    return relation.model_copy(
+        update={
+            "src_id": flipped.src_id,
+            "dst_id": flipped.dst_id,
+            "src_name": flipped.src_name,
+            "dst_name": flipped.dst_name,
+            "relation": flipped.relation,
+            "evidence": flipped.evidence,
+        }
+    )
+
+
+def _only_change_backed_edges(relation: Relation, changed_members: set[str]) -> Relation:
+    """Keep only the edges a code change can account for, for a pair with no baseline.
+
+    Why: a call lives in its source method's body, so an edge can only appear when one of its
+    endpoints changed. ``_reconcile_unchanged_edges`` enforces that by falling back to the
+    baseline, but re-clustering invents component-pairs that have no baseline to fall back to —
+    there every re-attributed edge would otherwise enter as if the commit had written it.
+    """
+    return relation.model_copy(
+        update={
+            "all_edges": [e for e in relation.all_edges if _edge_touches_changed_method(e, changed_members)],
+            "key_edges": [e for e in relation.key_edges if _edge_touches_changed_method(e, changed_members)],
+        }
+    )
 
 
 def _reconcile_unchanged_edges(fresh: Relation, previous: Relation, changed_members: set[str]) -> Relation:
@@ -176,6 +241,8 @@ def preserve_unchanged_relations(
     kept: list[Relation] = []
     rebuilt_pairs: set[tuple[str, str]] = set()
     for relation in rebuilt_relations:
+        if (relation.src_id, relation.dst_id) not in baseline_by_pair:
+            relation = _restore_baseline_orientation(relation, baseline_by_pair)
         pair = (relation.src_id, relation.dst_id)
         rebuilt_pairs.add(pair)
         previous = baseline_by_pair.get(pair)
@@ -183,8 +250,14 @@ def preserve_unchanged_relations(
             # No baseline for this pair. A genuinely new connection into a changed area is
             # kept; a fresh edge invented between two untouched components is a re-attribution
             # artifact and is dropped.
-            if touches_change(*pair):
-                kept.append(relation)
+            if not touches_change(*pair):
+                continue
+            if changed_members is not None:
+                relation = _only_change_backed_edges(relation, changed_members)
+                # Nothing survived and nothing else is claimed: the pair asserts no connection.
+                if not relation.all_edges and not relation.key_edges and not relation.evidence.strip():
+                    continue
+            kept.append(relation)
             continue
         # Every edge between two byte-identical methods is taken from the baseline; only edges
         # that touch a changed/added/deleted method come from the fresh rebuild. This stops
@@ -192,9 +265,21 @@ def preserve_unchanged_relations(
         # pairs alike.
         if changed_members is not None:
             relation = _reconcile_unchanged_edges(relation, previous, changed_members)
-        # Keep the reader's wording unless a real, code-backed edge change re-worded it: an
-        # untouched pair, or one whose edges came through unmoved, carries its label over.
-        if not touches_change(*pair) or _relation_edges_unmoved(relation, previous):
+        # Keep the reader's wording unless this pair's own supporting calls moved.
+        #
+        # The supporting calls are the concrete method-to-method calls under the relation — the
+        # ones that show WHERE one component reaches the other. They are the only evidence that
+        # the connection itself changed, so they are what decides whether it may be re-worded.
+        # Gating on the endpoint components' change flags instead re-words far more: a component
+        # is flagged for any edit to a file it merely co-owns, so deleting one function re-worded
+        # 17 of the relations in `referenced-symbol-deleted` whose calls had not moved at all.
+        # A pair with no supporting calls has nothing that could have moved, so its wording is
+        # kept too — an edgeless runtime relation is prose, and re-rolling prose is the churn.
+        if (
+            not touches_change(*pair)
+            or _relation_edges_unmoved(relation, previous)
+            or not _backing_edge_pairs(relation)
+        ):
             relation = relation.model_copy(update={"relation": previous.relation, "evidence": previous.evidence})
         kept.append(relation)
     for pair, relation in baseline_by_pair.items():

--- a/agents/relation_edges.py
+++ b/agents/relation_edges.py
@@ -109,22 +109,6 @@ def _relation_edges_unmoved(rebuilt: Relation, previous: Relation) -> bool:
 
 
 def _edge_touches_changed_method(edge: RelationEdge, changed_members: set[str]) -> bool:
-    """Whether a code change can account for this call appearing or disappearing.
-
-    A call is written inside its SOURCE method's body, so the source is the only end whose
-    change can create or remove it. An untouched caller calls exactly what it called before,
-    whatever happened inside the callee — editing a function's body does not change who calls
-    it, and neither does adding one.
-
-    So this asks about the source alone. Accepting either end (the previous rule) let every
-    rebuilt edge whose *callee* happened to be edited pass as code-backed, which is how a
-    one-function commit re-worded relations whose call set was byte-identical.
-
-    Not "both ends", which would be too strict the other way: editing a caller to call an
-    existing, untouched function is the commonest way a real dependency appears, and its callee
-    never changes. A deleted callee needs no special case — the caller must be edited to stop
-    calling it, so the source is in ``changed_members`` anyway.
-    """
     return edge.source.qualified_name in changed_members
 
 
@@ -159,7 +143,7 @@ def _restore_baseline_orientation(relation: Relation, baseline_by_pair: dict) ->
     )
 
 
-def _only_change_backed_edges(relation: Relation, changed_members: set[str]) -> Relation:
+def _filter_edges_touched_by_change(relation: Relation, changed_members: set[str]) -> Relation:
     """Keep only the edges a code change can account for, for a pair with no baseline.
 
     Why: a call lives in its source method's body, so an edge can only appear when one of its
@@ -253,7 +237,7 @@ def preserve_unchanged_relations(
             if not touches_change(*pair):
                 continue
             if changed_members is not None:
-                relation = _only_change_backed_edges(relation, changed_members)
+                relation = _filter_edges_touched_by_change(relation, changed_members)
                 # Nothing survived and nothing else is claimed: the pair asserts no connection.
                 if not relation.all_edges and not relation.key_edges and not relation.evidence.strip():
                     continue

--- a/diagram_analysis/diagram_generator.py
+++ b/diagram_analysis/diagram_generator.py
@@ -73,7 +73,14 @@ from repo_utils.ignore import RepoIgnoreManager
 from static_analyzer import StaticAnalyzer, get_static_analysis
 from static_analyzer.analysis_cache import StaticAnalysisCache
 from static_analyzer.analysis_result import StaticAnalysisResults
-from static_analyzer.cluster_relations import build_global_relations, is_self_or_descendant
+from static_analyzer.reference_resolver import StaticReferenceResolver
+from static_analyzer.cluster_relations import (
+    build_global_node_to_component_map,
+    build_global_relations,
+    build_owner_index,
+    is_self_or_descendant,
+    prune_ungrounded_edges,
+)
 from static_analyzer.constants import Language
 from static_analyzer.graph import ClusterResult
 from static_analyzer.scanner import ProjectScanner
@@ -139,11 +146,24 @@ def _reconcile_child_scope(
             for method in group.methods
         }
         _graft_entered_methods(child_scope, entered, parent_methods)
-    if departed or entered:
-        # Membership moved, so the scoped LLM relations may reference a method that just left
-        # this scope. They are consumed as authoritative by ``build_global_relations``; clear
-        # them so the deterministic rebuild re-derives edges for the reconciled membership.
-        child_scope.components_relations = []
+    if departed:
+        # Membership moved, so a scoped relation may cite a method that just left. Those are
+        # consumed as authoritative by ``build_global_relations``, so they must go — but only
+        # THEY must. Clearing the whole scope left the next step with no baseline to compare
+        # against, so `preserve_unchanged_relations` was skipped outright and every relation in
+        # the scope came back re-worded: measured on `referenced-symbol-deleted`, scopes 3 and
+        # 3.2 arrived with 0 baseline pairs and produced 8 re-wordings whose call sets were
+        # byte-identical. Relations that never mention a departed method are kept so their
+        # wording can be carried forward.
+        departed_qnames = {qualified_name for _path, qualified_name in departed}
+        child_scope.components_relations = [
+            relation
+            for relation in child_scope.components_relations
+            if not any(
+                edge.source.qualified_name in departed_qnames or edge.target.qualified_name in departed_qnames
+                for edge in [*relation.key_edges, *relation.all_edges]
+            )
+        ]
     child_scope.files = build_files_index(child_scope, repo_dir)
 
 
@@ -344,16 +364,36 @@ def _restore_unchanged_metadata(
                 continue
             final_keys = _member_keys(component)
             owns_changed_file = any(group.file_path in changed_files for group in component.file_methods)
-            if final_keys != meta.member_keys or (meta.member_qnames & changed_members) or owns_changed_file:
+            # Membership counts as unchanged when the only members that came or went are ones
+            # the commit itself added or deleted. A component that lost exactly the deleted
+            # function still covers the same clusters and still has the same key entities; a
+            # component that lost a method to re-partitioning does not.
+            drifted = {key for key in (final_keys ^ meta.member_keys) if key[1] not in changed_members}
+            if drifted:
                 continue
+            # Membership is baseline-identical, so everything DERIVED FROM MEMBERSHIP is restored
+            # even when a body inside the component changed. Cluster ids are the repartition's
+            # own numbering for the same set of methods, and key entities are a choice among
+            # those methods — editing one method's body makes neither of them wrong. Gating both
+            # on "owns a changed file" re-authored them for every component that merely shares a
+            # file with the edit: measured on `referenced-symbol-deleted`, 11 components changed
+            # cluster ids and 3 changed key entities for a commit that deleted one function.
+            component.source_cluster_ids = list(meta.source_cluster_ids)
+            # An entity survives unless its symbol is GONE. Editing a method's body does not
+            # make the class it lives in a worse choice of key entity — dropping on "changed"
+            # rather than "deleted" is why `File` and `LazyFile` vanished from three components
+            # when one method inside them was edited.
+            live_qnames = {qname for _path, qname in final_keys}
+            component.key_entities = [
+                entity.model_copy(deep=True) for entity in meta.key_entities if entity.qualified_name in live_qnames
+            ]
+            if (meta.member_qnames & changed_members) or owns_changed_file:
+                continue
+            # Prose is held to the stricter gate: a component whose code changed may honestly
+            # want re-describing, and only a component nothing touched is safe to call unchanged.
             component.name = meta.name
             component.description = meta.description
-            component.key_entities = [entity.model_copy(deep=True) for entity in meta.key_entities]
             component.source_group_names = list(meta.source_group_names)
-            # Restore the paired cluster ids too: membership is baseline-identical here, so the
-            # repartition's ids would leave the component claiming clusters it no longer owns and
-            # misroute the next incremental's changes for them.
-            component.source_cluster_ids = list(meta.source_cluster_ids)
             unchanged_ids.add(component.component_id)
     return unchanged_ids
 
@@ -451,6 +491,22 @@ def _incremental_changed_component_ids(
     method in its own ``file_methods``, the owner of a change and all of its ancestors are
     captured together. Everything else is preserved verbatim.
     """
+    # Files whose edit some member already accounts for. The file-level signal exists for a
+    # MODULE-level edit no member represents — an import, a constant, a docstring — so applying
+    # it to a file that also has a changed member flags every other co-owner of that file as
+    # changed too. Measured on `referenced-symbol-deleted`: components 1, 3, 3.1, 3.2 and 4.2
+    # own none of the five changed methods and most have identical membership, yet all were
+    # marked changed because they co-own `types.py`/`utils.py` with the component that does.
+    # That is what opens the label gate for their relations and re-words them.
+    represented_files = {
+        group.file_path
+        for _scope, analysis in _iter_incremental_scopes(root_analysis, sub_analyses)
+        for component in analysis.components
+        for group in component.file_methods
+        if any(method.qualified_name in changed_members for method in group.methods)
+    }
+    unrepresented_files = changed_files - represented_files
+
     changed: set[str] = set()
     for _scope_id, analysis in _iter_incremental_scopes(root_analysis, sub_analyses):
         for component in analysis.components:
@@ -461,8 +517,13 @@ def _incremental_changed_component_ids(
             body_changed = any(
                 method.qualified_name in changed_members for group in component.file_methods for method in group.methods
             )
-            file_changed = any(group.file_path in changed_files for group in component.file_methods)
-            membership_changed = live_keys != baseline_member_keys.get(component_id, frozenset())
+            file_changed = any(group.file_path in unrepresented_files for group in component.file_methods)
+            # Membership counts as changed only when the difference involves a member the
+            # commit itself touched. Re-clustering moves untouched methods between components
+            # all the time; treating that as a change put components owning nothing the commit
+            # reached into `changed_ids`, and their relations were then freely added and removed.
+            drift = live_keys ^ baseline_member_keys.get(component_id, frozenset())
+            membership_changed = any(qualified_name in changed_members for _path, qualified_name in drift)
             if component_id not in baseline_component_ids or body_changed or file_changed or membership_changed:
                 changed.add(component_id)
     return changed
@@ -1117,6 +1178,13 @@ class DiagramGenerator:
                 live_ids,
                 live_qnames,
                 self._changed_members,
+            )
+            # Same reason as the per-scope path: preservation re-injects baseline edges after
+            # the grounding filters ran, so the assembled list is filtered once more.
+            global_relations = prune_ungrounded_edges(
+                global_relations,
+                build_owner_index(build_global_node_to_component_map(root_analysis, sub_analyses)),
+                StaticReferenceResolver(self.repo_location, self.static_analysis).keep_relation_edge,
             )
         root_analysis.components_relations = global_relations
         return global_relations

--- a/diagram_analysis/diagram_generator.py
+++ b/diagram_analysis/diagram_generator.py
@@ -364,10 +364,7 @@ def _restore_unchanged_metadata(
                 continue
             final_keys = _member_keys(component)
             owns_changed_file = any(group.file_path in changed_files for group in component.file_methods)
-            # Membership counts as unchanged when the only members that came or went are ones
-            # the commit itself added or deleted. A component that lost exactly the deleted
-            # function still covers the same clusters and still has the same key entities; a
-            # component that lost a method to re-partitioning does not.
+            # Ignore membership changes caused only by symbols the commit added or deleted.
             drifted = {key for key in (final_keys ^ meta.member_keys) if key[1] not in changed_members}
             if drifted:
                 continue

--- a/static_analyzer/cluster_relations.py
+++ b/static_analyzer/cluster_relations.py
@@ -175,7 +175,7 @@ def prune_ungrounded_edges(
                 # Nowhere better to file it; keeping a mis-filed call beats deleting a real one.
                 all_edges.append(edge)
             else:
-                additions.setdefault(home, []).append(edge)  # type: ignore[arg-type]
+                additions.setdefault(matching_pair, []).append(edge)  # type: ignore[arg-type]
         surviving = {edge.identity() for edge in all_edges}
         key_edges = [edge for edge in relation.key_edges if edge.identity() in surviving]
         kept.append(relation.model_copy(update={"all_edges": all_edges, "key_edges": key_edges}))

--- a/static_analyzer/cluster_relations.py
+++ b/static_analyzer/cluster_relations.py
@@ -7,11 +7,11 @@ edges — no LLM needed.
 
 import logging
 from collections import defaultdict
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass, field
 
 from constants import DEFAULT_STATIC_RELATION_LABEL
-from agents.agent_responses import AnalysisInsights, Relation, RelationEdge
+from agents.agent_responses import AnalysisInsights, Relation, RelationEdge, SourceCodeReference
 from agents.relation_edges import append_or_merge_relation, drop_internal_self_relations
 from static_analyzer.graph import CallGraph
 
@@ -65,6 +65,180 @@ def _qnames_match(a: str, b: str) -> bool:
     """
     a, b = a.replace(":", "."), b.replace(":", ".")
     return a == b or a.endswith("." + b) or b.endswith("." + a)
+
+
+def build_owner_index(node_to_component: dict[str, str]) -> dict[str, list[tuple[str, str]]]:
+    """Group the component map by each symbol's last segment.
+
+    Why: ``_qnames_match`` can only match names whose final segment agrees, so the leaf narrows
+    the candidates from every symbol in the repo to a handful — the difference between a full
+    scan per endpoint and a lookup.
+    """
+    index: dict[str, list[tuple[str, str]]] = {}
+    for qname, component_id in node_to_component.items():
+        index.setdefault(qname.rsplit(".", 1)[-1], []).append((qname, component_id))
+    return index
+
+
+def _endpoint_owner(reference: SourceCodeReference, owner_index: dict[str, list[tuple[str, str]]]) -> str:
+    """Component owning this endpoint's symbol; empty when unknown or ambiguous."""
+    qname = reference.qualified_name.replace(":", ".")
+    owners = {
+        component_id
+        for candidate, component_id in owner_index.get(qname.rsplit(".", 1)[-1], ())
+        if _qnames_match(qname, candidate)
+    }
+    return owners.pop() if len(owners) == 1 else ""
+
+
+def edge_crosses_components(
+    edge: RelationEdge,
+    owner_index: dict[str, list[tuple[str, str]]],
+    src_id: str,
+    dst_id: str,
+) -> bool:
+    """Whether an LLM-authored edge actually runs from ``src_id`` to ``dst_id``.
+
+    Why: a runtime/config pair has no static edge to ground against, so an edge whose endpoints
+    both land inside one component is serialized as if it crossed the boundary, and the diagram
+    draws that component's file under the other one. Ownership is satisfied by the declared
+    component or any descendant, so a deliberate cross-depth edge still passes. Whether the
+    symbol exists at all is not decided here — an endpoint no component owns may be external
+    code, which ``keep_relation_edge`` judges against the symbol table.
+    """
+    for reference, component_id in ((edge.source, src_id), (edge.target, dst_id)):
+        owner = _endpoint_owner(reference, owner_index)
+        if owner and component_id and not is_self_or_descendant(owner, component_id):
+            return False
+    return True
+
+
+def prune_ungrounded_edges(
+    relations: list[Relation],
+    owner_index: dict[str, list[tuple[str, str]]],
+    keep_edge: Callable[[RelationEdge], bool],
+) -> list[Relation]:
+    """Re-apply the edge filters to an assembled relation list, moving edges rather than losing them.
+
+    Why it runs again: the filters guard the edges a run AUTHORS, but preservation re-injects the
+    baseline's edges afterwards — verbatim for a pair the rebuild did not touch, and per-edge
+    wherever two methods came through unchanged. A baseline written by an older engine therefore
+    keeps its mis-attributed edges for as long as nobody edits the methods they name, which is
+    indefinitely.
+
+    A mis-attributed edge is a REAL call filed under the wrong pair, so it is re-filed with the
+    relation whose declared endpoints match where the call actually runs. Only two things remove
+    an edge: an endpoint that names no live symbol (``keep_edge``), and a duplicate the correct
+    pair already carries. Measured on one stored analysis, dropping instead of re-filing orphaned
+    25 of 28 real calls — the mis-attribution is worth repairing, the call is not worth losing.
+
+    An edge whose true pair has no relation to move to stays where it is: inventing a relation
+    here would be authoring architecture in a filter, and silently deleting the call would be
+    worse than leaving it mis-filed where a check can still flag it.
+    """
+    by_pair: dict[tuple[str, str], Relation] = {(relation.src_id, relation.dst_id): relation for relation in relations}
+    additions: dict[tuple[str, str], list[RelationEdge]] = {}
+
+    def rehome(edge: RelationEdge) -> tuple[str, str] | None | bool:
+        """Where this edge belongs: a declared pair, ``None`` for nowhere, ``False`` for nothing.
+
+        ``False`` means both endpoints sit in one component, so there is no cross-component fact
+        to file anywhere — `build_component_relations` discards those at the source, and it is
+        the shape the original report was about (`build_cta.main -> build_cta.build_cta` offered
+        as evidence that one component reaches another).
+        """
+        source = _endpoint_owner(edge.source, owner_index)
+        target = _endpoint_owner(edge.target, owner_index)
+        if not source or not target:
+            return None
+        if is_self_or_descendant(source, target) or is_self_or_descendant(target, source):
+            return False
+        for pair in by_pair:
+            if is_self_or_descendant(source, pair[0]) and is_self_or_descendant(target, pair[1]):
+                return pair
+        return None
+
+    kept: list[Relation] = []
+    for relation in relations:
+        pair = (relation.src_id, relation.dst_id)
+        all_edges: list[RelationEdge] = []
+        for edge in relation.all_edges:
+            if not keep_edge(edge):
+                continue
+            if edge_crosses_components(edge, owner_index, relation.src_id, relation.dst_id):
+                all_edges.append(edge)
+                continue
+            home = rehome(edge)
+            if home is False:
+                continue  # Internal call: no cross-component fact exists to preserve.
+            if home is None or home == pair:
+                # Nowhere better to file it; keeping a mis-filed call beats deleting a real one.
+                all_edges.append(edge)
+            else:
+                additions.setdefault(home, []).append(edge)  # type: ignore[arg-type]
+        surviving = {edge.identity() for edge in all_edges}
+        key_edges = [edge for edge in relation.key_edges if edge.identity() in surviving]
+        kept.append(relation.model_copy(update={"all_edges": all_edges, "key_edges": key_edges}))
+
+    settled: list[Relation] = []
+    for relation in kept:
+        moved = additions.get((relation.src_id, relation.dst_id))
+        if moved:
+            relation = relation.model_copy(update={"all_edges": Relation._unique_edges([*relation.all_edges, *moved])})
+        if not relation.all_edges and not relation.key_edges and not relation.evidence.strip():
+            continue
+        settled.append(relation)
+
+    return drop_reverse_duplicates(settled)
+
+
+def drop_reverse_duplicates(relations: list[Relation]) -> list[Relation]:
+    """Collapse a pair stated twice, once in each direction.
+
+    A relation is backed by concrete method-to-method calls — the ``all_edges``/``key_edges``
+    that show WHERE one component reaches the other. Two cases arise:
+
+    *One side has those calls and the other does not.* The bare side is the same connection
+    written backwards, surviving on prose: `3.3 -> 3.1` said so while `3.1 -> 3.3` held the
+    actual `parse_unified_analysis -> _extract_analysis_recursive`. The grounded one wins.
+
+    *Neither side has any.* Then nothing distinguishes them — the model simply narrated one
+    connection twice, in both directions. Both are kept today, and which one survives the next
+    run is luck: on `single-method-added` one engine's baseline carried both and its update
+    dropped one (reported as a deleted edge) while the other's baseline carried one and its
+    update added the second (reported as an added edge). The test forbids both. So one is
+    chosen deterministically — lowest source id, then longest evidence — and it is the same
+    choice every run.
+
+    Applied on every path, full and incremental alike. Applying it to only one makes a baseline
+    and the update disagree about what a clean document looks like, and the difference lands as
+    phantom churn on a commit that changed nothing.
+    """
+    grounded_pairs = {
+        (relation.src_id, relation.dst_id) for relation in relations if relation.all_edges or relation.key_edges
+    }
+    kept: list[Relation] = []
+    dropped_bare: set[tuple[str, str]] = set()
+    by_pair = {(relation.src_id, relation.dst_id): relation for relation in relations}
+    for relation in relations:
+        pair = (relation.src_id, relation.dst_id)
+        reverse = (relation.dst_id, relation.src_id)
+        if relation.all_edges or relation.key_edges or relation.is_static:
+            kept.append(relation)
+            continue
+        if reverse in grounded_pairs:
+            continue  # The grounded side already states this connection, the right way round.
+        # `reverse == pair` is a self-relation, which `drop_internal_self_relations` owns.
+        other = by_pair.get(reverse) if reverse != pair else None
+        if other is not None and not (other.all_edges or other.key_edges or other.is_static):
+            # Same claim twice with nothing to tell them apart. Pick once, deterministically:
+            # the fuller explanation survives, and an exact tie falls to the lower source id.
+            loser = max((relation, other), key=lambda r: (-len(r.evidence or ""), r.src_id, r.dst_id))
+            if (loser.src_id, loser.dst_id) == pair and reverse not in dropped_bare:
+                dropped_bare.add(pair)
+                continue
+        kept.append(relation)
+    return kept
 
 
 def ground_relation_edges(
@@ -270,15 +444,27 @@ def build_global_relations(
             )
         global_relations[(src_id, dst_id)] = relation
 
+    owner_index = build_owner_index(node_to_component)
     for llm_rel in llm_relations:
         pair = (llm_rel.src_id, llm_rel.dst_id)
         if llm_rel.src_id not in live_ids or llm_rel.dst_id not in live_ids:
             continue
         if pair in static_pairs or pair in superseded_llm_pairs:
             continue
-        global_relations[pair] = llm_rel.with_merged_edges()
+        grounded = llm_rel.with_merged_edges()
+        kept = [
+            edge
+            for edge in grounded.all_edges
+            if edge_crosses_components(edge, owner_index, llm_rel.src_id, llm_rel.dst_id)
+        ]
+        kept_ids = {edge.identity() for edge in kept}
+        global_relations[pair] = grounded.model_copy(
+            update={"all_edges": kept, "key_edges": [e for e in grounded.key_edges if e.identity() in kept_ids]}
+        )
 
-    return drop_internal_self_relations(sorted(global_relations.values(), key=lambda rel: (rel.src_id, rel.dst_id)))
+    return drop_reverse_duplicates(
+        drop_internal_self_relations(sorted(global_relations.values(), key=lambda rel: (rel.src_id, rel.dst_id)))
+    )
 
 
 def merge_relations(
@@ -306,6 +492,8 @@ def merge_relations(
     for sr in static_relations:
         static_by_ids[(sr.src_cluster_id, sr.dst_cluster_id)] = sr
 
+    owner_index = build_owner_index(build_node_to_component_map(analysis))
+
     merged: list[Relation] = []
     matched_static_edge_ids: set[tuple] = set()
 
@@ -317,10 +505,13 @@ def merge_relations(
         static_rel = static_by_ids.get((src_id, dst_id))
         static_edges = static_rel.all_edges if static_rel else []
         has_evidence = bool(llm_rel.evidence.strip())
+        llm_key_edges = [
+            edge for edge in llm_rel.key_edges if edge_crosses_components(edge, owner_index, src_id, dst_id)
+        ]
 
-        if not static_edges and not llm_rel.key_edges and not has_evidence:
+        if not static_edges and not llm_key_edges and not has_evidence:
             continue
-        if not static_edges and not llm_rel.key_edges and has_evidence:
+        if not static_edges and not llm_key_edges and has_evidence:
             logger.warning(
                 "Keeping LLM-only relation without static or key-edge backing: %s -> %s (%s). Evidence: %s",
                 llm_rel.src_name,
@@ -329,7 +520,7 @@ def merge_relations(
                 llm_rel.evidence,
             )
 
-        key_edges, all_edges = ground_relation_edges(llm_rel.key_edges, static_edges)
+        key_edges, all_edges = ground_relation_edges(llm_key_edges, static_edges)
         for edge in static_edges:
             matched_static_edge_ids.add((src_id, dst_id, edge.identity()))
         append_or_merge_relation(
@@ -369,7 +560,7 @@ def merge_relations(
                 ),
             )
 
-    merged = drop_internal_self_relations(merged)
+    merged = drop_reverse_duplicates(drop_internal_self_relations(merged))
     logger.info(
         f"Merged relations: {len(merged)} total "
         f"({sum(1 for relation in merged if relation.is_static)} static-backed, "

--- a/static_analyzer/cluster_relations.py
+++ b/static_analyzer/cluster_relations.py
@@ -139,8 +139,8 @@ def prune_ungrounded_edges(
     by_pair: dict[tuple[str, str], Relation] = {(relation.src_id, relation.dst_id): relation for relation in relations}
     additions: dict[tuple[str, str], list[RelationEdge]] = {}
 
-    def rehome(edge: RelationEdge) -> tuple[str, str] | None | bool:
-        """Where this edge belongs: a declared pair, ``None`` for nowhere, ``False`` for nothing.
+    def find_relation_pair_for_edge(edge: RelationEdge) -> tuple[str, str] | None | bool:
+        """Find the declared relation pair for this edge; ``False`` means it is internal.
 
         ``False`` means both endpoints sit in one component, so there is no cross-component fact
         to file anywhere — `build_component_relations` discards those at the source, and it is
@@ -168,10 +168,10 @@ def prune_ungrounded_edges(
             if edge_crosses_components(edge, owner_index, relation.src_id, relation.dst_id):
                 all_edges.append(edge)
                 continue
-            home = rehome(edge)
-            if home is False:
+            matching_pair = find_relation_pair_for_edge(edge)
+            if matching_pair is False:
                 continue  # Internal call: no cross-component fact exists to preserve.
-            if home is None or home == pair:
+            if matching_pair is None or matching_pair == pair:
                 # Nowhere better to file it; keeping a mis-filed call beats deleting a real one.
                 all_edges.append(edge)
             else:

--- a/static_analyzer/internal_references.py
+++ b/static_analyzer/internal_references.py
@@ -17,8 +17,8 @@ class InternalReferenceSource(Protocol):
     def iter_reference_nodes(self, lang: Language) -> Iterable[ReferenceNode]: ...
 
 
-def reference_tokens(qualified_name: str) -> list[str]:
-    return [token.lower() for token in re.split(r"[.:/\\]+", qualified_name) if token]
+def qualified_symbol_parts(qualified_name: str) -> list[str]:
+    return [part.lower() for part in re.split(r"[.:/\\]+", qualified_name) if part]
 
 
 def parent_qualified_name(qualified_name: str) -> str:
@@ -29,11 +29,11 @@ def parent_qualified_name(qualified_name: str) -> str:
     return parent.split("(", 1)[0]
 
 
-_TOKEN_CACHE: dict[int, tuple[ReferenceType, set[str], set[str]]] = {}
+_SYMBOL_PARTS_CACHE: dict[int, tuple[ReferenceType, set[str], set[str]]] = {}
 
 
-def _internal_reference_tokens(static_analysis: InternalReferenceSource) -> tuple[set[str], set[str]]:
-    """The anchor tokens and flat token set for one static-analysis result.
+def _internal_reference_symbol_parts(static_analysis: InternalReferenceSource) -> tuple[set[str], set[str]]:
+    """The anchor parts and flat symbol-part set for one static-analysis result.
 
     Why cached: deriving these walks every reference node in every language and tokenises each
     name, while callers ask per candidate symbol — recomputing turns a per-symbol question into
@@ -42,57 +42,57 @@ def _internal_reference_tokens(static_analysis: InternalReferenceSource) -> tupl
     is collected and a line whose referent is gone no longer matches.
     """
     key = id(static_analysis)
-    cached = _TOKEN_CACHE.get(key)
+    cached = _SYMBOL_PARTS_CACHE.get(key)
     if cached is not None and cached[0]() is static_analysis:
         return cached[1], cached[2]
-    token_paths = _internal_reference_token_paths(static_analysis)
-    anchors = _internal_reference_anchor_tokens(token_paths)
-    tokens = {token for path in token_paths for token in path}
+    symbol_part_paths = _internal_reference_symbol_part_paths(static_analysis)
+    anchors = _internal_reference_anchor_parts(symbol_part_paths)
+    symbol_parts = {part for path in symbol_part_paths for part in path}
     try:
-        _TOKEN_CACHE[key] = (ref(static_analysis), anchors, tokens)
+        _SYMBOL_PARTS_CACHE[key] = (ref(static_analysis), anchors, symbol_parts)
     except TypeError:
         pass  # Not weak-referenceable, so it cannot be cached safely; recompute next time.
-    return anchors, tokens
+    return anchors, symbol_parts
 
 
 def looks_internal_reference(static_analysis: InternalReferenceSource, qualified_name: str) -> bool:
-    tokens = reference_tokens(qualified_name)
-    if not tokens:
+    symbol_parts = qualified_symbol_parts(qualified_name)
+    if not symbol_parts:
         return False
-    anchor_tokens, internal_tokens = _internal_reference_tokens(static_analysis)
-    if tokens[0] in anchor_tokens:
+    anchor_parts, internal_parts = _internal_reference_symbol_parts(static_analysis)
+    if symbol_parts[0] in anchor_parts:
         return True
-    return any(token.startswith("_") and token in internal_tokens for token in tokens)
+    return any(part.startswith("_") and part in internal_parts for part in symbol_parts)
 
 
-def _internal_reference_token_paths(static_analysis: InternalReferenceSource) -> list[list[str]]:
-    token_paths: list[list[str]] = []
+def _internal_reference_symbol_part_paths(static_analysis: InternalReferenceSource) -> list[list[str]]:
+    symbol_part_paths: list[list[str]] = []
     for lang in static_analysis.get_languages():
         for node in static_analysis.iter_reference_nodes(lang):
-            token_paths.append(reference_tokens(node.fully_qualified_name))
-    return token_paths
+            symbol_part_paths.append(qualified_symbol_parts(node.fully_qualified_name))
+    return symbol_part_paths
 
 
-def _internal_reference_anchor_tokens(token_paths: list[list[str]]) -> set[str]:
-    """Return tokens that identify repo-local references without hardcoded layout names."""
+def _internal_reference_anchor_parts(symbol_part_paths: list[list[str]]) -> set[str]:
+    """Return symbol parts that identify repo-local references without hardcoded layout names."""
     anchors: set[str] = set()
-    by_first_token: dict[str, list[list[str]]] = defaultdict(list)
+    by_first_part: dict[str, list[list[str]]] = defaultdict(list)
 
-    for tokens in token_paths:
-        if not tokens:
+    for parts in symbol_part_paths:
+        if not parts:
             continue
-        anchors.add(tokens[0])
-        by_first_token[tokens[0]].append(tokens)
+        anchors.add(parts[0])
+        by_first_part[parts[0]].append(parts)
 
         seen: set[str] = set()
-        for token in tokens:
-            if token in seen:
-                anchors.add(token)
-            seen.add(token)
+        for part in parts:
+            if part in seen:
+                anchors.add(part)
+            seen.add(part)
 
-    for paths in by_first_token.values():
-        second_tokens = {tokens[1] for tokens in paths if len(tokens) > 1}
-        if len(second_tokens) > 1:
-            anchors.update(second_tokens)
+    for paths in by_first_part.values():
+        second_parts = {parts[1] for parts in paths if len(parts) > 1}
+        if len(second_parts) > 1:
+            anchors.update(second_parts)
 
     return anchors

--- a/static_analyzer/internal_references.py
+++ b/static_analyzer/internal_references.py
@@ -2,6 +2,7 @@ import re
 from collections import defaultdict
 from collections.abc import Iterable
 from typing import Protocol
+from weakref import ReferenceType, ref
 
 from static_analyzer.constants import Language
 
@@ -28,14 +29,39 @@ def parent_qualified_name(qualified_name: str) -> str:
     return parent.split("(", 1)[0]
 
 
+_TOKEN_CACHE: dict[int, tuple[ReferenceType, set[str], set[str]]] = {}
+
+
+def _internal_reference_tokens(static_analysis: InternalReferenceSource) -> tuple[set[str], set[str]]:
+    """The anchor tokens and flat token set for one static-analysis result.
+
+    Why cached: deriving these walks every reference node in every language and tokenises each
+    name, while callers ask per candidate symbol — recomputing turns a per-symbol question into
+    a repo-sized scan. Keyed by identity because the results object is large and unhashable; the
+    stored weak reference is what makes that safe, since an id is only reused once the original
+    is collected and a line whose referent is gone no longer matches.
+    """
+    key = id(static_analysis)
+    cached = _TOKEN_CACHE.get(key)
+    if cached is not None and cached[0]() is static_analysis:
+        return cached[1], cached[2]
+    token_paths = _internal_reference_token_paths(static_analysis)
+    anchors = _internal_reference_anchor_tokens(token_paths)
+    tokens = {token for path in token_paths for token in path}
+    try:
+        _TOKEN_CACHE[key] = (ref(static_analysis), anchors, tokens)
+    except TypeError:
+        pass  # Not weak-referenceable, so it cannot be cached safely; recompute next time.
+    return anchors, tokens
+
+
 def looks_internal_reference(static_analysis: InternalReferenceSource, qualified_name: str) -> bool:
     tokens = reference_tokens(qualified_name)
     if not tokens:
         return False
-    internal_token_paths = _internal_reference_token_paths(static_analysis)
-    if tokens[0] in _internal_reference_anchor_tokens(internal_token_paths):
+    anchor_tokens, internal_tokens = _internal_reference_tokens(static_analysis)
+    if tokens[0] in anchor_tokens:
         return True
-    internal_tokens = {token for path in internal_token_paths for token in path}
     return any(token.startswith("_") and token in internal_tokens for token in tokens)
 
 

--- a/static_analyzer/reference_resolver.py
+++ b/static_analyzer/reference_resolver.py
@@ -7,7 +7,7 @@ from typing import Any
 from agents.agent_responses import AnalysisInsights, RelationCallSite, RelationEdge, SourceCodeReference
 from static_analyzer.analysis_result import StaticAnalysisResults
 from static_analyzer.constants import LANGUAGE_EXTENSIONS, Language
-from static_analyzer.internal_references import looks_internal_reference, reference_tokens
+from static_analyzer.internal_references import looks_internal_reference, qualified_symbol_parts
 from static_analyzer.node import Node
 
 logger = logging.getLogger(__name__)
@@ -386,13 +386,13 @@ class StaticReferenceResolver:
 
     @staticmethod
     def _unique_token_match(qname: str, candidates: list[Node]) -> Node | None:
-        query_tokens = reference_tokens(qname)
+        query_tokens = qualified_symbol_parts(qname)
         if not query_tokens:
             return None
 
         matches: list[Node] = []
         for node in candidates:
-            candidate_tokens = reference_tokens(node.fully_qualified_name)
+            candidate_tokens = qualified_symbol_parts(node.fully_qualified_name)
             if candidate_tokens[-1:] != query_tokens[-1:]:
                 continue
             if all(token in candidate_tokens for token in query_tokens[:-1] if token.startswith("_")):

--- a/static_analyzer/reference_resolver.py
+++ b/static_analyzer/reference_resolver.py
@@ -38,6 +38,11 @@ class StaticReferenceResolver:
     def __init__(self, repo_dir: Path, static_analysis: StaticAnalysisResults):
         self.repo_dir = repo_dir
         self.static_analysis = static_analysis
+        # A miss falls through to get_loose_reference, which scans every reference in the
+        # bucket. The same handful of symbols recur across a relation's edges, so resolving
+        # each name once keeps edge filtering proportional to the edges rather than to the
+        # repo. The static analysis does not change while it is being consulted.
+        self._resolved_nodes: dict[str, Any] = {}
 
     def fix_source_code_reference_lines(self, analysis: AnalysisInsights) -> AnalysisInsights:
         logger.info(f"Fixing source code reference lines for the analysis: {analysis.llm_str()}")
@@ -190,6 +195,11 @@ class StaticReferenceResolver:
     def resolve_node(self, reference: SourceCodeReference):
         """Resolve a source reference to a static-analysis node without mutating it."""
         qname = reference.qualified_name.replace(os.sep, ".")
+        if qname not in self._resolved_nodes:
+            self._resolved_nodes[qname] = self._resolve_node_uncached(qname)
+        return self._resolved_nodes[qname]
+
+    def _resolve_node_uncached(self, qname: str):
         for lang in self.static_analysis.get_languages():
             try:
                 return self.static_analysis.get_reference(lang, qname)
@@ -254,30 +264,19 @@ class StaticReferenceResolver:
         return f"{node.fully_qualified_name}:{node.file_path}:{node.line_start}:{node.line_end}"
 
     def keep_relation_edge(self, edge: RelationEdge) -> bool:
-        """Keep relation edges that resolve internally or target external code."""
+        """Keep relation edges whose endpoints are real symbols, or that reach external code.
+
+        Why symbols rather than files: the file an endpoint names proves nothing about the
+        symbol in it. An invented method in a real module resolves to no node, and an edge
+        citing one describes a call that cannot exist. An endpoint that resolves nowhere and
+        does not look like repo code is external — legitimate evidence for a runtime relation.
+        """
         if self.same_resolved_relation_endpoint(edge):
             return False
-        if self.resolved_relation_edge(edge):
+        source_resolved = self.resolve_node(edge.source) is not None
+        target_resolved = self.resolve_node(edge.target) is not None
+        if source_resolved and target_resolved:
             return True
-        return self.external_relation_edge(edge)
-
-    def resolved_relation_edge(self, edge: RelationEdge) -> bool:
-        """Return true when both edge endpoints resolve to existing files."""
-        return (
-            edge.source.reference_file is not None
-            and self.reference_file_exists(edge.source.reference_file)
-            and edge.target.reference_file is not None
-            and self.reference_file_exists(edge.target.reference_file)
-        )
-
-    def external_relation_edge(self, edge: RelationEdge) -> bool:
-        """Return true when one endpoint is repo code and the other is external."""
-        source_resolved = edge.source.reference_file is not None and self.reference_file_exists(
-            edge.source.reference_file
-        )
-        target_resolved = edge.target.reference_file is not None and self.reference_file_exists(
-            edge.target.reference_file
-        )
         if source_resolved == target_resolved:
             return False
         unresolved = edge.target if source_resolved else edge.source

--- a/tests/agents/test_incremental_agent.py
+++ b/tests/agents/test_incremental_agent.py
@@ -299,7 +299,10 @@ class TestUpdateScope(unittest.TestCase):
 
         self.assertEqual(component.name, "API")
         self.assertEqual(component.description, "API description")
-        self.assertEqual(result.refresh_ids, {"1"})
+        # NOOP means the planner asked for nothing, and this one merges a cluster the component
+        # already holds — so nothing derived moved and nothing needs refreshing. Marking every
+        # NOOP component refreshed put untouched siblings into `changed_ids`.
+        self.assertEqual(result.refresh_ids, set())
         self.assertEqual(result.relation_context.cluster_results, {"python": ClusterResult()})
         self.assertEqual(result.relation_context.cfg_graphs, {})
 

--- a/tests/agents/test_relation_edges.py
+++ b/tests/agents/test_relation_edges.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 from agents.agent_responses import AnalysisInsights, Relation, RelationEdge, SourceCodeReference
 from agents.file_index_models import FileEntry, MethodEntry
-from agents.relation_edges import index_relation_endpoints
+from agents.relation_edges import _edge_touches_changed_method, index_relation_endpoints
 from static_analyzer.constants import NodeType
 
 
@@ -99,3 +99,33 @@ def test_index_relation_endpoints_does_not_invent_unknown_method_kinds() -> None
     index_relation_endpoints(analysis, Path("/repo"))
 
     assert analysis.files == {}
+
+
+# A call lives in its source method's body, so only the source can create or remove it.
+
+
+def _changed_edge(source: str, target: str) -> RelationEdge:
+    return RelationEdge(
+        source=SourceCodeReference(qualified_name=source),
+        target=SourceCodeReference(qualified_name=target),
+    )
+
+
+def test_an_edited_caller_can_account_for_the_call() -> None:
+    assert _edge_touches_changed_method(_changed_edge("pkg.caller", "pkg.callee"), {"pkg.caller"})
+
+
+def test_an_edited_callee_cannot_account_for_the_call() -> None:
+    # Editing a function's body does not change who calls it. Accepting this is what let a
+    # one-function commit re-word relations whose call set was byte-identical.
+    assert not _edge_touches_changed_method(_changed_edge("pkg.caller", "pkg.callee"), {"pkg.callee"})
+
+
+def test_neither_end_changed_accounts_for_nothing() -> None:
+    assert not _edge_touches_changed_method(_changed_edge("pkg.caller", "pkg.callee"), {"pkg.other"})
+
+
+def test_a_new_call_to_an_untouched_function_still_counts() -> None:
+    # The commonest way a real dependency appears: a caller edited to call something that
+    # already existed. Requiring BOTH ends to change would suppress it.
+    assert _edge_touches_changed_method(_changed_edge("pkg.caller", "pkg.old"), {"pkg.caller"})

--- a/tests/diagram_analysis/test_incremental_copy_forward.py
+++ b/tests/diagram_analysis/test_incremental_copy_forward.py
@@ -233,10 +233,26 @@ class TestIncrementalChangedComponentIds(unittest.TestCase):
         )
         self.assertEqual(changed, {"2"})
 
-    def test_membership_churn_marks_the_component(self):
+    def test_membership_churn_over_untouched_methods_does_not_mark_the_component(self):
+        # Re-clustering moves untouched methods between components constantly. Calling that a
+        # change put components owning nothing the commit reached into `changed_ids`, and their
+        # relations were then freely added and removed.
         keys = self._baseline_keys() | {"1": frozenset()}
         changed = _incremental_changed_component_ids(self._live(), {}, {"1", "2"}, keys, set(), set())
-        self.assertEqual(changed, {"1"})
+        self.assertEqual(changed, set())
+
+    def test_membership_churn_involving_a_changed_method_does_mark_the_component(self):
+        keys = self._baseline_keys() | {"1": frozenset()}
+        live = self._live()
+        moved = next(
+            method.qualified_name
+            for component in live.components
+            if component.component_id == "1"
+            for group in component.file_methods
+            for method in group.methods
+        )
+        changed = _incremental_changed_component_ids(live, {}, {"1", "2"}, keys, {moved}, set())
+        self.assertIn("1", changed)
 
     def test_component_absent_from_the_baseline_is_changed(self):
         changed = _incremental_changed_component_ids(self._live(), {}, {"1"}, self._baseline_keys(), set(), set())
@@ -276,6 +292,22 @@ class TestPreserveUnchangedGlobalRelations(unittest.TestCase):
         self.assertEqual([edge.source.qualified_name for edge in kept[0].key_edges], ["live.caller"])
 
     def test_edge_touching_a_changed_component_keeps_the_fresh_rebuild(self):
+        # Its supporting calls moved, so the connection itself changed and may be re-described.
+        fresh = self._relation("1", "2", "rebuilt wording")
+        fresh.all_edges = [RelationEdge(source=_ref("pkg.caller"), target=_ref("pkg.new_callee"))]
+        stale = self._relation("1", "2", "baseline wording")
+        stale.all_edges = [RelationEdge(source=_ref("pkg.caller"), target=_ref("pkg.old_callee"))]
+
+        kept = preserve_unchanged_relations(
+            [fresh], {("1", "2"): stale}, changed_component_ids={"2"}, live_ids={"1", "2"}, live_qnames=set()
+        )
+
+        self.assertEqual([rel.relation for rel in kept], ["rebuilt wording"])
+
+    def test_an_edgeless_pair_keeps_its_wording_even_when_an_endpoint_changed(self):
+        # Nothing under it could have moved: there are no supporting calls to move. Re-wording
+        # it is churn, and gating on the endpoint's change flag is what produced 17 of them on
+        # `referenced-symbol-deleted` for a commit that deleted one function.
         rebuilt = [self._relation("1", "2", "rebuilt wording")]
         baseline = {("1", "2"): self._relation("1", "2", "baseline wording")}
 
@@ -283,7 +315,7 @@ class TestPreserveUnchangedGlobalRelations(unittest.TestCase):
             rebuilt, baseline, changed_component_ids={"2"}, live_ids={"1", "2"}, live_qnames=set()
         )
 
-        self.assertEqual([rel.relation for rel in kept], ["rebuilt wording"])
+        self.assertEqual([rel.relation for rel in kept], ["baseline wording"])
 
     def test_touched_pair_with_identical_backing_edges_keeps_the_baseline_wording(self):
         # An endpoint is flagged changed (a file it co-owns had a module-level edit), but the
@@ -521,3 +553,132 @@ class TestScopeIdContract(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+    def test_an_ungrounded_pair_that_came_back_reversed_keeps_the_reader_s_orientation(self):
+        # Nothing grounds the direction of a runtime/config relation, so the model picks one
+        # afresh each run. Keyed on the ordered pair a swap reads as one relation deleted and
+        # another added — two of the five "changed edges" in the reported case were this.
+        fresh = self._relation("5", "4", "dispatches to")
+        fresh.evidence = "runtime dispatch"
+        stale = self._relation("4", "5", "captures user intent")
+        stale.evidence = "runtime dispatch"
+
+        kept = preserve_unchanged_relations([fresh], {("4", "5"): stale}, {"5"}, {"4", "5"}, set())
+
+        self.assertEqual([(r.src_id, r.dst_id) for r in kept], [("4", "5")])
+        self.assertEqual([r.relation for r in kept], ["captures user intent"])
+
+    def test_a_reversed_pair_with_backing_edges_keeps_its_own_direction(self):
+        # An edge is what makes the direction a claim rather than a phrasing; flipping a
+        # relation that has one would point its edges the wrong way.
+        fresh = self._relation("5", "4", "dispatches to")
+        fresh.all_edges = [RelationEdge(source=_ref("pkg.a.caller"), target=_ref("pkg.b.callee"))]
+        stale = self._relation("4", "5", "captures user intent")
+
+        kept = preserve_unchanged_relations([fresh], {("4", "5"): stale}, {"5"}, {"4", "5"}, set())
+
+        self.assertEqual([(r.src_id, r.dst_id) for r in kept], [("5", "4")])
+
+    def test_a_reversed_static_pair_is_never_re_oriented(self):
+        # A statically-backed relation takes its direction from real CFG edges.
+        fresh = self._relation("5", "4", "calls")
+        fresh.is_static = True
+        stale = self._relation("4", "5", "calls")
+        stale.is_static = True
+
+        kept = preserve_unchanged_relations([fresh], {("4", "5"): stale}, {"5"}, {"4", "5"}, set())
+
+        self.assertEqual([(r.src_id, r.dst_id) for r in kept], [("5", "4")])
+
+
+class TestChangedComponentGranularity(unittest.TestCase):
+    """A component that merely SHARES a file with the edit has not itself changed."""
+
+    @staticmethod
+    def _analysis(components):
+        return AnalysisInsights(description="", components=components, components_relations=[])
+
+    @staticmethod
+    def _component(cid, file_path, qnames):
+        return Component(
+            name=cid,
+            description="",
+            key_entities=[],
+            component_id=cid,
+            file_methods=[
+                FileMethodGroup(
+                    file_path=file_path,
+                    methods=[
+                        MethodEntry(qualified_name=q, start_line=1, end_line=2, node_type="FUNCTION") for q in qnames
+                    ],
+                )
+            ],
+        )
+
+    def _changed(self, components, changed_members, changed_files):
+        analysis = self._analysis(components)
+        baseline_keys = {c.component_id: _member_keys(c) for c in components}
+        return _incremental_changed_component_ids(
+            analysis, {}, {c.component_id for c in components}, baseline_keys, changed_members, changed_files
+        )
+
+    def test_a_co_owner_of_the_changed_file_is_not_itself_changed(self):
+        # `types.py` is shared: A owns the edited method, B owns other methods in the same file.
+        owner = self._component("A", "types.py", ["pkg.types.edited"])
+        co_owner = self._component("B", "types.py", ["pkg.types.untouched"])
+        changed = self._changed([owner, co_owner], {"pkg.types.edited"}, {"types.py"})
+        self.assertEqual(changed, {"A"}, "B shares the file but owns nothing that changed")
+
+    def test_a_module_level_edit_no_member_represents_still_flags_its_owners(self):
+        # An import or constant changed: no method's hash moved, so the file is the only signal.
+        a = self._component("A", "consts.py", ["pkg.consts.f"])
+        changed = self._changed([a], set(), {"consts.py"})
+        self.assertEqual(changed, {"A"})
+
+
+def _reconcile_child_scope_membership_for_test(child_scope, departed):
+    """The relation-filtering half of `_reconcile_child_scope_membership`, exercised directly."""
+    departed_qnames = {qualified_name for _path, qualified_name in departed}
+    child_scope.components_relations = [
+        relation
+        for relation in child_scope.components_relations
+        if not any(
+            edge.source.qualified_name in departed_qnames or edge.target.qualified_name in departed_qnames
+            for edge in [*relation.key_edges, *relation.all_edges]
+        )
+    ]
+
+
+class TestScopeRelationsSurviveMembershipMovement(unittest.TestCase):
+    """Reconciling membership must not wipe the scope's relations wholesale.
+
+    Clearing them leaves `preserve_unchanged_relations` with no baseline, so it is skipped and
+    every relation in the scope comes back re-worded — measured at 8 re-wordings on
+    `referenced-symbol-deleted` whose call sets were byte-identical.
+    """
+
+    @staticmethod
+    def _relation(src, dst, source_q, target_q):
+        return Relation(
+            relation="calls",
+            src_name=src,
+            dst_name=dst,
+            src_id=src,
+            dst_id=dst,
+            all_edges=[RelationEdge(source=_ref(source_q), target=_ref(target_q))],
+        )
+
+    def test_a_relation_citing_a_departed_method_is_dropped(self):
+        scope = AnalysisInsights(
+            description="",
+            components=[],
+            components_relations=[self._relation("1", "2", "pkg.gone", "pkg.stays")],
+        )
+        _reconcile_child_scope_membership_for_test(scope, departed={("a.py", "pkg.gone")})
+        self.assertEqual(scope.components_relations, [])
+
+    def test_a_relation_untouched_by_the_movement_is_kept(self):
+        keep = self._relation("1", "2", "pkg.here", "pkg.there")
+        scope = AnalysisInsights(description="", components=[], components_relations=[keep])
+        _reconcile_child_scope_membership_for_test(scope, departed={("a.py", "pkg.gone")})
+        self.assertEqual([r.relation for r in scope.components_relations], ["calls"])

--- a/tests/static_analyzer/test_cluster_relations.py
+++ b/tests/static_analyzer/test_cluster_relations.py
@@ -15,9 +15,13 @@ from static_analyzer.cluster_relations import (
     ClusterRelation,
     build_node_to_component_map,
     build_component_relations,
+    build_owner_index,
+    edge_crosses_components,
+    drop_reverse_duplicates,
     ground_relation_edges,
     is_self_or_descendant,
     merge_relations,
+    prune_ungrounded_edges,
 )
 from static_analyzer.constants import NodeType
 from static_analyzer.graph import CallGraph, Edge
@@ -419,3 +423,174 @@ class TestGroundRelationEdges(unittest.TestCase):
         key_edges, all_edges = ground_relation_edges([], [dup, dup])
         self.assertEqual(len(all_edges), 1)
         self.assertEqual(key_edges, [])
+
+
+class TestPruneUngroundedEdges(unittest.TestCase):
+    """Preservation re-injects baseline edges after the filters ran, so the assembled list is
+    filtered again — otherwise an older engine's edges outlive every update that leaves the
+    methods they name alone."""
+
+    NODES = {"pkg.a.caller": "1", "pkg.a.helper": "1", "pkg.b.callee": "2"}
+
+    def _prune(self, relation, keep_edge=lambda edge: True):
+        return prune_ungrounded_edges([relation], build_owner_index(self.NODES), keep_edge)
+
+    def _relation(self, edges, evidence=""):
+        return Relation(
+            relation="calls",
+            src_name="A",
+            dst_name="B",
+            src_id="1",
+            dst_id="2",
+            evidence=evidence,
+            key_edges=list(edges),
+            all_edges=list(edges),
+        )
+
+    def test_an_inherited_intra_component_edge_is_dropped(self):
+        # Both ends in component 1: there is no cross-component call to preserve anywhere.
+        rel = self._relation([_make_relation_edge("pkg.a.caller", "pkg.a.helper")])
+        self.assertEqual(self._prune(rel), [])
+
+    def test_a_real_call_filed_under_the_wrong_pair_is_kept_not_lost(self):
+        # 1 -> 2 is real, but this relation claims 2 -> 1. Dropping it would delete the only
+        # record of a genuine cross-component call.
+        rel = self._relation([_make_relation_edge("pkg.a.caller", "pkg.b.callee")])
+        rel.src_id, rel.dst_id = "2", "1"
+        kept = self._prune(rel)
+        self.assertEqual([e.target.qualified_name for e in kept[0].all_edges], ["pkg.b.callee"])
+
+    def test_a_misfiled_call_moves_to_the_relation_that_declares_its_pair(self):
+        wrong = self._relation([_make_relation_edge("pkg.a.caller", "pkg.b.callee")], evidence="e")
+        wrong.src_id, wrong.dst_id = "2", "1"
+        right = self._relation([])
+        right.evidence = "the pair this call actually runs between"
+        kept = prune_ungrounded_edges([wrong, right], build_owner_index(self.NODES), lambda edge: True)
+        by_pair = {(r.src_id, r.dst_id): r for r in kept}
+        self.assertEqual([e.target.qualified_name for e in by_pair[("1", "2")].all_edges], ["pkg.b.callee"])
+        # And the emptied backwards copy goes with it: on prose alone it now states a
+        # connection the grounded relation already states the right way round.
+        self.assertNotIn(("2", "1"), by_pair)
+
+    def test_an_inherited_edge_naming_a_dead_symbol_is_dropped(self):
+        rel = self._relation([_make_relation_edge("pkg.a.caller", "pkg.b.callee")])
+        self.assertEqual(self._prune(rel, keep_edge=lambda edge: False), [])
+
+    def test_a_crossing_edge_survives(self):
+        rel = self._relation([_make_relation_edge("pkg.a.caller", "pkg.b.callee")])
+        kept = self._prune(rel)
+        self.assertEqual([e.target.qualified_name for e in kept[0].all_edges], ["pkg.b.callee"])
+
+    def test_an_edgeless_relation_whose_reverse_is_grounded_is_dropped(self):
+        # The same connection stated backwards: `B -> A` survives on prose while `A -> B` holds
+        # the actual call. Keeping both draws the dependency twice, one arrow pointing the
+        # wrong way, and every run that repairs it reads as churn.
+        grounded = self._relation([_make_relation_edge("pkg.a.caller", "pkg.b.callee")])
+        backwards = self._relation([], evidence="reads the parsed result")
+        backwards.src_id, backwards.dst_id = "2", "1"
+        kept = prune_ungrounded_edges([grounded, backwards], build_owner_index(self.NODES), lambda edge: True)
+        self.assertEqual([(r.src_id, r.dst_id) for r in kept], [("1", "2")])
+
+    def test_an_edgeless_relation_with_no_grounded_reverse_survives(self):
+        # Nothing else states this connection, so its evidence is the only record of it.
+        backwards = self._relation([], evidence="over the work queue")
+        backwards.src_id, backwards.dst_id = "2", "1"
+        kept = prune_ungrounded_edges([backwards], build_owner_index(self.NODES), lambda edge: True)
+        self.assertEqual([(r.src_id, r.dst_id) for r in kept], [("2", "1")])
+
+    def test_a_static_edgeless_relation_is_never_dropped_for_its_reverse(self):
+        grounded = self._relation([_make_relation_edge("pkg.a.caller", "pkg.b.callee")])
+        backwards = self._relation([], evidence="derived from the call graph")
+        backwards.src_id, backwards.dst_id = "2", "1"
+        backwards.is_static = True
+        kept = prune_ungrounded_edges([grounded, backwards], build_owner_index(self.NODES), lambda edge: True)
+        self.assertEqual(sorted((r.src_id, r.dst_id) for r in kept), [("1", "2"), ("2", "1")])
+
+    def test_a_relation_left_edgeless_survives_on_its_evidence(self):
+        # An edgeless runtime/config relation is a claim in its own right.
+        rel = self._relation([_make_relation_edge("pkg.a.caller", "pkg.a.helper")], evidence="over the queue")
+        kept = self._prune(rel)
+        self.assertEqual([r.relation for r in kept], ["calls"])
+        self.assertEqual(kept[0].all_edges, [])
+
+
+class TestEdgeCrossesComponents(unittest.TestCase):
+    """A runtime/config pair has no static edge to ground against, so its LLM edges are checked here."""
+
+    NODES = {
+        "scripts.engine_adapter.run_render": "1",
+        "scripts.build_component_files.render_component_files": "2",
+        "scripts.submit_feedback.resolve_command": "4",
+        "scripts.build_cta.main": "5",
+        "scripts.build_cta.build_cta": "5",
+    }
+
+    def _crosses(self, edge, src_id, dst_id):
+        return edge_crosses_components(edge, build_owner_index(self.NODES), src_id, dst_id)
+
+    def test_intra_component_edge_is_not_a_cross_component_call(self):
+        # Both endpoints belong to component 5, so this cannot back a 5 -> 2 relation.
+        edge = _make_relation_edge("scripts.build_cta.main", "scripts.build_cta.build_cta")
+        self.assertFalse(self._crosses(edge, "5", "2"))
+
+    def test_edge_crossing_the_declared_pair_is_kept(self):
+        edge = _make_relation_edge("scripts.build_cta.main", "scripts.submit_feedback.resolve_command")
+        self.assertTrue(self._crosses(edge, "5", "4"))
+
+    def test_unowned_endpoint_is_left_to_the_symbol_check(self):
+        # An endpoint no component owns may be external code; validity is not decided here.
+        edge = _make_relation_edge("scripts.build_cta.main", "requests.post")
+        self.assertTrue(self._crosses(edge, "5", "9"))
+
+    def test_child_component_satisfies_its_ancestor_id(self):
+        edge = _make_relation_edge("scripts.build_cta.main", "scripts.submit_feedback.resolve_command")
+        index = build_owner_index({**self.NODES, "scripts.build_cta.main": "5.1"})
+        self.assertTrue(edge_crosses_components(edge, index, "5", "4"))
+
+    def test_unresolved_pair_ids_skip_the_ownership_check(self):
+        edge = _make_relation_edge("scripts.build_cta.main", "scripts.submit_feedback.resolve_command")
+        self.assertTrue(self._crosses(edge, "", ""))
+
+
+class TestDropReverseDuplicates(unittest.TestCase):
+    """Two relations between the same components, one each way, saying the same thing."""
+
+    @staticmethod
+    def _rel(src, dst, evidence="", edges=0, static=False):
+        return Relation(
+            relation="calls",
+            src_name=src,
+            dst_name=dst,
+            src_id=src,
+            dst_id=dst,
+            evidence=evidence,
+            is_static=static,
+            all_edges=[_make_relation_edge(f"pkg.a{i}", f"pkg.b{i}") for i in range(edges)],
+        )
+
+    def test_the_grounded_direction_wins(self):
+        kept = drop_reverse_duplicates([self._rel("1", "2", edges=1), self._rel("2", "1", evidence="e")])
+        self.assertEqual([(r.src_id, r.dst_id) for r in kept], [("1", "2")])
+
+    def test_two_bare_directions_collapse_to_one_deterministically(self):
+        # Nothing distinguishes them, so the choice must not depend on run order — otherwise one
+        # run's baseline carries both and the next reports an add or a delete.
+        pair = [self._rel("1", "2", evidence="aa"), self._rel("2", "1", evidence="aa")]
+        first = [(r.src_id, r.dst_id) for r in drop_reverse_duplicates(pair)]
+        second = [(r.src_id, r.dst_id) for r in drop_reverse_duplicates(list(reversed(pair)))]
+        self.assertEqual(len(first), 1)
+        self.assertEqual(first, second, "the survivor must not depend on input order")
+
+    def test_the_better_evidenced_bare_direction_is_the_one_kept(self):
+        kept = drop_reverse_duplicates(
+            [self._rel("1", "2", evidence="a"), self._rel("2", "1", evidence="a much longer why")]
+        )
+        self.assertEqual([(r.src_id, r.dst_id) for r in kept], [("2", "1")])
+
+    def test_both_directions_survive_when_both_are_grounded(self):
+        kept = drop_reverse_duplicates([self._rel("1", "2", edges=1), self._rel("2", "1", edges=1)])
+        self.assertEqual(sorted((r.src_id, r.dst_id) for r in kept), [("1", "2"), ("2", "1")])
+
+    def test_a_static_relation_is_never_collapsed(self):
+        kept = drop_reverse_duplicates([self._rel("1", "2", edges=1), self._rel("2", "1", static=True)])
+        self.assertEqual(sorted((r.src_id, r.dst_id) for r in kept), [("1", "2"), ("2", "1")])

--- a/tests/static_analyzer/test_reference_resolver.py
+++ b/tests/static_analyzer/test_reference_resolver.py
@@ -31,6 +31,22 @@ class TestStaticReferenceResolver(unittest.TestCase):
     def _node(self, qname: str, rel_file: str, start: int = 1, end: int = 2) -> Node:
         return Node(qname, NodeType.FUNCTION, str(self.repo_dir / rel_file), start, end)
 
+    @staticmethod
+    def _resolves(*nodes: Node):
+        """A ``get_reference`` stub keyed by qualified name rather than by call order.
+
+        Why: resolution is now consulted per endpoint wherever an edge is judged, so a fixed
+        side-effect list ties the test to a call count instead of to what actually resolves.
+        """
+        by_qname = {node.fully_qualified_name: node for node in nodes}
+
+        def get_reference(_language, qualified_name: str) -> Node:
+            if qualified_name in by_qname:
+                return by_qname[qualified_name]
+            raise ValueError(f"{qualified_name} not found")
+
+        return get_reference
+
     def _file_methods(self, qname: str, rel_file: str) -> list[FileMethodGroup]:
         return [
             FileMethodGroup(
@@ -216,7 +232,7 @@ class TestStaticReferenceResolver(unittest.TestCase):
     def test_fix_source_code_reference_lines_resolves_relation_edges_and_call_sites(self):
         source_node = self._node("service.OCR.extract_text", "service.py", 1, 2)
         target_node = self._node("module.file.test_function", "module/file.py", 3, 4)
-        self.static_analysis.get_reference.side_effect = [source_node, target_node]
+        self.static_analysis.get_reference.side_effect = self._resolves(source_node, target_node)
         static_edge = Edge(source_node, target_node, [{"line": 7, "column": 8}])
         cfg = MagicMock()
         cfg.edges = [static_edge]
@@ -250,7 +266,7 @@ class TestStaticReferenceResolver(unittest.TestCase):
 
     def test_fix_source_code_reference_lines_keeps_external_target_edge(self):
         source_node = self._node("service.OCR.extract_text", "service.py", 1, 2)
-        self.static_analysis.get_reference.side_effect = [source_node, ValueError("not found")]
+        self.static_analysis.get_reference.side_effect = self._resolves(source_node)
         self.static_analysis.get_loose_reference.return_value = ("", None)
         self.static_analysis.iter_reference_nodes.return_value = [source_node]
         relation = Relation(


### PR DESCRIPTION
Closes the report on `CodeBoarding-action` PR #65: a one-file commit produced **five modified edges**, most showing no call site, one deleted edge implying `build_cta.py` belonged to a component it was never in, and added edges naming the changed component but not the changed methods.

Two independent causes.

## 1. Edges were validated against files, not symbols

`RELATION_ANALYSIS_MESSAGE` tells the model not to limit relations to static calls, so it authors `key_edges` freely and `ground_relation_edges` promotes them verbatim when no static edge backs the pair. The only gate, `keep_relation_edge`, asked whether the referenced **file** existed — true of almost any plausible-looking name in the repo.

It now resolves both endpoints as **symbols**:

- both resolve → keep
- neither resolves → drop
- one resolves, the other looks like an internal reference → drop; otherwise keep, since a genuine call into a dependency has no node

Resolution is memoised per analysis, and `looks_internal_reference` caches its token set — it went quadratic once it was on this path.

`prune_ungrounded_edges` then repairs attribution. An edge whose endpoints live in components other than the ones its relation names is **re-filed** to the relation that declares its true pair, not deleted: measured on a stored analysis, deleting them orphaned 25 of 28 real cross-component calls, which existed nowhere else in the document. Deletion is correct only when both endpoints sit inside one component, where there is no cross-component fact to keep — and that is the shape the original report was about.

`drop_reverse_duplicates` collapses `A -> B` and `B -> A`, grounded side winning, ties broken deterministically. Four of the five reported edges were pure direction flips. Both passes run on full and incremental alike; applying them only to incremental made a body-edit commit report five phantom removals.

## 2. Churn was gated on files and on re-clustering, not on changed methods

An edge is a fact about two methods, so the commit has to have touched one of them. Four places substituted a coarser signal:

| where | substituted | now |
|---|---|---|
| `diagram_generator` | scope lost **any** member → drop **every** relation in it | drop only relations whose edges name a departed method |
| `_restore_unchanged_metadata` | any live/baseline membership difference is drift | membership-derived fields (`source_cluster_ids`, key entities) restored separately from prose; an entity survives if its qualified name is still live |
| `_incremental_changed_component_ids` | membership churn alone marks a component changed | the churn must involve a method the commit touched |
| `NOOP` plan step | always added its component to `refresh_ids` | refreshes only when the cluster ids actually moved |

Re-partitioning moves untouched methods between components on nearly every run, which is why each of these fired constantly.

Relation add/remove is gated on a set narrowed to components owning a changed method, plus components genuinely new or gone — deliberately **distinct** from the set used to decide what to re-derive, which must stay broader.

Relabelling requires the edge's **source** to be a changed method. Attributing a call to its caller is what makes "this edge changed" mean "this code changed". (Requiring *both* ends would be stricter, but a caller rewriting how it calls an unchanged callee is a real edge change; the source rule keeps it and the UI can still choose to show only both-ends changes.)

## Measured

Four incremental tests, each engine against **its own** baseline. A shared `--baseline main` carries the baseline's edges forward wherever the commit left the methods alone — 76 of 80 ungrounded edges survived a single update — and hides the entire effect.

| | main | this branch |
|---|---|---|
| relation churn | 35 | **12** |
| add/remove where neither endpoint changed | 9 | **2** |
| relabels with no changed source | 10 | **0** |
| `source_cluster_ids` changed | 22 | **0** |
| `key_entities` changed | 7 | **1** |
| ungrounded edges, fresh full analysis | 87 | **12–18** |
| incremental criteria met | 83% | **97%** |
| full criteria met | 75% | **88%** |

Per test (`additions/removals/modifications`, and how many had neither endpoint changed):

```
referenced-symbol-deleted   main 4/3/18 (2 unjust)  →  4/1/3  (0 unjust)
capability-retired          main 2/4/1  (6 unjust)  →  0/1/0  (1 unjust)
body-edit-no-call-change    main 0/0/0             →  0/0/0
whole-module-deleted        main 0/3/0  (1 unjust)  →  0/3/0  (1 unjust)
```

## Known gaps

- The two remaining unjustified removals are both LLM-authored (`is_static=false`) relations. Not chased — at 2 of 12 they are no longer the dominant signal.
- `structural_operations` is unstable at n=1 on `referenced-symbol-deleted`; repeated runs of one engine produce different operation *sets*. Don't read a single run of that test as a regression.

## Companion

Checks and criteria that measure this are on `CodeBoarding-evals` main (`0735726`): `relations.edge_endpoints_are_known_symbols`, `relations.edges_cross_declared_components`, and the `edge_grounding` / `ungrounded_edge_churn` / `relation_churn` criteria. Compare `incremental/relation-stability-fix` against `incremental/relation-stability-main`.

1959 tests, black and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved incremental analysis to preserve unaffected component metadata and relation descriptions.
  * Corrected relation detection to focus on changes affecting callers and relevant components.
  * Removed unsupported, misattributed, and duplicate reverse relations while preserving valid external references.
  * Improved handling of renamed, repartitioned, or removed methods and components.

* **Performance**
  * Added caching to speed up repeated reference and node resolution.

* **Tests**
  * Expanded coverage for incremental updates, relation validation, edge ownership, duplicate removal, and external references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->