### PR TITLE
Fix C# workspace readiness timeouts with explicit solution loading

### DIFF
--- a/static_analyzer/__init__.py
+++ b/static_analyzer/__init__.py
@@ -42,6 +42,7 @@ class EngineConfig:
     adapter: LanguageAdapter
     project_path: Path
     source_files: list[Path] = field(default_factory=list)
+    project_file: Path | None = None
 
 
 class StaticAnalysisFatalError(RuntimeError):
@@ -135,7 +136,9 @@ def _create_engine_configs(
                             f"Creating engine config for CSharp ({csharp_config.project_type}) at: "
                             f"{csharp_config.root.relative_to(repository_path)}"
                         )
-                        configs.append(EngineConfig(adapter, csharp_config.root))
+                        configs.append(
+                            EngineConfig(adapter, csharp_config.root, project_file=csharp_config.project_file)
+                        )
                 else:
                     logger.info("No C# projects detected")
 
@@ -250,8 +253,8 @@ class StaticAnalyzer:
                 t_start = time.monotonic()
                 # Allow adapters to prepare the project before LSP startup
                 # (e.g. ``dotnet restore`` so csharp-ls sees framework refs).
-                adapter.prepare_project(project_path)
-                command = adapter.get_lsp_command(project_path)
+                adapter.prepare_project(project_path, engine_config.project_file)
+                command = adapter.get_lsp_command(project_path, engine_config.project_file)
                 init_options = adapter.get_lsp_init_options(self.ignore_manager)
                 extra_env = adapter.get_lsp_env(project_path)
                 # Node-based LSPs spawn child ``node`` processes by name; on
@@ -620,6 +623,8 @@ class StaticAnalyzer:
             except StaticAnalysisFatalError:
                 raise
             except Exception as e:
+                if adapter.fail_on_empty_symbols:
+                    raise StaticAnalysisFatalError(f"{adapter.language} analysis failed: {e}") from e
                 logger.error(f"Error during engine analysis for {adapter.language}: {e}")
                 track_lsp_result(
                     language=adapter.language_enum.value,

--- a/static_analyzer/csharp_config_scanner.py
+++ b/static_analyzer/csharp_config_scanner.py
@@ -21,12 +21,17 @@ class CSharpProjectConfig:
         self,
         root: Path,
         project_type: str,  # "solution", "project", or "none"
+        project_file: Path | None = None,
     ):
         self.root = root
         self.project_type = project_type
+        self.project_file = project_file
 
     def __repr__(self) -> str:
-        return f"CSharpProjectConfig(root={self.root}, project_type={self.project_type})"
+        return (
+            f"CSharpProjectConfig(root={self.root}, project_type={self.project_type}, "
+            f"project_file={self.project_file})"
+        )
 
 
 class CSharpConfigScanner:
@@ -51,19 +56,20 @@ class CSharpConfigScanner:
         configs: list[CSharpProjectConfig] = []
 
         # 1. Solution files (highest priority)
-        solution_roots = self._find_solution_roots()
-        for root in solution_roots:
-            if not self.ignore_manager.should_ignore(root):
-                configs.append(CSharpProjectConfig(root, "solution"))
+        solution_files = self._find_solution_files()
+        for solution_file in solution_files:
+            if not self.ignore_manager.should_ignore(solution_file):
+                configs.append(CSharpProjectConfig(solution_file.parent, "solution", solution_file))
 
         # 2. Standalone .csproj files not covered by a solution
-        project_roots = self._find_project_roots()
-        for root in project_roots:
-            if self.ignore_manager.should_ignore(root):
+        project_files = self._find_project_files()
+        for project_file in project_files:
+            root = project_file.parent
+            if self.ignore_manager.should_ignore(project_file):
                 continue
             if any(self._is_subpath(root, c.root) for c in configs):
                 continue
-            configs.append(CSharpProjectConfig(root, "project"))
+            configs.append(CSharpProjectConfig(root, "project", project_file))
 
         # 3. Fallback: .cs files exist but no project infrastructure
         if not configs and self._has_cs_files(self.repo_path):
@@ -74,16 +80,16 @@ class CSharpConfigScanner:
 
         return configs
 
