### PR TITLE
Fix csharp-ls hang on multi-targeted C# monorepos

### DIFF
--- a/static_analyzer/engine/adapters/csharp_adapter.py
+++ b/static_analyzer/engine/adapters/csharp_adapter.py
@@ -21,9 +21,38 @@ from tool_registry import (
     install_package_manager_tools,
     package_manager_tool_is_current,
     package_manager_tool_path,
+    user_data_dir,
 )
 
 logger = logging.getLogger(__name__)
+
+# MSBuild file that rewrites every multi-targeted project to a single target framework.
+#
+# Why: before opening a workspace, csharp-ls folds the per-project target-framework sets
+# together pairwise and only deduplicates once, at the end. Each project that declares
+# ``<TargetFrameworks>`` (plural) roughly doubles the work, so a solution with ~30 or more
+# of them takes hours-to-years to load and our readiness probe times out with no C# result.
+# One framework per project keeps that fold linear.
+#
+# The .NET SDK imports this after the project body, so it also catches multi-targeting that
+# only a ``Directory.Build.props`` declares and no csproj mentions. Prefer the SDK's own
+# current framework when the project offers it: positional picks land on .NET Framework or a
+# mobile target for the many repos that order their list newest-first.
+SINGLE_TARGET_FRAMEWORK_TARGETS = r"""<Project>
+  <PropertyGroup Condition="'$(TargetFrameworks)' != ''">
+    <_CbTfms>$([System.Text.RegularExpressions.Regex]::Replace('$(TargetFrameworks)', '\s', ''))</_CbTfms>
+    <_CbTfms>$([System.Text.RegularExpressions.Regex]::Replace('$(_CbTfms)', ';+', ';'))</_CbTfms>
+    <_CbTfms>;$([System.Text.RegularExpressions.Regex]::Replace('$(_CbTfms)', '^;|;$', ''));</_CbTfms>
+    <_CbSdkTfm Condition="'$(BundledNETCoreAppTargetFrameworkVersion)' != ''">net$(BundledNETCoreAppTargetFrameworkVersion)</_CbSdkTfm>
+    <_CbTfm>$([System.Text.RegularExpressions.Regex]::Replace('$(_CbTfms.Substring(1))', ';.*', ''))</_CbTfm>
+    <_CbTfm Condition="'$(_CbSdkTfm)' != '' and $(_CbTfms.Contains(';$(_CbSdkTfm);'))">$(_CbSdkTfm)</_CbTfm>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(_CbTfm)' != ''">
+    <TargetFramework Condition="'$(TargetFramework)' == ''">$(_CbTfm)</TargetFramework>
+    <TargetFrameworks></TargetFrameworks>
+  </PropertyGroup>
+</Project>
+"""
 
 
 class CSharpAdapter(LanguageAdapter):
