### PR TITLE
fix(lsp): surface why a slow LSP request is slow

### DIFF
--- a/static_analyzer/engine/lsp_client.py
+++ b/static_analyzer/engine/lsp_client.py
@@ -13,15 +13,19 @@ import queue
 import subprocess
 import threading
 import time
+from collections import deque
 from collections.abc import Callable
 from pathlib import Path
 
+from static_analyzer.engine.process_memory import format_bytes, process_tree_rss
 from static_analyzer.engine.utils import uri_to_path
 from static_analyzer.lsp_client.diagnostics import FileDiagnosticsMap, LSPDiagnostic
 
 logger = logging.getLogger(__name__)
 
 LSP_METHOD_NOT_FOUND = -32601
+SLOW_REQUEST_HEARTBEAT_SECONDS = 60.0
+RETAINED_STDERR_LINES = 40
 ProgressToken = str | int
 
 
@@ -77,6 +81,8 @@ class LSPClient:
         self._request_id = 0
         self._msg_queue: queue.Queue[dict] = queue.Queue()
         self._reader_thread: threading.Thread | None = None
+        self._stderr_thread: threading.Thread | None = None
+        self._stderr_tail: deque[str] = deque(maxlen=RETAINED_STDERR_LINES)
         self._shutdown_event = threading.Event()
         self._write_lock = threading.Lock()
 
@@ -117,7 +123,7 @@ class LSPClient:
                 self._command,
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
-                stderr=subprocess.DEVNULL,
+                stderr=subprocess.PIPE,
                 env=env,
                 cwd=str(self._project_root),
             )
@@ -136,6 +142,8 @@ class LSPClient:
         # Start background reader
         self._reader_thread = threading.Thread(target=self._reader_loop, daemon=True)
         self._reader_thread.start()
+        self._stderr_thread = threading.Thread(target=self._drain_stderr, daemon=True)
+        self._stderr_thread.start()
 
         root_uri = self._project_root.as_uri()
 
@@ -602,10 +610,22 @@ class LSPClient:
         }
         self._write_message(message)
 
-        deadline = time.monotonic() + timeout
+        started = time.monotonic()
+        deadline = started + timeout
+        next_heartbeat = started + SLOW_REQUEST_HEARTBEAT_SECONDS
         while time.monotonic() < deadline:
             msg = self._next_response(deadline)
             if msg is None:
+                if time.monotonic() >= next_heartbeat:
+                    next_heartbeat = time.monotonic() + SLOW_REQUEST_HEARTBEAT_SECONDS
+                    logger.info(
+                        "Still waiting on %s (request %d): %.0fs of %ds elapsed, server memory %s",
+                        method,
+                        req_id,
+                        time.monotonic() - started,
+                        timeout,
+                        self._server_memory(),
+                    )
                 continue
             if msg.get("id") != req_id:
                 continue
@@ -623,7 +643,47 @@ class LSPClient:
                 return None
             return msg.get("result")
 
-        raise TimeoutError(f"Timeout waiting for LSP response to request {req_id}")
+        raise TimeoutError(
+            f"Timeout waiting for LSP response to request {req_id} ({method}) after {timeout}s; "
+            f"server memory {self._server_memory()}{self._stderr_suffix()}"
+        )
+
+    def _drain_stderr(self) -> None:
+        """Retain the tail of the server's stderr.
+
+        Why: a language server that dies mid-request explains itself on stderr and
+        nowhere else -- csharp-ls prints ``Out of memory.`` there when its heap
+        ceiling is hit. Discarding the stream leaves only a bare timeout.
+        """
+        stream = self._process.stderr if self._process else None
+        if stream is None:
+            return
+        for raw in iter(stream.readline, b""):
+            line = raw.decode("utf-8", errors="replace").rstrip()
+            if line:
+                self._stderr_tail.append(line)
+
+    def _stderr_suffix(self) -> str:
+        """Server stderr formatted for appending to an exception message."""
+        tail = self.server_stderr_tail()
+        return f"; server stderr:\n{tail}" if tail else ""
+
+    def server_stderr_tail(self) -> str:
+        """The retained stderr tail, newest last, empty when the server said nothing."""
+        return "\n".join(self._stderr_tail)
+
+    def _server_memory(self) -> str:
+        """Resident memory of the server process tree, for slow-request diagnostics.
+
+        Why: a server that is still allocating is working or leaking, whereas a
+        flat one is stuck. That distinction is invisible from a bare timeout.
+        """
+        if self._process is None or self._process.poll() is not None:
+            return "server not running"
+        try:
+            return format_bytes(process_tree_rss(self._process.pid))
+        except OSError:
+            return "unavailable"
 
     def _send_notification(self, method: str, params: dict | list | None) -> None:
         """Send a JSON-RPC notification (no response expected)."""