-    def _find_solution_roots(self) -> list[Path]:
-        """Find directories containing ``.sln`` or ``.slnx`` files."""
-        roots: set[Path] = set()
+    def _find_solution_files(self) -> list[Path]:
+        """Find ``.sln`` and ``.slnx`` files without discarding their names."""
+        files: set[Path] = set()
         for pattern in SOLUTION_GLOBS:
-            roots.update(p.parent for p in self.repo_path.rglob(pattern) if p.is_file())
-        return sorted(roots)
+            files.update(p for p in self.repo_path.rglob(pattern) if p.is_file())
+        return sorted(files)
 
-    def _find_project_roots(self) -> list[Path]:
-        """Find directories containing .csproj files."""
-        return sorted({p.parent for p in self.repo_path.rglob("*.csproj") if p.is_file()})
+    def _find_project_files(self) -> list[Path]:
+        """Find .csproj files."""
+        return sorted(p for p in self.repo_path.rglob("*.csproj") if p.is_file())
 
     def _has_cs_files(self, directory: Path) -> bool:
         """Check if directory contains any .cs files."""

--- a/static_analyzer/engine/adapters/csharp_adapter.py
+++ b/static_analyzer/engine/adapters/csharp_adapter.py
@@ -48,15 +48,19 @@ class CSharpAdapter(LanguageAdapter):
     def language_id(self) -> str:
         return "csharp"
 
-    def get_lsp_command(self, project_root: Path) -> list[str]:
-        """Resolve the .NET SDK and ensure the managed csharp-ls install is current."""
+    def get_lsp_command(self, project_root: Path, project_file: Path | None = None) -> list[str]:
+        """Resolve csharp-ls and select the discovered solution explicitly."""
         try:
             resolution = resolve_dotnet_sdk(project_root)
         except DotnetSdkError as exc:
             raise RuntimeError(str(exc)) from exc
 
         self._ensure_csharp_ls_installed(project_root, resolution.dotnet_path, resolution.env)
-        return super().get_lsp_command(project_root)
+        command = super().get_lsp_command(project_root, project_file)
+        if project_file is not None and project_file.suffix.lower() in {".sln", ".slnx"}:
+            logger.info("Starting csharp-ls with explicit solution: %s", project_file)
+            command.extend(["--solution", str(project_file)])
+        return command
 
     def _ensure_csharp_ls_installed(self, project_root: Path, dotnet_path: str, dotnet_env: dict[str, str]) -> None:
         dep = next((d for d in TOOL_REGISTRY if d.key == "csharp" and d.kind is ToolKind.PACKAGE_MANAGER), None)
@@ -88,7 +92,7 @@ class CSharpAdapter(LanguageAdapter):
             )
         if not package_manager_tool_is_current(servers_dir, dep):
             raise RuntimeError(
-                "csharp-ls could not be installed. CodeBoarding needs csharp-ls 0.24.0 and a .NET 10 SDK "
+                "csharp-ls could not be installed. CodeBoarding needs csharp-ls 0.25.0 and a .NET 10 SDK "
                 "to analyze C# projects."
             )
 
@@ -194,7 +198,7 @@ class CSharpAdapter(LanguageAdapter):
         """
         client.wait_for_diagnostics_quiesce(idle_seconds=2.0, max_wait=30.0)
 
-    def prepare_project(self, project_root: Path) -> None:
+    def prepare_project(self, project_root: Path, project_file: Path | None = None) -> None:
         """Run ``dotnet restore`` so csharp-ls can resolve framework references.
 
         Why: csharp-ls relies on Roslyn / MSBuild to load the project, and
