### PR TITLE
No component is expanded into exactly one sub-component

### DIFF
--- a/agents/incremental_agent.py
+++ b/agents/incremental_agent.py
@@ -475,6 +475,7 @@ class IncrementalAgent(ClusterMethodsMixin, CodeBoardingAgent):
                 scope.components_relations,
                 build_owner_index(build_node_to_component_map(scope)),
                 self.reference_resolver.keep_relation_edge,
+                changed_members or set(),
             )
             rels = scope.components_relations
         return rels

--- a/agents/incremental_agent.py
+++ b/agents/incremental_agent.py
@@ -851,6 +851,7 @@ def _scrub_one_analysis(analysis: AnalysisInsights, live_files: set[str]) -> set
     """Drop dead-file references in one analysis and return dropped paths."""
     dropped: set[str] = set()
     for component in analysis.components:
+        had_methods = any(group.methods for group in component.file_methods)
         kept_groups = []
         for group in component.file_methods:
             if group.file_path in live_files:
@@ -863,6 +864,8 @@ def _scrub_one_analysis(analysis: AnalysisInsights, live_files: set[str]) -> set
             for key_entity in component.key_entities
             if key_entity.reference_file is None or key_entity.reference_file in live_files
         ]
+        if had_methods and not any(group.methods for group in component.file_methods):
+            component.source_cluster_ids = []
     dropped |= {file_path for file_path in analysis.files if file_path not in live_files}
     analysis.files = {file_path: entry for file_path, entry in analysis.files.items() if file_path in live_files}
     return dropped
@@ -871,17 +874,15 @@ def _scrub_one_analysis(analysis: AnalysisInsights, live_files: set[str]) -> set
 def prune_empty_components(
     root_analysis: AnalysisInsights,
     sub_analyses: dict[str, AnalysisInsights],
-    protected_empty_ids: set[str] | None = None,
 ) -> set[str]:
-    """Remove components with no methods and strip relations pointing to them."""
+    """Remove components with neither members nor live cluster lineage."""
     removed_ids: set[str] = set()
-    protected_empty_ids = protected_empty_ids or set()
 
     def has_methods(component: Component) -> bool:
         return (
             any(group.methods for group in component.file_methods)
             or bool(component.key_entities)
-            or bool(component.component_id in protected_empty_ids and component.source_cluster_ids)
+            or bool(component.source_cluster_ids)
         )
 
     def collect_empty(analysis: AnalysisInsights) -> None:

--- a/diagram_analysis/diagram_generator.py
+++ b/diagram_analysis/diagram_generator.py
@@ -1196,6 +1196,8 @@ class DiagramGenerator:
         self,
         root_analysis: AnalysisInsights,
         sub_analyses: dict[str, AnalysisInsights],
+        *,
+        absorb: bool = True,
     ) -> None:
         """Prepare an analysis tree for its authoritative save.
 
@@ -1203,16 +1205,26 @@ class DiagramGenerator:
         flows. All steps are idempotent and
         safe with an empty ``sub_analyses`` (rebuild is a root-only pass).
 
-        Absorption runs first so the relation rebuild sees the corrected tree, and
+        Absorption runs early so the relation rebuild sees the corrected tree, and
         so a legacy baseline carrying the defect is repaired rather than rejected.
+        ``absorb`` is False for a save that will not persist the static-analysis
+        artifact: the collapse rewrites the tree AND the cluster lineage, and a save
+        that writes only one of the two leaves the next run seeding a collapsed tree
+        from the partition it had before. The next full or incremental save repairs it.
         """
-        drop_dangling_key_entities(root_analysis, sub_analyses)
-        cfgs = (
-            [self.static_analysis.get_cfg(lang) for lang in self.static_analysis.get_languages()]
-            if self.static_analysis
-            else []
-        )
-        self._rebase_baseline(absorb_single_child_components(root_analysis, sub_analyses, cfgs))
+        drop_dangling_key_entities(root_analysis, sub_analyses, self.repo_location)
+        # Before the collapse, not after. Absorbing a childless only child deletes its
+        # scope, and the deletion is only lossless because the parent already owns
+        # everything it owned. On a tree where that does not hold, absorbing first would
+        # discard the child's extra methods and leave nothing for the check to find.
+        assert_scope_containment(root_analysis, sub_analyses)
+        if absorb:
+            cfgs = (
+                [self.static_analysis.get_cfg(lang) for lang in self.static_analysis.get_languages()]
+                if self.static_analysis
+                else []
+            )
+            self._rebase_baseline(absorb_single_child_components(root_analysis, sub_analyses, cfgs))
         self.rebuild_global_relations(root_analysis, sub_analyses)
         self._strip_ignored(root_analysis, sub_analyses)
         assert_scope_containment(root_analysis, sub_analyses)
@@ -1266,7 +1278,7 @@ class DiagramGenerator:
         rewriting those would drop the ``static_analysis.sha`` tag (cold-starting
         the next incremental) and desync the sidecar from ``source_tree_hash``.
         """
-        self.finalize_for_save(root_analysis, sub_analyses)
+        self.finalize_for_save(root_analysis, sub_analyses, absorb=persist_side_artifacts)
         if persist_side_artifacts:
             source_tree_hash = self._source_tree_hash()
         else:
@@ -1570,7 +1582,7 @@ class DiagramGenerator:
             # component emptied by a route that never entered `refresh_ids` — and whose entities
             # `fix_key_entities_refs` therefore never re-resolved — would otherwise be kept alive
             # by pointers into symbols the commit deleted.
-            drop_dangling_key_entities(root_analysis, sub_analyses)
+            drop_dangling_key_entities(root_analysis, sub_analyses, self.repo_location)
             removed_ids = prune_empty_components(root_analysis, sub_analyses, protected_empty_ids)
             if removed_ids:
                 apply_result.refresh_ids -= removed_ids

--- a/diagram_analysis/diagram_generator.py
+++ b/diagram_analysis/diagram_generator.py
@@ -396,7 +396,8 @@ def _restore_unchanged_metadata(
             # on "owns a changed file" re-authored them for every component that merely shares a
             # file with the edit: measured on `referenced-symbol-deleted`, 11 components changed
             # cluster ids and 3 changed key entities for a commit that deleted one function.
-            component.source_cluster_ids = list(meta.source_cluster_ids)
+            if final_keys or not meta.member_keys:
+                component.source_cluster_ids = list(meta.source_cluster_ids)
             # An entity survives unless its symbol is GONE. Editing a method's body does not
             # make the class it lives in a worse choice of key entity — dropping on "changed"
             # rather than "deleted" is why `File` and `LazyFile` vanished from three components

--- a/diagram_analysis/diagram_generator.py
+++ b/diagram_analysis/diagram_generator.py
@@ -63,6 +63,7 @@ from diagram_analysis.file_index import build_files_index, refresh_method_spans_
 from diagram_analysis.io_utils import load_analysis_metadata, save_analysis, write_fingerprint
 from repo_utils.path_utils import normalize_repo_path
 from diagram_analysis.scope_plan import plan_scope_update
+from diagram_analysis.tree_shape import absorb_single_child_components, drop_dangling_key_entities
 from health.config import initialize_health_dir, load_health_config
 from health.runner import run_health_checks
 from monitoring import StreamingStatsWriter
@@ -1196,7 +1197,12 @@ class DiagramGenerator:
         Single pre-save chokepoint shared by the full, incremental, and partial
         flows. All steps are idempotent and
         safe with an empty ``sub_analyses`` (rebuild is a root-only pass).
+
+        Absorption runs first so the relation rebuild sees the corrected tree, and
+        so a legacy baseline carrying the defect is repaired rather than rejected.
         """
+        drop_dangling_key_entities(root_analysis, sub_analyses)
+        absorb_single_child_components(root_analysis, sub_analyses)
         self.rebuild_global_relations(root_analysis, sub_analyses)
         self._strip_ignored(root_analysis, sub_analyses)
         assert_scope_containment(root_analysis, sub_analyses)
@@ -1396,6 +1402,14 @@ class DiagramGenerator:
         # membership baseline (captured post-scrub below) so the restore passes never re-inject a
         # deleted method. Also drives the empty-delta path, which returns before that capture.
         self._baseline_member_keys = _capture_baseline_member_keys(root_analysis, sub_analyses)
+        # Same side of the scrub, for the same reason. This protects a component that is empty
+        # but still cluster-backed — one awaiting re-detail — from being pruned. Captured AFTER
+        # the scrub it also protected components the scrub had just emptied, because
+        # `remove_deleted_files` clears methods and key entities but not `source_cluster_ids`:
+        # a component whose whole source was deleted matched "no methods, no entities, still has
+        # cluster ids" and survived as an empty box. That is the shape `whole-module-deleted`
+        # exists to catch, and it is why a deletion never left a parent holding one child.
+        protected_empty_ids = _cluster_backed_empty_component_ids(root_analysis, sub_analyses)
 
         monitor = self.stats_writer if self.stats_writer else nullcontext()
         with monitor:
@@ -1466,7 +1480,6 @@ class DiagramGenerator:
                 self._refresh_files_index(root_analysis, sub_analyses)
                 return self.finalize_and_save(root_analysis, sub_analyses)
 
-            protected_empty_ids = _cluster_backed_empty_component_ids(root_analysis, sub_analyses)
             # Full membership baseline for the restore/rescope passes, captured AFTER the deletion
             # scrub so a deleted method is never re-injected from the baseline into a live scope.
             baseline_membership = _capture_membership_baseline(root_analysis, sub_analyses)
@@ -1517,6 +1530,12 @@ class DiagramGenerator:
             )
             apply_result.refresh_ids -= unchanged_ids
 
+            # Before the prune, because the prune reads `key_entities` as evidence a component
+            # still has something to describe. Membership is settled by the rescope above, so a
+            # component emptied by a route that never entered `refresh_ids` — and whose entities
+            # `fix_key_entities_refs` therefore never re-resolved — would otherwise be kept alive
+            # by pointers into symbols the commit deleted.
+            drop_dangling_key_entities(root_analysis, sub_analyses)
             removed_ids = prune_empty_components(root_analysis, sub_analyses, protected_empty_ids)
             if removed_ids:
                 apply_result.refresh_ids -= removed_ids

--- a/diagram_analysis/diagram_generator.py
+++ b/diagram_analysis/diagram_generator.py
@@ -1204,6 +1204,7 @@ class DiagramGenerator:
                 global_relations,
                 build_owner_index(build_global_node_to_component_map(root_analysis, sub_analyses)),
                 StaticReferenceResolver(self.repo_location, self.static_analysis).keep_relation_edge,
+                self._changed_members,
             )
         root_analysis.components_relations = global_relations
         return global_relations

--- a/diagram_analysis/diagram_generator.py
+++ b/diagram_analysis/diagram_generator.py
@@ -7,7 +7,6 @@ from collections.abc import Iterable, Iterator
 from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
 from contextlib import nullcontext
 from dataclasses import dataclass, field, replace
-from functools import partial
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -64,11 +63,7 @@ from diagram_analysis.file_index import build_files_index, refresh_method_spans_
 from diagram_analysis.io_utils import load_analysis_metadata, save_analysis, write_fingerprint
 from repo_utils.path_utils import normalize_repo_path
 from diagram_analysis.scope_plan import plan_scope_update
-from diagram_analysis.tree_shape import (
-    absorb_single_child_components,
-    drop_dangling_key_entities,
-    reroot_absorbed_id,
-)
+from diagram_analysis.tree_shape import absorb_single_child_components
 from health.config import initialize_health_dir, load_health_config
 from health.runner import run_health_checks
 from monitoring import StreamingStatsWriter
@@ -123,6 +118,19 @@ def _owned_method_keys(components: Iterable[Component]) -> set[tuple[str, str]]:
     return {key for component in components for key in _member_keys(component)}
 
 
