### PR TITLE
chore: prepare release 0.13.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "codeboarding"
-version = "0.13.6"
+version = "0.13.7"
 description = "Interactive Diagrams for Code"
 readme = "PYPI.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -332,7 +332,7 @@ wheels = [
 
 [[package]]
 name = "codeboarding"
-version = "0.13.6"
+version = "0.13.7"
 source = { editable = "." }
 dependencies = [
     { name = "docker" },


### PR DESCRIPTION
Bump CodeBoarding version to 0.13.7 and update lockfile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project version to 0.13.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->