@@ -204,8 +208,9 @@ class CSharpAdapter(LanguageAdapter):
         defined`` diagnostics for every file. Restore is idempotent and
         only writes under ``obj/`` (which we already gitignore).
         """
-        # Find solution or csproj/fsproj at the project_root level
-        target = next(iter(project_root.glob("*.sln")), None)
+        target = project_file
+        if target is None:
+            target = next(iter(project_root.glob("*.sln")), None)
         if target is None:
             target = next(iter(project_root.glob("*.slnx")), None)
         if target is None:
@@ -225,7 +230,7 @@ class CSharpAdapter(LanguageAdapter):
         env.update(resolution.env)
         try:
             result = subprocess.run(
-                [resolution.dotnet_path, "restore", str(target.name), "--nologo", "--verbosity", "minimal"],
+                [resolution.dotnet_path, "restore", str(target), "--nologo", "--verbosity", "minimal"],
                 cwd=str(project_root),
                 env=env,
                 capture_output=True,

--- a/static_analyzer/engine/adapters/go_adapter.py
+++ b/static_analyzer/engine/adapters/go_adapter.py
@@ -103,7 +103,7 @@ class GoAdapter(LanguageAdapter):
     def language_id(self) -> str:
         return "go"
 
-    def get_lsp_command(self, project_root: Path) -> list[str]:
+    def get_lsp_command(self, project_root: Path, project_file: Path | None = None) -> list[str]:
         """Fail fast if the Go toolchain is missing.
 
         gopls needs ``go`` on PATH to resolve modules and stdlib — without
@@ -115,7 +115,7 @@ class GoAdapter(LanguageAdapter):
                 "resolve modules and the standard library. Install one via "
                 "https://go.dev/dl/ and re-run the analysis."
             )
-        return super().get_lsp_command(project_root)
+        return super().get_lsp_command(project_root, project_file)
 
     def build_qualified_name(
         self,

--- a/static_analyzer/engine/adapters/java_adapter.py
+++ b/static_analyzer/engine/adapters/java_adapter.py
@@ -48,7 +48,7 @@ class JavaAdapter(LanguageAdapter):
     def language_id(self) -> str:
         return "java"
 
-    def get_lsp_command(self, project_root: Path) -> list[str]:
+    def get_lsp_command(self, project_root: Path, project_file: Path | None = None) -> list[str]:
         """Build the full JDTLS launch command.
 
         JDTLS cannot be started with a simple binary name — it requires a Java

--- a/static_analyzer/engine/adapters/rust_adapter.py
+++ b/static_analyzer/engine/adapters/rust_adapter.py
@@ -137,7 +137,7 @@ class RustAdapter(LanguageAdapter):
     def language_id(self) -> str:
         return "rust"
 
-    def get_lsp_command(self, project_root: Path) -> list[str]:
+    def get_lsp_command(self, project_root: Path, project_file: Path | None = None) -> list[str]:
         """Fail fast if cargo is missing.
 
         rust-analyzer needs ``cargo metadata`` to index any Cargo workspace
@@ -152,7 +152,7 @@ class RustAdapter(LanguageAdapter):
                 "https://rustup.rs/ and re-run the analysis."
             )
         self._check_cargo_usable(project_root, cargo_path)
-        return super().get_lsp_command(project_root)
+        return super().get_lsp_command(project_root, project_file)
 
     def _check_cargo_usable(self, project_root: Path, cargo_path: str) -> None:
         """Reject broken Cargo installs before rust-analyzer returns empty edges."""

--- a/static_analyzer/engine/language_adapter.py
+++ b/static_analyzer/engine/language_adapter.py
@@ -64,7 +64,7 @@ class LanguageAdapter(ABC):
         """
         return self.language_id
 
-    def get_lsp_command(self, project_root: Path) -> list[str]:
+    def get_lsp_command(self, project_root: Path, project_file: Path | None = None) -> list[str]:
         """Get the LSP command with binary paths resolved from tool_registry.
 
         Looks up the resolved command for this language in the tool config
@@ -243,7 +243,7 @@ class LanguageAdapter(ABC):
         """Return extra environment variables for the LSP server process."""
         return {}
 
