### PR TITLE
fix(csharp): stop the workspace TargetFramework inverting project conditions

### DIFF
--- a/static_analyzer/engine/adapters/csharp_adapter.py
+++ b/static_analyzer/engine/adapters/csharp_adapter.py
@@ -36,7 +36,7 @@ _SINGLE_TARGET_FRAMEWORK_TARGETS = r"""<Project>
   <Import
     Project="$(CodeBoardingDirectoryBuildTargetsPath)"
     Condition="Exists('$(CodeBoardingDirectoryBuildTargetsPath)')" />
-  <PropertyGroup Condition="'$(TargetFrameworks)' != ''">
+  <PropertyGroup Condition="'$(TargetFrameworks)' != '' and '$(CodeBoardingFoldMultiTargetFrameworks)' == 'true'">
     <CodeBoardingTargetFrameworks>$([System.Text.RegularExpressions.Regex]::Replace('$(TargetFrameworks)', '\s', ''))</CodeBoardingTargetFrameworks>
     <CodeBoardingTargetFrameworks>$([System.Text.RegularExpressions.Regex]::Replace('$(CodeBoardingTargetFrameworks)', ';+', ';'))</CodeBoardingTargetFrameworks>
     <CodeBoardingTargetFrameworks>;$([System.String]::Copy('$(CodeBoardingTargetFrameworks)').Trim(';'));</CodeBoardingTargetFrameworks>
@@ -44,27 +44,76 @@ _SINGLE_TARGET_FRAMEWORK_TARGETS = r"""<Project>
     <TargetFrameworks>$([System.String]::Copy('$(CodeBoardingTargetFrameworks)').Trim(';').Split(';')[0])</TargetFrameworks>
     <TargetFrameworks Condition="'$(CodeBoardingPreferredTargetFramework)' != '' and $(CodeBoardingTargetFrameworks.Contains(';$(CodeBoardingPreferredTargetFramework);'))">$(CodeBoardingPreferredTargetFramework)</TargetFrameworks>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == '' and '$(TargetFrameworks)' != ''">
+    <TargetFramework Condition="$(TargetFrameworks.Contains('$(CodeBoardingWorkspaceTargetFramework)'))">$(CodeBoardingWorkspaceTargetFramework)</TargetFramework>
+    <TargetFramework Condition="'$(TargetFramework)' == ''">$(TargetFrameworks)</TargetFramework>
+  </PropertyGroup>
+</Project>
+"""
+
+_WORKSPACE_TARGET_FRAMEWORK_PROPS = r"""<Project TreatAsLocalProperty="TargetFramework">
+  <PropertyGroup>
+    <CodeBoardingWorkspaceTargetFramework>$(TargetFramework)</CodeBoardingWorkspaceTargetFramework>
+    <CodeBoardingDirectoryBuildPropsPath Condition="'$(CodeBoardingOriginalDirectoryBuildPropsPath)' == ''">$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildProjectDirectory)'))</CodeBoardingDirectoryBuildPropsPath>
+  </PropertyGroup>
+  <Import
+    Project="$(CodeBoardingOriginalDirectoryBuildPropsPath)"
+    Condition="Exists('$(CodeBoardingOriginalDirectoryBuildPropsPath)')" />
+  <Import
+    Project="$(CodeBoardingDirectoryBuildPropsPath)"
+    Condition="Exists('$(CodeBoardingDirectoryBuildPropsPath)')" />
 </Project>
 """
 
 
+def _write_injected_import(name: str, content: str) -> Path:
+    """Materialize an MSBuild import CodeBoarding injects via environment variable."""
+    path = get_servers_dir() / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if not path.exists() or path.read_text(encoding="utf-8") != content:
+        temporary_path = path.with_name(f"{path.name}.{os.getpid()}.tmp")
+        temporary_path.write_text(content, encoding="utf-8")
+        os.replace(temporary_path, path)
+    return path
+
+
 def _single_target_framework_env(project_root: Path) -> dict[str, str]:
-    """Prevent csharp-ls's exponential multi-target framework fold."""
+    """Keep csharp-ls's workspace-wide TargetFramework from rewriting single-target projects.
+
+    Why: csharp-ls folds every project's frameworks into one global MSBuild
+    ``TargetFramework``. A global property outranks a project's own
+    ``<TargetFramework>``, so a solution whose projects do not all share one
+    framework has that property forced onto the odd ones out. Conditions keyed
+    on ``$(TargetFramework)`` then evaluate against a framework the project does
+    not target -- the idiomatic ``Condition="'$(TargetFramework)' !=
+    'netstandard2.0'"`` guard around analyzer ``ProjectReference`` items inverts
+    and the analyzer projects reference themselves, which sends Roslyn's
+    solution load into unbounded growth. ``TreatAsLocalProperty`` demotes the
+    property so each project sees its declared framework again; the targets file
+    reinstates it for projects that genuinely multi-target and so need one
+    picked for them.
+
+    Folding a multi-target project down to a single framework stays behind
+    ``_MULTI_TARGET_PROJECT_THRESHOLD``, because that fold discards frameworks a
+    small solution may want analyzed. Demoting the property has no such cost: it
+    only changes evaluation for a project whose declared framework the workspace
+    value contradicts, so it applies to every solution.
+    """
+    targets_path = _write_injected_import("csharp-ls-single-target.targets", _SINGLE_TARGET_FRAMEWORK_TARGETS)
+    props_path = _write_injected_import("csharp-ls-workspace-tfm.props", _WORKSPACE_TARGET_FRAMEWORK_PROPS)
+
+    env = {"DirectoryBuildTargetsPath": str(targets_path), "DirectoryBuildPropsPath": str(props_path)}
+
     project_count = sum(1 for pattern in ("*.csproj", "*.fsproj") for _ in project_root.rglob(pattern))