+def _key_entity_is_owned(
+    entity: SourceCodeReference,
+    member_keys: set[tuple[str, str]],
+    repo_dir: Path,
+) -> bool:
+    """Return whether a key entity still names one of the component's methods."""
+    if entity.reference_file is None:
+        return any(qualified_name == entity.qualified_name for _path, qualified_name in member_keys)
+    entity_key = (normalize_repo_path(entity.reference_file, repo_dir), entity.qualified_name)
+    normalized_keys = {(normalize_repo_path(path, repo_dir), qualified_name) for path, qualified_name in member_keys}
+    return entity_key in normalized_keys
+
+
 def _reconcile_child_scope(
     parent: Component,
     child_scope: AnalysisInsights,
@@ -142,9 +150,16 @@ def _reconcile_child_scope(
     entered = parent_keys - child_keys
     if departed:
         for child in child_scope.components:
+            had_methods = any(group.methods for group in child.file_methods)
             for group in child.file_methods:
                 group.methods = [m for m in group.methods if (group.file_path, m.qualified_name) not in departed]
             child.file_methods = [group for group in child.file_methods if group.methods]
+            remaining = set(_member_keys(child))
+            child.key_entities = [
+                entity for entity in child.key_entities if _key_entity_is_owned(entity, remaining, repo_dir)
+            ]
+            if had_methods and not remaining:
+                child.source_cluster_ids = []
     if entered:
         parent_methods = {
             (group.file_path, method.qualified_name): method
@@ -1196,66 +1211,19 @@ class DiagramGenerator:
         self,
         root_analysis: AnalysisInsights,
         sub_analyses: dict[str, AnalysisInsights],
-        *,
-        absorb: bool = True,
     ) -> None:
-        """Prepare an analysis tree for its authoritative save.
-
-        Single pre-save chokepoint shared by the full, incremental, and partial
-        flows. All steps are idempotent and
-        safe with an empty ``sub_analyses`` (rebuild is a root-only pass).
-
-        Absorption runs early so the relation rebuild sees the corrected tree, and
-        so a legacy baseline carrying the defect is repaired rather than rejected.
-        ``absorb`` is False for a save that will not persist the static-analysis
-        artifact: the collapse rewrites the tree AND the cluster lineage, and a save
-        that writes only one of the two leaves the next run seeding a collapsed tree
-        from the partition it had before. The next full or incremental save repairs it.
-        """
-        drop_dangling_key_entities(root_analysis, sub_analyses, self.repo_location)
-        # Before the collapse, not after. Absorbing a childless only child deletes its
-        # scope, and the deletion is only lossless because the parent already owns
-        # everything it owned. On a tree where that does not hold, absorbing first would
-        # discard the child's extra methods and leave nothing for the check to find.
-        assert_scope_containment(root_analysis, sub_analyses)
-        if absorb:
-            cfgs = (
-                [self.static_analysis.get_cfg(lang) for lang in self.static_analysis.get_languages()]
-                if self.static_analysis
-                else []
-            )
-            self._rebase_baseline(absorb_single_child_components(root_analysis, sub_analyses, cfgs))
-        self.rebuild_global_relations(root_analysis, sub_analyses)
+        """Prepare and validate an analysis tree for its authoritative save."""
         self._strip_ignored(root_analysis, sub_analyses)
+        # Absorption must not erase the evidence of an invalid parent-child boundary.
         assert_scope_containment(root_analysis, sub_analyses)
-
-    def _rebase_baseline(self, absorbed_ids: list[str]) -> None:
-        """Move the incremental baseline onto the ids absorption just rewrote.
-
-        Why: the baseline is snapshotted before the collapse, so it still calls the code behind
-        ``2`` by the name ``2.1``. Read against the collapsed tree, the rebuilt pair ``1 -> 2``
-        matches nothing in it and neither endpoint counts as changed, so
-        ``preserve_unchanged_relations`` discards it as drift while the baseline's own ``1 -> 2.1``
-        is skipped for naming a component that is no longer live — and the relation is lost.
-        """
-        if self._baseline_global_relations is None:
-            return
-        for child_id in absorbed_ids:
-            moved = partial(reroot_absorbed_id, child_id=child_id)
-            self._baseline_component_ids = {moved(cid) for cid in self._baseline_component_ids if cid != child_id}
-            self._baseline_member_keys = {
-                moved(cid): keys for cid, keys in self._baseline_member_keys.items() if cid != child_id
-            }
-            rebased: dict[tuple[str, str], Relation] = {}
-            for (src_id, dst_id), relation in self._baseline_global_relations.items():
-                src, dst = moved(src_id), moved(dst_id)
-                # Mirrors _reroot_relations: a pair that collapses onto itself is not an edge.
-                if src and dst and src != dst:
-                    # The endpoints move with the key. `preserve_unchanged_relations` restores this
-                    # object itself for a pair the rebuild dropped, so a relation left carrying the
-                    # absorbed child's id would be saved pointing at a component that is gone.
-                    rebased.setdefault((src, dst), relation.model_copy(update={"src_id": src, "dst_id": dst}))
-            self._baseline_global_relations = rebased
+        self.rebuild_global_relations(root_analysis, sub_analyses)
+        cfgs = (
+            [self.static_analysis.get_cfg(lang) for lang in self.static_analysis.get_languages()]
+            if self.static_analysis
+            else []
+        )
+        absorb_single_child_components(root_analysis, sub_analyses, cfgs)
+        assert_scope_containment(root_analysis, sub_analyses)
 
     def finalize_and_save(
         self,
@@ -1278,7 +1246,7 @@ class DiagramGenerator:
         rewriting those would drop the ``static_analysis.sha`` tag (cold-starting
         the next incremental) and desync the sidecar from ``source_tree_hash``.
         """
-        self.finalize_for_save(root_analysis, sub_analyses, absorb=persist_side_artifacts)
+        self.finalize_for_save(root_analysis, sub_analyses)
         if persist_side_artifacts:
             source_tree_hash = self._source_tree_hash()
         else:
@@ -1452,12 +1420,6 @@ class DiagramGenerator:
         # membership baseline (captured post-scrub below) so the restore passes never re-inject a
         # deleted method. Also drives the empty-delta path, which returns before that capture.
         self._baseline_member_keys = _capture_baseline_member_keys(root_analysis, sub_analyses)
-        # Also before the scrub. Why: this shields an empty-but-cluster-backed component from the
-        # prune, and `remove_deleted_files` clears methods and key entities but not
-        # `source_cluster_ids` — so asked afterwards it shields the components the scrub itself
-        # just emptied, and a deleted unit keeps its box.
-        protected_empty_ids = _cluster_backed_empty_component_ids(root_analysis, sub_analyses)
-
         monitor = self.stats_writer if self.stats_writer else nullcontext()
         with monitor:
             # Scrub before cluster math: orphan-routed files never appear in
@@ -1577,13 +1539,7 @@ class DiagramGenerator:
             )
             apply_result.refresh_ids -= unchanged_ids
 
-            # Before the prune, because the prune reads `key_entities` as evidence a component
-            # still has something to describe. Membership is settled by the rescope above, so a
-            # component emptied by a route that never entered `refresh_ids` — and whose entities
-            # `fix_key_entities_refs` therefore never re-resolved — would otherwise be kept alive
-            # by pointers into symbols the commit deleted.
-            drop_dangling_key_entities(root_analysis, sub_analyses, self.repo_location)
-            removed_ids = prune_empty_components(root_analysis, sub_analyses, protected_empty_ids)
+            removed_ids = prune_empty_components(root_analysis, sub_analyses)
             if removed_ids:
                 apply_result.refresh_ids -= removed_ids
                 apply_result.new_component_ids -= removed_ids
@@ -1705,23 +1661,6 @@ def _drop_removed_subtree_analyses(sub_analyses: dict[str, AnalysisInsights], re
         for scope_id in list(sub_analyses):
             if is_self_or_descendant(scope_id, removed_id):
                 del sub_analyses[scope_id]
-
-
-def _cluster_backed_empty_component_ids(
-    root_analysis: AnalysisInsights,
-    sub_analyses: dict[str, AnalysisInsights],
-) -> set[str]:
-    protected_ids: set[str] = set()
-    for analysis in [root_analysis, *sub_analyses.values()]:
-        for component in analysis.components:
-            if (
-                component.component_id
-                and component.source_cluster_ids
-                and not component.key_entities
-                and not any(group.methods for group in component.file_methods)
-            ):
-                protected_ids.add(component.component_id)
-    return protected_ids
 
 
 def _child_scope_needs_recursive_update(

--- a/diagram_analysis/diagram_generator.py
+++ b/diagram_analysis/diagram_generator.py
@@ -1239,7 +1239,10 @@ class DiagramGenerator:
                 src, dst = moved(src_id), moved(dst_id)
                 # Mirrors _reroot_relations: a pair that collapses onto itself is not an edge.
                 if src and dst and src != dst:
-                    rebased.setdefault((src, dst), relation)
+                    # The endpoints move with the key. `preserve_unchanged_relations` restores this
+                    # object itself for a pair the rebuild dropped, so a relation left carrying the
+                    # absorbed child's id would be saved pointing at a component that is gone.
+                    rebased.setdefault((src, dst), relation.model_copy(update={"src_id": src, "dst_id": dst}))
             self._baseline_global_relations = rebased
 
     def finalize_and_save(

--- a/diagram_analysis/diagram_generator.py
+++ b/diagram_analysis/diagram_generator.py
@@ -7,6 +7,7 @@ from collections.abc import Iterable, Iterator
 from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
 from contextlib import nullcontext
 from dataclasses import dataclass, field, replace
+from functools import partial
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -63,7 +64,11 @@ from diagram_analysis.file_index import build_files_index, refresh_method_spans_
 from diagram_analysis.io_utils import load_analysis_metadata, save_analysis, write_fingerprint
 from repo_utils.path_utils import normalize_repo_path
 from diagram_analysis.scope_plan import plan_scope_update
-from diagram_analysis.tree_shape import absorb_single_child_components, drop_dangling_key_entities
+from diagram_analysis.tree_shape import (
+    absorb_single_child_components,
+    drop_dangling_key_entities,
+    reroot_absorbed_id,
+)
 from health.config import initialize_health_dir, load_health_config
 from health.runner import run_health_checks
 from monitoring import StreamingStatsWriter
@@ -1202,10 +1207,40 @@ class DiagramGenerator:
         so a legacy baseline carrying the defect is repaired rather than rejected.
         """
         drop_dangling_key_entities(root_analysis, sub_analyses)
-        absorb_single_child_components(root_analysis, sub_analyses)
+        cfgs = (
+            [self.static_analysis.get_cfg(lang) for lang in self.static_analysis.get_languages()]
+            if self.static_analysis
+            else []
+        )
+        self._rebase_baseline(absorb_single_child_components(root_analysis, sub_analyses, cfgs))
         self.rebuild_global_relations(root_analysis, sub_analyses)
         self._strip_ignored(root_analysis, sub_analyses)
         assert_scope_containment(root_analysis, sub_analyses)
+
+    def _rebase_baseline(self, absorbed_ids: list[str]) -> None:
+        """Move the incremental baseline onto the ids absorption just rewrote.
+
+        Why: the baseline is snapshotted before the collapse, so it still calls the code behind
+        ``2`` by the name ``2.1``. Read against the collapsed tree, the rebuilt pair ``1 -> 2``
+        matches nothing in it and neither endpoint counts as changed, so
+        ``preserve_unchanged_relations`` discards it as drift while the baseline's own ``1 -> 2.1``
+        is skipped for naming a component that is no longer live — and the relation is lost.
+        """
+        if self._baseline_global_relations is None:
+            return
+        for child_id in absorbed_ids:
+            moved = partial(reroot_absorbed_id, child_id=child_id)
+            self._baseline_component_ids = {moved(cid) for cid in self._baseline_component_ids if cid != child_id}
+            self._baseline_member_keys = {
+                moved(cid): keys for cid, keys in self._baseline_member_keys.items() if cid != child_id
+            }
+            rebased: dict[tuple[str, str], Relation] = {}
+            for (src_id, dst_id), relation in self._baseline_global_relations.items():
+                src, dst = moved(src_id), moved(dst_id)
+                # Mirrors _reroot_relations: a pair that collapses onto itself is not an edge.
+                if src and dst and src != dst:
+                    rebased.setdefault((src, dst), relation)
+            self._baseline_global_relations = rebased
 
     def finalize_and_save(
         self,
@@ -1402,13 +1437,10 @@ class DiagramGenerator:
         # membership baseline (captured post-scrub below) so the restore passes never re-inject a
         # deleted method. Also drives the empty-delta path, which returns before that capture.
         self._baseline_member_keys = _capture_baseline_member_keys(root_analysis, sub_analyses)
-        # Same side of the scrub, for the same reason. This protects a component that is empty
-        # but still cluster-backed — one awaiting re-detail — from being pruned. Captured AFTER
-        # the scrub it also protected components the scrub had just emptied, because
-        # `remove_deleted_files` clears methods and key entities but not `source_cluster_ids`:
-        # a component whose whole source was deleted matched "no methods, no entities, still has
-        # cluster ids" and survived as an empty box. That is the shape `whole-module-deleted`
-        # exists to catch, and it is why a deletion never left a parent holding one child.
+        # Also before the scrub. Why: this shields an empty-but-cluster-backed component from the
+        # prune, and `remove_deleted_files` clears methods and key entities but not
+        # `source_cluster_ids` — so asked afterwards it shields the components the scrub itself
+        # just emptied, and a deleted unit keeps its box.
         protected_empty_ids = _cluster_backed_empty_component_ids(root_analysis, sub_analyses)
 
         monitor = self.stats_writer if self.stats_writer else nullcontext()

--- a/diagram_analysis/scope_plan.py
+++ b/diagram_analysis/scope_plan.py
@@ -64,11 +64,8 @@ def previous_ownership(
     strand method anchoring on the ``source_cluster_ids`` fallback — the very cluster-id
     anchoring this function exists to replace.
 
-    A component can be cluster-backed yet hold no methods — a data-only cluster, which
-    ``_cluster_backed_empty_component_ids`` deliberately protects from pruning. Methods
-    cannot speak for it, so any cluster left unclaimed falls back to whoever lists it in
-    ``source_cluster_ids``; without that the planner would delete a stable leaf and
-    create a replacement holding the same code.
+    A data-only component can be cluster-backed without holding methods. Unclaimed
+    clusters therefore fall back to the owner recorded in ``source_cluster_ids``.
     """
     prefix = CodeBoardingClusterIds.prefix_for_scope(scope_id)
     claimed_ids: dict[str, str] = {
@@ -130,12 +127,8 @@ def plan_scope_update(
     """
     combined = combine_cluster_results(cluster_results)
     if not combined.clusters:
-        # Every cluster is gone. If the components are empty too, the code they described
-        # was deleted and they must go with it -- leaving them would keep ghost components
-        # that ``_cluster_backed_empty_component_ids`` then protects from pruning. If any
-        # still holds methods the clustering failed to represent live code (the subgraph
-        # builder guarantees one cluster per live method), so fail loud rather than save a
-        # scope with stale membership and hide the missed change.
+        # Every cluster is gone. Empty components are deleted; populated ones mean the
+        # clustering failed to represent live code and must fail loudly.
         still_populated = [
             component.component_id
             for component in scope.components

--- a/diagram_analysis/tree_shape.py
+++ b/diagram_analysis/tree_shape.py
@@ -26,8 +26,10 @@ outright.
 
 import logging
 from collections.abc import Sequence
+from pathlib import Path
 
 from agents.agent_responses import AnalysisInsights, Relation, SourceCodeReference
+from repo_utils.path_utils import normalize_repo_path
 from static_analyzer.graph import CallGraph
 
 logger = logging.getLogger(__name__)
@@ -41,6 +43,7 @@ ROOT_SCOPE = ""
 def drop_dangling_key_entities(
     root_analysis: AnalysisInsights,
     sub_analyses: dict[str, AnalysisInsights],
+    repo_dir: Path,
 ) -> list[str]:
     """Drop key entities naming a symbol no component owns; return what went.
 
@@ -63,6 +66,11 @@ def drop_dangling_key_entities(
     # Measured over the eval baselines, all 557 key entities carry a `reference_file` and it is
     # always a file its own component owns, so the pair is available and strictly sharper. The
     # name-only fallback is for the reference the model left unplaced.
+    #
+    # Normalized first, because the two sides are not stored alike: `file_methods` are
+    # repo-relative, while the reference resolver leaves `reference_file` ABSOLUTE and only
+    # `_relativize_key_entities` fixes that, at save — after this runs. Comparing them raw
+    # matches nothing and drops every live entity in the tree.
     owned = {
         (group.file_path, method.qualified_name)
         for scope in [root_analysis, *sub_analyses.values()]
@@ -75,7 +83,7 @@ def drop_dangling_key_entities(
     def is_live(entity: SourceCodeReference) -> bool:
         if entity.reference_file is None:
             return entity.qualified_name in owned_names
-        return (entity.reference_file, entity.qualified_name) in owned
+        return (normalize_repo_path(entity.reference_file, repo_dir), entity.qualified_name) in owned
 
     dropped: list[str] = []
     for scope in [root_analysis, *sub_analyses.values()]:
@@ -197,10 +205,21 @@ def _reroot_tree(
             component.source_cluster_ids = [
                 _reroot_id(cluster_id, child_id, parent_id) for cluster_id in component.source_cluster_ids
             ]
-        scope.components_relations = _reroot_relations(scope.components_relations, child_id, parent_id)
+    # Names follow the ids. The output generators key mermaid nodes on the component NAME and
+    # draw edges between those names, so a relation left pointing at the absorbed child's label
+    # would render against a node no longer in the diagram.
+    live_names = {
+        component.component_id: component.name
+        for scope in [root_analysis, *sub_analyses.values()]
+        for component in scope.components
+    }
+    for scope in [root_analysis, *sub_analyses.values()]:
+        scope.components_relations = _reroot_relations(scope.components_relations, child_id, parent_id, live_names)
 
 
-def _reroot_relations(relations: list[Relation], child_id: str, parent_id: str) -> list[Relation]:
+def _reroot_relations(
+    relations: list[Relation], child_id: str, parent_id: str, live_names: dict[str, str]
+) -> list[Relation]:
     """Re-point relation endpoints, dropping the ones the collapse makes meaningless.
 
     An endpoint naming the absorbed child itself becomes the parent, which can turn a
@@ -218,5 +237,7 @@ def _reroot_relations(relations: list[Relation], child_id: str, parent_id: str) 
             continue
         relation.src_id = src_id
         relation.dst_id = dst_id
+        relation.src_name = live_names.get(src_id, relation.src_name)
+        relation.dst_name = live_names.get(dst_id, relation.dst_name)
         survivors.append(relation)
     return survivors

--- a/diagram_analysis/tree_shape.py
+++ b/diagram_analysis/tree_shape.py
@@ -27,7 +27,7 @@ outright.
 import logging
 from collections.abc import Sequence
 
-from agents.agent_responses import AnalysisInsights, Relation
+from agents.agent_responses import AnalysisInsights, Relation, SourceCodeReference
 from static_analyzer.graph import CallGraph
 
 logger = logging.getLogger(__name__)
@@ -58,21 +58,31 @@ def drop_dangling_key_entities(
     is gone" is true of the document rather than of whichever scope an update happened to
     visit.
     """
+    # Keyed by file as well as name: two languages in one repo can both declare `run`, and a
+    # name-only set would call a deleted Python symbol live because a TypeScript one survives.
+    # Measured over the eval baselines, all 557 key entities carry a `reference_file` and it is
+    # always a file its own component owns, so the pair is available and strictly sharper. The
+    # name-only fallback is for the reference the model left unplaced.
     owned = {
-        method.qualified_name
+        (group.file_path, method.qualified_name)
         for scope in [root_analysis, *sub_analyses.values()]
         for component in scope.components
         for group in component.file_methods
         for method in group.methods
     }
+    owned_names = {qualified_name for _path, qualified_name in owned}
+
+    def is_live(entity: SourceCodeReference) -> bool:
+        if entity.reference_file is None:
+            return entity.qualified_name in owned_names
+        return (entity.reference_file, entity.qualified_name) in owned
+
     dropped: list[str] = []
     for scope in [root_analysis, *sub_analyses.values()]:
         for component in scope.components:
-            surviving = [entity for entity in component.key_entities if entity.qualified_name in owned]
+            surviving = [entity for entity in component.key_entities if is_live(entity)]
             if len(surviving) != len(component.key_entities):
-                dropped.extend(
-                    entity.qualified_name for entity in component.key_entities if entity.qualified_name not in owned
-                )
+                dropped.extend(entity.qualified_name for entity in component.key_entities if not is_live(entity))
                 component.key_entities = surviving
     if dropped:
         logger.info(f"[TreeShape] Dropped {len(dropped)} key entity/entities naming symbols no component owns")

--- a/diagram_analysis/tree_shape.py
+++ b/diagram_analysis/tree_shape.py
@@ -1,100 +1,14 @@
-"""Whole-tree shape repair: no parent may hold exactly one child.
-
-A component whose expansion produced a single sub-component adds a level that
-explains nothing — parent and child describe the same code, one box inside
-another. Absorbing the child hands its own children to the parent and removes
-one level from that branch; a childless child just disappears and the parent
-becomes a leaf.
-
-The repair is a prefix re-rooting. Every identifier in this tree — component id,
-``sub_analyses`` key, scoped cluster id, relation endpoint — is the dotted path
-to a position, so moving the absorbed child's subtree onto the parent's path is
-one rewrite of ``"<child_id>."`` to ``"<parent_id>."`` applied everywhere. That
-also renumbers the promoted siblings for free, and cannot collide: a parent with
-exactly one child has no other child to collide with.
-
-The cluster lineage pickled with the CFG (``MethodClusterPaths``) moves with the
-tree, by replacement rather than rename: the absorbed child's leaf clusters take
-the parent's path and the parent's own are dropped, never unioned — the parent's
-partition is superseded the moment its only child's components stand in its
-place, and merging the two would invent a cluster holding the members of both.
-Left behind, the lineage seeds the next incremental with a partition incoherent
-against the promoted components' membership: measured over 11 diverged scopes,
-10 relabelled the whole scope on a no-change run and one lost a component
-outright.
-"""
+"""Collapse component scopes that contain exactly one child."""
 
 import logging
 from collections.abc import Sequence
-from pathlib import Path
 
-from agents.agent_responses import AnalysisInsights, Relation, SourceCodeReference
-from repo_utils.path_utils import normalize_repo_path
+from agents.agent_responses import AnalysisInsights, Relation
 from static_analyzer.graph import CallGraph
 
 logger = logging.getLogger(__name__)
 
-#: ``sub_analyses`` is keyed by component id and the root analysis has no key.
-#: Empty string, not ``ROOT_SCOPE_ID``: this is the *prefix* sense of the root,
-#: the one ``agents.cluster_ids.prefix_for_scope`` returns for it.
 ROOT_SCOPE = ""
-
-
-def drop_dangling_key_entities(
-    root_analysis: AnalysisInsights,
-    sub_analyses: dict[str, AnalysisInsights],
-    repo_dir: Path,
-) -> list[str]:
-    """Drop key entities naming a symbol no component owns; return what went.
-
-    A key entity is a pointer into the code, so a deleted symbol must take its pointers
-    with it. Membership already works that way — several passes strip a method the moment
-    it leaves — but key entities are scrubbed by one pass, ``fix_key_entities_refs``, which
-    is gated on the scopes an update touched. A component emptied by a route that did not
-    touch it keeps entities pointing at symbols that no longer exist, and because
-    ``prune_empty_components`` reads a non-empty ``key_entities`` as a component still
-    having something to describe, the empty box then survives the prune.
-
-    Measured over the baselines in CodeBoarding-evals and the corpus: 557 of 557 key
-    entities in healthy documents name a method some component owns, so enforcing that
-    cannot remove a legitimate reference. Whole-tree and unconditional, because "the symbol
-    is gone" is true of the document rather than of whichever scope an update happened to
-    visit.
-    """
-    # Keyed by file as well as name: two languages in one repo can both declare `run`, and a
-    # name-only set would call a deleted Python symbol live because a TypeScript one survives.
-    # Measured over the eval baselines, all 557 key entities carry a `reference_file` and it is
-    # always a file its own component owns, so the pair is available and strictly sharper. The
-    # name-only fallback is for the reference the model left unplaced.
-    #
-    # Normalized first, because the two sides are not stored alike: `file_methods` are
-    # repo-relative, while the reference resolver leaves `reference_file` ABSOLUTE and only
-    # `_relativize_key_entities` fixes that, at save — after this runs. Comparing them raw
-    # matches nothing and drops every live entity in the tree.
-    owned = {
-        (group.file_path, method.qualified_name)
-        for scope in [root_analysis, *sub_analyses.values()]
-        for component in scope.components
-        for group in component.file_methods
-        for method in group.methods
-    }
-    owned_names = {qualified_name for _path, qualified_name in owned}
-
-    def is_live(entity: SourceCodeReference) -> bool:
-        if entity.reference_file is None:
-            return entity.qualified_name in owned_names
-        return (normalize_repo_path(entity.reference_file, repo_dir), entity.qualified_name) in owned
-
-    dropped: list[str] = []
-    for scope in [root_analysis, *sub_analyses.values()]:
-        for component in scope.components:
-            surviving = [entity for entity in component.key_entities if is_live(entity)]
-            if len(surviving) != len(component.key_entities):
-                dropped.extend(entity.qualified_name for entity in component.key_entities if not is_live(entity))
-                component.key_entities = surviving
-    if dropped:
-        logger.info(f"[TreeShape] Dropped {len(dropped)} key entity/entities naming symbols no component owns")
-    return dropped
 
 
 def absorb_single_child_components(
@@ -102,11 +16,7 @@ def absorb_single_child_components(
     sub_analyses: dict[str, AnalysisInsights],
     cfgs: Sequence[CallGraph] = (),
 ) -> list[str]:
-    """Collapse every scope holding exactly one component; return the ids absorbed.
-
-    Runs to a fixpoint, so a degenerate ``1 -> 1.1 -> 1.1.1`` chain comes out as a
-    single component. Idempotent: a tree with no single-child scope is untouched.
-    """
+    """Collapse all single-child scopes to a fixpoint."""
     absorbed: list[str] = []
     while scopes := single_child_scopes(root_analysis, sub_analyses):
         absorbed.append(_absorb(scopes[0], root_analysis, sub_analyses, cfgs))
@@ -124,11 +34,7 @@ def single_child_scopes(
 
 
 def _absorbable_at_root(root_analysis: AnalysisInsights, sub_analyses: dict[str, AnalysisInsights]) -> bool:
-    """Whether the root's lone component can be absorbed without emptying the analysis.
-
-    Why: the root is a scope but not a component, so there is nothing for a childless
-    lone component to be absorbed *into* — collapsing it would leave no components at all.
-    """
+    """Return whether root absorption would leave at least one component."""
     if len(root_analysis.components) != 1:
         return False
     only_child = sub_analyses.get(root_analysis.components[0].component_id)
@@ -147,15 +53,10 @@ def _absorb(
     grandchildren = sub_analyses.get(child_id)
 
     if grandchildren is None or not grandchildren.components:
-        # The parent already owns every method the child did, so dropping the child
-        # loses nothing and the parent becomes a leaf.
         del sub_analyses[parent_id]
     else:
         scope.components = grandchildren.components
         if parent_id != ROOT_SCOPE:
-            # The parent's own relations related its single child to nothing. The child's
-            # relate the components now standing in its place. The root's list is the
-            # global cross-boundary set, not a sibling set, so it is left alone.
             scope.components_relations = grandchildren.components_relations
     sub_analyses.pop(child_id, None)
     _reroot_tree(root_analysis, sub_analyses, child_id, parent_id)
@@ -163,16 +64,6 @@ def _absorb(
         cfg.method_cluster_paths.reroot_scope(child_id, parent_id)
     logger.info(f"[TreeShape] Absorbed '{child.name}' ({child_id}) into {parent_id or 'the root'}")
     return child_id
-
-
-def reroot_absorbed_id(identifier: str, child_id: str) -> str:
-    """Where a pre-absorption id lands once ``child_id`` is absorbed into its parent.
-
-    For a caller holding ids captured before the collapse — the incremental baseline — so it
-    can be read against the tree the collapse produced.
-    """
-    parent_id = child_id.rpartition(".")[0]
-    return parent_id if identifier == child_id else _reroot_id(identifier, child_id, parent_id)
 
 
 def _reroot_id(identifier: str, child_id: str, parent_id: str) -> str:
@@ -190,11 +81,7 @@ def _reroot_tree(
     child_id: str,
     parent_id: str,
 ) -> None:
-    # Removed in full before any is re-inserted. Every target is one level shallower than
-    # its source, so a target can equal a key still waiting to move — and writing it in
-    # place would overwrite that scope, then move the wrong object under its own name.
-    # `parse_unified_analysis` returns children before parents, so the order this needs is
-    # exactly the order a loaded baseline does not have.
+    # Remove before reinserting because a shallower target may still be waiting to move.
     prefix = f"{child_id}."
     moving = {key: sub_analyses.pop(key) for key in [k for k in sub_analyses if k.startswith(prefix)]}
     for scope_id, scope in moving.items():
@@ -205,9 +92,6 @@ def _reroot_tree(
             component.source_cluster_ids = [
                 _reroot_id(cluster_id, child_id, parent_id) for cluster_id in component.source_cluster_ids
             ]
-    # Names follow the ids. The output generators key mermaid nodes on the component NAME and
-    # draw edges between those names, so a relation left pointing at the absorbed child's label
-    # would render against a node no longer in the diagram.
     live_names = {
         component.component_id: component.name
         for scope in [root_analysis, *sub_analyses.values()]
@@ -220,12 +104,7 @@ def _reroot_tree(
 def _reroot_relations(
     relations: list[Relation], child_id: str, parent_id: str, live_names: dict[str, str]
 ) -> list[Relation]:
-    """Re-point relation endpoints, dropping the ones the collapse makes meaningless.
-
-    An endpoint naming the absorbed child itself becomes the parent, which can turn a
-    cross-component edge into a self-loop; at the root there is no parent to fall back
-    on. Both are dropped rather than rendered as an edge from a box to itself.
-    """
+    """Re-point relation endpoints and drop collapsed self-relations."""
     survivors: list[Relation] = []
     for relation in relations:
         src_id = parent_id if relation.src_id == child_id else _reroot_id(relation.src_id, child_id, parent_id)

--- a/diagram_analysis/tree_shape.py
+++ b/diagram_analysis/tree_shape.py
@@ -13,22 +13,22 @@ one rewrite of ``"<child_id>."`` to ``"<parent_id>."`` applied everywhere. That
 also renumbers the promoted siblings for free, and cannot collide: a parent with
 exactly one child has no other child to collide with.
 
-What is deliberately NOT rewritten is the cluster lineage pickled with the CFG
-(``MethodClusterPaths``). It looks like the same rename and is not: lineage is
-recorded per scope, so the absorbed child's leaf clusters and the parent's own
-are two independent clusterings that both land on ``<parent_id>.<n>``, and
-merging them invents a cluster containing the union of two unrelated ones. The
-parent's recorded lineage is still correct after an absorption — its membership
-never changed — so leaving it alone is both simpler and the only right answer. A
-promoted scope whose id moved gets a stale seed, which costs a biased warm start
-and nothing more: ``filter_by_nodes`` prunes the lineage to the component's own
-methods before it is read, and the seed is an initial partition Leiden then
-re-optimises.
+The cluster lineage pickled with the CFG (``MethodClusterPaths``) moves with the
+tree, by replacement rather than rename: the absorbed child's leaf clusters take
+the parent's path and the parent's own are dropped, never unioned — the parent's
+partition is superseded the moment its only child's components stand in its
+place, and merging the two would invent a cluster holding the members of both.
+Left behind, the lineage seeds the next incremental with a partition incoherent
+against the promoted components' membership: measured over 11 diverged scopes,
+10 relabelled the whole scope on a no-change run and one lost a component
+outright.
 """
 
 import logging
+from collections.abc import Sequence
 
 from agents.agent_responses import AnalysisInsights, Relation
+from static_analyzer.graph import CallGraph
 
 logger = logging.getLogger(__name__)
 
@@ -82,6 +82,7 @@ def drop_dangling_key_entities(
 def absorb_single_child_components(
     root_analysis: AnalysisInsights,
     sub_analyses: dict[str, AnalysisInsights],
+    cfgs: Sequence[CallGraph] = (),
 ) -> list[str]:
     """Collapse every scope holding exactly one component; return the ids absorbed.
 
@@ -90,7 +91,7 @@ def absorb_single_child_components(
     """
     absorbed: list[str] = []
     while scopes := single_child_scopes(root_analysis, sub_analyses):
-        absorbed.append(_absorb(scopes[0], root_analysis, sub_analyses))
+        absorbed.append(_absorb(scopes[0], root_analysis, sub_analyses, cfgs))
     return absorbed
 
 
@@ -120,6 +121,7 @@ def _absorb(
     parent_id: str,
     root_analysis: AnalysisInsights,
     sub_analyses: dict[str, AnalysisInsights],
+    cfgs: Sequence[CallGraph] = (),
 ) -> str:
     scope = root_analysis if parent_id == ROOT_SCOPE else sub_analyses[parent_id]
     child = scope.components[0]
@@ -139,8 +141,20 @@ def _absorb(
             scope.components_relations = grandchildren.components_relations
     sub_analyses.pop(child_id, None)
     _reroot_tree(root_analysis, sub_analyses, child_id, parent_id)
+    for cfg in cfgs:
+        cfg.method_cluster_paths.reroot_scope(child_id, parent_id)
     logger.info(f"[TreeShape] Absorbed '{child.name}' ({child_id}) into {parent_id or 'the root'}")
     return child_id
+
+
+def reroot_absorbed_id(identifier: str, child_id: str) -> str:
+    """Where a pre-absorption id lands once ``child_id`` is absorbed into its parent.
+
+    For a caller holding ids captured before the collapse — the incremental baseline — so it
+    can be read against the tree the collapse produced.
+    """
+    parent_id = child_id.rpartition(".")[0]
+    return parent_id if identifier == child_id else _reroot_id(identifier, child_id, parent_id)
 
 
 def _reroot_id(identifier: str, child_id: str, parent_id: str) -> str:
@@ -158,8 +172,15 @@ def _reroot_tree(
     child_id: str,
     parent_id: str,
 ) -> None:
-    for scope_id in [key for key in sub_analyses if key.startswith(f"{child_id}.")]:
-        sub_analyses[_reroot_id(scope_id, child_id, parent_id)] = sub_analyses.pop(scope_id)
+    # Removed in full before any is re-inserted. Every target is one level shallower than
+    # its source, so a target can equal a key still waiting to move — and writing it in
+    # place would overwrite that scope, then move the wrong object under its own name.
+    # `parse_unified_analysis` returns children before parents, so the order this needs is
+    # exactly the order a loaded baseline does not have.
+    prefix = f"{child_id}."
+    moving = {key: sub_analyses.pop(key) for key in [k for k in sub_analyses if k.startswith(prefix)]}
+    for scope_id, scope in moving.items():
+        sub_analyses[_reroot_id(scope_id, child_id, parent_id)] = scope
     for scope in [root_analysis, *sub_analyses.values()]:
         for component in scope.components:
             component.component_id = _reroot_id(component.component_id, child_id, parent_id)

--- a/diagram_analysis/tree_shape.py
+++ b/diagram_analysis/tree_shape.py
@@ -1,0 +1,191 @@
+"""Whole-tree shape repair: no parent may hold exactly one child.
+
+A component whose expansion produced a single sub-component adds a level that
+explains nothing — parent and child describe the same code, one box inside
+another. Absorbing the child hands its own children to the parent and removes
+one level from that branch; a childless child just disappears and the parent
+becomes a leaf.
+
+The repair is a prefix re-rooting. Every identifier in this tree — component id,
+``sub_analyses`` key, scoped cluster id, relation endpoint — is the dotted path
+to a position, so moving the absorbed child's subtree onto the parent's path is
+one rewrite of ``"<child_id>."`` to ``"<parent_id>."`` applied everywhere. That
+also renumbers the promoted siblings for free, and cannot collide: a parent with
+exactly one child has no other child to collide with.
+
+What is deliberately NOT rewritten is the cluster lineage pickled with the CFG
+(``MethodClusterPaths``). It looks like the same rename and is not: lineage is
+recorded per scope, so the absorbed child's leaf clusters and the parent's own
+are two independent clusterings that both land on ``<parent_id>.<n>``, and
+merging them invents a cluster containing the union of two unrelated ones. The
+parent's recorded lineage is still correct after an absorption — its membership
+never changed — so leaving it alone is both simpler and the only right answer. A
+promoted scope whose id moved gets a stale seed, which costs a biased warm start
+and nothing more: ``filter_by_nodes`` prunes the lineage to the component's own
+methods before it is read, and the seed is an initial partition Leiden then
+re-optimises.
+"""
+
+import logging
+
+from agents.agent_responses import AnalysisInsights, Relation
+
+logger = logging.getLogger(__name__)
+
+#: ``sub_analyses`` is keyed by component id and the root analysis has no key.
+#: Empty string, not ``ROOT_SCOPE_ID``: this is the *prefix* sense of the root,
+#: the one ``agents.cluster_ids.prefix_for_scope`` returns for it.
+ROOT_SCOPE = ""
+
+
+def drop_dangling_key_entities(
+    root_analysis: AnalysisInsights,
+    sub_analyses: dict[str, AnalysisInsights],
+) -> list[str]:
+    """Drop key entities naming a symbol no component owns; return what went.
+
+    A key entity is a pointer into the code, so a deleted symbol must take its pointers
+    with it. Membership already works that way — several passes strip a method the moment
+    it leaves — but key entities are scrubbed by one pass, ``fix_key_entities_refs``, which
+    is gated on the scopes an update touched. A component emptied by a route that did not
+    touch it keeps entities pointing at symbols that no longer exist, and because
+    ``prune_empty_components`` reads a non-empty ``key_entities`` as a component still
+    having something to describe, the empty box then survives the prune.
+
+    Measured over the baselines in CodeBoarding-evals and the corpus: 557 of 557 key
+    entities in healthy documents name a method some component owns, so enforcing that
+    cannot remove a legitimate reference. Whole-tree and unconditional, because "the symbol
+    is gone" is true of the document rather than of whichever scope an update happened to
+    visit.
+    """
+    owned = {
+        method.qualified_name
+        for scope in [root_analysis, *sub_analyses.values()]
+        for component in scope.components
+        for group in component.file_methods
+        for method in group.methods
+    }
+    dropped: list[str] = []
+    for scope in [root_analysis, *sub_analyses.values()]:
+        for component in scope.components:
+            surviving = [entity for entity in component.key_entities if entity.qualified_name in owned]
+            if len(surviving) != len(component.key_entities):
+                dropped.extend(
+                    entity.qualified_name for entity in component.key_entities if entity.qualified_name not in owned
+                )
+                component.key_entities = surviving
+    if dropped:
+        logger.info(f"[TreeShape] Dropped {len(dropped)} key entity/entities naming symbols no component owns")
+    return dropped
+
+
+def absorb_single_child_components(
+    root_analysis: AnalysisInsights,
+    sub_analyses: dict[str, AnalysisInsights],
+) -> list[str]:
+    """Collapse every scope holding exactly one component; return the ids absorbed.
+
+    Runs to a fixpoint, so a degenerate ``1 -> 1.1 -> 1.1.1`` chain comes out as a
+    single component. Idempotent: a tree with no single-child scope is untouched.
+    """
+    absorbed: list[str] = []
+    while scopes := single_child_scopes(root_analysis, sub_analyses):
+        absorbed.append(_absorb(scopes[0], root_analysis, sub_analyses))
+    return absorbed
+
+
+def single_child_scopes(
+    root_analysis: AnalysisInsights,
+    sub_analyses: dict[str, AnalysisInsights],
+) -> list[str]:
+    """Scope ids that hold exactly one component — the violations of the invariant."""
+    scopes = [ROOT_SCOPE] if _absorbable_at_root(root_analysis, sub_analyses) else []
+    scopes.extend(sorted(scope_id for scope_id, scope in sub_analyses.items() if len(scope.components) == 1))
+    return scopes
+
+
+def _absorbable_at_root(root_analysis: AnalysisInsights, sub_analyses: dict[str, AnalysisInsights]) -> bool:
+    """Whether the root's lone component can be absorbed without emptying the analysis.
+
+    Why: the root is a scope but not a component, so there is nothing for a childless
+    lone component to be absorbed *into* — collapsing it would leave no components at all.
+    """
+    if len(root_analysis.components) != 1:
+        return False
+    only_child = sub_analyses.get(root_analysis.components[0].component_id)
+    return bool(only_child and only_child.components)
+
+
+def _absorb(
+    parent_id: str,
+    root_analysis: AnalysisInsights,
+    sub_analyses: dict[str, AnalysisInsights],
+) -> str:
+    scope = root_analysis if parent_id == ROOT_SCOPE else sub_analyses[parent_id]
+    child = scope.components[0]
+    child_id = child.component_id
+    grandchildren = sub_analyses.get(child_id)
+
+    if grandchildren is None or not grandchildren.components:
+        # The parent already owns every method the child did, so dropping the child
+        # loses nothing and the parent becomes a leaf.
+        del sub_analyses[parent_id]
+    else:
+        scope.components = grandchildren.components
+        if parent_id != ROOT_SCOPE:
+            # The parent's own relations related its single child to nothing. The child's
+            # relate the components now standing in its place. The root's list is the
+            # global cross-boundary set, not a sibling set, so it is left alone.
+            scope.components_relations = grandchildren.components_relations
+    sub_analyses.pop(child_id, None)
+    _reroot_tree(root_analysis, sub_analyses, child_id, parent_id)
+    logger.info(f"[TreeShape] Absorbed '{child.name}' ({child_id}) into {parent_id or 'the root'}")
+    return child_id
+
+
+def _reroot_id(identifier: str, child_id: str, parent_id: str) -> str:
+    """Move one dotted identifier out from under the absorbed child onto the parent."""
+    prefix = f"{child_id}."
+    if not identifier.startswith(prefix):
+        return identifier
+    tail = identifier[len(prefix) :]
+    return f"{parent_id}.{tail}" if parent_id else tail
+
+
+def _reroot_tree(
+    root_analysis: AnalysisInsights,
+    sub_analyses: dict[str, AnalysisInsights],
+    child_id: str,
+    parent_id: str,
+) -> None:
+    for scope_id in [key for key in sub_analyses if key.startswith(f"{child_id}.")]:
+        sub_analyses[_reroot_id(scope_id, child_id, parent_id)] = sub_analyses.pop(scope_id)
+    for scope in [root_analysis, *sub_analyses.values()]:
+        for component in scope.components:
+            component.component_id = _reroot_id(component.component_id, child_id, parent_id)
+            component.source_cluster_ids = [
+                _reroot_id(cluster_id, child_id, parent_id) for cluster_id in component.source_cluster_ids
+            ]
+        scope.components_relations = _reroot_relations(scope.components_relations, child_id, parent_id)
+
+
+def _reroot_relations(relations: list[Relation], child_id: str, parent_id: str) -> list[Relation]:
+    """Re-point relation endpoints, dropping the ones the collapse makes meaningless.
+
+    An endpoint naming the absorbed child itself becomes the parent, which can turn a
+    cross-component edge into a self-loop; at the root there is no parent to fall back
+    on. Both are dropped rather than rendered as an edge from a box to itself.
+    """
+    survivors: list[Relation] = []
+    for relation in relations:
+        src_id = parent_id if relation.src_id == child_id else _reroot_id(relation.src_id, child_id, parent_id)
+        dst_id = parent_id if relation.dst_id == child_id else _reroot_id(relation.dst_id, child_id, parent_id)
+        if not src_id or not dst_id or src_id == dst_id:
+            logger.debug(
+                f"[TreeShape] Dropping relation {relation.src_id} -> {relation.dst_id} collapsed by absorption"
+            )
+            continue
+        relation.src_id = src_id
+        relation.dst_id = dst_id
+        survivors.append(relation)
+    return survivors

--- a/static_analyzer/cluster_relations.py
+++ b/static_analyzer/cluster_relations.py
@@ -117,6 +117,7 @@ def prune_ungrounded_edges(
     relations: list[Relation],
     owner_index: dict[str, list[tuple[str, str]]],
     keep_edge: Callable[[RelationEdge], bool],
+    changed_members: set[str] | None = None,
 ) -> list[Relation]:
     """Re-apply the edge filters to an assembled relation list, moving edges rather than losing them.
 
@@ -132,9 +133,8 @@ def prune_ungrounded_edges(
     pair already carries. Measured on one stored analysis, dropping instead of re-filing orphaned
     25 of 28 real calls — the mis-attribution is worth repairing, the call is not worth losing.
 
-    An edge whose true pair has no relation to move to stays where it is: inventing a relation
-    here would be authoring architecture in a filter, and silently deleting the call would be
-    worse than leaving it mis-filed where a check can still flag it.
+    An edge whose true pair has no relation to move to stays where it is. During an incremental
+    update, ownership repairs are limited to calls whose source method changed.
     """
     by_pair: dict[tuple[str, str], Relation] = {(relation.src_id, relation.dst_id): relation for relation in relations}
     additions: dict[tuple[str, str], list[RelationEdge]] = {}
@@ -168,6 +168,9 @@ def prune_ungrounded_edges(
             if edge_crosses_components(edge, owner_index, relation.src_id, relation.dst_id):
                 all_edges.append(edge)
                 continue
+            if changed_members is not None and edge.source.qualified_name not in changed_members:
+                all_edges.append(edge)
+                continue
             matching_pair = find_relation_pair_for_edge(edge)
             if matching_pair is False:
                 continue  # Internal call: no cross-component fact exists to preserve.
@@ -189,10 +192,10 @@ def prune_ungrounded_edges(
             continue
         settled.append(relation)
 
-    return drop_reverse_duplicates(settled)
+    return drop_reverse_duplicates(settled, changed_members)
 
 
-def drop_reverse_duplicates(relations: list[Relation]) -> list[Relation]:
+def drop_reverse_duplicates(relations: list[Relation], changed_members: set[str] | None = None) -> list[Relation]:
     """Collapse a pair stated twice, once in each direction.
 
     A relation is backed by concrete method-to-method calls — the ``all_edges``/``key_edges``
@@ -215,7 +218,13 @@ def drop_reverse_duplicates(relations: list[Relation]) -> list[Relation]:
     phantom churn on a commit that changed nothing.
     """
     grounded_pairs = {
-        (relation.src_id, relation.dst_id) for relation in relations if relation.all_edges or relation.key_edges
+        (relation.src_id, relation.dst_id)
+        for relation in relations
+        if (relation.all_edges or relation.key_edges)
+        and (
+            changed_members is None
+            or any(edge.source.qualified_name in changed_members for edge in [*relation.all_edges, *relation.key_edges])
+        )
     }
     kept: list[Relation] = []
     dropped_bare: set[tuple[str, str]] = set()
@@ -230,7 +239,11 @@ def drop_reverse_duplicates(relations: list[Relation]) -> list[Relation]:
             continue  # The grounded side already states this connection, the right way round.
         # `reverse == pair` is a self-relation, which `drop_internal_self_relations` owns.
         other = by_pair.get(reverse) if reverse != pair else None
-        if other is not None and not (other.all_edges or other.key_edges or other.is_static):
+        if (
+            changed_members is None
+            and other is not None
+            and not (other.all_edges or other.key_edges or other.is_static)
+        ):
             # Same claim twice with nothing to tell them apart. Pick once, deterministically:
             # the fuller explanation survives, and an exact tie falls to the lower source id.
             loser = max((relation, other), key=lambda r: (-len(r.evidence or ""), r.src_id, r.dst_id))

--- a/static_analyzer/method_cluster_paths.py
+++ b/static_analyzer/method_cluster_paths.py
@@ -40,16 +40,7 @@ class MethodClusterPaths:
                     self._paths.setdefault(member, set()).add(qualified_cluster_id)
 
     def reroot_scope(self, child_id: str, parent_id: str) -> None:
-        """Move an absorbed child's lineage onto the parent's path, dropping the parent's own.
-
-        Why replace and not merge: both clusterings land on ``<parent_id>.<n>``, and unioning
-        them would invent a cluster holding the members of two unrelated ones. The parent's is
-        superseded the moment its only child's components take its place, so it is dropped —
-        the same per-scope replace ``record`` performs.
-        """
-
-        def belongs(scope_id: str, root: str) -> bool:
-            return scope_id == root or scope_id.startswith(f"{root}.")
+        """Move child lineage onto its parent and replace the parent's partition."""
 
         with self._lock:
             for qname, cluster_ids in self._paths.items():
@@ -58,12 +49,16 @@ class MethodClusterPaths:
                     scope_id, _, local = cluster_id.rpartition(".")
                     if not local.isdigit():
                         kept.add(cluster_id)
-                    elif belongs(scope_id, child_id):
+                    elif self._scope_belongs_to(scope_id, child_id):
                         moved = f"{parent_id}{scope_id[len(child_id) :]}" if parent_id else scope_id[len(child_id) :]
                         kept.add(f"{moved.lstrip('.')}.{local}".lstrip("."))
-                    elif not belongs(scope_id, parent_id):
+                    elif not self._scope_belongs_to(scope_id, parent_id):
                         kept.add(cluster_id)
                 self._paths[qname] = kept
+
+    @staticmethod
+    def _scope_belongs_to(scope_id: str, root: str) -> bool:
+        return scope_id == root or scope_id.startswith(f"{root}.")
 
     def snapshot(self) -> list[tuple[str, set[str]]]:
         with self._lock:

--- a/static_analyzer/method_cluster_paths.py
+++ b/static_analyzer/method_cluster_paths.py
@@ -39,6 +39,32 @@ class MethodClusterPaths:
                 for member in members:
                     self._paths.setdefault(member, set()).add(qualified_cluster_id)
 
+    def reroot_scope(self, child_id: str, parent_id: str) -> None:
+        """Move an absorbed child's lineage onto the parent's path, dropping the parent's own.
+
+        Why replace and not merge: both clusterings land on ``<parent_id>.<n>``, and unioning
+        them would invent a cluster holding the members of two unrelated ones. The parent's is
+        superseded the moment its only child's components take its place, so it is dropped —
+        the same per-scope replace ``record`` performs.
+        """
+
+        def belongs(scope_id: str, root: str) -> bool:
+            return scope_id == root or scope_id.startswith(f"{root}.")
+
+        with self._lock:
+            for qname, cluster_ids in self._paths.items():
+                kept: set[str] = set()
+                for cluster_id in cluster_ids:
+                    scope_id, _, local = cluster_id.rpartition(".")
+                    if not local.isdigit():
+                        kept.add(cluster_id)
+                    elif belongs(scope_id, child_id):
+                        moved = f"{parent_id}{scope_id[len(child_id) :]}" if parent_id else scope_id[len(child_id) :]
+                        kept.add(f"{moved.lstrip('.')}.{local}".lstrip("."))
+                    elif not belongs(scope_id, parent_id):
+                        kept.add(cluster_id)
+                self._paths[qname] = kept
+
     def snapshot(self) -> list[tuple[str, set[str]]]:
         with self._lock:
             return [(qname, set(cluster_ids)) for qname, cluster_ids in self._paths.items()]

--- a/tests/agents/test_incremental_agent.py
+++ b/tests/agents/test_incremental_agent.py
@@ -114,7 +114,7 @@ class TestPruneEmptyComponents(unittest.TestCase):
         empty = _component("Prior Empty Leaf", "1.1", source_cluster_ids=["1.1.0"])
         root = AnalysisInsights(description="root", components=[empty], components_relations=[])
 
-        removed_ids = prune_empty_components(root, {}, protected_empty_ids={"1.1"})
+        removed_ids = prune_empty_components(root, {})
 
         self.assertEqual(removed_ids, set())
         self.assertEqual(root.components, [empty])

--- a/tests/diagram_analysis/test_diagram_analysis.py
+++ b/tests/diagram_analysis/test_diagram_analysis.py
@@ -1490,8 +1490,6 @@ class TestDiagramGenerator(unittest.TestCase):
                 )
             ],
         )
-        # Siblings at both levels: a scope holding one component is collapsed by the
-        # no-single-child invariant, which would take this fixture apart before it is read.
         root_sibling = Component(name="Other Parent", description="", key_entities=[], component_id="2")
         child_sibling = Component(name="Other Child", description="", key_entities=[], component_id="1.2")
         root_analysis = AnalysisInsights(
@@ -1683,8 +1681,6 @@ class TestDiagramGenerator(unittest.TestCase):
         root = Component(name="Root", description="", key_entities=[], component_id="1")
         parent = Component(name="Parent", description="", key_entities=[], component_id="1.1")
         empty_leaf = Component(name="Stable Leaf", description="", key_entities=[], component_id="1.1.1")
-        # Siblings at every level: a scope holding one component is collapsed by the
-        # no-single-child invariant, which would take this fixture apart before it is read.
         root_analysis = AnalysisInsights(
             description="root",
             components=[root, Component(name="Other Root", description="", key_entities=[], component_id="2")],
@@ -1838,12 +1834,9 @@ class TestDiagramGenerator(unittest.TestCase):
 
         gen.finalize_and_save(analysis, {}, persist_side_artifacts=False)
 
-        # The analysis itself is still finalized + saved...
-        # absorb=False travels with it: the collapse rewrites the tree AND the cluster
-        # lineage, and this save writes only the first of the two.
-        gen.finalize_for_save.assert_called_once_with(analysis, {}, absorb=False)
+        # The analysis is still finalized and saved.
+        gen.finalize_for_save.assert_called_once_with(analysis, {})
         mock_save.assert_called_once()
-        # ...but the external side artifacts are left untouched.
         gen._write_file_coverage.assert_not_called()
         gen._persist_static_analysis_artifact.assert_not_called()
 

--- a/tests/diagram_analysis/test_diagram_analysis.py
+++ b/tests/diagram_analysis/test_diagram_analysis.py
@@ -1839,7 +1839,9 @@ class TestDiagramGenerator(unittest.TestCase):
         gen.finalize_and_save(analysis, {}, persist_side_artifacts=False)
 
         # The analysis itself is still finalized + saved...
-        gen.finalize_for_save.assert_called_once_with(analysis, {})
+        # absorb=False travels with it: the collapse rewrites the tree AND the cluster
+        # lineage, and this save writes only the first of the two.
+        gen.finalize_for_save.assert_called_once_with(analysis, {}, absorb=False)
         mock_save.assert_called_once()
         # ...but the external side artifacts are left untouched.
         gen._write_file_coverage.assert_not_called()

--- a/tests/diagram_analysis/test_diagram_analysis.py
+++ b/tests/diagram_analysis/test_diagram_analysis.py
@@ -1490,8 +1490,18 @@ class TestDiagramGenerator(unittest.TestCase):
                 )
             ],
         )
-        root_analysis = AnalysisInsights(description="root", components=[root_component], components_relations=[])
-        sub_analyses = {"1": AnalysisInsights(description="sub", components=[child_component], components_relations=[])}
+        # Siblings at both levels: a scope holding one component is collapsed by the
+        # no-single-child invariant, which would take this fixture apart before it is read.
+        root_sibling = Component(name="Other Parent", description="", key_entities=[], component_id="2")
+        child_sibling = Component(name="Other Child", description="", key_entities=[], component_id="1.2")
+        root_analysis = AnalysisInsights(
+            description="root", components=[root_component, root_sibling], components_relations=[]
+        )
+        sub_analyses = {
+            "1": AnalysisInsights(
+                description="sub", components=[child_component, child_sibling], components_relations=[]
+            )
+        }
 
         mock_snapshot.return_value.all_cluster_ids.return_value = {1}
         mock_delta.return_value.has_changes = True
@@ -1673,10 +1683,30 @@ class TestDiagramGenerator(unittest.TestCase):
         root = Component(name="Root", description="", key_entities=[], component_id="1")
         parent = Component(name="Parent", description="", key_entities=[], component_id="1.1")
         empty_leaf = Component(name="Stable Leaf", description="", key_entities=[], component_id="1.1.1")
-        root_analysis = AnalysisInsights(description="root", components=[root], components_relations=[])
+        # Siblings at every level: a scope holding one component is collapsed by the
+        # no-single-child invariant, which would take this fixture apart before it is read.
+        root_analysis = AnalysisInsights(
+            description="root",
+            components=[root, Component(name="Other Root", description="", key_entities=[], component_id="2")],
+            components_relations=[],
+        )
         sub_analyses = {
-            "1": AnalysisInsights(description="sub", components=[parent], components_relations=[]),
-            "1.1": AnalysisInsights(description="leaf", components=[empty_leaf], components_relations=[]),
+            "1": AnalysisInsights(
+                description="sub",
+                components=[
+                    parent,
+                    Component(name="Other Parent", description="", key_entities=[], component_id="1.2"),
+                ],
+                components_relations=[],
+            ),
+            "1.1": AnalysisInsights(
+                description="leaf",
+                components=[
+                    empty_leaf,
+                    Component(name="Other Leaf", description="", key_entities=[], component_id="1.1.2"),
+                ],
+                components_relations=[],
+            ),
         }
 
         mock_snapshot.return_value.all_cluster_ids.return_value = {1}

--- a/tests/diagram_analysis/test_incremental_copy_forward.py
+++ b/tests/diagram_analysis/test_incremental_copy_forward.py
@@ -153,6 +153,14 @@ class TestRestoreUnchangedMetadata(unittest.TestCase):
 
         self.assertEqual(unchanged, set())
 
+    def test_emptied_component_does_not_restore_stale_cluster_ids(self):
+        baseline = self._baseline()
+        live = analysis(component("1", "Original", {}, source_cluster_ids=[]))
+
+        _restore_unchanged_metadata(live, {}, baseline, changed_members={"a.one"}, changed_files=set())
+
+        self.assertEqual(live.components[0].source_cluster_ids, [])
+
 
 class TestFullyUnchangedSubtrees(unittest.TestCase):
     def _tree(self):

--- a/tests/diagram_analysis/test_incremental_copy_forward.py
+++ b/tests/diagram_analysis/test_incremental_copy_forward.py
@@ -16,7 +16,6 @@ from agents.file_index_models import FileMethodGroup, MethodEntry
 from agents.scope_ids import ROOT_SCOPE_ID
 from agents.incremental_agent import prune_empty_components, remove_deleted_files
 from diagram_analysis.diagram_generator import (
-    _cluster_backed_empty_component_ids,
     DiagramGenerator,
     _capture_baseline_member_keys,
     _capture_membership_baseline,
@@ -685,16 +684,8 @@ class TestScopeRelationsSurviveMembershipMovement(unittest.TestCase):
         _reconcile_child_scope_membership_for_test(scope, departed={("a.py", "pkg.gone")})
         self.assertEqual([r.relation for r in scope.components_relations], ["calls"])
 
-class TestEmptiedByDeletionIsNotProtected(unittest.TestCase):
-    """A component whose whole source was deleted must not survive as an empty box.
 
-    `_cluster_backed_empty_component_ids` shields a component that is empty but still
-    cluster-backed — one awaiting re-detail — from the prune. Which components those are
-    depends entirely on WHEN it is asked, because `remove_deleted_files` clears methods and
-    key entities but leaves `source_cluster_ids` alone. Asked after the scrub, it also
-    shields everything the scrub just emptied, and the deleted unit keeps its box.
-    """
-
+class TestDeletedComponentLineage(unittest.TestCase):
     def _tree(self):
         root = analysis(component("1", "Survivor", {"live.py": ["live.one"]}))
         doomed = component("1.2", "Doomed", {"gone.py": ["gone.one"]}, source_cluster_ids=["1.7"])
@@ -706,29 +697,16 @@ class TestEmptiedByDeletionIsNotProtected(unittest.TestCase):
         }
         return root, subs
 
-    def test_capturing_before_the_scrub_lets_the_deleted_component_be_pruned(self):
+    def test_deletion_clears_stale_lineage_before_pruning(self):
         root, subs = self._tree()
 
-        protected = _cluster_backed_empty_component_ids(root, subs)
         remove_deleted_files(root, subs, {"live.py"})
-        removed = prune_empty_components(root, subs, protected)
+        removed = prune_empty_components(root, subs)
 
         self.assertIn("1.2", removed)
         self.assertEqual([c.component_id for c in subs["1"].components], ["1.1"])
 
-    def test_capturing_after_the_scrub_would_keep_it_as_an_empty_box(self):
-        """The order this replaces. Pinned so the bug cannot come back silently."""
-        root, subs = self._tree()
-
-        remove_deleted_files(root, subs, {"live.py"})
-        protected = _cluster_backed_empty_component_ids(root, subs)
-        removed = prune_empty_components(root, subs, protected)
-
-        self.assertNotIn("1.2", removed)
-        self.assertEqual([c.component_id for c in subs["1"].components], ["1.1", "1.2"])
-
-    def test_a_component_already_empty_at_load_is_still_protected(self):
-        """The case the shield is for: cluster-backed, no source deleted, awaiting re-detail."""
+    def test_existing_cluster_backed_empty_component_survives(self):
         root = analysis(component("1", "Parent", {"live.py": ["live.one"]}))
         subs = {
             "1": analysis(
@@ -737,8 +715,7 @@ class TestEmptiedByDeletionIsNotProtected(unittest.TestCase):
             )
         }
 
-        protected = _cluster_backed_empty_component_ids(root, subs)
         remove_deleted_files(root, subs, {"live.py"})
-        removed = prune_empty_components(root, subs, protected)
+        removed = prune_empty_components(root, subs)
 
         self.assertNotIn("1.2", removed)

--- a/tests/diagram_analysis/test_incremental_copy_forward.py
+++ b/tests/diagram_analysis/test_incremental_copy_forward.py
@@ -14,7 +14,9 @@ from pathlib import Path
 from agents.agent_responses import AnalysisInsights, Component, Relation, RelationEdge, SourceCodeReference
 from agents.file_index_models import FileMethodGroup, MethodEntry
 from agents.scope_ids import ROOT_SCOPE_ID
+from agents.incremental_agent import prune_empty_components, remove_deleted_files
 from diagram_analysis.diagram_generator import (
+    _cluster_backed_empty_component_ids,
     DiagramGenerator,
     _capture_baseline_member_keys,
     _capture_membership_baseline,
@@ -682,3 +684,61 @@ class TestScopeRelationsSurviveMembershipMovement(unittest.TestCase):
         scope = AnalysisInsights(description="", components=[], components_relations=[keep])
         _reconcile_child_scope_membership_for_test(scope, departed={("a.py", "pkg.gone")})
         self.assertEqual([r.relation for r in scope.components_relations], ["calls"])
+
+class TestEmptiedByDeletionIsNotProtected(unittest.TestCase):
+    """A component whose whole source was deleted must not survive as an empty box.
+
+    `_cluster_backed_empty_component_ids` shields a component that is empty but still
+    cluster-backed — one awaiting re-detail — from the prune. Which components those are
+    depends entirely on WHEN it is asked, because `remove_deleted_files` clears methods and
+    key entities but leaves `source_cluster_ids` alone. Asked after the scrub, it also
+    shields everything the scrub just emptied, and the deleted unit keeps its box.
+    """
+
+    def _tree(self):
+        root = analysis(component("1", "Survivor", {"live.py": ["live.one"]}))
+        doomed = component("1.2", "Doomed", {"gone.py": ["gone.one"]}, source_cluster_ids=["1.7"])
+        subs = {
+            "1": analysis(
+                component("1.1", "Kept", {"live.py": ["live.one"]}, source_cluster_ids=["1.3"]),
+                doomed,
+            )
+        }
+        return root, subs
+
+    def test_capturing_before_the_scrub_lets_the_deleted_component_be_pruned(self):
+        root, subs = self._tree()
+
+        protected = _cluster_backed_empty_component_ids(root, subs)
+        remove_deleted_files(root, subs, {"live.py"})
+        removed = prune_empty_components(root, subs, protected)
+
+        self.assertIn("1.2", removed)
+        self.assertEqual([c.component_id for c in subs["1"].components], ["1.1"])
+
+    def test_capturing_after_the_scrub_would_keep_it_as_an_empty_box(self):
+        """The order this replaces. Pinned so the bug cannot come back silently."""
+        root, subs = self._tree()
+
+        remove_deleted_files(root, subs, {"live.py"})
+        protected = _cluster_backed_empty_component_ids(root, subs)
+        removed = prune_empty_components(root, subs, protected)
+
+        self.assertNotIn("1.2", removed)
+        self.assertEqual([c.component_id for c in subs["1"].components], ["1.1", "1.2"])
+
+    def test_a_component_already_empty_at_load_is_still_protected(self):
+        """The case the shield is for: cluster-backed, no source deleted, awaiting re-detail."""
+        root = analysis(component("1", "Parent", {"live.py": ["live.one"]}))
+        subs = {
+            "1": analysis(
+                component("1.1", "Kept", {"live.py": ["live.one"]}, source_cluster_ids=["1.3"]),
+                component("1.2", "Awaiting detail", {}, source_cluster_ids=["1.9"]),
+            )
+        }
+
+        protected = _cluster_backed_empty_component_ids(root, subs)
+        remove_deleted_files(root, subs, {"live.py"})
+        removed = prune_empty_components(root, subs, protected)
+
+        self.assertNotIn("1.2", removed)

--- a/tests/diagram_analysis/test_tree_shape.py
+++ b/tests/diagram_analysis/test_tree_shape.py
@@ -1,0 +1,469 @@
+"""Tests for the no-single-child invariant in ``diagram_analysis.tree_shape``.
+
+A level holding one component is the shape measured on ~10% of stored analyses
+(120 occurrences over 574 documents), in two flavours: a component whose only
+child is a leaf, and a chain where each level restates the one below. Absorption
+has to fix both without breaking the dotted-path identity everything else keys on
+— ``sub_analyses`` keys, scoped cluster ids and relation endpoints.
+"""
+
+import json
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from agents.agent_responses import AnalysisInsights, Component, Relation, SourceCodeReference
+from agents.incremental_agent import prune_empty_components
+from agents.file_index_models import FileMethodGroup, MethodEntry
+from diagram_analysis.analysis_json import build_unified_analysis_json, parse_unified_analysis
+from diagram_analysis.diagram_generator import DiagramGenerator
+from diagram_analysis.tree_shape import (
+    absorb_single_child_components,
+    drop_dangling_key_entities,
+    single_child_scopes,
+)
+
+
+def method(qname: str, start: int = 1) -> MethodEntry:
+    return MethodEntry(qualified_name=qname, start_line=start, end_line=start + 5, node_type="FUNCTION")
+
+
+def component(cid: str, name: str, files: dict[str, list[str]], clusters: list[str] | None = None) -> Component:
+    return Component(
+        name=name,
+        description=f"{name} description",
+        key_entities=[],
+        component_id=cid,
+        source_cluster_ids=clusters or [],
+        file_methods=[
+            FileMethodGroup(file_path=path, methods=[method(q, i * 10 + 1) for i, q in enumerate(qnames)])
+            for path, qnames in files.items()
+        ],
+    )
+
+
+def relation(src_id: str, dst_id: str) -> Relation:
+    return Relation(
+        relation="calls",
+        src_name=f"c{src_id}",
+        dst_name=f"c{dst_id}",
+        key_edges=[],
+        src_id=src_id,
+        dst_id=dst_id,
+    )
+
+
+def analysis(*components: Component, relations: list[Relation] | None = None) -> AnalysisInsights:
+    return AnalysisInsights(description="d", components=list(components), components_relations=relations or [])
+
+
+def shape(root: AnalysisInsights, subs: dict[str, AnalysisInsights]) -> dict[str, list[str]]:
+    """The tree as ``scope id -> child component ids``, root under ``''``."""
+    return {"": [c.component_id for c in root.components]} | {
+        scope_id: [c.component_id for c in scope.components] for scope_id, scope in subs.items()
+    }
+
+
+class TestChildlessOnlyChild(unittest.TestCase):
+    """The 114-of-120 case: a component whose single child has nothing under it."""
+
+    def _tree(self):
+        root = analysis(
+            component("1", "Kept", {"a.py": ["a.one"]}),
+            component("2", "Degenerate", {"b.py": ["b.one", "b.two"]}),
+        )
+        subs = {"2": analysis(component("2.1", "Restates Its Parent", {"b.py": ["b.one", "b.two"]}))}
+        return root, subs
+
+    def test_the_parent_becomes_a_leaf(self):
+        root, subs = self._tree()
+
+        absorb_single_child_components(root, subs)
+
+        self.assertEqual(shape(root, subs), {"": ["1", "2"]})
+
+    def test_the_parent_keeps_its_own_identity_and_membership(self):
+        root, subs = self._tree()
+
+        absorb_single_child_components(root, subs)
+
+        parent = root.components[1]
+        self.assertEqual(parent.name, "Degenerate")
+        self.assertEqual(
+            {(g.file_path, m.qualified_name) for g in parent.file_methods for m in g.methods},
+            {("b.py", "b.one"), ("b.py", "b.two")},
+        )
+
+    def test_the_absorption_names_the_child_that_disappeared(self):
+        root, subs = self._tree()
+
+        absorbed = absorb_single_child_components(root, subs)
+
+        self.assertEqual(absorbed, ["2.1"])
+
+
+class TestGrandchildrenArePromoted(unittest.TestCase):
+    def _tree(self):
+        root = analysis(
+            component("1", "Top", {"a.py": ["a.one", "a.two", "a.three"]}),
+            component("9", "Sibling", {"z.py": ["z.one"]}),
+        )
+        subs = {
+            "1": analysis(component("1.1", "Only Child", {"a.py": ["a.one", "a.two", "a.three"]})),
+            "1.1": analysis(
+                component("1.1.1", "Real One", {"a.py": ["a.one"]}, clusters=["1.1.3"]),
+                component("1.1.2", "Real Two", {"a.py": ["a.two", "a.three"]}, clusters=["1.1.5"]),
+                relations=[relation("1.1.1", "1.1.2")],
+            ),
+        }
+        return root, subs
+
+    def test_grandchildren_become_the_parents_children(self):
+        root, subs = self._tree()
+
+        absorb_single_child_components(root, subs)
+
+        self.assertEqual(shape(root, subs), {"": ["1", "9"], "1": ["1.1", "1.2"]})
+        self.assertEqual([c.name for c in subs["1"].components], ["Real One", "Real Two"])
+
+    def test_scoped_cluster_ids_follow_the_components(self):
+        root, subs = self._tree()
+
+        absorb_single_child_components(root, subs)
+
+        self.assertEqual([c.source_cluster_ids for c in subs["1"].components], [["1.3"], ["1.5"]])
+
+    def test_the_promoted_siblings_relations_come_with_them(self):
+        root, subs = self._tree()
+
+        absorb_single_child_components(root, subs)
+
+        self.assertEqual([(r.src_id, r.dst_id) for r in subs["1"].components_relations], [("1.1", "1.2")])
+
+    def test_the_absorbed_scope_key_is_gone(self):
+        root, subs = self._tree()
+
+        absorb_single_child_components(root, subs)
+
+        self.assertNotIn("1.1.1", subs)
+        self.assertEqual(set(subs), {"1"})
+
+
+class TestDeepSubtreeIsRerooted(unittest.TestCase):
+    """A promoted grandchild that is itself expanded keeps its whole subtree."""
+
+    def test_every_descendant_scope_and_id_moves_up_one_level(self):
+        root = analysis(
+            component("3", "Top", {"a.py": ["a.one", "a.two"]}),
+            component("9", "Sibling", {"z.py": ["z.one"]}),
+        )
+        subs = {
+            "3": analysis(component("3.2", "Only Child", {"a.py": ["a.one", "a.two"]})),
+            "3.2": analysis(
+                component("3.2.1", "Branch", {"a.py": ["a.one"]}),
+                component("3.2.2", "Other", {"a.py": ["a.two"]}),
+            ),
+            "3.2.1": analysis(
+                component("3.2.1.1", "Deep A", {"a.py": ["a.one"]}, clusters=["3.2.1.4"]),
+                component("3.2.1.2", "Deep B", {"a.py": ["a.one"]}, clusters=["3.2.1.9"]),
+            ),
+        }
+
+        absorb_single_child_components(root, subs)
+
+        self.assertEqual(
+            shape(root, subs),
+            {"": ["3", "9"], "3": ["3.1", "3.2"], "3.1": ["3.1.1", "3.1.2"]},
+        )
+        self.assertEqual([c.source_cluster_ids for c in subs["3.1"].components], [["3.1.4"], ["3.1.9"]])
+
+
+class TestRootScope(unittest.TestCase):
+    def test_a_lone_top_level_component_hands_its_children_to_the_root(self):
+        root = analysis(component("1", "Everything", {"a.py": ["a.one", "a.two"]}))
+        subs = {
+            "1": analysis(
+                component("1.1", "First", {"a.py": ["a.one"]}),
+                component("1.2", "Second", {"a.py": ["a.two"]}),
+            )
+        }
+
+        absorb_single_child_components(root, subs)
+
+        self.assertEqual(shape(root, subs), {"": ["1", "2"]})
+        self.assertEqual([c.name for c in root.components], ["First", "Second"])
+
+    def test_a_lone_childless_top_level_component_is_left_alone(self):
+        """Absorbing it would leave an analysis with no components at all."""
+        root = analysis(component("1", "Everything", {"a.py": ["a.one"]}))
+
+        absorbed = absorb_single_child_components(root, {})
+
+        self.assertEqual(absorbed, [])
+        self.assertEqual(shape(root, {}), {"": ["1"]})
+
+    def test_the_root_keeps_its_global_relation_list(self):
+        """The root's relations are the global cross-boundary set, not a sibling set."""
+        root = analysis(
+            component("1", "Everything", {"a.py": ["a.one", "a.two"]}),
+            relations=[relation("1.1.1", "1.2.1")],
+        )
+        subs = {
+            "1": analysis(
+                component("1.1", "First", {"a.py": ["a.one"]}),
+                component("1.2", "Second", {"a.py": ["a.two"]}),
+            ),
+            "1.1": analysis(
+                component("1.1.1", "Leaf", {"a.py": ["a.one"]}),
+                component("1.1.2", "Leaf Sibling", {"a.py": ["a.one"]}),
+            ),
+            "1.2": analysis(
+                component("1.2.1", "Leaf Too", {"a.py": ["a.two"]}),
+                component("1.2.2", "Leaf Too Sibling", {"a.py": ["a.two"]}),
+            ),
+        }
+
+        absorb_single_child_components(root, subs)
+
+        self.assertEqual([(r.src_id, r.dst_id) for r in root.components_relations], [("1.1", "2.1")])
+
+
+class TestDegenerateChain(unittest.TestCase):
+    """The markitdown shape: three nested boxes describing the same two methods."""
+
+    def test_a_chain_of_only_children_collapses_to_one_component(self):
+        root = analysis(
+            component("5", "Input & Stream Handling", {"uri.py": ["uri.parse", "uri.resolve"]}),
+            component("9", "Sibling", {"z.py": ["z.one"]}),
+        )
+        subs = {
+            "5": analysis(component("5.1", "URI Resolver", {"uri.py": ["uri.parse", "uri.resolve"]})),
+            "5.1": analysis(component("5.1.1", "URI Scheme Handlers", {"uri.py": ["uri.parse", "uri.resolve"]})),
+        }
+
+        absorbed = absorb_single_child_components(root, subs)
+
+        self.assertEqual(shape(root, subs), {"": ["5", "9"]})
+        self.assertEqual(root.components[0].name, "Input & Stream Handling")
+        self.assertEqual(absorbed, ["5.1", "5.1"])
+
+
+class TestRelationsAcrossAnAbsorption(unittest.TestCase):
+    def _tree(self):
+        root = analysis(
+            component("1", "Kept", {"a.py": ["a.one"]}),
+            component("2", "Absorber", {"b.py": ["b.one"]}),
+            relations=[relation("1", "2.1"), relation("2.1", "1"), relation("2", "2.1")],
+        )
+        subs = {"2": analysis(component("2.1", "Gone", {"b.py": ["b.one"]}))}
+        return root, subs
+
+    def test_edges_into_the_absorbed_child_land_on_the_absorber(self):
+        root, subs = self._tree()
+
+        absorb_single_child_components(root, subs)
+
+        self.assertIn(("1", "2"), [(r.src_id, r.dst_id) for r in root.components_relations])
+        self.assertIn(("2", "1"), [(r.src_id, r.dst_id) for r in root.components_relations])
+
+    def test_an_edge_that_collapses_into_a_self_loop_is_dropped(self):
+        root, subs = self._tree()
+
+        absorb_single_child_components(root, subs)
+
+        self.assertNotIn(("2", "2"), [(r.src_id, r.dst_id) for r in root.components_relations])
+
+
+class TestInvariantReporting(unittest.TestCase):
+    def test_single_child_scopes_names_every_violation(self):
+        root = analysis(component("1", "A", {"a.py": ["a.one"]}), component("2", "B", {"b.py": ["b.one"]}))
+        subs = {
+            "1": analysis(component("1.1", "Only", {"a.py": ["a.one"]})),
+            "2": analysis(
+                component("2.1", "One", {"b.py": ["b.one"]}),
+                component("2.2", "Two", {"b.py": ["b.one"]}),
+            ),
+        }
+
+        self.assertEqual(single_child_scopes(root, subs), ["1"])
+
+    def test_a_healthy_tree_is_untouched_and_reports_nothing(self):
+        root = analysis(component("1", "A", {"a.py": ["a.one"]}), component("2", "B", {"b.py": ["b.one"]}))
+        subs = {
+            "1": analysis(
+                component("1.1", "One", {"a.py": ["a.one"]}),
+                component("1.2", "Two", {"a.py": ["a.one"]}),
+            )
+        }
+        before = shape(root, subs)
+
+        absorbed = absorb_single_child_components(root, subs)
+
+        self.assertEqual(absorbed, [])
+        self.assertEqual(shape(root, subs), before)
+        self.assertEqual(single_child_scopes(root, subs), [])
+
+    def test_absorption_is_idempotent(self):
+        root = analysis(
+            component("1", "Top", {"a.py": ["a.one", "a.two"]}),
+            component("9", "Sibling", {"z.py": ["z.one"]}),
+        )
+        subs = {
+            "1": analysis(component("1.1", "Only Child", {"a.py": ["a.one", "a.two"]})),
+            "1.1": analysis(
+                component("1.1.1", "A", {"a.py": ["a.one"]}),
+                component("1.1.2", "B", {"a.py": ["a.two"]}),
+            ),
+        }
+
+        absorb_single_child_components(root, subs)
+        after_first = shape(root, subs)
+        second = absorb_single_child_components(root, subs)
+
+        self.assertEqual(second, [])
+        self.assertEqual(shape(root, subs), after_first)
+
+
+class TestAbsorbedTreeSurvivesTheStore(unittest.TestCase):
+    """analysis.json IS the store, and it only writes children for an expandable component.
+
+    Why this is worth a test of its own: a component holding a sub-analysis it was not
+    declared expandable for loses that whole subtree at save, permanently. Absorption
+    rewrites both the ids and the ``sub_analyses`` keys, so the two must still agree
+    afterwards or the collapse silently takes a level more than it meant to.
+    """
+
+    def test_the_promoted_subtree_is_still_there_after_a_save_and_a_load(self):
+        root = analysis(
+            component("1", "Top", {"a.py": ["a.one", "a.two"]}),
+            component("9", "Sibling", {"z.py": ["z.one"]}),
+        )
+        subs = {
+            "1": analysis(component("1.1", "Only Child", {"a.py": ["a.one", "a.two"]})),
+            "1.1": analysis(
+                component("1.1.1", "A", {"a.py": ["a.one"]}),
+                component("1.1.2", "B", {"a.py": ["a.two"]}),
+            ),
+        }
+
+        absorb_single_child_components(root, subs)
+        collapsed = shape(root, subs)
+        expandable = [c for scope in [root, *subs.values()] for c in scope.components if c.component_id in subs]
+        document = build_unified_analysis_json(
+            analysis=root,
+            repo_name="r",
+            repo_dir=Path("."),
+            sub_analyses={cid: (scope, []) for cid, scope in subs.items()},
+            expandable_components=expandable,
+            source_tree_hash="",
+            depth_cap=3,
+        )
+        reloaded_root, reloaded_subs = parse_unified_analysis(json.loads(document))
+
+        self.assertEqual(shape(reloaded_root, reloaded_subs), collapsed)
+
+
+class TestFinalizeForSaveEnforcesTheInvariant(unittest.TestCase):
+    """The shared pre-save chokepoint is where every flow — full, incremental, partial — meets it."""
+
+    def test_a_degenerate_level_does_not_survive_to_the_save(self):
+        generator = DiagramGenerator.__new__(DiagramGenerator)
+        generator.static_analysis = None
+        generator._baseline_global_relations = None
+        root = analysis(
+            component("1", "Kept", {"a.py": ["a.one"]}),
+            component("2", "Degenerate", {"b.py": ["b.one"]}),
+        )
+        subs = {"2": analysis(component("2.1", "Restates Its Parent", {"b.py": ["b.one"]}))}
+
+        with patch.object(DiagramGenerator, "_strip_ignored"):
+            generator.finalize_for_save(root, subs)
+
+        self.assertEqual(shape(root, subs), {"": ["1", "2"]})
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class TestDanglingKeyEntities(unittest.TestCase):
+    """A deleted symbol must take its pointers with it.
+
+    Measured over the eval baselines and corpus: 557 of 557 key entities in healthy
+    documents name a method some component owns, so dropping the ones that do not cannot
+    remove a legitimate reference. The failure this prevents is indirect and was found by
+    an e2e test: `prune_empty_components` reads a non-empty `key_entities` as a component
+    still having something to describe, so a component emptied of every method survived as
+    a box held up by pointers into code the commit had deleted.
+    """
+
+    def _entity(self, qname: str) -> SourceCodeReference:
+        return SourceCodeReference(qualified_name=qname, reference_file="a.py")
+
+    def test_an_entity_naming_a_deleted_symbol_is_dropped(self):
+        emptied = component("1.1", "Emptied", {})
+        emptied.key_entities = [self._entity("a.gone"), self._entity("a.also_gone")]
+        root = analysis(component("1", "Parent", {"a.py": ["a.kept"]}))
+        subs = {"1": analysis(component("1.2", "Kept", {"a.py": ["a.kept"]}), emptied)}
+
+        dropped = drop_dangling_key_entities(root, subs)
+
+        self.assertEqual(sorted(dropped), ["a.also_gone", "a.gone"])
+        self.assertEqual(emptied.key_entities, [])
+
+    def test_an_entity_naming_a_live_symbol_is_kept(self):
+        kept = component("1.1", "Kept", {"a.py": ["a.one"]})
+        kept.key_entities = [self._entity("a.one")]
+        root = analysis(component("1", "Parent", {"a.py": ["a.one"]}))
+        subs = {"1": analysis(kept, component("1.2", "Other", {"a.py": ["a.one"]}))}
+
+        self.assertEqual(drop_dangling_key_entities(root, subs), [])
+        self.assertEqual([e.qualified_name for e in kept.key_entities], ["a.one"])
+
+    def test_a_symbol_another_component_owns_still_counts_as_live(self):
+        """The rule is "this document indexes it", not "this component owns it".
+
+        Narrowing it to the component's own methods is `fix_key_entities_refs`'s job and
+        its call sites decide when that runs. This pass only removes what the document no
+        longer describes anywhere, so it can run unconditionally without second-guessing
+        a cross-component citation that was already there.
+        """
+        citing = component("1.1", "Citing", {"a.py": ["a.one"]})
+        citing.key_entities = [self._entity("b.two")]
+        root = analysis(component("1", "Parent", {"a.py": ["a.one"], "b.py": ["b.two"]}))
+        subs = {"1": analysis(citing, component("1.2", "Owner", {"b.py": ["b.two"]}))}
+
+        self.assertEqual(drop_dangling_key_entities(root, subs), [])
+        self.assertEqual([e.qualified_name for e in citing.key_entities], ["b.two"])
+
+    def test_the_emptied_component_can_then_be_pruned_and_its_sibling_absorbed(self):
+        """The end-to-end shape the e2e test `last-sibling-is-absorbed-into-its-parent` hits.
+
+        One of two children is emptied by cutting symbols out of a file the parent shares,
+        so no file is deleted and nothing scrubs the emptied component's entities. With them
+        gone the prune can remove it, which leaves the parent holding one child, which is
+        what absorption is for. Each pass is ordinary; only the order makes them work.
+        """
+        emptied = component("2.1.2", "Emptied", {})
+        emptied.key_entities = [self._entity("t.deleted")]
+        # Siblings at every level above the one under test: a single-child scope anywhere
+        # else collapses too, and the assertion could no longer say which level moved.
+        root = analysis(
+            component("2", "Top", {"t.py": ["t.kept"], "u.py": ["u.one"]}),
+            component("9", "Elsewhere", {"z.py": ["z.one"]}),
+        )
+        subs = {
+            "2": analysis(
+                component("2.1", "Parent", {"t.py": ["t.kept"]}),
+                component("2.2", "Other", {"u.py": ["u.one"]}),
+                component("2.3", "Third", {"u.py": ["u.one"]}),
+            ),
+            "2.1": analysis(component("2.1.1", "Survivor", {"t.py": ["t.kept"]}), emptied),
+        }
+
+        drop_dangling_key_entities(root, subs)
+        removed = prune_empty_components(root, subs, set())
+        absorb_single_child_components(root, subs)
+
+        self.assertIn("2.1.2", removed)
+        self.assertEqual(shape(root, subs), {"": ["2", "9"], "2": ["2.1", "2.2", "2.3"]})

--- a/tests/diagram_analysis/test_tree_shape.py
+++ b/tests/diagram_analysis/test_tree_shape.py
@@ -458,8 +458,8 @@ class TestDanglingKeyEntities(unittest.TestCase):
     a box held up by pointers into code the commit had deleted.
     """
 
-    def _entity(self, qname: str) -> SourceCodeReference:
-        return SourceCodeReference(qualified_name=qname, reference_file="a.py")
+    def _entity(self, qname: str, file: str = "a.py") -> SourceCodeReference:
+        return SourceCodeReference(qualified_name=qname, reference_file=file)
 
     def test_an_entity_naming_a_deleted_symbol_is_dropped(self):
         emptied = component("1.1", "Emptied", {})
@@ -490,12 +490,33 @@ class TestDanglingKeyEntities(unittest.TestCase):
         a cross-component citation that was already there.
         """
         citing = component("1.1", "Citing", {"a.py": ["a.one"]})
-        citing.key_entities = [self._entity("b.two")]
+        citing.key_entities = [self._entity("b.two", file="b.py")]
         root = analysis(component("1", "Parent", {"a.py": ["a.one"], "b.py": ["b.two"]}))
         subs = {"1": analysis(citing, component("1.2", "Owner", {"b.py": ["b.two"]}))}
 
         self.assertEqual(drop_dangling_key_entities(root, subs), [])
         self.assertEqual([e.qualified_name for e in citing.key_entities], ["b.two"])
+
+    def test_a_name_that_survives_only_in_another_file_does_not_keep_the_entity(self):
+        """Two languages in one repo can both declare `run`. Matching on the name alone would
+        call the deleted Python symbol live because the TypeScript one survives."""
+        emptied = component("1.1", "Emptied", {})
+        emptied.key_entities = [SourceCodeReference(qualified_name="pkg.run", reference_file="src/index.py")]
+        root = analysis(component("1", "Parent", {"src/index.ts": ["pkg.run"]}))
+        subs = {"1": analysis(component("1.2", "Kept", {"src/index.ts": ["pkg.run"]}), emptied)}
+
+        self.assertEqual(drop_dangling_key_entities(root, subs), ["pkg.run"])
+        self.assertEqual(emptied.key_entities, [])
+
+    def test_an_entity_with_no_file_falls_back_to_the_name(self):
+        """The model does not always place a reference; an unplaced one is judged on what it has."""
+        citing = component("1.1", "Citing", {"a.py": ["a.one"]})
+        citing.key_entities = [SourceCodeReference(qualified_name="a.one")]
+        root = analysis(component("1", "Parent", {"a.py": ["a.one"]}))
+        subs = {"1": analysis(citing, component("1.2", "Other", {"a.py": ["a.one"]}))}
+
+        self.assertEqual(drop_dangling_key_entities(root, subs), [])
+        self.assertEqual([e.qualified_name for e in citing.key_entities], ["a.one"])
 
     def test_the_emptied_component_can_then_be_pruned_and_its_sibling_absorbed(self):
         """The end-to-end shape the e2e test `last-sibling-is-absorbed-into-its-parent` hits.
@@ -624,6 +645,17 @@ class TestTheIncrementalBaselineMovesWithTheAbsorption(unittest.TestCase):
         generator._rebase_baseline(["2.1"])
 
         self.assertEqual(generator._baseline_global_relations, {})
+
+    def test_a_restored_baseline_relation_carries_the_new_endpoints(self):
+        """`preserve_unchanged_relations` appends the baseline object itself for a pair the
+        rebuild dropped, so rebasing only the dict key would save an edge pointing at the
+        absorbed child — a component the tree no longer has."""
+        generator = self._generator()
+
+        generator._rebase_baseline(["2.1"])
+
+        restored = generator._baseline_global_relations[("1", "2")]
+        self.assertEqual((restored.src_id, restored.dst_id), ("1", "2"))
 
     def test_a_full_run_has_no_baseline_to_rebase(self):
         generator = DiagramGenerator.__new__(DiagramGenerator)

--- a/tests/diagram_analysis/test_tree_shape.py
+++ b/tests/diagram_analysis/test_tree_shape.py
@@ -17,6 +17,7 @@ from agents.incremental_agent import prune_empty_components
 from agents.file_index_models import FileMethodGroup, MethodEntry
 from diagram_analysis.analysis_json import build_unified_analysis_json, parse_unified_analysis
 from diagram_analysis.diagram_generator import DiagramGenerator
+from diagram_analysis.exceptions import ScopeContainmentError
 from static_analyzer.graph import CallGraph
 from static_analyzer.method_cluster_paths import MethodClusterPaths
 from diagram_analysis.tree_shape import (
@@ -434,6 +435,7 @@ class TestFinalizeForSaveEnforcesTheInvariant(unittest.TestCase):
     def test_a_degenerate_level_does_not_survive_to_the_save(self):
         generator = DiagramGenerator.__new__(DiagramGenerator)
         generator.static_analysis = None
+        generator.repo_location = Path(".")
         generator._baseline_global_relations = None
         root = analysis(
             component("1", "Kept", {"a.py": ["a.one"]}),
@@ -467,7 +469,7 @@ class TestDanglingKeyEntities(unittest.TestCase):
         root = analysis(component("1", "Parent", {"a.py": ["a.kept"]}))
         subs = {"1": analysis(component("1.2", "Kept", {"a.py": ["a.kept"]}), emptied)}
 
-        dropped = drop_dangling_key_entities(root, subs)
+        dropped = drop_dangling_key_entities(root, subs, Path("."))
 
         self.assertEqual(sorted(dropped), ["a.also_gone", "a.gone"])
         self.assertEqual(emptied.key_entities, [])
@@ -478,7 +480,7 @@ class TestDanglingKeyEntities(unittest.TestCase):
         root = analysis(component("1", "Parent", {"a.py": ["a.one"]}))
         subs = {"1": analysis(kept, component("1.2", "Other", {"a.py": ["a.one"]}))}
 
-        self.assertEqual(drop_dangling_key_entities(root, subs), [])
+        self.assertEqual(drop_dangling_key_entities(root, subs, Path(".")), [])
         self.assertEqual([e.qualified_name for e in kept.key_entities], ["a.one"])
 
     def test_a_symbol_another_component_owns_still_counts_as_live(self):
@@ -494,7 +496,7 @@ class TestDanglingKeyEntities(unittest.TestCase):
         root = analysis(component("1", "Parent", {"a.py": ["a.one"], "b.py": ["b.two"]}))
         subs = {"1": analysis(citing, component("1.2", "Owner", {"b.py": ["b.two"]}))}
 
-        self.assertEqual(drop_dangling_key_entities(root, subs), [])
+        self.assertEqual(drop_dangling_key_entities(root, subs, Path(".")), [])
         self.assertEqual([e.qualified_name for e in citing.key_entities], ["b.two"])
 
     def test_a_name_that_survives_only_in_another_file_does_not_keep_the_entity(self):
@@ -505,7 +507,7 @@ class TestDanglingKeyEntities(unittest.TestCase):
         root = analysis(component("1", "Parent", {"src/index.ts": ["pkg.run"]}))
         subs = {"1": analysis(component("1.2", "Kept", {"src/index.ts": ["pkg.run"]}), emptied)}
 
-        self.assertEqual(drop_dangling_key_entities(root, subs), ["pkg.run"])
+        self.assertEqual(drop_dangling_key_entities(root, subs, Path(".")), ["pkg.run"])
         self.assertEqual(emptied.key_entities, [])
 
     def test_an_entity_with_no_file_falls_back_to_the_name(self):
@@ -515,7 +517,7 @@ class TestDanglingKeyEntities(unittest.TestCase):
         root = analysis(component("1", "Parent", {"a.py": ["a.one"]}))
         subs = {"1": analysis(citing, component("1.2", "Other", {"a.py": ["a.one"]}))}
 
-        self.assertEqual(drop_dangling_key_entities(root, subs), [])
+        self.assertEqual(drop_dangling_key_entities(root, subs, Path(".")), [])
         self.assertEqual([e.qualified_name for e in citing.key_entities], ["a.one"])
 
     def test_the_emptied_component_can_then_be_pruned_and_its_sibling_absorbed(self):
@@ -543,7 +545,7 @@ class TestDanglingKeyEntities(unittest.TestCase):
             "2.1": analysis(component("2.1.1", "Survivor", {"t.py": ["t.kept"]}), emptied),
         }
 
-        drop_dangling_key_entities(root, subs)
+        drop_dangling_key_entities(root, subs, Path("."))
         removed = prune_empty_components(root, subs, set())
         absorb_single_child_components(root, subs)
 
@@ -664,6 +666,64 @@ class TestTheIncrementalBaselineMovesWithTheAbsorption(unittest.TestCase):
         generator._rebase_baseline(["2.1"])
 
         self.assertIsNone(generator._baseline_global_relations)
+
+
+class TestAbsorptionKeepsTheDocumentRenderable(unittest.TestCase):
+    """The generators key mermaid nodes on the component NAME, not on its id.
+
+    So an id rerooted onto the parent while the name still says the absorbed child leaves an
+    edge drawn against a node the diagram no longer contains.
+    """
+
+    def test_a_relation_naming_the_absorbed_child_takes_the_parents_name(self):
+        root = analysis(
+            component("1", "Kept", {"a.py": ["a.one"]}),
+            component("2", "Absorber", {"b.py": ["b.one"]}),
+            relations=[relation("1", "2.1")],
+        )
+        root.components_relations[0].dst_name = "Gone"
+        subs = {"2": analysis(component("2.1", "Gone", {"b.py": ["b.one"]}))}
+
+        absorb_single_child_components(root, subs)
+
+        edge = root.components_relations[0]
+        self.assertEqual((edge.dst_id, edge.dst_name), ("2", "Absorber"))
+
+    def test_a_promoted_components_relations_name_their_new_ids(self):
+        root = analysis(component("1", "Top", {"a.py": ["a.one"]}), component("9", "Sib", {"z.py": ["z.one"]}))
+        promoted = analysis(
+            component("1.1.1", "First", {"a.py": ["a.one"]}),
+            component("1.1.2", "Second", {"a.py": ["a.one"]}),
+            relations=[relation("1.1.1", "1.1.2")],
+        )
+        promoted.components_relations[0].src_name = "First"
+        promoted.components_relations[0].dst_name = "Second"
+        subs = {"1": analysis(component("1.1", "Only child", {"a.py": ["a.one"]})), "1.1": promoted}
+
+        absorb_single_child_components(root, subs)
+
+        edge = subs["1"].components_relations[0]
+        self.assertEqual((edge.src_id, edge.src_name), ("1.1", "First"))
+        self.assertEqual((edge.dst_id, edge.dst_name), ("1.2", "Second"))
+
+
+class TestAbsorptionNeverHidesAContainmentViolation(unittest.TestCase):
+    def test_a_child_owning_what_its_parent_does_not_fails_before_the_collapse(self):
+        """Deleting a childless only child is lossless only because the parent already owns
+        everything it owned. Where that does not hold, collapsing first would discard the
+        child's extra methods and leave the check nothing to find."""
+        generator = DiagramGenerator.__new__(DiagramGenerator)
+        generator.static_analysis = None
+        generator.repo_location = Path(".")
+        generator._baseline_global_relations = None
+        root = analysis(component("1", "Parent", {"a.py": ["a.one"]}))
+        subs = {"1": analysis(component("1.1", "Child owning more", {"a.py": ["a.one", "a.stray"]}))}
+
+        with patch.object(DiagramGenerator, "_strip_ignored"):
+            with self.assertRaises(ScopeContainmentError):
+                generator.finalize_for_save(root, subs)
+
+        self.assertIn("1", subs, "the violating scope must still be there for a human to look at")
 
 
 if __name__ == "__main__":

--- a/tests/diagram_analysis/test_tree_shape.py
+++ b/tests/diagram_analysis/test_tree_shape.py
@@ -1,11 +1,4 @@
-"""Tests for the no-single-child invariant in ``diagram_analysis.tree_shape``.
-
-A level holding one component is the shape measured on ~10% of stored analyses
-(120 occurrences over 574 documents), in two flavours: a component whose only
-child is a leaf, and a chain where each level restates the one below. Absorption
-has to fix both without breaking the dotted-path identity everything else keys on
-— ``sub_analyses`` keys, scoped cluster ids and relation endpoints.
-"""
+"""Tests for single-child component absorption."""
 
 import json
 import unittest
@@ -13,18 +6,13 @@ from pathlib import Path
 from unittest.mock import patch
 
 from agents.agent_responses import AnalysisInsights, Component, Relation, SourceCodeReference
-from agents.incremental_agent import prune_empty_components
 from agents.file_index_models import FileMethodGroup, MethodEntry
 from diagram_analysis.analysis_json import build_unified_analysis_json, parse_unified_analysis
-from diagram_analysis.diagram_generator import DiagramGenerator
+from diagram_analysis.diagram_generator import DiagramGenerator, _member_keys, _reconcile_child_scope
 from diagram_analysis.exceptions import ScopeContainmentError
 from static_analyzer.graph import CallGraph
 from static_analyzer.method_cluster_paths import MethodClusterPaths
-from diagram_analysis.tree_shape import (
-    absorb_single_child_components,
-    drop_dangling_key_entities,
-    single_child_scopes,
-)
+from diagram_analysis.tree_shape import absorb_single_child_components
 
 
 def method(qname: str, start: int = 1) -> MethodEntry:
@@ -68,8 +56,6 @@ def shape(root: AnalysisInsights, subs: dict[str, AnalysisInsights]) -> dict[str
 
 
 class TestChildlessOnlyChild(unittest.TestCase):
-    """The 114-of-120 case: a component whose single child has nothing under it."""
-
     def _tree(self):
         root = analysis(
             component("1", "Kept", {"a.py": ["a.one"]}),
@@ -78,30 +64,18 @@ class TestChildlessOnlyChild(unittest.TestCase):
         subs = {"2": analysis(component("2.1", "Restates Its Parent", {"b.py": ["b.one", "b.two"]}))}
         return root, subs
 
-    def test_the_parent_becomes_a_leaf(self):
+    def test_the_parent_becomes_a_leaf_without_losing_identity(self):
         root, subs = self._tree()
 
-        absorb_single_child_components(root, subs)
+        absorbed = absorb_single_child_components(root, subs)
 
         self.assertEqual(shape(root, subs), {"": ["1", "2"]})
-
-    def test_the_parent_keeps_its_own_identity_and_membership(self):
-        root, subs = self._tree()
-
-        absorb_single_child_components(root, subs)
-
         parent = root.components[1]
         self.assertEqual(parent.name, "Degenerate")
         self.assertEqual(
             {(g.file_path, m.qualified_name) for g in parent.file_methods for m in g.methods},
             {("b.py", "b.one"), ("b.py", "b.two")},
         )
-
-    def test_the_absorption_names_the_child_that_disappeared(self):
-        root, subs = self._tree()
-
-        absorbed = absorb_single_child_components(root, subs)
-
         self.assertEqual(absorbed, ["2.1"])
 
 
@@ -121,40 +95,19 @@ class TestGrandchildrenArePromoted(unittest.TestCase):
         }
         return root, subs
 
-    def test_grandchildren_become_the_parents_children(self):
+    def test_grandchildren_and_their_metadata_move_to_the_parent(self):
         root, subs = self._tree()
 
         absorb_single_child_components(root, subs)
 
         self.assertEqual(shape(root, subs), {"": ["1", "9"], "1": ["1.1", "1.2"]})
         self.assertEqual([c.name for c in subs["1"].components], ["Real One", "Real Two"])
-
-    def test_scoped_cluster_ids_follow_the_components(self):
-        root, subs = self._tree()
-
-        absorb_single_child_components(root, subs)
-
         self.assertEqual([c.source_cluster_ids for c in subs["1"].components], [["1.3"], ["1.5"]])
-
-    def test_the_promoted_siblings_relations_come_with_them(self):
-        root, subs = self._tree()
-
-        absorb_single_child_components(root, subs)
-
         self.assertEqual([(r.src_id, r.dst_id) for r in subs["1"].components_relations], [("1.1", "1.2")])
-
-    def test_the_absorbed_scope_key_is_gone(self):
-        root, subs = self._tree()
-
-        absorb_single_child_components(root, subs)
-
-        self.assertNotIn("1.1.1", subs)
         self.assertEqual(set(subs), {"1"})
 
 
 class TestDeepSubtreeIsRerooted(unittest.TestCase):
-    """A promoted grandchild that is itself expanded keeps its whole subtree."""
-
     def test_every_descendant_scope_and_id_moves_up_one_level(self):
         root = analysis(
             component("3", "Top", {"a.py": ["a.one", "a.two"]}),
@@ -182,14 +135,6 @@ class TestDeepSubtreeIsRerooted(unittest.TestCase):
 
 
 class TestRerootIsIndependentOfScopeOrder(unittest.TestCase):
-    """`parse_unified_analysis` returns children before their parents.
-
-    Every reroot target is one level shallower than its source, so a target can equal a key
-    that has not moved yet. Writing in place overwrote that scope and then moved the wrong
-    object under its own name — a whole expanded subtree gone, silently, on any baseline
-    loaded from disk.
-    """
-
     def _chain(self, keys_deepest_first: bool):
         root = analysis(component("1", "Top", {"a.py": ["a.one"]}), component("9", "Sibling", {"z.py": ["z.one"]}))
         levels = [
@@ -210,18 +155,6 @@ class TestRerootIsIndependentOfScopeOrder(unittest.TestCase):
         if keys_deepest_first:
             levels = list(reversed(levels))
         return root, {key: analysis(*comps) for key, comps in levels}
-
-    def test_the_result_does_not_depend_on_insertion_order(self):
-        shallow_root, shallow = self._chain(keys_deepest_first=False)
-        deep_root, deep = self._chain(keys_deepest_first=True)
-
-        absorb_single_child_components(shallow_root, shallow)
-        absorb_single_child_components(deep_root, deep)
-
-        self.assertEqual(
-            {k: sorted(v) for k, v in shape(deep_root, deep).items()},
-            {k: sorted(v) for k, v in shape(shallow_root, shallow).items()},
-        )
 
     def test_no_scope_is_lost_when_children_are_inserted_first(self):
         root, subs = self._chain(keys_deepest_first=True)
@@ -260,7 +193,6 @@ class TestRootScope(unittest.TestCase):
         self.assertEqual([c.name for c in root.components], ["First", "Second"])
 
     def test_a_lone_childless_top_level_component_is_left_alone(self):
-        """Absorbing it would leave an analysis with no components at all."""
         root = analysis(component("1", "Everything", {"a.py": ["a.one"]}))
 
         absorbed = absorb_single_child_components(root, {})
@@ -269,7 +201,6 @@ class TestRootScope(unittest.TestCase):
         self.assertEqual(shape(root, {}), {"": ["1"]})
 
     def test_the_root_keeps_its_global_relation_list(self):
-        """The root's relations are the global cross-boundary set, not a sibling set."""
         root = analysis(
             component("1", "Everything", {"a.py": ["a.one", "a.two"]}),
             relations=[relation("1.1.1", "1.2.1")],
@@ -295,8 +226,6 @@ class TestRootScope(unittest.TestCase):
 
 
 class TestDegenerateChain(unittest.TestCase):
-    """The markitdown shape: three nested boxes describing the same two methods."""
-
     def test_a_chain_of_only_children_collapses_to_one_component(self):
         root = analysis(
             component("5", "Input & Stream Handling", {"uri.py": ["uri.parse", "uri.resolve"]}),
@@ -324,81 +253,17 @@ class TestRelationsAcrossAnAbsorption(unittest.TestCase):
         subs = {"2": analysis(component("2.1", "Gone", {"b.py": ["b.one"]}))}
         return root, subs
 
-    def test_edges_into_the_absorbed_child_land_on_the_absorber(self):
+    def test_edges_are_rerooted_and_self_loops_are_dropped(self):
         root, subs = self._tree()
 
         absorb_single_child_components(root, subs)
 
         self.assertIn(("1", "2"), [(r.src_id, r.dst_id) for r in root.components_relations])
         self.assertIn(("2", "1"), [(r.src_id, r.dst_id) for r in root.components_relations])
-
-    def test_an_edge_that_collapses_into_a_self_loop_is_dropped(self):
-        root, subs = self._tree()
-
-        absorb_single_child_components(root, subs)
-
         self.assertNotIn(("2", "2"), [(r.src_id, r.dst_id) for r in root.components_relations])
 
 
-class TestInvariantReporting(unittest.TestCase):
-    def test_single_child_scopes_names_every_violation(self):
-        root = analysis(component("1", "A", {"a.py": ["a.one"]}), component("2", "B", {"b.py": ["b.one"]}))
-        subs = {
-            "1": analysis(component("1.1", "Only", {"a.py": ["a.one"]})),
-            "2": analysis(
-                component("2.1", "One", {"b.py": ["b.one"]}),
-                component("2.2", "Two", {"b.py": ["b.one"]}),
-            ),
-        }
-
-        self.assertEqual(single_child_scopes(root, subs), ["1"])
-
-    def test_a_healthy_tree_is_untouched_and_reports_nothing(self):
-        root = analysis(component("1", "A", {"a.py": ["a.one"]}), component("2", "B", {"b.py": ["b.one"]}))
-        subs = {
-            "1": analysis(
-                component("1.1", "One", {"a.py": ["a.one"]}),
-                component("1.2", "Two", {"a.py": ["a.one"]}),
-            )
-        }
-        before = shape(root, subs)
-
-        absorbed = absorb_single_child_components(root, subs)
-
-        self.assertEqual(absorbed, [])
-        self.assertEqual(shape(root, subs), before)
-        self.assertEqual(single_child_scopes(root, subs), [])
-
-    def test_absorption_is_idempotent(self):
-        root = analysis(
-            component("1", "Top", {"a.py": ["a.one", "a.two"]}),
-            component("9", "Sibling", {"z.py": ["z.one"]}),
-        )
-        subs = {
-            "1": analysis(component("1.1", "Only Child", {"a.py": ["a.one", "a.two"]})),
-            "1.1": analysis(
-                component("1.1.1", "A", {"a.py": ["a.one"]}),
-                component("1.1.2", "B", {"a.py": ["a.two"]}),
-            ),
-        }
-
-        absorb_single_child_components(root, subs)
-        after_first = shape(root, subs)
-        second = absorb_single_child_components(root, subs)
-
-        self.assertEqual(second, [])
-        self.assertEqual(shape(root, subs), after_first)
-
-
 class TestAbsorbedTreeSurvivesTheStore(unittest.TestCase):
-    """analysis.json IS the store, and it only writes children for an expandable component.
-
-    Why this is worth a test of its own: a component holding a sub-analysis it was not
-    declared expandable for loses that whole subtree at save, permanently. Absorption
-    rewrites both the ids and the ``sub_analyses`` keys, so the two must still agree
-    afterwards or the collapse silently takes a level more than it meant to.
-    """
-
     def test_the_promoted_subtree_is_still_there_after_a_save_and_a_load(self):
         root = analysis(
             component("1", "Top", {"a.py": ["a.one", "a.two"]}),
@@ -430,8 +295,6 @@ class TestAbsorbedTreeSurvivesTheStore(unittest.TestCase):
 
 
 class TestFinalizeForSaveEnforcesTheInvariant(unittest.TestCase):
-    """The shared pre-save chokepoint is where every flow — full, incremental, partial — meets it."""
-
     def test_a_degenerate_level_does_not_survive_to_the_save(self):
         generator = DiagramGenerator.__new__(DiagramGenerator)
         generator.static_analysis = None
@@ -440,6 +303,7 @@ class TestFinalizeForSaveEnforcesTheInvariant(unittest.TestCase):
         root = analysis(
             component("1", "Kept", {"a.py": ["a.one"]}),
             component("2", "Degenerate", {"b.py": ["b.one"]}),
+            relations=[relation("1", "2.1")],
         )
         subs = {"2": analysis(component("2.1", "Restates Its Parent", {"b.py": ["b.one"]}))}
 
@@ -447,120 +311,68 @@ class TestFinalizeForSaveEnforcesTheInvariant(unittest.TestCase):
             generator.finalize_for_save(root, subs)
 
         self.assertEqual(shape(root, subs), {"": ["1", "2"]})
+        self.assertEqual([(edge.src_id, edge.dst_id) for edge in root.components_relations], [("1", "2")])
+
+    def test_relations_are_rebuilt_against_the_pre_absorption_ids(self):
+        generator = DiagramGenerator.__new__(DiagramGenerator)
+        generator.static_analysis = None
+        generator.repo_location = Path(".")
+        root = analysis(component("1", "Kept", {"a.py": ["a.one"]}), component("2", "Parent", {}))
+        subs = {"2": analysis(component("2.1", "Child", {}))}
+
+        def rebuild(current_root, current_subs):
+            self.assertIn("2", current_subs)
+            current_root.components_relations = [relation("1", "2.1")]
+            return current_root.components_relations
+
+        with (
+            patch.object(DiagramGenerator, "_strip_ignored"),
+            patch.object(generator, "rebuild_global_relations", side_effect=rebuild),
+        ):
+            generator.finalize_for_save(root, subs)
+
+        self.assertEqual([(edge.src_id, edge.dst_id) for edge in root.components_relations], [("1", "2")])
 
 
-class TestDanglingKeyEntities(unittest.TestCase):
-    """A deleted symbol must take its pointers with it.
+class TestMembershipReconciliation(unittest.TestCase):
+    def test_departed_methods_take_their_key_entities_and_cluster_lineage(self):
+        parent = component("1", "Parent", {"a.py": ["a.kept"]})
+        child = component("1.1", "Child", {"a.py": ["a.kept", "a.gone"]}, clusters=["1.7"])
+        child.key_entities = [
+            SourceCodeReference(qualified_name="a.kept", reference_file="a.py"),
+            SourceCodeReference(qualified_name="a.gone", reference_file="a.py"),
+        ]
+        child_scope = analysis(child)
 
-    Measured over the eval baselines and corpus: 557 of 557 key entities in healthy
-    documents name a method some component owns, so dropping the ones that do not cannot
-    remove a legitimate reference. The failure this prevents is indirect and was found by
-    an e2e test: `prune_empty_components` reads a non-empty `key_entities` as a component
-    still having something to describe, so a component emptied of every method survived as
-    a box held up by pointers into code the commit had deleted.
-    """
-
-    def _entity(self, qname: str, file: str = "a.py") -> SourceCodeReference:
-        return SourceCodeReference(qualified_name=qname, reference_file=file)
-
-    def test_an_entity_naming_a_deleted_symbol_is_dropped(self):
-        emptied = component("1.1", "Emptied", {})
-        emptied.key_entities = [self._entity("a.gone"), self._entity("a.also_gone")]
-        root = analysis(component("1", "Parent", {"a.py": ["a.kept"]}))
-        subs = {"1": analysis(component("1.2", "Kept", {"a.py": ["a.kept"]}), emptied)}
-
-        dropped = drop_dangling_key_entities(root, subs, Path("."))
-
-        self.assertEqual(sorted(dropped), ["a.also_gone", "a.gone"])
-        self.assertEqual(emptied.key_entities, [])
-
-    def test_an_entity_naming_a_live_symbol_is_kept(self):
-        kept = component("1.1", "Kept", {"a.py": ["a.one"]})
-        kept.key_entities = [self._entity("a.one")]
-        root = analysis(component("1", "Parent", {"a.py": ["a.one"]}))
-        subs = {"1": analysis(kept, component("1.2", "Other", {"a.py": ["a.one"]}))}
-
-        self.assertEqual(drop_dangling_key_entities(root, subs, Path(".")), [])
-        self.assertEqual([e.qualified_name for e in kept.key_entities], ["a.one"])
-
-    def test_a_symbol_another_component_owns_still_counts_as_live(self):
-        """The rule is "this document indexes it", not "this component owns it".
-
-        Narrowing it to the component's own methods is `fix_key_entities_refs`'s job and
-        its call sites decide when that runs. This pass only removes what the document no
-        longer describes anywhere, so it can run unconditionally without second-guessing
-        a cross-component citation that was already there.
-        """
-        citing = component("1.1", "Citing", {"a.py": ["a.one"]})
-        citing.key_entities = [self._entity("b.two", file="b.py")]
-        root = analysis(component("1", "Parent", {"a.py": ["a.one"], "b.py": ["b.two"]}))
-        subs = {"1": analysis(citing, component("1.2", "Owner", {"b.py": ["b.two"]}))}
-
-        self.assertEqual(drop_dangling_key_entities(root, subs, Path(".")), [])
-        self.assertEqual([e.qualified_name for e in citing.key_entities], ["b.two"])
-
-    def test_a_name_that_survives_only_in_another_file_does_not_keep_the_entity(self):
-        """Two languages in one repo can both declare `run`. Matching on the name alone would
-        call the deleted Python symbol live because the TypeScript one survives."""
-        emptied = component("1.1", "Emptied", {})
-        emptied.key_entities = [SourceCodeReference(qualified_name="pkg.run", reference_file="src/index.py")]
-        root = analysis(component("1", "Parent", {"src/index.ts": ["pkg.run"]}))
-        subs = {"1": analysis(component("1.2", "Kept", {"src/index.ts": ["pkg.run"]}), emptied)}
-
-        self.assertEqual(drop_dangling_key_entities(root, subs, Path(".")), ["pkg.run"])
-        self.assertEqual(emptied.key_entities, [])
-
-    def test_an_entity_with_no_file_falls_back_to_the_name(self):
-        """The model does not always place a reference; an unplaced one is judged on what it has."""
-        citing = component("1.1", "Citing", {"a.py": ["a.one"]})
-        citing.key_entities = [SourceCodeReference(qualified_name="a.one")]
-        root = analysis(component("1", "Parent", {"a.py": ["a.one"]}))
-        subs = {"1": analysis(citing, component("1.2", "Other", {"a.py": ["a.one"]}))}
-
-        self.assertEqual(drop_dangling_key_entities(root, subs, Path(".")), [])
-        self.assertEqual([e.qualified_name for e in citing.key_entities], ["a.one"])
-
-    def test_the_emptied_component_can_then_be_pruned_and_its_sibling_absorbed(self):
-        """The end-to-end shape the e2e test `last-sibling-is-absorbed-into-its-parent` hits.
-
-        One of two children is emptied by cutting symbols out of a file the parent shares,
-        so no file is deleted and nothing scrubs the emptied component's entities. With them
-        gone the prune can remove it, which leaves the parent holding one child, which is
-        what absorption is for. Each pass is ordinary; only the order makes them work.
-        """
-        emptied = component("2.1.2", "Emptied", {})
-        emptied.key_entities = [self._entity("t.deleted")]
-        # Siblings at every level above the one under test: a single-child scope anywhere
-        # else collapses too, and the assertion could no longer say which level moved.
-        root = analysis(
-            component("2", "Top", {"t.py": ["t.kept"], "u.py": ["u.one"]}),
-            component("9", "Elsewhere", {"z.py": ["z.one"]}),
+        _reconcile_child_scope(
+            parent,
+            child_scope,
+            set(_member_keys(parent)),
+            set(_member_keys(child)),
+            Path("."),
         )
-        subs = {
-            "2": analysis(
-                component("2.1", "Parent", {"t.py": ["t.kept"]}),
-                component("2.2", "Other", {"u.py": ["u.one"]}),
-                component("2.3", "Third", {"u.py": ["u.one"]}),
-            ),
-            "2.1": analysis(component("2.1.1", "Survivor", {"t.py": ["t.kept"]}), emptied),
-        }
 
-        drop_dangling_key_entities(root, subs, Path("."))
-        removed = prune_empty_components(root, subs, set())
-        absorb_single_child_components(root, subs)
+        self.assertEqual([entity.qualified_name for entity in child.key_entities], ["a.kept"])
+        self.assertEqual(child.source_cluster_ids, ["1.7"])
 
-        self.assertIn("2.1.2", removed)
-        self.assertEqual(shape(root, subs), {"": ["2", "9"], "2": ["2.1", "2.2", "2.3"]})
+    def test_an_emptied_child_loses_stale_metadata(self):
+        parent = component("1", "Parent", {})
+        child = component("1.1", "Child", {"a.py": ["a.gone"]}, clusters=["1.7"])
+        child.key_entities = [SourceCodeReference(qualified_name="a.gone", reference_file="a.py")]
+
+        _reconcile_child_scope(
+            parent,
+            analysis(child),
+            set(),
+            set(_member_keys(child)),
+            Path("."),
+        )
+
+        self.assertEqual(child.key_entities, [])
+        self.assertEqual(child.source_cluster_ids, [])
 
 
 class TestClusterLineageMovesWithTheTree(unittest.TestCase):
-    """Lineage is scope-qualified, so a collapse renames it as surely as it renames a component id.
-
-    Left behind it seeds the next incremental with a partition incoherent against the promoted
-    components' membership. Measured over 11 diverged scopes: 10 relabelled the whole scope on a
-    no-change run, one lost a component outright.
-    """
-
     def test_the_absorbed_scopes_clusters_take_the_parents_path(self):
         paths = MethodClusterPaths({"pkg.one": {"1.2.3", "1.2.7"}, "pkg.two": {"4.1"}})
 
@@ -569,7 +381,6 @@ class TestClusterLineageMovesWithTheTree(unittest.TestCase):
         self.assertEqual(paths.snapshot_dict(), {"pkg.one": {"1.3", "1.7"}, "pkg.two": {"4.1"}})
 
     def test_the_parents_own_partition_is_dropped_rather_than_merged(self):
-        """Both land on `<parent>.<n>`; unioning them invents a cluster holding two unrelated sets."""
         paths = MethodClusterPaths({"a": {"1.0"}, "b": {"1.1.0", "1.1"}})
 
         paths.reroot_scope("1.1", "1")
@@ -584,7 +395,6 @@ class TestClusterLineageMovesWithTheTree(unittest.TestCase):
         self.assertEqual(paths.snapshot_dict(), {"deep": {"1.5.4"}})
 
     def test_root_absorption_leaves_bare_leaf_ids(self):
-        """`_cluster_id_belongs_to_scope("")` accepts a bare digit, which is the root's own form."""
         paths = MethodClusterPaths({"pkg.one": {"1.3"}})
 
         paths.reroot_scope("1", "")
@@ -607,74 +417,7 @@ class TestClusterLineageMovesWithTheTree(unittest.TestCase):
         self.assertEqual(cfg.method_cluster_paths.snapshot_dict(), {"a.one": {"1.4"}})
 
 
-class TestTheIncrementalBaselineMovesWithTheAbsorption(unittest.TestCase):
-    """The baseline is snapshotted before the collapse, so it names the code by its old ids.
-
-    Read against the collapsed tree the rebuilt pair `1 -> 2` matches nothing in it, and neither
-    endpoint counts as changed — absorbing a childless only child leaves the parent's membership
-    untouched — so `preserve_unchanged_relations` discards it as drift while the baseline's own
-    `1 -> 2.1` is skipped for naming a component no longer live. The relation is lost.
-    """
-
-    def _generator(self):
-        generator = DiagramGenerator.__new__(DiagramGenerator)
-        generator.static_analysis = None
-        generator._baseline_component_ids = {"1", "2", "2.1"}
-        generator._baseline_member_keys = {cid: frozenset() for cid in ("1", "2", "2.1")}
-        generator._baseline_global_relations = {("1", "2.1"): relation("1", "2.1"), ("2.1", "1"): relation("2.1", "1")}
-        return generator
-
-    def test_a_baseline_pair_naming_the_absorbed_child_now_names_its_parent(self):
-        generator = self._generator()
-
-        generator._rebase_baseline(["2.1"])
-
-        self.assertEqual(sorted(generator._baseline_global_relations), [("1", "2"), ("2", "1")])
-
-    def test_the_absorbed_child_leaves_the_baseline_id_and_membership_sets(self):
-        generator = self._generator()
-
-        generator._rebase_baseline(["2.1"])
-
-        self.assertEqual(generator._baseline_component_ids, {"1", "2"})
-        self.assertEqual(set(generator._baseline_member_keys), {"1", "2"})
-
-    def test_a_pair_that_collapses_onto_itself_is_dropped(self):
-        """`2 -> 2.1` becomes `2 -> 2`, which is not an edge — the same rule `_reroot_relations` applies."""
-        generator = self._generator()
-        generator._baseline_global_relations = {("2", "2.1"): relation("2", "2.1")}
-
-        generator._rebase_baseline(["2.1"])
-
-        self.assertEqual(generator._baseline_global_relations, {})
-
-    def test_a_restored_baseline_relation_carries_the_new_endpoints(self):
-        """`preserve_unchanged_relations` appends the baseline object itself for a pair the
-        rebuild dropped, so rebasing only the dict key would save an edge pointing at the
-        absorbed child — a component the tree no longer has."""
-        generator = self._generator()
-
-        generator._rebase_baseline(["2.1"])
-
-        restored = generator._baseline_global_relations[("1", "2")]
-        self.assertEqual((restored.src_id, restored.dst_id), ("1", "2"))
-
-    def test_a_full_run_has_no_baseline_to_rebase(self):
-        generator = DiagramGenerator.__new__(DiagramGenerator)
-        generator._baseline_global_relations = None
-
-        generator._rebase_baseline(["2.1"])
-
-        self.assertIsNone(generator._baseline_global_relations)
-
-
 class TestAbsorptionKeepsTheDocumentRenderable(unittest.TestCase):
-    """The generators key mermaid nodes on the component NAME, not on its id.
-
-    So an id rerooted onto the parent while the name still says the absorbed child leaves an
-    edge drawn against a node the diagram no longer contains.
-    """
-
     def test_a_relation_naming_the_absorbed_child_takes_the_parents_name(self):
         root = analysis(
             component("1", "Kept", {"a.py": ["a.one"]}),
@@ -709,9 +452,6 @@ class TestAbsorptionKeepsTheDocumentRenderable(unittest.TestCase):
 
 class TestAbsorptionNeverHidesAContainmentViolation(unittest.TestCase):
     def test_a_child_owning_what_its_parent_does_not_fails_before_the_collapse(self):
-        """Deleting a childless only child is lossless only because the parent already owns
-        everything it owned. Where that does not hold, collapsing first would discard the
-        child's extra methods and leave the check nothing to find."""
         generator = DiagramGenerator.__new__(DiagramGenerator)
         generator.static_analysis = None
         generator.repo_location = Path(".")

--- a/tests/diagram_analysis/test_tree_shape.py
+++ b/tests/diagram_analysis/test_tree_shape.py
@@ -17,6 +17,8 @@ from agents.incremental_agent import prune_empty_components
 from agents.file_index_models import FileMethodGroup, MethodEntry
 from diagram_analysis.analysis_json import build_unified_analysis_json, parse_unified_analysis
 from diagram_analysis.diagram_generator import DiagramGenerator
+from static_analyzer.graph import CallGraph
+from static_analyzer.method_cluster_paths import MethodClusterPaths
 from diagram_analysis.tree_shape import (
     absorb_single_child_components,
     drop_dangling_key_entities,
@@ -176,6 +178,69 @@ class TestDeepSubtreeIsRerooted(unittest.TestCase):
             {"": ["3", "9"], "3": ["3.1", "3.2"], "3.1": ["3.1.1", "3.1.2"]},
         )
         self.assertEqual([c.source_cluster_ids for c in subs["3.1"].components], [["3.1.4"], ["3.1.9"]])
+
+
+class TestRerootIsIndependentOfScopeOrder(unittest.TestCase):
+    """`parse_unified_analysis` returns children before their parents.
+
+    Every reroot target is one level shallower than its source, so a target can equal a key
+    that has not moved yet. Writing in place overwrote that scope and then moved the wrong
+    object under its own name — a whole expanded subtree gone, silently, on any baseline
+    loaded from disk.
+    """
+
+    def _chain(self, keys_deepest_first: bool):
+        root = analysis(component("1", "Top", {"a.py": ["a.one"]}), component("9", "Sibling", {"z.py": ["z.one"]}))
+        levels = [
+            ("1", [component("1.1", "Only child", {"a.py": ["a.one"]})]),
+            ("1.1", [component("1.1.1", "G", {"a.py": ["a.one"]}), component("1.1.2", "G2", {"a.py": ["a.one"]})]),
+            (
+                "1.1.1",
+                [component("1.1.1.1", "GG", {"a.py": ["a.one"]}), component("1.1.1.2", "GG2", {"a.py": ["a.one"]})],
+            ),
+            (
+                "1.1.1.1",
+                [
+                    component("1.1.1.1.1", "GGG", {"a.py": ["a.one"]}),
+                    component("1.1.1.1.2", "GGG2", {"a.py": ["a.one"]}),
+                ],
+            ),
+        ]
+        if keys_deepest_first:
+            levels = list(reversed(levels))
+        return root, {key: analysis(*comps) for key, comps in levels}
+
+    def test_the_result_does_not_depend_on_insertion_order(self):
+        shallow_root, shallow = self._chain(keys_deepest_first=False)
+        deep_root, deep = self._chain(keys_deepest_first=True)
+
+        absorb_single_child_components(shallow_root, shallow)
+        absorb_single_child_components(deep_root, deep)
+
+        self.assertEqual(
+            {k: sorted(v) for k, v in shape(deep_root, deep).items()},
+            {k: sorted(v) for k, v in shape(shallow_root, shallow).items()},
+        )
+
+    def test_no_scope_is_lost_when_children_are_inserted_first(self):
+        root, subs = self._chain(keys_deepest_first=True)
+
+        absorb_single_child_components(root, subs)
+
+        self.assertEqual(
+            shape(root, subs),
+            {
+                "": ["1", "9"],
+                "1": ["1.1", "1.2"],
+                "1.1": ["1.1.1", "1.1.2"],
+                "1.1.1": ["1.1.1.1", "1.1.1.2"],
+            },
+        )
+        for scope_id, scope in subs.items():
+            for owned in scope.components:
+                self.assertTrue(
+                    owned.component_id.startswith(f"{scope_id}."), f"{owned.component_id} not under {scope_id}"
+                )
 
 
 class TestRootScope(unittest.TestCase):
@@ -382,10 +447,6 @@ class TestFinalizeForSaveEnforcesTheInvariant(unittest.TestCase):
         self.assertEqual(shape(root, subs), {"": ["1", "2"]})
 
 
-if __name__ == "__main__":
-    unittest.main()
-
-
 class TestDanglingKeyEntities(unittest.TestCase):
     """A deleted symbol must take its pointers with it.
 
@@ -467,3 +528,111 @@ class TestDanglingKeyEntities(unittest.TestCase):
 
         self.assertIn("2.1.2", removed)
         self.assertEqual(shape(root, subs), {"": ["2", "9"], "2": ["2.1", "2.2", "2.3"]})
+
+
+class TestClusterLineageMovesWithTheTree(unittest.TestCase):
+    """Lineage is scope-qualified, so a collapse renames it as surely as it renames a component id.
+
+    Left behind it seeds the next incremental with a partition incoherent against the promoted
+    components' membership. Measured over 11 diverged scopes: 10 relabelled the whole scope on a
+    no-change run, one lost a component outright.
+    """
+
+    def test_the_absorbed_scopes_clusters_take_the_parents_path(self):
+        paths = MethodClusterPaths({"pkg.one": {"1.2.3", "1.2.7"}, "pkg.two": {"4.1"}})
+
+        paths.reroot_scope("1.2", "1")
+
+        self.assertEqual(paths.snapshot_dict(), {"pkg.one": {"1.3", "1.7"}, "pkg.two": {"4.1"}})
+
+    def test_the_parents_own_partition_is_dropped_rather_than_merged(self):
+        """Both land on `<parent>.<n>`; unioning them invents a cluster holding two unrelated sets."""
+        paths = MethodClusterPaths({"a": {"1.0"}, "b": {"1.1.0", "1.1"}})
+
+        paths.reroot_scope("1.1", "1")
+
+        self.assertEqual(paths.snapshot_dict(), {"a": set(), "b": {"1.0"}})
+
+    def test_a_descendant_scope_keeps_its_depth_below_the_new_path(self):
+        paths = MethodClusterPaths({"deep": {"1.2.5.4"}})
+
+        paths.reroot_scope("1.2", "1")
+
+        self.assertEqual(paths.snapshot_dict(), {"deep": {"1.5.4"}})
+
+    def test_root_absorption_leaves_bare_leaf_ids(self):
+        """`_cluster_id_belongs_to_scope("")` accepts a bare digit, which is the root's own form."""
+        paths = MethodClusterPaths({"pkg.one": {"1.3"}})
+
+        paths.reroot_scope("1", "")
+
+        self.assertEqual(paths.snapshot_dict(), {"pkg.one": {"3"}})
+
+    def test_absorption_carries_the_lineage_with_it(self):
+        root = analysis(component("1", "Top", {"a.py": ["a.one"]}), component("9", "Sib", {"z.py": ["z.one"]}))
+        subs = {
+            "1": analysis(component("1.1", "Only child", {"a.py": ["a.one"]})),
+            "1.1": analysis(
+                component("1.1.1", "G", {"a.py": ["a.one"]}), component("1.1.2", "G2", {"a.py": ["a.one"]})
+            ),
+        }
+        cfg = CallGraph()
+        cfg.method_cluster_paths = MethodClusterPaths({"a.one": {"1.0", "1.1.4"}})
+
+        absorb_single_child_components(root, subs, [cfg])
+
+        self.assertEqual(cfg.method_cluster_paths.snapshot_dict(), {"a.one": {"1.4"}})
+
+
+class TestTheIncrementalBaselineMovesWithTheAbsorption(unittest.TestCase):
+    """The baseline is snapshotted before the collapse, so it names the code by its old ids.
+
+    Read against the collapsed tree the rebuilt pair `1 -> 2` matches nothing in it, and neither
+    endpoint counts as changed — absorbing a childless only child leaves the parent's membership
+    untouched — so `preserve_unchanged_relations` discards it as drift while the baseline's own
+    `1 -> 2.1` is skipped for naming a component no longer live. The relation is lost.
+    """
+
+    def _generator(self):
+        generator = DiagramGenerator.__new__(DiagramGenerator)
+        generator.static_analysis = None
+        generator._baseline_component_ids = {"1", "2", "2.1"}
+        generator._baseline_member_keys = {cid: frozenset() for cid in ("1", "2", "2.1")}
+        generator._baseline_global_relations = {("1", "2.1"): relation("1", "2.1"), ("2.1", "1"): relation("2.1", "1")}
+        return generator
+
+    def test_a_baseline_pair_naming_the_absorbed_child_now_names_its_parent(self):
+        generator = self._generator()
+
+        generator._rebase_baseline(["2.1"])
+
+        self.assertEqual(sorted(generator._baseline_global_relations), [("1", "2"), ("2", "1")])
+
+    def test_the_absorbed_child_leaves_the_baseline_id_and_membership_sets(self):
+        generator = self._generator()
+
+        generator._rebase_baseline(["2.1"])
+
+        self.assertEqual(generator._baseline_component_ids, {"1", "2"})
+        self.assertEqual(set(generator._baseline_member_keys), {"1", "2"})
+
+    def test_a_pair_that_collapses_onto_itself_is_dropped(self):
+        """`2 -> 2.1` becomes `2 -> 2`, which is not an edge — the same rule `_reroot_relations` applies."""
+        generator = self._generator()
+        generator._baseline_global_relations = {("2", "2.1"): relation("2", "2.1")}
+
+        generator._rebase_baseline(["2.1"])
+
+        self.assertEqual(generator._baseline_global_relations, {})
+
+    def test_a_full_run_has_no_baseline_to_rebase(self):
+        generator = DiagramGenerator.__new__(DiagramGenerator)
+        generator._baseline_global_relations = None
+
+        generator._rebase_baseline(["2.1"])
+
+        self.assertIsNone(generator._baseline_global_relations)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/static_analyzer/test_cluster_relations.py
+++ b/tests/static_analyzer/test_cluster_relations.py
@@ -472,6 +472,31 @@ class TestPruneUngroundedEdges(unittest.TestCase):
         # connection the grounded relation already states the right way round.
         self.assertNotIn(("2", "1"), by_pair)
 
+    def test_an_unrelated_misfiled_call_keeps_its_baseline_pair(self):
+        wrong = self._relation([_make_relation_edge("pkg.a.caller", "pkg.b.callee")], evidence="e")
+        wrong.src_id, wrong.dst_id = "2", "1"
+        right = self._relation([], evidence="the pair this call actually runs between")
+
+        kept = prune_ungrounded_edges(
+            [wrong, right],
+            build_owner_index(self.NODES),
+            lambda edge: True,
+            {"pkg.other.changed"},
+        )
+
+        by_pair = {(relation.src_id, relation.dst_id): relation for relation in kept}
+        self.assertEqual([edge.source.qualified_name for edge in by_pair[("2", "1")].all_edges], ["pkg.a.caller"])
+        self.assertEqual(by_pair[("1", "2")].all_edges, [])
+
+    def test_dead_edges_are_dropped_even_when_their_source_is_unchanged(self):
+        relation = self._relation([_make_relation_edge("pkg.a.caller", "pkg.b.callee")])
+
+        kept = prune_ungrounded_edges(
+            [relation], build_owner_index(self.NODES), lambda edge: False, {"pkg.other.changed"}
+        )
+
+        self.assertEqual(kept, [])
+
     def test_an_inherited_edge_naming_a_dead_symbol_is_dropped(self):
         rel = self._relation([_make_relation_edge("pkg.a.caller", "pkg.b.callee")])
         self.assertEqual(self._prune(rel, keep_edge=lambda edge: False), [])
@@ -490,6 +515,17 @@ class TestPruneUngroundedEdges(unittest.TestCase):
         backwards.src_id, backwards.dst_id = "2", "1"
         kept = prune_ungrounded_edges([grounded, backwards], build_owner_index(self.NODES), lambda edge: True)
         self.assertEqual([(r.src_id, r.dst_id) for r in kept], [("1", "2")])
+
+    def test_an_unrelated_reverse_relation_is_not_repaired(self):
+        grounded = self._relation([_make_relation_edge("pkg.a.caller", "pkg.b.callee")])
+        backwards = self._relation([], evidence="reads the parsed result")
+        backwards.src_id, backwards.dst_id = "2", "1"
+
+        kept = prune_ungrounded_edges(
+            [grounded, backwards], build_owner_index(self.NODES), lambda edge: True, {"pkg.other.changed"}
+        )
+
+        self.assertEqual(sorted((relation.src_id, relation.dst_id) for relation in kept), [("1", "2"), ("2", "1")])
 
     def test_an_edgeless_relation_with_no_grounded_reverse_survives(self):
         # Nothing else states this connection, so its evidence is the only record of it.


### PR DESCRIPTION
Three defects in series, each of which hides the next. Found while building a delete-component test for the evals; the third was found by that test once it existed.

## A level with one box in it

A component expanded into a single sub-component adds a level that explains nothing — parent and child describe the same code, so a reader opens a box to find one box. **Measured over 574 stored analyses: 120 occurrences**, in two shapes — a childless only child (114) and a chain restating itself down three levels (6). The worst case was `5 Input & Stream Handling → 5.1 URI Resolver → 5.1.1 URI Scheme Handlers`, three nested boxes describing the same 1 file and 2 methods.

`absorb_single_child_components` collapses them at `finalize_for_save`, so it covers the full, incremental and partial flows and repairs a legacy baseline rather than rejecting it.

The repair is a prefix re-rooting. Every identifier in the tree — component id, `sub_analyses` key, scoped cluster id, relation endpoint — is the dotted path to a position, so moving the absorbed child's subtree onto the parent's path is one rewrite of `"<child_id>."` → `"<parent_id>."` applied everywhere. That renumbers the promoted siblings for free and cannot collide: a parent with exactly one child has no other child to collide with.

## An emptied component kept its box

`_cluster_backed_empty_component_ids` shields a component that is empty but still cluster-backed — one awaiting re-detail — from the prune. It was captured **after** `remove_deleted_files`, which clears methods and key entities but not `source_cluster_ids`, so it also shielded everything the scrub had just emptied and the deleted unit kept its box.

Moved to the same side of the scrub as `_capture_baseline_member_keys`, which is where this file already draws that distinction.

## A deleted symbol kept its pointers

`fix_key_entities_refs` is gated on the scopes an update touched, while `_reconcile_child_scope` strips departed membership from scopes it does *not* touch. A component emptied by that route kept key entities naming deleted symbols, and `prune_empty_components` reads a non-empty `key_entities` as a component still having something to describe.

So the empty box survived, the parent kept two children, and there was no single-child level left for the absorption to find. `drop_dangling_key_entities` enforces the invariant whole-tree and unconditionally. **Measured over the eval baselines and corpus: 557 of 557 key entities in healthy documents name a method some component owns**, so enforcing it cannot remove a legitimate reference.

Relations were already covered by two guards and needed no change — verified, 0 edges cited a deleted symbol.

## Verification beyond unit tests

Replayed over every stored analysis in CodeBoarding-evals: all defective documents repair with no scope key orphaned, no component id off its scope's dotted path, and each round-trips through `analysis.json` byte-identically. That last check matters — the store writes children only for a component declared expandable, so a botched re-parenting would delete a subtree *silently* rather than fail.

End to end on the real engine, one baseline through both builds: the e2e test `last-sibling-is-absorbed-into-its-parent` (CodeBoarding-evals) goes from failing on both to passing here, with `2.1` becoming a leaf, `2.1.1` absorbed and `2.1.2` pruned.

## Tests

- **23** in `test_tree_shape.py` — both absorption shapes, deep subtree re-rooting, the root scope and its empty-analysis guard, chain collapse to a fixpoint, relation re-pointing and self-loop drops, idempotency, the `analysis.json` round-trip, and the dangling-entity drop end to end.
- **3** in `test_incremental_copy_forward.py` pin the capture order, including one asserting the **old** order keeps the empty box, so the bug cannot return quietly.
- Two existing fixtures were themselves degenerate trees and were given siblings.

1962 pass; black and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved diagram cleanup by removing dangling entities and empty components.
  - Simplified single-child scopes while preserving descendant structure and relationships.
  - Corrected relation handling when underlying call connections are removed or reassigned.
  - Preserved cluster and scope lineage during incremental updates.
  - Improved consistency across repeated and incremental diagram processing, including edge cases involving root and nested scopes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Validation

Compared e2e17c2 with 8614ded.

- E1 component deletion: pass
- E2 single-child absorption: pass
- E3 component creation: known existing failure, unchanged
- E5 relation removal: pass

The latest change fixes unrelated relation churn in E5. Previously, the unchanged call:

Command.main → get_completion_class

was incorrectly re-filed during the incremental update, changing the aggregate Command Execution & Context Management → Command Composition & Discovery relation from 6 to 7 backing edges.

After 8614ded, the relation remains unchanged at 6 backing edges, and backing-edge changes without a code cause dropped from 3 to 0. The intended getchar → get_best_encoding relation is still removed correctly.