-    def prepare_project(self, project_root: Path) -> None:
+    def prepare_project(self, project_root: Path, project_file: Path | None = None) -> None:
         """Run any pre-LSP project preparation (e.g. dependency restore).
 
         Default no-op. C# overrides to run ``dotnet restore`` so csharp-ls

--- a/static_analyzer/engine/lsp_client.py
+++ b/static_analyzer/engine/lsp_client.py
@@ -77,6 +77,7 @@ class LSPClient:
         self._request_id = 0
         self._msg_queue: queue.Queue[dict] = queue.Queue()
         self._reader_thread: threading.Thread | None = None
+        self._stderr_thread: threading.Thread | None = None
         self._shutdown_event = threading.Event()
         self._write_lock = threading.Lock()
 
@@ -117,7 +118,7 @@ class LSPClient:
                 self._command,
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
-                stderr=subprocess.DEVNULL,
+                stderr=subprocess.PIPE,
                 env=env,
                 cwd=str(self._project_root),
             )
@@ -136,6 +137,8 @@ class LSPClient:
         # Start background reader
         self._reader_thread = threading.Thread(target=self._reader_loop, daemon=True)
         self._reader_thread.start()
+        self._stderr_thread = threading.Thread(target=self._stderr_loop, daemon=True)
+        self._stderr_thread.start()
 
         root_uri = self._project_root.as_uri()
 
@@ -225,6 +228,8 @@ class LSPClient:
                     pass
         if self._reader_thread and self._reader_thread.is_alive():
             self._reader_thread.join(timeout=2)
+        if self._stderr_thread and self._stderr_thread.is_alive():
+            self._stderr_thread.join(timeout=2)
         if self._stdout_fd is not None:
             try:
                 os.close(self._stdout_fd)
@@ -623,7 +628,17 @@ class LSPClient:
                 return None
             return msg.get("result")
 
-        raise TimeoutError(f"Timeout waiting for LSP response to request {req_id}")
+        process_status = self._process_status()
+        logger.error(
+            "LSP request %d (%s) timed out after %ds; %s",
+            req_id,
+            method,
+            timeout,
+            process_status,
+        )
+        raise TimeoutError(
+            f"Timeout waiting for LSP response to request {req_id} ({method}) after {timeout}s; {process_status}"
+        )
 
     def _send_notification(self, method: str, params: dict | list | None) -> None:
         """Send a JSON-RPC notification (no response expected)."""
@@ -763,6 +778,37 @@ class LSPClient:
                 if not self._shutdown_event.is_set():
                     logger.debug("Reader loop error: %s", e)
                 break
+
+    def _stderr_loop(self) -> None:
+        """Drain server stderr so workspace-load diagnostics remain visible."""
+        if self._process is None or self._process.stderr is None:
+            return
+        server_name = Path(self._command[0]).name if self._command else "lsp"
+        while not self._shutdown_event.is_set():
+            line = self._process.stderr.readline()
+            if not line:
+                break
+            text = line.decode("utf-8", errors="replace").rstrip()
+            if text:
+                logger.info("[%s stderr] %s", server_name, text)
+
+    def _process_status(self) -> str:
+        """Return process state and RSS for timeout diagnostics."""
+        if self._process is None:
+            return "process=not-started"
+        return_code = self._process.poll()
+        if return_code is not None:
+            return f"process=exited({return_code})"
+        rss = "unknown"
+        try:
+            status = Path(f"/proc/{self._process.pid}/status").read_text()
+            for line in status.splitlines():
+                if line.startswith("VmRSS:"):
+                    rss = line.removeprefix("VmRSS:").strip()
+                    break
+        except OSError:
+            pass
+        return f"process=running pid={self._process.pid} rss={rss}"
 
     def _handle_server_request(self, message: dict) -> object:
         """Respond to server-initiated requests.

--- a/tests/static_analyzer/test_csharp_adapter.py
+++ b/tests/static_analyzer/test_csharp_adapter.py
@@ -48,6 +48,19 @@ class TestGetLspCommandDotnetCheck:
             cmd = CSharpAdapter().get_lsp_command(tmp_path)
         assert cmd[0] == resolved
 
+    def test_passes_discovered_solution_to_csharp_ls(self, tmp_path: Path) -> None:
+        solution = tmp_path / "Rapidata.slnx"
+        with (
+            patch(
+                "static_analyzer.engine.adapters.csharp_adapter.resolve_dotnet_sdk",
+                return_value=_dotnet_resolution(),
+            ),
+            patch.object(CSharpAdapter, "_ensure_csharp_ls_installed"),
+            patch("static_analyzer.engine.language_adapter.get_config", return_value={}),
+        ):
+            cmd = CSharpAdapter().get_lsp_command(tmp_path, solution)
+        assert cmd == ["csharp-ls", "--solution", str(solution)]
+
 
 class TestCSharpAdapterProperties:
     """Tests for basic adapter properties."""