@@ -663,7 +723,9 @@ class LSPClient:
             message = self._msg_queue.get(timeout=min(remaining, 1.0))
         except queue.Empty:
             if self._process and self._process.poll() is not None:
-                raise RuntimeError(f"LSP server process exited with code {self._process.returncode}") from None
+                raise RuntimeError(
+                    f"LSP server process exited with code {self._process.returncode}{self._stderr_suffix()}"
+                ) from None
             return None
 
         # Skip notifications that leaked past the reader loop

--- a/tests/static_analyzer/test_lsp_client.py
+++ b/tests/static_analyzer/test_lsp_client.py
@@ -4,8 +4,10 @@ These tests mock subprocess/IO to test the protocol logic
 without starting a real LSP server.
 """
 
+import io
 import json
 import os
+import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -1068,3 +1070,56 @@ class TestShutdown:
 
         assert len(client._opened_uris) == 0
         assert len(client._doc_versions) == 0
+
+
+class TestSlowRequestDiagnostics:
+    """A bare timeout cannot distinguish a server that is stuck from one that is leaking."""
+
+    @staticmethod
+    def _client_with_server(stderr_lines: list[str]) -> tuple[LSPClient, MagicMock]:
+        client = LSPClient(["cmd"], Path("/root"))
+        mock_process = MagicMock()
+        mock_process.stdin = MagicMock()
+        mock_process.poll.return_value = None
+        client._process = mock_process
+        client._stderr_tail.extend(stderr_lines)
+        return client, mock_process
+
+    def test_timeout_names_the_method_and_reports_memory(self):
+        client, _ = self._client_with_server([])
+        with patch("static_analyzer.engine.lsp_client.process_tree_rss", return_value=12_479 * 1024 * 1024):
+            with pytest.raises(TimeoutError) as excinfo:
+                client._send_request("textDocument/documentSymbol", {}, timeout=1)
+
+        message = str(excinfo.value)
+        assert "textDocument/documentSymbol" in message
+        assert "12.2 GB" in message or "GB" in message
+
+    def test_timeout_includes_server_stderr(self):
+        client, _ = self._client_with_server(["Roslyn.Solution: loading", "Out of memory."])
+        with patch("static_analyzer.engine.lsp_client.process_tree_rss", return_value=0):
+            with pytest.raises(TimeoutError, match="Out of memory."):
+                client._send_request("textDocument/documentSymbol", {}, timeout=1)
+
+    def test_process_exit_includes_server_stderr(self):
+        client, mock_process = self._client_with_server(["Out of memory."])
+        mock_process.poll.return_value = 134
+        with pytest.raises(RuntimeError, match="Out of memory."):
+            client._next_response(time.monotonic() + 0.05)
+
+    def test_stderr_tail_is_bounded(self):
+        from static_analyzer.engine.lsp_client import RETAINED_STDERR_LINES
+
+        client = LSPClient(["cmd"], Path("/root"))
+        mock_process = MagicMock()
+        mock_process.stderr = io.BytesIO(b"".join(f"line{i}\n".encode() for i in range(500)))
+        client._process = mock_process
+
+        client._drain_stderr()
+
+        assert len(client._stderr_tail) == RETAINED_STDERR_LINES
+        assert client.server_stderr_tail().endswith("line499")
+
+    def test_server_memory_reports_not_running(self):
+        client = LSPClient(["cmd"], Path("/root"))
+        assert client._server_memory() == "server not running"


### PR DESCRIPTION
## WHAT

Make a stalled LSP request explain itself. No behaviour change to analysis, no timeout values touched.

Follow-up to #456/#457. Those fixed *a* cause of an unbounded C# solution load; this makes the *next* one diagnosable in minutes instead of never.

## WHY

The failure mode #457 fixed presented like this, and this is the entire log:

```
Analyzing 7585 CSharp files
Waiting for LSP server indexing (timeout=1800s)...
<1800 seconds of silence>
Error during engine analysis for CSharp: Timeout waiting for LSP response to request 2
```

Three things are missing from that, and each cost real investigation time:

1. **The message names no method.** "request 2" does not say the sync probe stalled.
2. **No sign of what the server was doing.** A server that is stuck and a server that is allocating without bound need opposite responses — wait longer vs. never succeeds. Nothing distinguished them.
3. **The server's own explanation was thrown away.** `stderr` went to `DEVNULL`, and that is the *only* place csharp-ls prints `Out of memory.` when it hits its heap ceiling. Combined with the probe deadline landing ~10 minutes *before* the crash, the actual error had never been observed upstream — the 1800s cap hid it, and `DEVNULL` would have hidden it even with a longer cap.

## HOW

- Requests outliving `SLOW_REQUEST_HEARTBEAT_SECONDS` (60s) log elapsed time and the server's process-tree RSS once a minute, reusing `process_memory` from #448.
- `TimeoutError` now carries the method, the timeout, and the server's memory.
- The server's stderr is drained into a bounded `deque` (last 40 lines) and appended to timeouts and to the unexpected-exit `RuntimeError`.

The heartbeat only evaluates on an empty-queue iteration and only after the interval elapses, so a normal fast request pays nothing. `stderr` moves from `DEVNULL` to `PIPE` with a dedicated drain thread, so no server can block on a full stderr pipe.

## HOW TESTED

Live, driving the engine against a 2404-file synthetic solution that reproduces an unbounded solution load, with csharp-ls's heap capped so it dies within minutes. The leak is now visible while it happens:

```
Still waiting on textDocument/documentSymbol (request 2): 60s of 1800s elapsed, server memory 342.5MB
Still waiting on textDocument/documentSymbol (request 2): 120s of 1800s elapsed, server memory 592.9MB
Still waiting on textDocument/documentSymbol (request 2): 180s of 1800s elapsed, server memory 842.2MB
Still waiting on textDocument/documentSymbol (request 2): 240s of 1800s elapsed, server memory 1.1GB
Still waiting on textDocument/documentSymbol (request 2): 300s of 1800s elapsed, server memory 1.3GB
```

and the death is attributed instead of reported as a timeout:

```
Error during engine analysis for CSharp: LSP server process exited with code -6; server stderr:
...
      Will use MSBuild props: map [(TargetFramework, net10.0)]
Out of memory.
```

That is the message that took a long investigation to see once. Exit `-6` is `SIGABRT`, which is how CoreCLR ends a fatal OOM.

Also confirmed the heartbeat fires on a *healthy* slow load (a 304-project solution whose probe legitimately takes ~180s) without affecting the result.

`uv run pytest` — 2024 passed, 28 skipped. `uv run mypy .` clean on 313 files, `black --check` clean. Five unit tests added covering the enriched timeout, the enriched exit error, stderr-tail bounding, and the not-running case.

## Note

I deliberately did **not** touch `_PROBE_MAX_TIMEOUT`. On the solution that prompted this, the probe answers in ~130-250s once #457 applies, so 1800s is not the constraint — raising it would only have converted a timeout into an OOM.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostics when language services respond slowly, time out, or exit unexpectedly.
  * Error messages now include relevant server output and memory usage details to make failures easier to understand.
  * Preserved recent server error output while limiting retained diagnostic information.
  * Improved handling of server output during startup and ongoing requests.

* **Tests**
  * Added coverage for timeout, process-exit, memory-reporting, and retained-output scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->