### PR TITLE
fix(csharp): handle mixed single- and multi-target workspaces

### DIFF
--- a/static_analyzer/engine/adapters/csharp_adapter.py
+++ b/static_analyzer/engine/adapters/csharp_adapter.py
@@ -44,10 +44,6 @@ _SINGLE_TARGET_FRAMEWORK_TARGETS = r"""<Project>
     <TargetFrameworks>$([System.String]::Copy('$(CodeBoardingTargetFrameworks)').Trim(';').Split(';')[0])</TargetFrameworks>
     <TargetFrameworks Condition="'$(CodeBoardingPreferredTargetFramework)' != '' and $(CodeBoardingTargetFrameworks.Contains(';$(CodeBoardingPreferredTargetFramework);'))">$(CodeBoardingPreferredTargetFramework)</TargetFrameworks>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == '' and '$(TargetFrameworks)' != ''">
-    <TargetFramework Condition="$(TargetFrameworks.Contains('$(CodeBoardingWorkspaceTargetFramework)'))">$(CodeBoardingWorkspaceTargetFramework)</TargetFramework>
-    <TargetFramework Condition="'$(TargetFramework)' == ''">$(TargetFrameworks)</TargetFramework>
-  </PropertyGroup>
 </Project>
 """
 
@@ -89,9 +85,8 @@ def _single_target_framework_env(project_root: Path) -> dict[str, str]:
     'netstandard2.0'"`` guard around analyzer ``ProjectReference`` items inverts
     and the analyzer projects reference themselves, which sends Roslyn's
     solution load into unbounded growth. ``TreatAsLocalProperty`` demotes the
-    property so each project sees its declared framework again; the targets file
-    reinstates it for projects that genuinely multi-target and so need one
-    picked for them.
+    property so each project sees its declared framework again. Roslyn retains
+    its normal inner-build expansion for projects that genuinely multi-target.
 
     Folding a multi-target project down to a single framework stays behind
     ``_MULTI_TARGET_PROJECT_THRESHOLD``, because that fold discards frameworks a

--- a/static_analyzer/engine/adapters/csharp_adapter.py
+++ b/static_analyzer/engine/adapters/csharp_adapter.py
@@ -36,7 +36,7 @@ _SINGLE_TARGET_FRAMEWORK_TARGETS = r"""<Project>
   <Import
     Project="$(CodeBoardingDirectoryBuildTargetsPath)"
     Condition="Exists('$(CodeBoardingDirectoryBuildTargetsPath)')" />
-  <PropertyGroup Condition="'$(TargetFrameworks)' != ''">
+  <PropertyGroup Condition="'$(TargetFrameworks)' != '' and '$(CodeBoardingFoldMultiTargetFrameworks)' == 'true'">
     <CodeBoardingTargetFrameworks>$([System.Text.RegularExpressions.Regex]::Replace('$(TargetFrameworks)', '\s', ''))</CodeBoardingTargetFrameworks>
     <CodeBoardingTargetFrameworks>$([System.Text.RegularExpressions.Regex]::Replace('$(CodeBoardingTargetFrameworks)', ';+', ';'))</CodeBoardingTargetFrameworks>
     <CodeBoardingTargetFrameworks>;$([System.String]::Copy('$(CodeBoardingTargetFrameworks)').Trim(';'));</CodeBoardingTargetFrameworks>
@@ -44,27 +44,76 @@ _SINGLE_TARGET_FRAMEWORK_TARGETS = r"""<Project>
     <TargetFrameworks>$([System.String]::Copy('$(CodeBoardingTargetFrameworks)').Trim(';').Split(';')[0])</TargetFrameworks>
     <TargetFrameworks Condition="'$(CodeBoardingPreferredTargetFramework)' != '' and $(CodeBoardingTargetFrameworks.Contains(';$(CodeBoardingPreferredTargetFramework);'))">$(CodeBoardingPreferredTargetFramework)</TargetFrameworks>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == '' and '$(TargetFrameworks)' != ''">