@@ -365,7 +378,7 @@ class TestPrepareProject:
         )
         CSharpAdapter().prepare_project(tmp_path)
         assert called["cmd"][:2] == ["/opt/dotnet/dotnet", "restore"]
-        assert called["cmd"][2] == "Foo.csproj"
+        assert called["cmd"][2] == str(tmp_path / "Foo.csproj")
         assert called["cwd"] == str(tmp_path)
         assert called["env"]["DOTNET_ROOT"] == "/opt/dotnet"
 
@@ -388,7 +401,25 @@ class TestPrepareProject:
             lambda _root: _dotnet_resolution(),
         )
         CSharpAdapter().prepare_project(tmp_path)
-        assert called["cmd"][2] == "Foo.sln"
+        assert called["cmd"][2] == str(tmp_path / "Foo.sln")
+
+    def test_restores_explicit_solution(self, tmp_path, monkeypatch):
+        selected = tmp_path / "Rapidata.slnx"
+        selected.write_text("<Solution />")
+        (tmp_path / "Other.sln").write_text("")
+        called = {}
+
+        def fake_run(cmd, **kwargs):
+            called["cmd"] = cmd
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr("static_analyzer.engine.adapters.csharp_adapter.subprocess.run", fake_run)
+        monkeypatch.setattr(
+            "static_analyzer.engine.adapters.csharp_adapter.resolve_dotnet_sdk",
+            lambda _root: _dotnet_resolution(),
+        )
+        CSharpAdapter().prepare_project(tmp_path, selected)
+        assert called["cmd"][2] == str(selected)
 
     def test_skips_when_no_project_file(self, tmp_path, monkeypatch):
         def fake_run(*_args, **_kwargs):

--- a/tests/static_analyzer/test_csharp_config_scanner.py
+++ b/tests/static_analyzer/test_csharp_config_scanner.py
@@ -10,9 +10,10 @@ class TestCSharpProjectConfig:
     """Tests for CSharpProjectConfig data class."""
 
     def test_init(self):
-        config = CSharpProjectConfig(Path("/project"), "solution")
+        config = CSharpProjectConfig(Path("/project"), "solution", Path("/project/App.slnx"))
         assert config.root == Path("/project")
         assert config.project_type == "solution"
+        assert config.project_file == Path("/project/App.slnx")
 
     def test_repr(self):
         config = CSharpProjectConfig(Path("/project"), "project")
@@ -36,6 +37,7 @@ class TestCSharpConfigScanner:
         assert len(projects) == 1
         assert projects[0].root == tmp_path
         assert projects[0].project_type == "solution"
+        assert projects[0].project_file == tmp_path / "MyApp.sln"
 
     def test_scan_slnx_solution_file(self, tmp_path: Path):
         """Ensure .slnx files are recognized to avoid per-project fallback scanning."""
@@ -50,6 +52,7 @@ class TestCSharpConfigScanner:
         assert len(projects) == 1
         assert projects[0].root == tmp_path
         assert projects[0].project_type == "solution"
+        assert projects[0].project_file == tmp_path / "MyApp.slnx"
 
     def test_scan_csproj_file(self, tmp_path: Path):
         (tmp_path / "MyApp.csproj").write_text('<Project Sdk="Microsoft.NET.Sdk"/>')
@@ -59,6 +62,7 @@ class TestCSharpConfigScanner:
         assert len(projects) == 1
         assert projects[0].root == tmp_path
         assert projects[0].project_type == "project"
+        assert projects[0].project_file == tmp_path / "MyApp.csproj"
 
     def test_solution_takes_precedence_over_csproj(self, tmp_path: Path):
         """When .sln and .csproj coexist at the same root, only solution is returned."""

--- a/tests/static_analyzer/test_static_analyzer_start_clients.py
+++ b/tests/static_analyzer/test_static_analyzer_start_clients.py
@@ -164,6 +164,16 @@ class TestStartClientsGracefulDegradation:
 
         analyzer._validate_analysis_results(results)
 