-    if project_count <= _MULTI_TARGET_PROJECT_THRESHOLD:
-        return {}
+    if project_count > _MULTI_TARGET_PROJECT_THRESHOLD:
+        env["CodeBoardingFoldMultiTargetFrameworks"] = "true"
 
-    targets_path = get_servers_dir() / "csharp-ls-single-target.targets"
-    targets_path.parent.mkdir(parents=True, exist_ok=True)
-    if not targets_path.exists() or targets_path.read_text(encoding="utf-8") != _SINGLE_TARGET_FRAMEWORK_TARGETS:
-        temporary_path = targets_path.with_name(f"{targets_path.name}.{os.getpid()}.tmp")
-        temporary_path.write_text(_SINGLE_TARGET_FRAMEWORK_TARGETS, encoding="utf-8")
-        os.replace(temporary_path, targets_path)
-
-    env = {"DirectoryBuildTargetsPath": str(targets_path)}
     original_targets_path = os.environ.get("DirectoryBuildTargetsPath")
     if original_targets_path:
         env["CodeBoardingOriginalDirectoryBuildTargetsPath"] = original_targets_path
+    original_props_path = os.environ.get("DirectoryBuildPropsPath")
+    if original_props_path:
+        env["CodeBoardingOriginalDirectoryBuildPropsPath"] = original_props_path
     return env
 
 