+    <TargetFramework Condition="$(TargetFrameworks.Contains('$(CodeBoardingWorkspaceTargetFramework)'))">$(CodeBoardingWorkspaceTargetFramework)</TargetFramework>
+    <TargetFramework Condition="'$(TargetFramework)' == ''">$(TargetFrameworks)</TargetFramework>
+  </PropertyGroup>
+</Project>
+"""
+
+_WORKSPACE_TARGET_FRAMEWORK_PROPS = r"""<Project TreatAsLocalProperty="TargetFramework">
+  <PropertyGroup>
+    <CodeBoardingWorkspaceTargetFramework>$(TargetFramework)</CodeBoardingWorkspaceTargetFramework>
+    <CodeBoardingDirectoryBuildPropsPath Condition="'$(CodeBoardingOriginalDirectoryBuildPropsPath)' == ''">$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildProjectDirectory)'))</CodeBoardingDirectoryBuildPropsPath>
+  </PropertyGroup>
+  <Import
+    Project="$(CodeBoardingOriginalDirectoryBuildPropsPath)"
+    Condition="Exists('$(CodeBoardingOriginalDirectoryBuildPropsPath)')" />
+  <Import
+    Project="$(CodeBoardingDirectoryBuildPropsPath)"
+    Condition="Exists('$(CodeBoardingDirectoryBuildPropsPath)')" />
 </Project>
 """
 
 
+def _write_injected_import(name: str, content: str) -> Path:
+    """Materialize an MSBuild import CodeBoarding injects via environment variable."""
+    path = get_servers_dir() / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if not path.exists() or path.read_text(encoding="utf-8") != content:
+        temporary_path = path.with_name(f"{path.name}.{os.getpid()}.tmp")
+        temporary_path.write_text(content, encoding="utf-8")
+        os.replace(temporary_path, path)
+    return path
+
+
 def _single_target_framework_env(project_root: Path) -> dict[str, str]:
-    """Prevent csharp-ls's exponential multi-target framework fold."""
+    """Keep csharp-ls's workspace-wide TargetFramework from rewriting single-target projects.
+
+    Why: csharp-ls folds every project's frameworks into one global MSBuild
+    ``TargetFramework``. A global property outranks a project's own
+    ``<TargetFramework>``, so a solution whose projects do not all share one
+    framework has that property forced onto the odd ones out. Conditions keyed
+    on ``$(TargetFramework)`` then evaluate against a framework the project does
+    not target -- the idiomatic ``Condition="'$(TargetFramework)' !=
+    'netstandard2.0'"`` guard around analyzer ``ProjectReference`` items inverts
+    and the analyzer projects reference themselves, which sends Roslyn's
+    solution load into unbounded growth. ``TreatAsLocalProperty`` demotes the
+    property so each project sees its declared framework again; the targets file
+    reinstates it for projects that genuinely multi-target and so need one
+    picked for them.
+
+    Folding a multi-target project down to a single framework stays behind
+    ``_MULTI_TARGET_PROJECT_THRESHOLD``, because that fold discards frameworks a
+    small solution may want analyzed. Demoting the property has no such cost: it
+    only changes evaluation for a project whose declared framework the workspace
+    value contradicts, so it applies to every solution.
+    """
+    targets_path = _write_injected_import("csharp-ls-single-target.targets", _SINGLE_TARGET_FRAMEWORK_TARGETS)
+    props_path = _write_injected_import("csharp-ls-workspace-tfm.props", _WORKSPACE_TARGET_FRAMEWORK_PROPS)
+
+    env = {"DirectoryBuildTargetsPath": str(targets_path), "DirectoryBuildPropsPath": str(props_path)}
+
     project_count = sum(1 for pattern in ("*.csproj", "*.fsproj") for _ in project_root.rglob(pattern))
-    if project_count <= _MULTI_TARGET_PROJECT_THRESHOLD:
-        return {}
+    if project_count > _MULTI_TARGET_PROJECT_THRESHOLD:
+        env["CodeBoardingFoldMultiTargetFrameworks"] = "true"
 