+    def test_csharp_analysis_timeout_is_fatal(self, analyzer: StaticAnalyzer, tmp_path: Path) -> None:
+        cs_adapter = _make_adapter("CSharp", language_enum=Language.CSHARP, fail_on_empty_symbols=True)
+        analyzer._engine_clients = [(EngineConfig(cs_adapter, tmp_path), MagicMock())]
+
+        with (
+            patch.object(analyzer, "_run_full_analysis", side_effect=TimeoutError("documentSymbol timed out")),
+            pytest.raises(StaticAnalysisFatalError, match="CSharp analysis failed: documentSymbol timed out"),
+        ):
+            analyzer._run_full_lsp_pass()
+
     def test_all_success_records_no_failures(self, analyzer: StaticAnalyzer, tmp_path: Path) -> None:
         py_adapter = _make_adapter("Python")
         ts_adapter = _make_adapter("TypeScript")

--- a/tests/test_tool_registry.py
+++ b/tests/test_tool_registry.py
@@ -1733,7 +1733,7 @@ class TestInstallPackageManagerTools(unittest.TestCase):
         csharp = next(d for d in TOOL_REGISTRY if d.key == "csharp")
         assert isinstance(csharp.source, PackageManagerToolSource)
         self.assertNotIn("--framework", csharp.source.install_args)
-        self.assertEqual(csharp.source.tag, "0.24.0")
+        self.assertEqual(csharp.source.tag, "0.25.0")
 
 
 if __name__ == "__main__":

--- a/tool_registry/registry.py
+++ b/tool_registry/registry.py
@@ -211,8 +211,8 @@ TOOL_REGISTRY: list[ToolDependency] = [
         js_entry_parent="intelephense",
     ),
     # csharp-ls ships only as a NuGet dotnet-tool; installed via ``dotnet tool install``.
