### PR TITLE
Stop keeping a relation whose backing calls the commit deleted

### DIFF
--- a/agents/relation_edges.py
+++ b/agents/relation_edges.py
@@ -165,7 +165,7 @@ def _commit_deleted_the_backing(rebuilt: Relation, previous: Relation, changed_m
     A call belongs to its source method, so only lost edges from changed sources prove deletion.
     """
     baseline_edges = previous.all_edges or previous.key_edges
-    if not baseline_edges or rebuilt.all_edges or rebuilt.key_edges:
+    if not baseline_edges or rebuilt.all_edges or rebuilt.key_edges or rebuilt.evidence.strip():
         return False
     return any(_edge_touches_changed_method(edge, changed_members) for edge in baseline_edges)
 
@@ -220,11 +220,8 @@ def preserve_unchanged_relations(
     their inter-component edges are byte-identical. Gating on the pair's own edges instead of
     on its endpoints' change flags is what keeps those untouched connections stable.
 
-    A pair whose backing calls the commit deleted is dropped rather than re-worded.
-    Regeneration authors a relation for every pair it still believes in, prose and all, with
-    no edges behind it — so without this a deleted call leaves the relation standing under a
-    freshly invented label, and the diagram keeps the connection while losing the only
-    evidence it ever had.
+    A pair whose changed source lost every baseline call is dropped unless the rebuild supplies
+    alternate runtime/config evidence.
 
     A baseline relation between two unchanged, still-live components that regeneration
     dropped is restored — but only when its backing edges still exist in live code. The
@@ -281,7 +278,7 @@ def preserve_unchanged_relations(
         if (
             not touches_change(*pair)
             or _relation_edges_unmoved(relation, previous)
-            or not _backing_edge_pairs(relation)
+            or (not _backing_edge_pairs(relation) and not relation.evidence.strip())
         ):
             relation = relation.model_copy(update={"relation": previous.relation, "evidence": previous.evidence})
         kept.append(relation)

--- a/agents/relation_edges.py
+++ b/agents/relation_edges.py
@@ -159,6 +159,17 @@ def _filter_edges_touched_by_change(relation: Relation, changed_members: set[str
     )
 
 
+def _commit_deleted_the_backing(rebuilt: Relation, previous: Relation, changed_members: set[str]) -> bool:
+    """Return whether a changed source removed every baseline backing edge.
+
+    A call belongs to its source method, so only lost edges from changed sources prove deletion.
+    """
+    baseline_edges = previous.all_edges or previous.key_edges
+    if not baseline_edges or rebuilt.all_edges or rebuilt.key_edges:
+        return False
+    return any(_edge_touches_changed_method(edge, changed_members) for edge in baseline_edges)
+
+
 def _reconcile_unchanged_edges(fresh: Relation, previous: Relation, changed_members: set[str]) -> Relation:
     """Carry the baseline's edges forward for calls between two byte-identical methods.
 
@@ -209,6 +220,12 @@ def preserve_unchanged_relations(
     their inter-component edges are byte-identical. Gating on the pair's own edges instead of
     on its endpoints' change flags is what keeps those untouched connections stable.
 
+    A pair whose backing calls the commit deleted is dropped rather than re-worded.
+    Regeneration authors a relation for every pair it still believes in, prose and all, with
+    no edges behind it — so without this a deleted call leaves the relation standing under a
+    freshly invented label, and the diagram keeps the connection while losing the only
+    evidence it ever had.
+
     A baseline relation between two unchanged, still-live components that regeneration
     dropped is restored — but only when its backing edges still exist in live code. The
     deterministic rebuild drops a pair when the code connecting the two components was
@@ -249,6 +266,8 @@ def preserve_unchanged_relations(
         # pairs alike.
         if changed_members is not None:
             relation = _reconcile_unchanged_edges(relation, previous, changed_members)
+            if _commit_deleted_the_backing(relation, previous, changed_members):
+                continue
         # Keep the reader's wording unless this pair's own supporting calls moved.
         #
         # The supporting calls are the concrete method-to-method calls under the relation — the

--- a/tests/diagram_analysis/test_incremental_copy_forward.py
+++ b/tests/diagram_analysis/test_incremental_copy_forward.py
@@ -398,10 +398,6 @@ class TestPreserveUnchangedGlobalRelations(unittest.TestCase):
         self.assertEqual(kept, [])
 
     def test_pair_whose_only_backing_call_the_commit_deleted_is_dropped(self):
-        # The rebuild reads the live CFG, so an empty edge set on a pair the baseline drew
-        # from a call written inside an edited method means the commit deleted that call.
-        # Regeneration re-authors wording, so keeping it shows a freshly invented label over
-        # no evidence at all.
         stale = self._relation("1", "2", "baseline wording")
         stale.all_edges = [RelationEdge(source=_ref("pkg.caller"), target=_ref("pkg.callee"))]
         fresh = self._relation("1", "2", "invented wording")
@@ -413,9 +409,6 @@ class TestPreserveUnchangedGlobalRelations(unittest.TestCase):
         self.assertEqual(kept, [])
 
     def test_backing_that_vanished_with_no_code_cause_does_not_delete_the_pair(self):
-        # Both endpoints are byte-identical and the rebuild still lost the edge: that is the
-        # re-attribution artifact, not a deleted call. Deleting the relation over it would
-        # show the reader a box losing a line the commit never touched.
         stale = self._relation("1", "2", "baseline wording")
         stale.all_edges = [RelationEdge(source=_ref("pkg.caller"), target=_ref("pkg.callee"))]
         fresh = self._relation("1", "2", "invented wording")
@@ -427,8 +420,6 @@ class TestPreserveUnchangedGlobalRelations(unittest.TestCase):
         self.assertEqual([(rel.src_id, rel.dst_id) for rel in kept], [("1", "2")])
 
     def test_edgeless_baseline_pair_survives_a_rebuild_with_no_edges(self):
-        # A runtime/config relation never had a call to lose, so an edgeless rebuild says
-        # nothing about it and the pair stays.
         stale = self._relation("1", "2", "baseline wording")
         fresh = self._relation("1", "2", "rebuilt wording")
 
@@ -436,11 +427,9 @@ class TestPreserveUnchangedGlobalRelations(unittest.TestCase):
             [fresh], {("1", "2"): stale}, {"1"}, {"1", "2"}, set(), changed_members={"pkg.changed"}
         )
 
-        self.assertEqual([rel.relation for rel in kept], ["rebuilt wording"])
+        self.assertEqual([rel.relation for rel in kept], ["baseline wording"])
 
     def test_pair_keeping_one_backing_call_between_unchanged_methods_survives(self):
-        # Only one of two backing calls is deleted: the pair still has code behind it, so
-        # the drop must not fire.
         stale = self._relation("1", "2", "baseline wording")
         stale.all_edges = [
             RelationEdge(source=_ref("pkg.changed"), target=_ref("pkg.callee")),
@@ -454,6 +443,20 @@ class TestPreserveUnchangedGlobalRelations(unittest.TestCase):
 
         edge_pairs = {(e.source.qualified_name, e.target.qualified_name) for e in kept[0].all_edges}
         self.assertEqual(edge_pairs, {("pkg.stable", "pkg.callee")})
+
+    def test_evidence_backed_rebuild_survives_after_static_call_is_deleted(self):
+        stale = self._relation("1", "2", "baseline wording")
+        stale.all_edges = [RelationEdge(source=_ref("pkg.caller"), target=_ref("pkg.callee"))]
+        fresh = self._relation("1", "2", "runtime wording")
+        fresh.evidence = "Routes requests through a configured endpoint."
+
+        kept = preserve_unchanged_relations(
+            [fresh], {("1", "2"): stale}, {"1"}, {"1", "2"}, set(), changed_members={"pkg.caller"}
+        )
+
+        self.assertEqual(
+            [(relation.relation, relation.evidence) for relation in kept], [(fresh.relation, fresh.evidence)]
+        )
 
     def test_restored_relation_whose_backing_symbol_was_deleted_is_dropped(self):
         # The rebuild dropped this pair because the only edge connecting the two components

--- a/tests/diagram_analysis/test_incremental_copy_forward.py
+++ b/tests/diagram_analysis/test_incremental_copy_forward.py
@@ -397,6 +397,64 @@ class TestPreserveUnchangedGlobalRelations(unittest.TestCase):
 
         self.assertEqual(kept, [])
 
+    def test_pair_whose_only_backing_call_the_commit_deleted_is_dropped(self):
+        # The rebuild reads the live CFG, so an empty edge set on a pair the baseline drew
+        # from a call written inside an edited method means the commit deleted that call.
+        # Regeneration re-authors wording, so keeping it shows a freshly invented label over
+        # no evidence at all.
+        stale = self._relation("1", "2", "baseline wording")
+        stale.all_edges = [RelationEdge(source=_ref("pkg.caller"), target=_ref("pkg.callee"))]
+        fresh = self._relation("1", "2", "invented wording")
+
+        kept = preserve_unchanged_relations(
+            [fresh], {("1", "2"): stale}, {"1"}, {"1", "2"}, set(), changed_members={"pkg.caller"}
+        )
+
+        self.assertEqual(kept, [])
+
+    def test_backing_that_vanished_with_no_code_cause_does_not_delete_the_pair(self):
+        # Both endpoints are byte-identical and the rebuild still lost the edge: that is the
+        # re-attribution artifact, not a deleted call. Deleting the relation over it would
+        # show the reader a box losing a line the commit never touched.
+        stale = self._relation("1", "2", "baseline wording")
+        stale.all_edges = [RelationEdge(source=_ref("pkg.caller"), target=_ref("pkg.callee"))]
+        fresh = self._relation("1", "2", "invented wording")
+
+        kept = preserve_unchanged_relations(
+            [fresh], {("1", "2"): stale}, {"1"}, {"1", "2"}, set(), changed_members={"pkg.elsewhere"}
+        )
+
+        self.assertEqual([(rel.src_id, rel.dst_id) for rel in kept], [("1", "2")])
+
+    def test_edgeless_baseline_pair_survives_a_rebuild_with_no_edges(self):
+        # A runtime/config relation never had a call to lose, so an edgeless rebuild says
+        # nothing about it and the pair stays.
+        stale = self._relation("1", "2", "baseline wording")
+        fresh = self._relation("1", "2", "rebuilt wording")
+
+        kept = preserve_unchanged_relations(
+            [fresh], {("1", "2"): stale}, {"1"}, {"1", "2"}, set(), changed_members={"pkg.changed"}
+        )
+
+        self.assertEqual([rel.relation for rel in kept], ["rebuilt wording"])
+
+    def test_pair_keeping_one_backing_call_between_unchanged_methods_survives(self):
+        # Only one of two backing calls is deleted: the pair still has code behind it, so
+        # the drop must not fire.
+        stale = self._relation("1", "2", "baseline wording")
+        stale.all_edges = [
+            RelationEdge(source=_ref("pkg.changed"), target=_ref("pkg.callee")),
+            RelationEdge(source=_ref("pkg.stable"), target=_ref("pkg.callee")),
+        ]
+        fresh = self._relation("1", "2", "rebuilt wording")
+
+        kept = preserve_unchanged_relations(
+            [fresh], {("1", "2"): stale}, {"1"}, {"1", "2"}, set(), changed_members={"pkg.changed"}
+        )
+
+        edge_pairs = {(e.source.qualified_name, e.target.qualified_name) for e in kept[0].all_edges}
+        self.assertEqual(edge_pairs, {("pkg.stable", "pkg.callee")})
+
     def test_restored_relation_whose_backing_symbol_was_deleted_is_dropped(self):
         # The rebuild dropped this pair because the only edge connecting the two components
         # cited a method the diff deleted; restoring it verbatim resurrects a phantom edge.


### PR DESCRIPTION
## What

An incremental update regenerates the relations of every scope it touches, and regeneration authors a relation for **every pair it still believes in** — prose and all, with no edges behind it. So deleting the only call between two components left the relation standing under a freshly invented label: the diagram kept the connection and lost the only evidence it ever had.

`preserve_unchanged_relations` now drops such a pair.

## The measurement

On `click`, `2.3.1 -> 2.3.2` is backed by exactly one call — `_termui_impl.getchar -> _compat.get_best_encoding`, one call site. Rewriting that line to decode as UTF-8 removes the edge from the CFG cleanly (verified: the head document contains no edge mentioning `getchar` at all). The relation came back as:

```json
{ "relation": "provides stream state for encoding selection",
  "is_static": false, "key_edges": [], "all_edges": [] }
```

A fresh sentence over nothing.

## Three conditions, and the third is what keeps it honest

The baseline had backing edges, the rebuild has none, **and** one of those edges was written in a method the commit touched.

The first two alone also fire when a rebuild loses an edge between two byte-identical methods — re-attribution noise rather than deleted code. Measured across the stored eval corpus: **3 of the 8** backed-to-edgeless pairs have no code cause, and deleting a relation over one of those would show the reader a box losing a line the commit never touched.

## What is deliberately not changed

A baseline with no edge of its own is a runtime/config relation with nothing to invalidate, and is left alone. The LLM-only escape hatch (`is_static=false`, prose evidence, no `key_edges`) is instructed in the prompts and pinned by three existing tests; it accounts for **4.58%** of relations across the corpus, 36.5% on the C# subject. This changes none of them.

Applied inside `preserve_unchanged_relations`, the rule reaches both serializations of a pair — the owning scope's and the global rebuild's — and because the scope no longer contributes it, `build_global_relations` cannot re-materialise it.

## Verification

- e2e `removed-call-removes-the-relation` goes from violated to **met**; the relation is reported gone.
- Four new cases in `test_incremental_copy_forward.py`: the drop, the negative where no code cause explains the loss, the edgeless baseline, and the pair that keeps one of two calls.
- 1934 tests pass; mypy and black clean.

One caveat worth stating: this rule is inexpressible without a baseline, so a *full* run on the same tree still draws the ungrounded pair. That asymmetry already pervades `preserve_unchanged_relations`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed diagram relationships when their only supporting call is deleted.
  * Preserved valid relationships when unrelated edges change, when no backing calls exist, or when other supporting calls remain.
  * Rebuilt relationships with fresh evidence when supporting static calls are removed.

* **Tests**
  * Added coverage for incremental relationship preservation and removal scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->