@@ -255,14 +284,33 @@ class CSharpAdapter(LanguageAdapter):
         """
         if project_root is not None:
             try:
-                return resolve_dotnet_sdk(project_root).env
+                env = dict(resolve_dotnet_sdk(project_root).env)
             except DotnetSdkError as exc:
                 raise RuntimeError(str(exc)) from exc
-        dotnet = shutil.which("dotnet")
-        env = system_dotnet_env(Path(dotnet)) if dotnet else {}
-        if not os.environ.get("DOTNET_ROLL_FORWARD"):
-            env["DOTNET_ROLL_FORWARD"] = "Major"
+        else:
+            dotnet = shutil.which("dotnet")
+            env = system_dotnet_env(Path(dotnet)) if dotnet else {}
+            if not os.environ.get("DOTNET_ROLL_FORWARD"):
+                env["DOTNET_ROLL_FORWARD"] = "Major"
+
+        # Both hooks are needed: MSBuild imports the cross-targeting one while
+        # evaluating a project that still declares several frameworks, and the
+        # common one once csharp-ls reopens it pinned to the single framework.
+        targets = str(self._write_single_target_framework_targets())
+        env["CustomAfterMicrosoftCommonTargets"] = targets
+        env["CustomAfterMicrosoftCommonCrossTargetingTargets"] = targets
         return env
+
+    def _write_single_target_framework_targets(self) -> Path:
+        """Materialize ``SINGLE_TARGET_FRAMEWORK_TARGETS`` and return its path."""
+        path = user_data_dir() / "msbuild" / "CodeBoarding.SingleTargetFramework.targets"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        # Written per run and shared across concurrent analyses, so swap it in
+        # atomically -- MSBuild reading a half-written file fails every project.
+        scratch = path.with_name(f"{path.name}.{os.getpid()}.tmp")
+        scratch.write_text(SINGLE_TARGET_FRAMEWORK_TARGETS, encoding="utf-8")
+        os.replace(scratch, path)
+        return path
 
     @property
     def fail_on_empty_symbols(self) -> bool:

--- a/static_analyzer/engine/adapters/csharp_adapter.py
+++ b/static_analyzer/engine/adapters/csharp_adapter.py
@@ -307,8 +307,9 @@ class CSharpAdapter(LanguageAdapter):
         path.parent.mkdir(parents=True, exist_ok=True)
         # One shared file, so a concurrent analysis may be importing it right
         # now -- on Windows, replacing a file another process holds open fails.
-        # Rewrite it only when the contents actually changed.
-        if path.is_file() and path.read_text(encoding="utf-8") == SINGLE_TARGET_FRAMEWORK_TARGETS:
+        # Rewrite it only when the contents actually changed; anything we cannot
+        # read back as our own text (corrupt, hand-edited) is a mismatch.
+        if path.is_file() and path.read_text(encoding="utf-8", errors="ignore") == SINGLE_TARGET_FRAMEWORK_TARGETS:
             return path
         # MSBuild reading a half-written file fails every project it evaluates,
         # so the new contents have to appear in one step.

--- a/static_analyzer/engine/adapters/csharp_adapter.py
+++ b/static_analyzer/engine/adapters/csharp_adapter.py
@@ -305,8 +305,13 @@ class CSharpAdapter(LanguageAdapter):
         """Materialize ``SINGLE_TARGET_FRAMEWORK_TARGETS`` and return its path."""
         path = user_data_dir() / "msbuild" / "CodeBoarding.SingleTargetFramework.targets"
         path.parent.mkdir(parents=True, exist_ok=True)
-        # Written per run and shared across concurrent analyses, so swap it in
-        # atomically -- MSBuild reading a half-written file fails every project.
+        # One shared file, so a concurrent analysis may be importing it right
+        # now -- on Windows, replacing a file another process holds open fails.
+        # Rewrite it only when the contents actually changed.
+        if path.is_file() and path.read_text(encoding="utf-8") == SINGLE_TARGET_FRAMEWORK_TARGETS:
+            return path
+        # MSBuild reading a half-written file fails every project it evaluates,
+        # so the new contents have to appear in one step.
         scratch = path.with_name(f"{path.name}.{os.getpid()}.tmp")
         scratch.write_text(SINGLE_TARGET_FRAMEWORK_TARGETS, encoding="utf-8")
         os.replace(scratch, path)

--- a/tests/static_analyzer/test_csharp_adapter.py
+++ b/tests/static_analyzer/test_csharp_adapter.py
@@ -303,7 +303,49 @@ class TestLspEnv:
             lambda _root: _dotnet_resolution("/private/dotnet", {"DOTNET_ROOT": "/private"}),
         )
         adapter = CSharpAdapter()
-        assert adapter.get_lsp_env(tmp_path) == {"DOTNET_ROOT": "/private"}
+        assert adapter.get_lsp_env(tmp_path)["DOTNET_ROOT"] == "/private"
+
+
+class TestSingleTargetFrameworkTargets:
+    """csharp-ls folds per-project target-framework sets pairwise without
+    deduplicating between steps, so a solution with ~30 or more multi-targeted
+    projects never finishes loading. The adapter hands MSBuild a targets file
+    that leaves every project with exactly one framework, keeping that fold
+    linear."""
+
+    def test_env_points_both_msbuild_hooks_at_the_targets_file(self, monkeypatch, tmp_path):
+        monkeypatch.setattr("static_analyzer.engine.adapters.csharp_adapter.user_data_dir", lambda: tmp_path)
+        monkeypatch.setattr(
+            "static_analyzer.engine.adapters.csharp_adapter.resolve_dotnet_sdk",
+            lambda _root: _dotnet_resolution("/private/dotnet", {"DOTNET_ROOT": "/private"}),
+        )
+        env = CSharpAdapter().get_lsp_env(tmp_path)
+
+        targets = Path(env["CustomAfterMicrosoftCommonTargets"])
+        # The cross-targeting hook is the one that fires while a project still
+        # declares several frameworks -- the common hook alone would never run.
+        assert env["CustomAfterMicrosoftCommonCrossTargetingTargets"] == str(targets)
+        assert targets.is_file()
+
+    def test_targets_file_clears_target_frameworks(self, monkeypatch, tmp_path):
+        monkeypatch.setattr("static_analyzer.engine.adapters.csharp_adapter.user_data_dir", lambda: tmp_path)
+        monkeypatch.setattr("shutil.which", lambda _: None)
+        targets = Path(CSharpAdapter().get_lsp_env()["CustomAfterMicrosoftCommonTargets"]).read_text()
+
+        assert "<TargetFrameworks></TargetFrameworks>" in targets
+        assert "$(BundledNETCoreAppTargetFrameworkVersion)" in targets
+
+    def test_rewrites_the_targets_file_atomically(self, monkeypatch, tmp_path):
+        monkeypatch.setattr("static_analyzer.engine.adapters.csharp_adapter.user_data_dir", lambda: tmp_path)
+        monkeypatch.setattr("shutil.which", lambda _: None)
+        adapter = CSharpAdapter()
+        targets = Path(adapter.get_lsp_env()["CustomAfterMicrosoftCommonTargets"])
+        targets.write_text("stale")
+
+        assert Path(adapter.get_lsp_env()["CustomAfterMicrosoftCommonTargets"]).read_text() != "stale"
+        # A half-written file breaks every project MSBuild evaluates, so the
+        # scratch copy must not survive next to the real one.
+        assert sorted(p.name for p in targets.parent.iterdir()) == [targets.name]
 
 
 class TestReferenceTracking:


### PR DESCRIPTION
## What

Makes C# analysis finish on multi-targeted .NET monorepos, which is the customer failure investigated in #452.

## The bug

Before opening a workspace, csharp-ls picks one target framework for the whole solution by folding the per-project framework sets together pairwise, deduplicating **only once, at the very end** (`Roslyn/Solution.fs`):

```fsharp
tfmSets |> List.skip 1 |> Seq.fold compatibleTfmsOfTwoSets firstSet |> Set.ofSeq
```

Every project declaring `<TargetFrameworks>` (plural) roughly doubles the sequence the final `Set.ofSeq` has to enumerate, so the cost is O(2^N) in the number of multi-targeted projects. At ~30 projects the load already exceeds our 1800s probe cap; and every project past that doubles it again -- 40 projects is already days of work. csharp-ls queues every solution-dependent request until the load finishes, so from our side it is indistinguishable from a dead server holding its stdio open:

```
Waiting for LSP server indexing (timeout=1800s)...
Error during engine analysis for CSharp: Timeout waiting for LSP response to request 2
StaticAnalysisFatalError: No component groups found
```

**A version bump does not fix this.** I checked out the fold in each release: it is byte-identical in 0.24.0, 0.25.0, 0.26.0 and current `main`. 0.25.0's PR #369 parallelized TFM *reading*, which is a different (linear) cost.

## The fix

Point MSBuild's `CustomAfterMicrosoftCommonTargets` and `CustomAfterMicrosoftCommonCrossTargetingTargets` at a generated targets file that leaves every project on exactly one framework. One framework per project makes the fold linear, and csharp-ls still picks the workspace framework itself — it just picks it from singletons.

Two details worth flagging:

- **Both hooks are needed.** The cross-targeting one fires while a project still declares several frameworks (that is the evaluation whose result feeds the fold); the common one fires afterwards, once csharp-ls reopens the solution pinned to a single framework.
- **The SDK imports it after the project body**, so it also catches multi-targeting declared centrally in `Directory.Build.props` and absent from every csproj. That case is real — it is the second reproduction in #452 and a `grep` over csproj files reports such a repo as single-targeted.

Framework selection prefers the SDK's own current framework (`net$(BundledNETCoreAppTargetFrameworkVersion)`) when the project offers it, falling back to the first entry. A positional pick alone is wrong in practice: opentelemetry-dotnet orders its list newest-first (`net10.0;net9.0;net8.0;netstandard2.0;net462`), so "last" lands on .NET Framework, while the SDK-template convention is ascending, so "first" lands on `netstandard2.0`.

## Measurements

csharp-ls 0.24.0, .NET SDK 10.0.301, Linux. "before" is the same run with only the two hook variables removed:

| Repository | Before | After |
|---|---|---|
| 40 synthetic projects, `<TargetFrameworks>` in csproj | no load in 180s | 9.5s |
| 40 synthetic projects, `<TargetFrameworks>` in `Directory.Build.props` only | no load in 150s | 9.7s |
| **open-telemetry/opentelemetry-dotnet** @ `core-1.17.0` (36 of 70 solution projects multi-target) | no load in 180s | 13.1s |

End-to-end through `get_static_analysis`, opentelemetry-dotnet now completes in 6m16s including clone, SDK install, `dotnet restore` and 767 C# files.

## Relationship to #451

#451 bumps the pin to 0.25.0, passes `--solution`, and improves timeout diagnostics. Those are worthwhile on their own, but per the check above 0.25.0 carries the same fold, so they do not address this hang. This PR is deliberately scoped to the hang and touches one adapter.

## Known limitation

A repository that sets `TargetFrameworks` in its own `Directory.Build.targets` would still win, because MSBuild imports that after both hooks. There is no import point after it; such a repo simply returns to today's behavior.

## Tests

- Unit: `tests/static_analyzer/test_csharp_adapter.py` — both hooks exported, targets file empties `<TargetFrameworks>`, rewrite is atomic.
- Integration (private suite): `tests/integration/test_csharp_multitarget_workspace_load.py` covers both declaration sites, one against opentelemetry-dotnet and one against a synthetic props-only monorepo.
- `pytest tests/` — 1837 passed (one pre-existing unrelated failure from stale `temp/repos/` clones in my working tree).
- `black --check` and `mypy` clean on the changed files.

Refs #452

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved C# project analysis for multi-targeted projects by selecting a single compatible framework.
  * Prefer the installed SDK framework when determining the analysis environment.
  * Improved reliability when generating and updating MSBuild configuration files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->