### PR TITLE
Mark automated traffic as internal on every telemetry event

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -53,8 +53,17 @@ never personal data.
 
 Every event also carries:
 
-- `source` — `"oss"` for the open-source CLI, `"vscode"` when invoked by the
-  extension, or `"core"` for other embeddings.
+- `source` — who invoked the run: `"oss"` for the open-source CLI, `"vscode"`
+  when invoked by the extension, `"github_action"` in CI, `"tests"` for
+  CodeBoarding's own test suite, `"evals"` for the benchmark harness, or
+  `"core"` for other embeddings.
+- `internal` — `true` when that source is **not** a person using the product
+  (`tests`, `evals`). Automated runs still emit, because an eval run is real
+  signal about analysis quality, but they must never be counted as usage. It is
+  derived from `source` in one place (`telemetry/service.py`) so a product
+  metric filters on one condition and stays correct when another internal
+  source is added — a hand-kept list of source values is right until it is
+  quietly not.
 - `distinct_id` — the anonymous id described above.
 
 Property meanings:

--- a/telemetry/service.py
+++ b/telemetry/service.py
@@ -12,10 +12,34 @@ POSTHOG_PROJECT_API_KEY = os.getenv("CODEBOARDING_POSTHOG_KEY", "phc_BQWpoXuPYQh
 POSTHOG_HOST = os.getenv("CODEBOARDING_POSTHOG_HOST", "https://us.i.posthog.com")
 
 
+#: Sources that are NOT a person using the product. They still emit — an eval
+#: run is real signal about LSP quality and analysis outcomes, and dropping it
+#: would lose that — but every product metric has to be able to exclude them.
+#:
+#: Declared here, once, and surfaced as the derived ``internal`` property, rather
+#: than left for each dashboard to maintain as a list of source values. A filter
+#: written as ``source not in ('tests', 'evals')`` is correct until the next
+#: internal source is added and then silently is not, which is exactly how
+#: automated traffic comes to be counted as usage.
+INTERNAL_SOURCES = frozenset({"tests", "evals"})
+
+
 def _telemetry_disabled() -> bool:
     if os.getenv("DO_NOT_TRACK", "").strip().lower() in ("1", "true", "yes"):
         return True
     return os.getenv("CODEBOARDING_TELEMETRY", "true").strip().lower() == "false"
+
+
+def _origin() -> dict[str, object]:
+    """Who invoked this run, and whether that is a person using the product.
+
+    ``source`` is the existing discriminator: "vscode" when invoked by the
+    extension, "oss" for the OSS CLI, "github_action" in CI, "tests" for the
+    engine's own suite, "evals" for the benchmark harness, "core" for any other
+    embedding. ``internal`` is derived from it so the two can never disagree.
+    """
+    source = os.getenv("CODEBOARDING_SOURCE", "core")
+    return {"source": source, "internal": source in INTERNAL_SOURCES}
 
 
 class ProductTelemetry:
@@ -61,13 +85,15 @@ class ProductTelemetry:
         if self._client is None:
             return
         try:
-            # "vscode" when invoked by the extension, "oss" for the OSS CLI
-            # (main.py), "core" for any other embedding.
-            source = os.getenv("CODEBOARDING_SOURCE", "core")
             self._client.capture(
                 distinct_id=self.user_id,
                 event=event,
-                properties={"source": source, **(properties or {})},
+                # Origin LAST, so it wins. Who invoked the run is a property of
+                # the process, not a field an event model gets to claim — and
+                # `internal` is the one property a product metric filters on, so
+                # a payload that could overwrite it is a payload that could hide
+                # automated traffic inside usage.
+                properties={**(properties or {}), **_origin()},
             )
         except Exception as e:
             logger.debug("Telemetry capture failed: %s", e)
@@ -77,11 +103,15 @@ class ProductTelemetry:
         if self._client is None:
             return
         try:
-            source = os.getenv("CODEBOARDING_SOURCE", "core")
             self._client.capture_exception(
                 exc,
                 distinct_id=self.user_id,
-                properties={"source": source, **(properties or {})},
+                # Origin LAST, so it wins. Who invoked the run is a property of
+                # the process, not a field an event model gets to claim — and
+                # `internal` is the one property a product metric filters on, so
+                # a payload that could overwrite it is a payload that could hide
+                # automated traffic inside usage.
+                properties={**(properties or {}), **_origin()},
             )
         except Exception as e:
             logger.debug("Telemetry capture_exception failed: %s", e)

--- a/tests/test_telemetry_service.py
+++ b/tests/test_telemetry_service.py
@@ -1,0 +1,99 @@
+"""What every event carries about who produced it.
+
+``source`` has always said which invoker a run came from. What it could not say
+is whether that invoker is a *person using the product*: a dashboard measuring
+usage had to spell out ``source not in ('tests', 'evals')`` and was silently
+wrong from the moment another internal source was added. ``internal`` is derived
+from the source in one place so that filter is one condition and stays correct.
+
+These exercise ``ProductTelemetry`` itself rather than ``telemetry.events``,
+which stubs ``capture`` out — the stamping happens below that stub, so it is
+invisible to every test in ``test_telemetry_events.py``.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from telemetry.service import INTERNAL_SOURCES, ProductTelemetry
+
+
+@pytest.fixture
+def client(monkeypatch):
+    """A recorder in place of the PostHog SDK, on the live singleton."""
+    seen = SimpleNamespace(captures=[], exceptions=[])
+    service = ProductTelemetry()
+    monkeypatch.setattr(
+        service,
+        "_client",
+        SimpleNamespace(
+            capture=lambda **kw: seen.captures.append(kw),
+            capture_exception=lambda exc, **kw: seen.exceptions.append((exc, kw)),
+            flush=lambda: None,
+        ),
+    )
+    seen.service = service
+    return seen
+
+
+def test_a_product_run_is_not_marked_internal(client, monkeypatch):
+    monkeypatch.setenv("CODEBOARDING_SOURCE", "oss")
+
+    client.service.capture("analysis_started", {"command": "run_full"})
+
+    props = client.captures[0]["properties"]
+    assert props["source"] == "oss"
+    assert props["internal"] is False
+
+
+@pytest.mark.parametrize("source", sorted(INTERNAL_SOURCES))
+def test_every_internal_source_is_marked_internal(client, monkeypatch, source):
+    """The benchmark harness sets ``evals``; the engine's own suite sets ``tests``.
+    Neither is a person using the product, and neither may be counted as one."""
+    monkeypatch.setenv("CODEBOARDING_SOURCE", source)
+
+    client.service.capture("analysis_completed", {"status": "success"})
+
+    props = client.captures[0]["properties"]
+    assert props["source"] == source
+    assert props["internal"] is True
+
+
+def test_an_unknown_source_defaults_to_product_traffic(client, monkeypatch):
+    """A source nobody declared is an embedding of the library, which IS usage.
+    Defaulting the other way would quietly drop a real integration's runs."""
+    monkeypatch.setenv("CODEBOARDING_SOURCE", "some-new-wrapper")
+
+    client.service.capture("analysis_started", {})
+
+    assert client.captures[0]["properties"]["internal"] is False
+
+
+def test_the_origin_travels_on_exceptions_too(client, monkeypatch):
+    """``$exception`` is an event like any other, and error-rate dashboards are
+    exactly where a run of the benchmark's deliberate failure cases would hurt."""
+    monkeypatch.setenv("CODEBOARDING_SOURCE", "evals")
+    exc = RuntimeError("boom")
+
+    client.service.capture_exception(exc, properties={"command": "run_incremental"})
+
+    _, kwargs = client.exceptions[0]
+    assert kwargs["properties"]["internal"] is True
+    assert kwargs["properties"]["command"] == "run_incremental"
+
+
+def test_a_caller_property_never_overwrites_the_origin(client, monkeypatch):
+    """The origin merges LAST, so a caller cannot claim it.
+
+    It used to go first, which left an event model free to overwrite `source`
+    simply by having a field of that name. No schema does today — but `internal`
+    is the one property a product metric filters on, so a payload that could
+    overwrite it is a payload that could hide automated traffic inside usage, and
+    that is not a thing to leave resting on nobody having added the field yet."""
+    monkeypatch.setenv("CODEBOARDING_SOURCE", "evals")
+
+    client.service.capture("repo_scanned", {"source": "oss", "internal": False})
+
+    props = client.captures[0]["properties"]
+    assert props["source"] == "evals"
+    assert props["internal"] is True


### PR DESCRIPTION
## What

`source` has always said which invoker a run came from. What it could not say is whether that invoker is **a person using the product**, so a dashboard measuring usage had to spell out `source not in ('tests', 'evals')` — correct until the next internal source is added, and silently wrong from that moment on. That is how automated traffic comes to be counted as usage.

Every event now also carries `internal`, derived from `source` in one place, so a product metric filters on one condition and stays correct when another internal source appears.

Automated runs still emit — an eval run is real signal about analysis quality and dropping it would lose that. They just must never be counted as usage.

## Also fixes an ordering hazard the change surfaced

The origin used to merge **first**:

```python
properties={"source": source, **(properties or {})}
```

which left an event model free to overwrite `source` just by having a field of that name. No schema does today — but `internal` is the property the metrics filter on, so a payload that could overwrite it is a payload that could hide automated traffic inside usage. It now merges last, in both `capture` and `capture_exception`.

## Every source is accounted for

| source | emitted by | internal |
|---|---|---|
| `oss` | `main.py` | no |
| `vscode` | the extension | no |
| `github_action` | `github_action.py` | no |
| `core` | any other embedding (default) | no |
| `tests` | `tests/conftest.py` | **yes** |
| `evals` | the benchmark harness's `_entry.py` | **yes** |

`core` stays product traffic on purpose: defaulting the other way would quietly drop a real integration's runs.

## Verification

Six tests in `test_telemetry_service.py` — a product source, every internal source, an undeclared source, an exception carrying the origin, and a caller property failing to overwrite it. They exercise `ProductTelemetry` directly because `test_telemetry_events.py` stubs `capture` out and the stamping happens below that stub.

1936 tests pass; mypy and black clean. `TELEMETRY.md` documents both properties.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented telemetry source categories, including product, development, testing, and evaluation environments.
  * Clarified how automated test and evaluation activity is identified in telemetry data.

* **Bug Fixes**
  * Standardized origin information across product and exception telemetry events.
  * Prevented event metadata from being incorrectly overridden by supplied values.
  * Improved classification of internal activity to support more accurate usage reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->