-    targets_path = get_servers_dir() / "csharp-ls-single-target.targets"
-    targets_path.parent.mkdir(parents=True, exist_ok=True)
-    if not targets_path.exists() or targets_path.read_text(encoding="utf-8") != _SINGLE_TARGET_FRAMEWORK_TARGETS:
-        temporary_path = targets_path.with_name(f"{targets_path.name}.{os.getpid()}.tmp")
-        temporary_path.write_text(_SINGLE_TARGET_FRAMEWORK_TARGETS, encoding="utf-8")
-        os.replace(temporary_path, targets_path)
-
-    env = {"DirectoryBuildTargetsPath": str(targets_path)}
     original_targets_path = os.environ.get("DirectoryBuildTargetsPath")
     if original_targets_path:
         env["CodeBoardingOriginalDirectoryBuildTargetsPath"] = original_targets_path
+    original_props_path = os.environ.get("DirectoryBuildPropsPath")
+    if original_props_path:
+        env["CodeBoardingOriginalDirectoryBuildPropsPath"] = original_props_path
     return env
 
 

--- a/tests/static_analyzer/scripts/csharp_mixed_framework_repro.py
+++ b/tests/static_analyzer/scripts/csharp_mixed_framework_repro.py
@@ -1,0 +1,131 @@
+"""Generate a C# solution that reproduces the csharp-ls solution-load blowup.
+
+csharp-ls folds every project's frameworks into one global MSBuild
+``TargetFramework``. A global property outranks a project's own
+``<TargetFramework>``, so in a solution that does not target one framework
+throughout, the odd projects out are evaluated under a framework they do not
+target. The generated solution wires Roslyn analyzers in through the idiomatic
+``Condition="'$(TargetFramework)' != 'netstandard2.0'"`` guard, which inverts
+under that property and makes the analyzer projects reference themselves.
+Roslyn's solution load then grows without bound.
+
+    uv run python tests/static_analyzer/scripts/csharp_mixed_framework_repro.py /tmp/repro
+    cd /tmp/repro && dotnet restore Synthetic.slnx
+
+Then point CodeBoarding at ``/tmp/repro``. Before the fix the CSharp sync probe
+never returns; after it the analysis completes in well under a minute.
+
+``--variant name-guard`` keys the same guard on ``$(MSBuildProjectName)``, which
+a global framework cannot invert. It is the control: it loads fine either way,
+which isolates the cause to the property rather than to solution size.
+"""
+
+import argparse
+import shutil
+from pathlib import Path
+
+ANALYZERS = ["Gen.Contracts", "Gen", "Analyzers", "CodeFixers"]
+
+NUGET_CONFIG = """<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>
+"""
+
+LIB_CSPROJ = """<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+</Project>
+"""
+
+ANALYZER_CSPROJ = """<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+</Project>
+"""
+
+CS_FILE = """namespace {ns};
+
+public sealed class {cls}
+{{
+    public int Value {{ get; init; }}
+
+    public int Compute(int seed) => seed + Value + {n};
+}}
+"""
+
+DIRECTORY_BUILD_PROPS = """<Project>
+  <PropertyGroup>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <!-- Wire the analyzers into every project except the analyzer projects themselves. -->
+  <ItemGroup Condition="{guard}">
+{refs}
+  </ItemGroup>
+</Project>
+"""
+
+
+def _guard(variant: str) -> str:
+    if variant == "name-guard":
+        return " and ".join(f"'$(MSBuildProjectName)' != '{a}'" for a in ANALYZERS)
+    return "'$(TargetFramework)' != 'netstandard2.0'"
+
+
+def generate(root: Path, projects: int, files_per_project: int, variant: str) -> None:
+    refs = "\n".join(
+        f'    <ProjectReference Include="$(MSBuildThisFileDirectory)src/analyzers/{a}/{a}.csproj"\n'
+        f'                      OutputItemType="Analyzer" ReferenceOutputAssembly="true" PrivateAssets="all" />'
+        for a in ANALYZERS
+    )
+    (root / "nuget.config").write_text(NUGET_CONFIG)
+    (root / "Directory.Build.props").write_text(DIRECTORY_BUILD_PROPS.format(guard=_guard(variant), refs=refs))
+
+    project_paths: list[str] = []
+    for analyzer in ANALYZERS:
+        directory = root / "src" / "analyzers" / analyzer
+        directory.mkdir(parents=True)
+        (directory / f"{analyzer}.csproj").write_text(ANALYZER_CSPROJ)
+        name = analyzer.replace(".", "")
+        (directory / f"{name}.cs").write_text(CS_FILE.format(ns=f"Synthetic.Analyzers.{analyzer}", cls=name, n=1))
+        project_paths.append(f"src/analyzers/{analyzer}/{analyzer}.csproj")
+
+    for index in range(projects):
+        name = f"Lib{index:03d}"
+        directory = root / "src" / "libs" / name
+        directory.mkdir(parents=True)
+        (directory / f"{name}.csproj").write_text(LIB_CSPROJ)
+        for file_index in range(files_per_project):
+            (directory / f"Type{file_index:02d}.cs").write_text(
+                CS_FILE.format(ns=f"Synthetic.{name}", cls=f"Type{file_index:02d}", n=index * 100 + file_index)
+            )
+        project_paths.append(f"src/libs/{name}/{name}.csproj")
+
+    entries = "\n".join(f'  <Project Path="{path}" />' for path in project_paths)
+    (root / "Synthetic.slnx").write_text(f"<Solution>\n{entries}\n</Solution>\n")
+
+    print(f"generated {root}: {len(project_paths)} projects, variant={variant}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("out", type=Path)
+    parser.add_argument("--projects", type=int, default=40)
+    parser.add_argument("--files-per-project", type=int, default=8)
+    parser.add_argument("--variant", choices=["tfm-guard", "name-guard"], default="tfm-guard")
+    args = parser.parse_args()
+
+    if args.out.exists():
+        shutil.rmtree(args.out)
+    args.out.mkdir(parents=True)
+    generate(args.out, args.projects, args.files_per_project, args.variant)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/static_analyzer/test_csharp_adapter.py
+++ b/tests/static_analyzer/test_csharp_adapter.py
@@ -310,19 +310,25 @@ class TestLspEnv:
         targets_path = Path(env["DirectoryBuildTargetsPath"])
 
         assert env["DOTNET_ROOT"] == "/private"
+        assert env["CodeBoardingFoldMultiTargetFrameworks"] == "true"
         assert targets_path.is_file()
         targets = targets_path.read_text()
         assert "<TargetFrameworks>" in targets
         assert "$(BundledNETCoreAppTargetFrameworkVersion)" in targets
 
-    def test_project_env_leaves_small_workspaces_unchanged(self, monkeypatch, tmp_path):
+    def test_project_env_leaves_small_workspaces_multi_targeting(self, monkeypatch, tmp_path):
+        """Folding away frameworks costs a small solution coverage; demoting the property does not."""
         (tmp_path / "Project.csproj").touch()
         monkeypatch.setattr(
             "static_analyzer.engine.adapters.csharp_adapter.resolve_dotnet_sdk",
             lambda _root: _dotnet_resolution("/private/dotnet", {"DOTNET_ROOT": "/private"}),
         )
+        monkeypatch.setattr("static_analyzer.engine.adapters.csharp_adapter.get_servers_dir", lambda: tmp_path)
 
-        assert CSharpAdapter().get_lsp_env(tmp_path) == {"DOTNET_ROOT": "/private"}
+        env = CSharpAdapter().get_lsp_env(tmp_path)
+
+        assert "CodeBoardingFoldMultiTargetFrameworks" not in env
+        assert Path(env["DirectoryBuildPropsPath"]).is_file()
 
     def test_project_env_preserves_custom_directory_build_targets(self, monkeypatch, tmp_path):
         for index in range(26):
@@ -339,6 +345,45 @@ class TestLspEnv:
 
         assert env["CodeBoardingOriginalDirectoryBuildTargetsPath"] == str(custom_targets)
         assert env["DirectoryBuildTargetsPath"] != str(custom_targets)
+
+    def test_project_env_demotes_workspace_target_framework(self, monkeypatch, tmp_path):
+        """A global TargetFramework silently rewrites projects that target something else."""
+        for index in range(26):
+            (tmp_path / f"Project{index}.csproj").touch()
+        monkeypatch.setattr(
+            "static_analyzer.engine.adapters.csharp_adapter.resolve_dotnet_sdk",
+            lambda _root: _dotnet_resolution(),
+        )
+        monkeypatch.setattr("static_analyzer.engine.adapters.csharp_adapter.get_servers_dir", lambda: tmp_path)
+
+        env = CSharpAdapter().get_lsp_env(tmp_path)
+        props_path = Path(env["DirectoryBuildPropsPath"])
+
+        assert props_path.is_file()
+        props = props_path.read_text()
+        assert 'TreatAsLocalProperty="TargetFramework"' in props
+        assert (
+            "<CodeBoardingWorkspaceTargetFramework>$(TargetFramework)</CodeBoardingWorkspaceTargetFramework>" in props
+        )
+        # Multi-target projects still get one framework picked for them.
+        targets = Path(env["DirectoryBuildTargetsPath"]).read_text()
+        assert "$(CodeBoardingWorkspaceTargetFramework)" in targets
+
+    def test_project_env_preserves_custom_directory_build_props(self, monkeypatch, tmp_path):
+        for index in range(26):
+            (tmp_path / f"Project{index}.csproj").touch()
+        custom_props = tmp_path / "custom.props"
+        monkeypatch.setenv("DirectoryBuildPropsPath", str(custom_props))
+        monkeypatch.setattr(
+            "static_analyzer.engine.adapters.csharp_adapter.resolve_dotnet_sdk",
+            lambda _root: _dotnet_resolution(),
+        )
+        monkeypatch.setattr("static_analyzer.engine.adapters.csharp_adapter.get_servers_dir", lambda: tmp_path)
+
+        env = CSharpAdapter().get_lsp_env(tmp_path)
+
+        assert env["CodeBoardingOriginalDirectoryBuildPropsPath"] == str(custom_props)
+        assert env["DirectoryBuildPropsPath"] != str(custom_props)
 
 
 class TestReferenceTracking:

--- a/tests/static_analyzer/test_csharp_adapter.py
+++ b/tests/static_analyzer/test_csharp_adapter.py
@@ -365,9 +365,9 @@ class TestLspEnv:
         assert (
             "<CodeBoardingWorkspaceTargetFramework>$(TargetFramework)</CodeBoardingWorkspaceTargetFramework>" in props
         )
-        # Multi-target projects still get one framework picked for them.
         targets = Path(env["DirectoryBuildTargetsPath"]).read_text()
-        assert "$(CodeBoardingWorkspaceTargetFramework)" in targets
+        assert "<TargetFramework Condition=" not in targets
+        assert "<TargetFramework>$(TargetFrameworks)</TargetFramework>" not in targets
 
     def test_project_env_preserves_custom_directory_build_props(self, monkeypatch, tmp_path):
         for index in range(26):


### PR DESCRIPTION
## Summary

- retain PR #456's `TreatAsLocalProperty` fix for workspace-wide `TargetFramework` overrides
- preserve Roslyn's normal outer/inner-build expansion for genuine multi-target projects
- keep the existing large-workspace framework fold separately gated

## Why

PR #456's targets fallback assigned the entire semicolon-delimited `TargetFrameworks` value to singular `TargetFramework` when no workspace framework was selected. That poisons normal multi-target evaluation and caused the C# integration regression. Removing only that fallback fixes the regression without weakening the analyzer self-reference fix.

This incorporates and corrects #456 because its source branch is in a contributor fork and cannot be updated from this repository branch.

## Validation

- focused C# adapter tests: 5 passed
- Black and mypy checks passed
- committed mixed-framework integration fixture: analyzer self-reference absent and normal multi-target outer build preserved
- fixture csharp-ls document-symbol probe passed
- existing real-repository C# document-symbol regression passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved C# project loading for large mixed-target-framework workspaces.
  * Preserved custom build configuration paths while applying workspace framework settings.
  * Stabilized generated build configuration updates to prevent incomplete files.

* **Tests**
  * Added coverage for small and large workspace framework behavior.
  * Added a utility for reproducing mixed-framework C# solution loading issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->