--- a/tests/static_analyzer/scripts/csharp_mixed_framework_repro.py
+++ b/tests/static_analyzer/scripts/csharp_mixed_framework_repro.py
@@ -1,0 +1,131 @@
+"""Generate a C# solution that reproduces the csharp-ls solution-load blowup.
+
+csharp-ls folds every project's frameworks into one global MSBuild
+``TargetFramework``. A global property outranks a project's own
+``<TargetFramework>``, so in a solution that does not target one framework
+throughout, the odd projects out are evaluated under a framework they do not
+target. The generated solution wires Roslyn analyzers in through the idiomatic
+``Condition="'$(TargetFramework)' != 'netstandard2.0'"`` guard, which inverts
+under that property and makes the analyzer projects reference themselves.
+Roslyn's solution load then grows without bound.
+
+    uv run python tests/static_analyzer/scripts/csharp_mixed_framework_repro.py /tmp/repro
+    cd /tmp/repro && dotnet restore Synthetic.slnx
+
+Then point CodeBoarding at ``/tmp/repro``. Before the fix the CSharp sync probe
+never returns; after it the analysis completes in well under a minute.
+
+``--variant name-guard`` keys the same guard on ``$(MSBuildProjectName)``, which
+a global framework cannot invert. It is the control: it loads fine either way,
+which isolates the cause to the property rather than to solution size.
+"""
+
+import argparse
+import shutil
+from pathlib import Path
+
+ANALYZERS = ["Gen.Contracts", "Gen", "Analyzers", "CodeFixers"]
+
+NUGET_CONFIG = """<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>
+"""
+
+LIB_CSPROJ = """<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+</Project>
+"""
+
+ANALYZER_CSPROJ = """<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+</Project>
+"""
+
+CS_FILE = """namespace {ns};
+
+public sealed class {cls}
+{{
+    public int Value {{ get; init; }}
+
+    public int Compute(int seed) => seed + Value + {n};
+}}
+"""
+
+DIRECTORY_BUILD_PROPS = """<Project>
+  <PropertyGroup>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <!-- Wire the analyzers into every project except the analyzer projects themselves. -->
+  <ItemGroup Condition="{guard}">
+{refs}
+  </ItemGroup>
+</Project>
+"""
+
+
+def _guard(variant: str) -> str:
+    if variant == "name-guard":
+        return " and ".join(f"'$(MSBuildProjectName)' != '{a}'" for a in ANALYZERS)
+    return "'$(TargetFramework)' != 'netstandard2.0'"
+
+
+def generate(root: Path, projects: int, files_per_project: int, variant: str) -> None:
+    refs = "\n".join(
+        f'    <ProjectReference Include="$(MSBuildThisFileDirectory)src/analyzers/{a}/{a}.csproj"\n'
+        f'                      OutputItemType="Analyzer" ReferenceOutputAssembly="true" PrivateAssets="all" />'
+        for a in ANALYZERS
+    )
+    (root / "nuget.config").write_text(NUGET_CONFIG)
+    (root / "Directory.Build.props").write_text(DIRECTORY_BUILD_PROPS.format(guard=_guard(variant), refs=refs))
+
+    project_paths: list[str] = []
+    for analyzer in ANALYZERS:
+        directory = root / "src" / "analyzers" / analyzer
+        directory.mkdir(parents=True)
+        (directory / f"{analyzer}.csproj").write_text(ANALYZER_CSPROJ)
+        name = analyzer.replace(".", "")
+        (directory / f"{name}.cs").write_text(CS_FILE.format(ns=f"Synthetic.Analyzers.{analyzer}", cls=name, n=1))
+        project_paths.append(f"src/analyzers/{analyzer}/{analyzer}.csproj")
+
+    for index in range(projects):
+        name = f"Lib{index:03d}"
+        directory = root / "src" / "libs" / name
+        directory.mkdir(parents=True)
+        (directory / f"{name}.csproj").write_text(LIB_CSPROJ)
+        for file_index in range(files_per_project):
+            (directory / f"Type{file_index:02d}.cs").write_text(
+                CS_FILE.format(ns=f"Synthetic.{name}", cls=f"Type{file_index:02d}", n=index * 100 + file_index)
+            )
+        project_paths.append(f"src/libs/{name}/{name}.csproj")
+
+    entries = "\n".join(f'  <Project Path="{path}" />' for path in project_paths)
+    (root / "Synthetic.slnx").write_text(f"<Solution>\n{entries}\n</Solution>\n")
+
+    print(f"generated {root}: {len(project_paths)} projects, variant={variant}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("out", type=Path)
+    parser.add_argument("--projects", type=int, default=40)
+    parser.add_argument("--files-per-project", type=int, default=8)
+    parser.add_argument("--variant", choices=["tfm-guard", "name-guard"], default="tfm-guard")
+    args = parser.parse_args()
+
+    if args.out.exists():
+        shutil.rmtree(args.out)
+    args.out.mkdir(parents=True)
+    generate(args.out, args.projects, args.files_per_project, args.variant)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/static_analyzer/test_csharp_adapter.py
+++ b/tests/static_analyzer/test_csharp_adapter.py
@@ -310,19 +310,25 @@ class TestLspEnv:
         targets_path = Path(env["DirectoryBuildTargetsPath"])
 
         assert env["DOTNET_ROOT"] == "/private"
+        assert env["CodeBoardingFoldMultiTargetFrameworks"] == "true"
         assert targets_path.is_file()
         targets = targets_path.read_text()
         assert "<TargetFrameworks>" in targets
         assert "$(BundledNETCoreAppTargetFrameworkVersion)" in targets
 
-    def test_project_env_leaves_small_workspaces_unchanged(self, monkeypatch, tmp_path):
+    def test_project_env_leaves_small_workspaces_multi_targeting(self, monkeypatch, tmp_path):
+        """Folding away frameworks costs a small solution coverage; demoting the property does not."""
         (tmp_path / "Project.csproj").touch()
         monkeypatch.setattr(
             "static_analyzer.engine.adapters.csharp_adapter.resolve_dotnet_sdk",
             lambda _root: _dotnet_resolution("/private/dotnet", {"DOTNET_ROOT": "/private"}),
         )
+        monkeypatch.setattr("static_analyzer.engine.adapters.csharp_adapter.get_servers_dir", lambda: tmp_path)
 
-        assert CSharpAdapter().get_lsp_env(tmp_path) == {"DOTNET_ROOT": "/private"}
+        env = CSharpAdapter().get_lsp_env(tmp_path)
+
+        assert "CodeBoardingFoldMultiTargetFrameworks" not in env
+        assert Path(env["DirectoryBuildPropsPath"]).is_file()
 
     def test_project_env_preserves_custom_directory_build_targets(self, monkeypatch, tmp_path):
         for index in range(26):
@@ -339,6 +345,45 @@ class TestLspEnv:
 
         assert env["CodeBoardingOriginalDirectoryBuildTargetsPath"] == str(custom_targets)
         assert env["DirectoryBuildTargetsPath"] != str(custom_targets)
+
+    def test_project_env_demotes_workspace_target_framework(self, monkeypatch, tmp_path):
+        """A global TargetFramework silently rewrites projects that target something else."""
+        for index in range(26):
+            (tmp_path / f"Project{index}.csproj").touch()
+        monkeypatch.setattr(
+            "static_analyzer.engine.adapters.csharp_adapter.resolve_dotnet_sdk",
+            lambda _root: _dotnet_resolution(),
+        )
+        monkeypatch.setattr("static_analyzer.engine.adapters.csharp_adapter.get_servers_dir", lambda: tmp_path)
+
+        env = CSharpAdapter().get_lsp_env(tmp_path)
+        props_path = Path(env["DirectoryBuildPropsPath"])
+
+        assert props_path.is_file()
+        props = props_path.read_text()
+        assert 'TreatAsLocalProperty="TargetFramework"' in props
+        assert (
+            "<CodeBoardingWorkspaceTargetFramework>$(TargetFramework)</CodeBoardingWorkspaceTargetFramework>" in props
+        )
+        # Multi-target projects still get one framework picked for them.
+        targets = Path(env["DirectoryBuildTargetsPath"]).read_text()
+        assert "$(CodeBoardingWorkspaceTargetFramework)" in targets
+
+    def test_project_env_preserves_custom_directory_build_props(self, monkeypatch, tmp_path):
+        for index in range(26):
+            (tmp_path / f"Project{index}.csproj").touch()
+        custom_props = tmp_path / "custom.props"
+        monkeypatch.setenv("DirectoryBuildPropsPath", str(custom_props))
+        monkeypatch.setattr(
+            "static_analyzer.engine.adapters.csharp_adapter.resolve_dotnet_sdk",
+            lambda _root: _dotnet_resolution(),
+        )
+        monkeypatch.setattr("static_analyzer.engine.adapters.csharp_adapter.get_servers_dir", lambda: tmp_path)
+
+        env = CSharpAdapter().get_lsp_env(tmp_path)
+
+        assert env["CodeBoardingOriginalDirectoryBuildPropsPath"] == str(custom_props)
+        assert env["DirectoryBuildPropsPath"] != str(custom_props)
 
 
 class TestReferenceTracking:


### PR DESCRIPTION
## WHAT

csharp-ls never answers the first `textDocument/documentSymbol` sync probe on a solution whose projects don't all target the same framework. The probe times out; left running past the deadline, csharp-ls dies of `Out of memory.`

The cause is a **self-referencing project graph that csharp-ls creates itself**, and it is independent of solution size. This fixes it by demoting the offending MSBuild property.

## WHY

`Roslyn/Solution.fs` folds every project's frameworks into one **global** MSBuild `TargetFramework` and passes it to `MSBuildWorkspace.Create`:

```
Roslyn.Solution: Will use MSBuild props: map [(TargetFramework, net10.0)]
```

A global property **outranks** a project's own `<TargetFramework>`. So in a solution of 281 `net10.0` projects plus 5 `netstandard2.0` Roslyn analyzer/generator projects, those 5 are evaluated as `net10.0`.

That inverts conditions keyed on `$(TargetFramework)`. The idiomatic guard that stops analyzer projects from referencing themselves —

```xml
<ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0'">
  <ProjectReference Include="...Analyzers.csproj" OutputItemType="Analyzer" ... />
```

— flips for exactly the `netstandard2.0` projects it exists to exclude. Measured on the affected repo with `dotnet msbuild -getItem:ProjectReference`:

| `Rapidata.Generators.csproj` (declares `netstandard2.0`) | ProjectReferences |
|---|---|
| as declared | **1** (its one real sibling) |
| under `-p:TargetFramework=net10.0` | **4, including itself** |

`OpenSolutionAsync` with `LoadMetadataForReferencedProjects = true` then chases that self-reference and the resulting sibling cycles, and grows without bound.

### Why #448 and #454 don't cover this

- **#454** injects a `.targets` override guarded by `Condition="'$(TargetFrameworks)' != ''"`. The affected repo has **zero** projects using `<TargetFrameworks>` (plural) — all 286 are single-target. The guard cannot fire. The damage here happens *because* projects are single-target: the fold has nothing to disambiguate, yet its result is still applied as a global property.
- **#448** targets the right subsystem but the wrong phase. This blows up during **solution load**, before any `references` query, so `LSPRecycler` never gets a turn. Bounding the heap would make the OOM arrive *sooner*, not later.
- **Raising the probe timeout is not the fix.** The load never converges; a higher cap converts a timeout into an OOM crash.

## HOW

`TreatAsLocalProperty="TargetFramework"` on a `Directory.Build.props` injected via `DirectoryBuildPropsPath` — the props analogue of the `DirectoryBuildTargetsPath` mechanism #454 already uses. That demotes the global property so each project sees its declared framework again. The injected props chains the repo's own `Directory.Build.props`, and honours a pre-existing `DirectoryBuildPropsPath` the same way #454 does for targets.

Multi-target projects still need a framework picked for them, so the targets file reinstates the workspace value when a project declares only `TargetFrameworks`.

**One deliberate behaviour change worth your attention:** the *fold* of a multi-target project down to one framework stays behind `_MULTI_TARGET_PROJECT_THRESHOLD` (now gated on a `CodeBoardingFoldMultiTargetFrameworks` env flag, so #454's behaviour is unchanged for repos above and below the threshold). But the **injection itself is now unconditional**, because the bug does not depend on project count — a 24-project reproduction hangs under the old `> 25` gate. Demoting the property is a no-op unless the workspace value contradicts a declared framework, i.e. it only takes effect in the broken case. This is why `test_project_env_leaves_small_workspaces_unchanged` became `test_project_env_leaves_small_workspaces_multi_targeting`.

## HOW TESTED

Reproduction added at `tests/static_analyzer/scripts/csharp_mixed_framework_repro.py` — it generates a synthetic solution with this shape, so **you don't need the affected private repo**:

```bash
uv run python tests/static_analyzer/scripts/csharp_mixed_framework_repro.py /tmp/repro --projects 40
cd /tmp/repro && dotnet restore Synthetic.slnx
# then point CodeBoarding at /tmp/repro
```

`--variant name-guard` keys the same guard on `$(MSBuildProjectName)`, which a global framework cannot invert. It is the control that isolates the cause to the property rather than to solution size:

| Synthetic solution, 44 projects, single variable changed | Result |
|---|---|
| guard on `$(TargetFramework)` (idiomatic) | never finishes — killed at 540s, 2.4GB still climbing |
| guard on `$(MSBuildProjectName)` — **control** | ✅ loads in **33.7s** |

Full CodeBoarding static analysis on the synthetic repro, with this change:

| | Before | After |
|---|---|---|
| 44 projects / 324 files | probe never returns | ✅ **52.6s** total, probe 27.8s, 1664 symbols |
| 24 projects / 164 files (below old threshold) | stuck >7 min in "Waiting for LSP server indexing" | ✅ **32.3s** total, probe 18.4s, 844 symbols |

On the real 286-project / 7585-file solution that prompted this, driving csharp-ls 0.24.0 over stdio with the same handshake the engine uses (`probe_before_open`), using the exact artifacts this code generates:

| | Before | After |
|---|---|---|
| `documentSymbol` probe (request 2) | never answers | ✅ **`PROBE OK in 131.5s`** |
| RSS | 774MB@90s → 7.3GB@754s, still climbing | peak **1.39GB**, bounded |
| left running past the cap | `Out of memory.`, server dead at ~43 min | loads, `Finished loading solution` at 128.7s |

Also verified no #454 regression: a `TargetFrameworks=netstandard2.0;net8.0;net10.0` project still resolves to a single `net10.0`, and a normal `net10.0` project still receives all four of its analyzer `ProjectReference`s.

`uv run pytest` — 2019 passed, 28 skipped. `uv run black . --check` and `uv run mypy` clean. Two unit tests added for the new env contract.

## Note for upstream

The root cause is arguably csharp-ls's: `resolveDefaultWorkspaceProps` emits a global `TargetFramework` even when no project multi-targets, so there is nothing to disambiguate. A fix there would make this workaround unnecessary, but you pin `csharp-ls 0.24.0`, so this keeps large mixed-framework solutions analyzable today. Happy to file that upstream too if useful.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved C# and F# workspace loading for projects targeting multiple frameworks.
  * Large workspaces now receive optimized multi-targeting configuration, while smaller workspaces retain their existing behavior.
  * Preserved custom build configuration paths and environment settings during analysis.
  * Improved handling of workspace-level framework settings to provide more reliable project discovery and analysis.
* **Tests**
  * Added coverage for mixed-framework solutions and large-workspace configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->