### PR TITLE
fix(ci): avoid duplicate CodeBoarding-tests dispatches

### DIFF
--- a/.github/workflows/codeboarding-sync.yml
+++ b/.github/workflows/codeboarding-sync.yml
@@ -11,6 +11,8 @@ on:
       - '.codeboarding/analysis.json'
       - '.codeboarding/fingerprint.json'
       - '.codeboarding/codeboarding_version.json'
+      - '.codeboarding/static_analysis.pkl'
+      - '.codeboarding/static_analysis.sha'
       - '.codeboarding/health/**'
       - 'docs/development/architecture.md'
   workflow_dispatch:

--- a/.github/workflows/codeboarding-sync.yml
+++ b/.github/workflows/codeboarding-sync.yml
@@ -40,8 +40,8 @@ jobs:
       # Mint the CodeBoarding GitHub App token so the baseline commit lands as
       # codeboarding[bot] (App avatar = the CodeBoarding logo) instead of the
       # generic github-actions[bot]. Mirrors the review workflow's token flow.
-      # Fails open: when App credentials are absent/invalid we fall back to
-      # github.token below, and the commit shows the default Actions identity.
+      # The baseline commit must use the App token: pushes made with
+      # github.token do not trigger the CodeBoarding-tests workflow.
       - name: Detect CodeBoarding GitHub App credentials
         id: codeboarding-app-config
         shell: bash
@@ -96,19 +96,19 @@ jobs:
         with:
           app-id: ${{ vars.CODEBOARDING_APP_ID }}
           private-key: ${{ secrets.CODEBOARDING_APP_PRIVATE_KEY }}
-      - name: Warn when CodeBoarding App token is unavailable
+      - name: Require a CodeBoarding App token for the baseline push
         if: steps.codeboarding-app-token-client.outputs.token == '' && steps.codeboarding-app-token-app.outputs.token == ''
         shell: bash
         run: |
-          echo "::warning::CodeBoarding GitHub App token is unavailable; the sync commit falls back to github-actions[bot]. Check CODEBOARDING_APP_PRIVATE_KEY formatting if app credentials are configured."
+          echo "::error::CodeBoarding GitHub App token is required so the baseline push triggers CodeBoarding-tests. Check CODEBOARDING_APP_CLIENT_ID (or CODEBOARDING_APP_ID) and CODEBOARDING_APP_PRIVATE_KEY formatting."
+          exit 1
       - uses: CodeBoarding/CodeBoarding-action@v1
         with:
           mode: sync
           force_full: ${{ inputs.force_full || false }}
-          # App token authenticates the baseline push so the commit is attributed
-          # to the CodeBoarding App (logo avatar). Falls back to the workflow token,
-          # which can push because this job grants contents: write.
-          push_token: ${{ steps.codeboarding-app-token-client.outputs.token || steps.codeboarding-app-token-app.outputs.token || github.token }}
+          # The App token both attributes the commit to CodeBoarding and emits a
+          # push event, which triggers the CodeBoarding-tests workflow.
+          push_token: ${{ steps.codeboarding-app-token-client.outputs.token || steps.codeboarding-app-token-app.outputs.token }}
           # Desired analysis depth for this repo. Sync is the baseline writer, so
           # setting it here re-seeds .codeboarding/analysis.json at depth 4 on the
           # next sync; review then inherits depth 4 from the committed baseline.

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -52,7 +52,6 @@ on:
     branches: ['main']
     paths:
       - '.codeboarding/**'
-      - 'docs/development/architecture.md'
 
 permissions:
   contents: read

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -46,10 +46,13 @@ on:
       - 'tests/test_tool_registry.py'
       - '.github/workflows/integration-tests.yml'
 
-  workflow_run:
-    workflows: ['CodeBoarding sync']
-    types:
-      - completed
+  # A completed sync pushes this generated baseline commit. Trigger from that
+  # commit so the CodeBoarding-tests check is attached to the sync result.
+  push:
+    branches: ['main']
+    paths:
+      - '.codeboarding/**'
+      - 'docs/development/architecture.md'
 
 permissions:
   contents: read
@@ -64,13 +67,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 75
     # Manual runs are always available. PR runs are intentionally skipped.
-    # Actual integration suite execution only happens after a successful sync
-    # workflow on main.
+    # Automatic execution is limited to the baseline commit pushed by sync.
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'workflow_run' &&
-       github.event.workflow_run.conclusion == 'success' &&
-       github.event.workflow_run.head_branch == 'main')
+      (github.event_name == 'push' &&
+       github.event.head_commit.message == 'chore(codeboarding): sync architecture baseline')
     steps:
       # Mint a short-lived installation token instead of carrying a PAT. It is
       # narrowed to the tests repo and to Actions - it cannot clone the suite

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -60,6 +60,7 @@ concurrency:
 
 jobs:
   private-suite:
+    name: CodeBoarding-tests
     runs-on: ubuntu-latest
     timeout-minutes: 75
     # Manual runs are always available. PR runs are intentionally skipped.


### PR DESCRIPTION
## What changed

- Require a valid CodeBoarding GitHub App token before sync can create its generated baseline commit.
- Keep the automatic dispatcher limited to the generated `chore(codeboarding): sync architecture baseline` push on `main`.
- Ignore generated static-analysis artifacts in the sync trigger to prevent a baseline push from starting another sync.
- Label the resulting check `CodeBoarding-tests`.

## Why

GitHub does not trigger a new workflow from a push made with `github.token`. The prior fallback therefore allowed sync to create a baseline commit without starting the private static-analysis suite. Requiring the non-default App credential ensures the baseline push triggers the dispatcher.

## Impact

A successful sync with valid App credentials pushes its baseline commit, which automatically receives one visible `CodeBoarding-tests` check. If the App token cannot be minted, sync fails before creating an untested baseline commit.

## Validation

- YAML parsing passed for both edited workflows.
- `git diff --check` passed.
- `actionlint` is not installed in this environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated automated workflows to skip unnecessary runs when generated analysis files change.
  * Improved architecture synchronization by requiring valid credentials before proceeding.
  * Improved integration test automation for architecture updates.
  * Clarified the displayed name of the integration test job.
  * Preserved manual test execution while enabling automatic runs for qualifying architecture updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->