### PR TITLE
feat: expose persisted analysis artifact manifest

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -1,6 +1,18 @@
 """Application-level constants for CodeBoarding."""
 
 CODEBOARDING_DIR_NAME = ".codeboarding"
+ANALYSIS_FILENAME = "analysis.json"
+FINGERPRINT_FILENAME = "fingerprint.json"
+STATIC_ANALYSIS_PKL = "static_analysis.pkl"
+STATIC_ANALYSIS_SHA = "static_analysis.sha"
+CODEBOARDING_VERSION_FILENAME = "codeboarding_version.json"
+PERSISTED_ANALYSIS_ARTIFACT_FILENAMES = (
+    ANALYSIS_FILENAME,
+    FINGERPRINT_FILENAME,
+    STATIC_ANALYSIS_PKL,
+    STATIC_ANALYSIS_SHA,
+    CODEBOARDING_VERSION_FILENAME,
+)
 # Ignore-file names read from a repo (``.gitignore`` at the repo root,
 # ``.codeboardingignore`` under ``CODEBOARDING_DIR_NAME``).
 GITIGNORE_FILENAME = ".gitignore"

--- a/static_analyzer/analysis_cache.py
+++ b/static_analyzer/analysis_cache.py
@@ -29,11 +29,12 @@ from typing import TYPE_CHECKING, Any
 
 from filelock import FileLock
 
+from constants import STATIC_ANALYSIS_PKL, STATIC_ANALYSIS_SHA
+from repo_utils.path_utils import to_absolute_path, to_relative_path
 from static_analyzer.analysis_result import AnalysisData, InvalidatedAnalysis, InvalidatedEdge
 from static_analyzer.graph import CallGraph, Edge, EdgeKind
 from static_analyzer.lsp_client.diagnostics import FileDiagnosticsMap
 from static_analyzer.node import Node
-from repo_utils.path_utils import to_absolute_path, to_relative_path
 
 if TYPE_CHECKING:
     from static_analyzer.analysis_result import StaticAnalysisResults
@@ -44,8 +45,6 @@ logger = logging.getLogger(__name__)
 # Run-artifact filenames. Stored in ``<repo>/.codeboarding/`` (sibling of
 # ``analysis.json``), not under ``cache/`` — losing them costs a full LSP
 # re-index, so they're not safe to wipe with the rest of the cache.
-STATIC_ANALYSIS_PKL = "static_analysis.pkl"
-STATIC_ANALYSIS_SHA = "static_analysis.sha"
 STATIC_ANALYSIS_LOCK = "static_analysis.lock"
 # Legacy location ``StaticAnalysisCache`` wrote to before the run-artifact
 # split. Kept for one-time read fallback so CLI users transition smoothly.

--- a/tests/test_persisted_analysis_artifacts.py
+++ b/tests/test_persisted_analysis_artifacts.py
@@ -1,0 +1,29 @@
+from constants import (
+    ANALYSIS_FILENAME,
+    CODEBOARDING_VERSION_FILENAME,
+    FINGERPRINT_FILENAME,
+    PERSISTED_ANALYSIS_ARTIFACT_FILENAMES,
+    STATIC_ANALYSIS_PKL,
+    STATIC_ANALYSIS_SHA,
+)
+from static_analyzer.analysis_cache import (
+    STATIC_ANALYSIS_PKL as COMPAT_STATIC_ANALYSIS_PKL,
+    STATIC_ANALYSIS_SHA as COMPAT_STATIC_ANALYSIS_SHA,
+)
+from utils import ANALYSIS_FILENAME as COMPAT_ANALYSIS_FILENAME
+from utils import FINGERPRINT_FILENAME as COMPAT_FINGERPRINT_FILENAME
+
+
+def test_persisted_analysis_artifact_manifest_and_compatibility_imports():
+    assert PERSISTED_ANALYSIS_ARTIFACT_FILENAMES == (
+        "analysis.json",
+        "fingerprint.json",
+        "static_analysis.pkl",
+        "static_analysis.sha",
+        "codeboarding_version.json",
+    )
+    assert CODEBOARDING_VERSION_FILENAME == "codeboarding_version.json"
+    assert COMPAT_ANALYSIS_FILENAME == ANALYSIS_FILENAME
+    assert COMPAT_FINGERPRINT_FILENAME == FINGERPRINT_FILENAME
+    assert COMPAT_STATIC_ANALYSIS_PKL == STATIC_ANALYSIS_PKL
+    assert COMPAT_STATIC_ANALYSIS_SHA == STATIC_ANALYSIS_SHA

--- a/utils.py
+++ b/utils.py
@@ -7,14 +7,12 @@ import uuid
 from collections.abc import Iterable
 from pathlib import Path
 
-from constants import CODEBOARDING_DIR_NAME
+from constants import ANALYSIS_FILENAME, CODEBOARDING_DIR_NAME, FINGERPRINT_FILENAME
 from repo_utils.path_utils import to_absolute_path, to_relative_path
 
 logger = logging.getLogger(__name__)
 
 RUN_OUTPUT_DIR_NAME = "run-output"
-ANALYSIS_FILENAME = "analysis.json"
-FINGERPRINT_FILENAME = "fingerprint.json"
 
 
 class CFGGenerationError(Exception):


### PR DESCRIPTION
## Summary
- centralize persisted analysis artifact filenames in Core
- preserve the existing compatibility imports
- expose one ordered manifest for thin integrations such as CodeBoarding-action v2

Companion to CodeBoarding/CodeBoarding-action#69.

## Validation
- focused manifest test passes
- Black and mypy pass on changed files
- full suite: 2019 passed, 28 skipped, 1 unrelated environment-dependent failure because dotnet is unavailable; coverage 83.14%

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Standardized the names of persisted analysis artifacts.
  * Added a complete manifest of stored analysis files, including version information.
  * Preserved compatibility for existing artifact constant imports.

* **Tests**
  * Added coverage verifying artifact filenames, version metadata, and compatibility imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->