-    # Pin to 0.24.0 so C# document symbols work reliably for modern .NET 10
-    # repositories. ``--tool-path`` avoids a misleading "DotnetToolSettings.xml
+    # Pin to 0.25.0 for its parallelized solution target-framework discovery.
+    # ``--tool-path`` avoids a misleading "DotnetToolSettings.xml
     # not found" error when no local manifest is present; the package's default
     # target framework is selected by dotnet.
     ToolDependency(
@@ -221,7 +221,7 @@ TOOL_REGISTRY: list[ToolDependency] = [
         kind=ToolKind.PACKAGE_MANAGER,
         config_section=ConfigSection.LSP_SERVERS,
         source=PackageManagerToolSource(
-            tag="0.24.0",
+            tag="0.25.0",
             manager_binary="dotnet",
             install_args=(
                 "tool",


### PR DESCRIPTION
## Summary

Fix C# analyses that stall in the initial `textDocument/documentSymbol` workspace-readiness probe by:

- preserving the exact discovered `.sln`, `.slnx`, or `.csproj` path through engine configuration;
- restoring that exact target and launching `csharp-ls --solution <path>` for solutions;
- upgrading the bundled `csharp-ls` from 0.24.0 to 0.25.0 for its faster, parallelized solution target-framework discovery;
- capturing and logging LSP stderr instead of discarding workspace-load diagnostics;
- including the timed-out method, elapsed limit, process state, PID, and RSS in timeout errors; and
- propagating C# analysis failures as fatal errors instead of continuing to a misleading downstream "No component groups found" result.

## Expected root cause

The affected run completes `dotnet restore` and the LSP initialization handshake, then blocks for 1,800 seconds on request 2, `textDocument/documentSymbol`. In `csharp-ls`, that request waits for Roslyn's solution workspace to finish loading. Therefore the reported C# LSP startup duration measures process startup and initialization—not workspace readiness.

The expected contributors are:

1. CodeBoarding 0.24.0 discarded the exact discovered solution filename and launched plain `csharp-ls`, requiring the server to search for and choose among visible solutions.
2. csharp-ls 0.24.0 performs serial target-framework probing before `MSBuildWorkspace.OpenSolutionAsync`; this is expensive for large multi-project solutions. Version 0.25.0 parallelizes the remaining probes and reads target frameworks directly.
3. LSP stderr was discarded, preventing the timeout from being localized to framework probing, MSBuild workspace loading, a build host, or a specific project.
4. The C# exception was treated as a recoverable per-language error, allowing later architecture generation to replace the actionable timeout with an unrelated empty-component error.

This PR addresses those conditions, but does not claim that csharp-ls 0.25.0 alone guarantees every large solution—including Rapidata—will load within the 1,800-second cap. Rapidata must be rerun to validate that outcome.

## Preconditions: behavior before this change

- The scanner retained only the directory containing a solution, not the exact solution path.
- C# restore independently selected the first matching solution/project in that directory.
- The server command was plain `csharp-ls`; solution selection was implicit.
- csharp-ls 0.24.0 could initialize quickly while Roslyn continued loading the workspace asynchronously.
- The first `documentSymbol` request could consume the full readiness timeout before symbol discovery began.
- Server stderr was sent to `/dev/null`.
- Timeout errors contained only a JSON-RPC request number.
- A C# timeout could be swallowed, after which small sibling languages were analyzed and downstream code reported "No component groups found".
- The LSP recycler and reference-memory optimization were never reached because they are constructed after symbol discovery.

## Postconditions: behavior after this change

- The exact scanner-selected `.sln`, `.slnx`, or `.csproj` is preserved in `EngineConfig`.
- `dotnet restore` uses the same exact target selected for analysis.
- Solution launches use `csharp-ls --solution <exact-path>` and log the selected path.
- New installs use csharp-ls 0.25.0.
- LSP stderr is continuously drained and included in normal CodeBoarding logs.
- A request timeout identifies the LSP method, configured duration, process state, PID, and RSS.
- A C# workspace/symbol failure terminates analysis with the original error context; it cannot silently become a downstream empty-architecture result.
- Other languages retain their existing graceful-degradation behavior.

## Public-repository reproduction

Reproduced against [`space-wizards/space-station-14`](https://github.com/space-wizards/space-station-14) at commit `f95b1461ad406ae6aff4305d88211ad744caf7d7` with recursive submodules:

- 11,300 C# files;
- 100 project files;
- 17 solution files;
- root `SpaceStation14.slnx` containing 50 project entries; and
- successful restore in 12.67 seconds.

Pre-fix csharp-ls 0.24.0, launched without `--solution`:

- initialized in 0.827 seconds;
- discovered 17 solutions;
- did not answer the initial pre-open `documentSymbol` probe within a deliberately shortened 5-second timeout;
- reached no bulk `didOpen`, symbol traversal, reference warmup, recycler, or references phase;
- eventually answered the same request after 33.204 seconds when allowed to continue; and
- used approximately 921 MiB RSS at completion.

With csharp-ls 0.25.0 and `--solution SpaceStation14.slnx`:

- workspace load completed in 20.073 seconds versus 23.746 seconds;
- the same `documentSymbol` response completed in 29.204 seconds versus 33.204 seconds.

The five-second failure is a controlled reproduction of the mechanism, not a claim that this fixture naturally exceeds the production 1,800-second timeout. The comparison is also sequential and may benefit from warm caches.

Upstream context: [csharp-language-server issue #242](https://github.com/razzmatazz/csharp-language-server/issues/242) and [csharp-ls 0.25.0 release](https://github.com/razzmatazz/csharp-language-server/releases/tag/0.25.0).

## Verification

- `pytest -q tests/static_analyzer/test_csharp_config_scanner.py tests/static_analyzer/test_csharp_adapter.py tests/static_analyzer/test_static_analyzer_start_clients.py tests/static_analyzer/test_lsp_client.py tests/test_tool_registry.py` — 262 passed.
- Final affected-module rerun — 156 passed.
- `mypy .` — no issues in 312 source files.
- Black checks and `git diff --check` passed.
- Full coverage run — 2,017 passed, 28 skipped, 83.05% coverage. One unrelated environment-dependent tool-registry test failed because the test orb had no system `dotnet`; the focused tool-registry suite passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved C# project detection and analysis for solutions and project files, including explicit solution selection.
  - Updated C# language-server support to version 0.25.0.

- **Bug Fixes**
  - Improved diagnostics for language-server timeouts by including process status and memory details.
  - C# analysis failures now correctly stop analysis when configured to treat missing results as fatal.
  - Improved handling of language-server error output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->