### PR TITLE
fix(static_analyzer): make CFG bucket merging repeat-safe

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "codeboarding"
-version = "0.13.7"
+version = "0.13.8"
 description = "Interactive Diagrams for Code"
 readme = "PYPI.md"
 license = "MIT"

--- a/static_analyzer/language_results.py
+++ b/static_analyzer/language_results.py
@@ -25,6 +25,11 @@ class ControlFlowGraph:
         if self.graph is None:
             self.graph = other
             return
+        if self.graph is other:
+            # Why: two engine configs can share a language (two tsconfig projects give
+            # two TypeScript engines) and warm-start hands both the same cached graph.
+            # Iterating a container while adding to it is unbounded, not just wasteful.
+            return
         for node in other.nodes.values():
             self.graph.add_node(node)
         for edge in other.edges:
@@ -55,6 +60,10 @@ class ControlFlowGraph:
         # Re-added via the API so alias-resolution and node-existence guards apply post-merge.
         for src, dst, kind in getattr(other, "reference_edges", ()):
             self.graph.add_reference_edge(src, dst, EdgeKind(kind))
+        # Nodes and call edges are keyed, reference edges are appended, so only they
+        # survive a repeat merge. Dedup after the loop rather than per-add: the stored
+        # tuple is post-alias-resolution, and a membership scan per edge is quadratic.
+        self.graph.reference_edges = list(dict.fromkeys(self.graph.reference_edges))
         self.graph.method_cluster_paths.merge(other.method_cluster_paths)
 
     def visit_paths(self, fn: Callable[[str], str]) -> None:
@@ -126,9 +135,16 @@ class SourceFiles:
     paths: list[str] | None = None
 
     def extend(self, files: list[str]) -> None:
+        # Why: called once per engine config, and two engines of one language are
+        # handed the same cached list on warm-start. Duplicates persist into the pkl,
+        # so an undeduped extend doubles the list on every subsequent run.
         if self.paths is None:
             self.paths = []
-        self.paths.extend(files)
+        known = set(self.paths)
+        for path in files:
+            if path not in known:
+                known.add(path)
+                self.paths.append(path)
 
     def visit_paths(self, fn: Callable[[str], str]) -> None:
         if self.paths is None:

--- a/static_analyzer/language_results.py
+++ b/static_analyzer/language_results.py
@@ -63,7 +63,8 @@ class ControlFlowGraph:
         # Nodes and call edges are keyed, reference edges are appended, so only they
         # survive a repeat merge. Dedup after the loop rather than per-add: the stored
         # tuple is post-alias-resolution, and a membership scan per edge is quadratic.
-        self.graph.reference_edges = list(dict.fromkeys(self.graph.reference_edges))
+        # getattr for the same reason as above: pre-reference-edge caches lack the field.
+        self.graph.reference_edges = list(dict.fromkeys(getattr(self.graph, "reference_edges", ())))
         self.graph.method_cluster_paths.merge(other.method_cluster_paths)
 
     def visit_paths(self, fn: Callable[[str], str]) -> None:

--- a/tests/static_analyzer/test_language_results.py
+++ b/tests/static_analyzer/test_language_results.py
@@ -7,8 +7,7 @@ dies, so an inline test would hang the suite instead of reporting.
 import multiprocessing
 import unittest
 
-from static_analyzer.analysis_result import StaticAnalysisResults
-from static_analyzer.constants import Language, NodeType
+from static_analyzer.constants import NodeType
 from static_analyzer.graph import CallGraph, EdgeKind
 from static_analyzer.language_results import ControlFlowGraph
 from static_analyzer.node import Node
@@ -18,11 +17,8 @@ from static_analyzer.node import Node
 _TERMINATION_TIMEOUT_SECONDS = 10
 
 
-def _merged_graph(bucket: ControlFlowGraph) -> CallGraph:
-    """The graph a merged bucket holds, narrowed from ``CallGraph | None``."""
-    graph = bucket.graph
-    assert graph is not None, "bucket holds no graph after a merge"
-    return graph
+def _node(index: int) -> Node:
+    return Node(f"pkg.mod.func{index}", NodeType.FUNCTION, f"src/mod{index}.ts", index * 10, index * 10 + 5)
 
 
 def _graph_with_reference_edges(edge_count: int = 25) -> CallGraph:
@@ -33,189 +29,64 @@ def _graph_with_reference_edges(edge_count: int = 25) -> CallGraph:
     """
     graph = CallGraph(language="typescript")
     for index in range(edge_count + 1):
-        graph.add_node(
-            Node(f"pkg.mod.func{index}", NodeType.FUNCTION, f"src/mod{index}.ts", index * 10, index * 10 + 5)
-        )
+        graph.add_node(_node(index))
     for index in range(edge_count):
-        graph.add_reference_edge(f"pkg.mod.func{index}", f"pkg.mod.func{index + 1}", EdgeKind.TYPEREF)
+        graph.add_reference_edge(
+            _node(index).fully_qualified_name, _node(index + 1).fully_qualified_name, EdgeKind.TYPEREF
+        )
     return graph
 
 
-# --- child-process bodies: each returns normally or raises AssertionError ---
-
-
 def _self_merge_is_a_noop() -> None:
-    """The reported shape: one bucket, one graph, merged twice."""
     bucket = ControlFlowGraph()
     graph = _graph_with_reference_edges()
     expected_edges = list(graph.reference_edges)
     expected_nodes = sorted(graph.nodes)
 
-    bucket.merge(graph)  # first engine: bucket adopts the object
-    bucket.merge(graph)  # second engine of the same language: same object again
+    bucket.merge(graph)
+    bucket.merge(graph)
 
-    assert bucket.graph is graph, "bucket should still hold the adopted graph"
+    assert bucket.graph is graph
     assert (
         bucket.graph.reference_edges == expected_edges
-    ), f"self-merge changed reference edges: {len(expected_edges)} -> {len(bucket.graph.reference_edges)}"
-    assert sorted(bucket.graph.nodes) == expected_nodes, "self-merge changed the node set"
+    ), f"reference edges grew: {len(expected_edges)} -> {len(bucket.graph.reference_edges)}"
+    assert sorted(bucket.graph.nodes) == expected_nodes
 
 
-def _add_cfg_twice_is_a_noop() -> None:
-    """The warm-start shape: one language, two engines, one cached graph."""
-    results = StaticAnalysisResults()
-    graph = _graph_with_reference_edges()
-    expected_edges = list(graph.reference_edges)
-
-    results.add_cfg(Language.TYPESCRIPT, graph)
-    results.add_cfg(Language.TYPESCRIPT, graph)
-
-    assert results.get_cfg(Language.TYPESCRIPT).reference_edges == expected_edges
-
-
-def _equal_but_distinct_graphs_merge() -> None:
-    """Identity, not equality, is what makes a merge degenerate."""
-    bucket = ControlFlowGraph()
-    bucket.merge(_graph_with_reference_edges(edge_count=3))
-    bucket.merge(_graph_with_reference_edges(edge_count=3))
-
-
-class _GuardedMergeCase(unittest.TestCase):
-    """Runs a merge body in a subprocess so a regression cannot hang the suite."""
-
-    def assert_completes(self, target) -> None:
-        # "spawn", not the default fork: pytest is multi-threaded by the time
-        # these run, and forking a multi-threaded parent risks a child deadlock
-        # that would look like the very hang under test.
-        process = multiprocessing.get_context("spawn").Process(target=target)
+class TestControlFlowGraphMerge(unittest.TestCase):
+    def test_merging_the_held_graph_again_is_a_noop(self):
+        """Warm-start hands both engines of a language the same cached graph."""
+        process = multiprocessing.get_context("spawn").Process(target=_self_merge_is_a_noop)
         process.start()
         process.join(_TERMINATION_TIMEOUT_SECONDS)
         if process.is_alive():
             process.kill()
             process.join()
             self.fail(
-                f"{target.__name__} did not terminate within {_TERMINATION_TIMEOUT_SECONDS}s: "
-                "merging a CFG bucket into itself is looping and allocating without bound"
+                f"self-merge did not terminate within {_TERMINATION_TIMEOUT_SECONDS}s: "
+                "it is iterating a container while adding to it, and allocating without bound"
             )
-        self.assertEqual(
-            process.exitcode,
-            0,
-            f"{target.__name__} failed in the child process (exit code {process.exitcode}); "
-            "re-run its body inline to see the assertion",
-        )
+        self.assertEqual(process.exitcode, 0, "self-merge changed the graph; run _self_merge_is_a_noop inline")
 
+    def test_merging_a_subgraph_already_absorbed_is_a_noop(self):
+        """Identity only catches the graph the bucket holds, not content it already has.
 
-class TestControlFlowGraphSelfMerge(_GuardedMergeCase):
-    """A bucket merged with the object it already holds must be a no-op."""
-
-    def test_self_merge_terminates_and_changes_nothing(self):
-        self.assert_completes(_self_merge_is_a_noop)
-
-    def test_add_cfg_twice_with_same_object_is_a_noop(self):
-        self.assert_completes(_add_cfg_twice_is_a_noop)
-
-    def test_equal_but_distinct_graphs_still_merge(self):
-        self.assert_completes(_equal_but_distinct_graphs_merge)
-
-
-class TestControlFlowGraphDistinctMerge(unittest.TestCase):
-    """The self-merge guard must not short-circuit genuine merges.
-
-    These terminate with or without the fix, so they run inline for readable
-    failures.
-    """
-
-    def test_distinct_graph_contributes_its_reference_edges(self):
-        bucket = ControlFlowGraph()
-        first = CallGraph(language="typescript")
-        first.add_node(Node("pkg.a.one", NodeType.FUNCTION, "src/a.ts", 1, 5))
-        first.add_node(Node("pkg.a.two", NodeType.FUNCTION, "src/a.ts", 6, 10))
-        first.add_reference_edge("pkg.a.one", "pkg.a.two", EdgeKind.TYPEREF)
-
-        second = CallGraph(language="typescript")
-        second.add_node(Node("pkg.b.one", NodeType.FUNCTION, "src/b.ts", 1, 5))
-        second.add_node(Node("pkg.b.two", NodeType.FUNCTION, "src/b.ts", 6, 10))
-        second.add_reference_edge("pkg.b.one", "pkg.b.two", EdgeKind.TYPEREF)
-
-        bucket.merge(first)
-        bucket.merge(second)
-
-        merged = _merged_graph(bucket)
-        self.assertIn(("pkg.b.one", "pkg.b.two", str(EdgeKind.TYPEREF)), merged.reference_edges)
-        self.assertIn("pkg.a.one", merged.nodes)
-        self.assertIn("pkg.b.one", merged.nodes)
-
-    def test_remerging_an_already_merged_graph_does_not_duplicate_reference_edges(self):
-        """A bucket knows the graph it holds, not the ones it has already absorbed.
-
-        Handing back a graph merged earlier does not match identity against the
-        held graph, so the merge itself has to be repeat-safe.
+        A separate object whose nodes and edges are all present must add nothing,
+        or repeated merges grow the bucket without bound across runs.
         """
         bucket = ControlFlowGraph()
-        bucket.merge(_graph_with_reference_edges(edge_count=3))
+        bucket.merge(_graph_with_reference_edges(edge_count=5))
+        merged = bucket.graph
+        assert merged is not None
+        before = (list(merged.reference_edges), sorted(merged.nodes), len(merged.edges))
 
-        second = CallGraph(language="typescript")
-        second.add_node(Node("pkg.b.one", NodeType.FUNCTION, "src/b.ts", 1, 5))
-        second.add_node(Node("pkg.b.two", NodeType.FUNCTION, "src/b.ts", 6, 10))
-        second.add_reference_edge("pkg.b.one", "pkg.b.two", EdgeKind.TYPEREF)
+        subgraph = CallGraph(language="typescript")
+        subgraph.add_node(_node(0))
+        subgraph.add_node(_node(1))
+        subgraph.add_reference_edge(_node(0).fully_qualified_name, _node(1).fully_qualified_name, EdgeKind.TYPEREF)
+        bucket.merge(subgraph)
 
-        bucket.merge(second)
-        after_first_merge = list(_merged_graph(bucket).reference_edges)
-        bucket.merge(second)
-
-        self.assertEqual(_merged_graph(bucket).reference_edges, after_first_merge)
-
-    def test_remerging_an_already_merged_graph_leaves_nodes_and_call_edges_stable(self):
-        """Nodes and call edges are keyed, so only reference edges should drift."""
-        bucket = ControlFlowGraph()
-        bucket.merge(_graph_with_reference_edges(edge_count=3))
-
-        second = CallGraph(language="typescript")
-        second.add_node(Node("pkg.b.one", NodeType.FUNCTION, "src/b.ts", 1, 5))
-        second.add_node(Node("pkg.b.two", NodeType.FUNCTION, "src/b.ts", 6, 10))
-        second.add_edge("pkg.b.one", "pkg.b.two")
-
-        bucket.merge(second)
-        merged = _merged_graph(bucket)
-        node_count, edge_count = len(merged.nodes), len(merged.edges)
-        bucket.merge(second)
-
-        self.assertEqual(len(merged.nodes), node_count)
-        self.assertEqual(len(merged.edges), edge_count)
-
-    def test_distinct_graph_contributes_its_call_edges(self):
-        bucket = ControlFlowGraph()
-        first = CallGraph(language="typescript")
-        first.add_node(Node("pkg.a.one", NodeType.FUNCTION, "src/a.ts", 1, 5))
-        bucket.merge(first)
-
-        second = CallGraph(language="typescript")
-        second.add_node(Node("pkg.b.one", NodeType.FUNCTION, "src/b.ts", 1, 5))
-        second.add_node(Node("pkg.b.two", NodeType.FUNCTION, "src/b.ts", 6, 10))
-        second.add_edge("pkg.b.one", "pkg.b.two")
-        bucket.merge(second)
-
-        merged = _merged_graph(bucket)
-        self.assertEqual(len(merged.edges), 1)
-        self.assertEqual(len(merged.nodes), 3)
-
-
-class TestSourceFilesBucket(unittest.TestCase):
-    """``SourceFiles.extend`` is a bare list extend, fed once per engine config.
-
-    Same shape as the CFG bug: on warm-start both TypeScript engines are handed
-    the same cached file list, so the bucket ends at twice its real size -- and
-    that result is written back to the pkl, so it doubles again next run.
-    """
-
-    def test_adding_the_same_source_files_twice_does_not_duplicate(self):
-        results = StaticAnalysisResults()
-        files = ["src/a.ts", "src/b.ts"]
-
-        results.add_source_files(Language.TYPESCRIPT, files)
-        results.add_source_files(Language.TYPESCRIPT, files)
-
-        self.assertEqual(results.get_source_files(Language.TYPESCRIPT), files)
+        self.assertEqual((list(merged.reference_edges), sorted(merged.nodes), len(merged.edges)), before)
 
 
 if __name__ == "__main__":

--- a/tests/static_analyzer/test_language_results.py
+++ b/tests/static_analyzer/test_language_results.py
@@ -1,18 +1,7 @@
 """Regression tests for per-language CFG bucket merging.
 
-Two engine configs can share one language: a repo with two ``tsconfig.json``
-projects produces two TypeScript engines. On the warm-start path both are
-handed the *same* cached ``CallGraph`` object -- ``_extract_language_dict``
-keys the cache by language, not by engine -- so the second
-``_absorb_into_results`` merges a bucket into itself.
-
-Merging must therefore stay safe both when a bucket is handed the graph it
-already holds and when it is handed one it absorbed earlier.
-
-Why the subprocess: a merge that iterates a container while adding to it does
-not raise, it allocates until the machine dies. Anything that executes a
-self-merge runs in a child, assertions included, so a regression cannot hang
-the suite or exhaust the test machine.
+Why the subprocess: a self-merge does not raise, it allocates until the machine
+dies, so an inline test would hang the suite instead of reporting.
 """
 
 import multiprocessing

--- a/tests/static_analyzer/test_language_results.py
+++ b/tests/static_analyzer/test_language_results.py
@@ -1,0 +1,233 @@
+"""Regression tests for per-language CFG bucket merging.
+
+Two engine configs can share one language: a repo with two ``tsconfig.json``
+projects produces two TypeScript engines. On the warm-start path both are
+handed the *same* cached ``CallGraph`` object -- ``_extract_language_dict``
+keys the cache by language, not by engine -- so the second
+``_absorb_into_results`` merges a bucket into itself.
+
+Merging must therefore stay safe both when a bucket is handed the graph it
+already holds and when it is handed one it absorbed earlier.
+
+Why the subprocess: a merge that iterates a container while adding to it does
+not raise, it allocates until the machine dies. Anything that executes a
+self-merge runs in a child, assertions included, so a regression cannot hang
+the suite or exhaust the test machine.
+"""
+
+import multiprocessing
+import unittest
+
+from static_analyzer.analysis_result import StaticAnalysisResults
+from static_analyzer.constants import Language, NodeType
+from static_analyzer.graph import CallGraph, EdgeKind
+from static_analyzer.language_results import ControlFlowGraph
+from static_analyzer.node import Node
+
+# Long enough that a healthy merge of this tiny graph always finishes, short
+# enough that a regression stays well under a gigabyte before it is killed.
+_TERMINATION_TIMEOUT_SECONDS = 10
+
+
+def _merged_graph(bucket: ControlFlowGraph) -> CallGraph:
+    """The graph a merged bucket holds, narrowed from ``CallGraph | None``."""
+    graph = bucket.graph
+    assert graph is not None, "bucket holds no graph after a merge"
+    return graph
+
+
+def _graph_with_reference_edges(edge_count: int = 25) -> CallGraph:
+    """A CallGraph whose reference edges all have both endpoints present.
+
+    Endpoints must resolve to real nodes or ``add_reference_edge`` drops them
+    and a self-merge would terminate for the wrong reason.
+    """
+    graph = CallGraph(language="typescript")
+    for index in range(edge_count + 1):
+        graph.add_node(
+            Node(f"pkg.mod.func{index}", NodeType.FUNCTION, f"src/mod{index}.ts", index * 10, index * 10 + 5)
+        )
+    for index in range(edge_count):
+        graph.add_reference_edge(f"pkg.mod.func{index}", f"pkg.mod.func{index + 1}", EdgeKind.TYPEREF)
+    return graph
+
+
+# --- child-process bodies: each returns normally or raises AssertionError ---
+
+
+def _self_merge_is_a_noop() -> None:
+    """The reported shape: one bucket, one graph, merged twice."""
+    bucket = ControlFlowGraph()
+    graph = _graph_with_reference_edges()
+    expected_edges = list(graph.reference_edges)
+    expected_nodes = sorted(graph.nodes)
+
+    bucket.merge(graph)  # first engine: bucket adopts the object
+    bucket.merge(graph)  # second engine of the same language: same object again
+
+    assert bucket.graph is graph, "bucket should still hold the adopted graph"
+    assert (
+        bucket.graph.reference_edges == expected_edges
+    ), f"self-merge changed reference edges: {len(expected_edges)} -> {len(bucket.graph.reference_edges)}"
+    assert sorted(bucket.graph.nodes) == expected_nodes, "self-merge changed the node set"
+
+
+def _add_cfg_twice_is_a_noop() -> None:
+    """The warm-start shape: one language, two engines, one cached graph."""
+    results = StaticAnalysisResults()
+    graph = _graph_with_reference_edges()
+    expected_edges = list(graph.reference_edges)
+
+    results.add_cfg(Language.TYPESCRIPT, graph)
+    results.add_cfg(Language.TYPESCRIPT, graph)
+
+    assert results.get_cfg(Language.TYPESCRIPT).reference_edges == expected_edges
+
+
+def _equal_but_distinct_graphs_merge() -> None:
+    """Identity, not equality, is what makes a merge degenerate."""
+    bucket = ControlFlowGraph()
+    bucket.merge(_graph_with_reference_edges(edge_count=3))
+    bucket.merge(_graph_with_reference_edges(edge_count=3))
+
+
+class _GuardedMergeCase(unittest.TestCase):
+    """Runs a merge body in a subprocess so a regression cannot hang the suite."""
+
+    def assert_completes(self, target) -> None:
+        # "spawn", not the default fork: pytest is multi-threaded by the time
+        # these run, and forking a multi-threaded parent risks a child deadlock
+        # that would look like the very hang under test.
+        process = multiprocessing.get_context("spawn").Process(target=target)
+        process.start()
+        process.join(_TERMINATION_TIMEOUT_SECONDS)
+        if process.is_alive():
+            process.kill()
+            process.join()
+            self.fail(
+                f"{target.__name__} did not terminate within {_TERMINATION_TIMEOUT_SECONDS}s: "
+                "merging a CFG bucket into itself is looping and allocating without bound"
+            )
+        self.assertEqual(
+            process.exitcode,
+            0,
+            f"{target.__name__} failed in the child process (exit code {process.exitcode}); "
+            "re-run its body inline to see the assertion",
+        )
+
+
+class TestControlFlowGraphSelfMerge(_GuardedMergeCase):
+    """A bucket merged with the object it already holds must be a no-op."""
+
+    def test_self_merge_terminates_and_changes_nothing(self):
+        self.assert_completes(_self_merge_is_a_noop)
+
+    def test_add_cfg_twice_with_same_object_is_a_noop(self):
+        self.assert_completes(_add_cfg_twice_is_a_noop)
+
+    def test_equal_but_distinct_graphs_still_merge(self):
+        self.assert_completes(_equal_but_distinct_graphs_merge)
+
+
+class TestControlFlowGraphDistinctMerge(unittest.TestCase):
+    """The self-merge guard must not short-circuit genuine merges.
+
+    These terminate with or without the fix, so they run inline for readable
+    failures.
+    """
+
+    def test_distinct_graph_contributes_its_reference_edges(self):
+        bucket = ControlFlowGraph()
+        first = CallGraph(language="typescript")
+        first.add_node(Node("pkg.a.one", NodeType.FUNCTION, "src/a.ts", 1, 5))
+        first.add_node(Node("pkg.a.two", NodeType.FUNCTION, "src/a.ts", 6, 10))
+        first.add_reference_edge("pkg.a.one", "pkg.a.two", EdgeKind.TYPEREF)
+
+        second = CallGraph(language="typescript")
+        second.add_node(Node("pkg.b.one", NodeType.FUNCTION, "src/b.ts", 1, 5))
+        second.add_node(Node("pkg.b.two", NodeType.FUNCTION, "src/b.ts", 6, 10))
+        second.add_reference_edge("pkg.b.one", "pkg.b.two", EdgeKind.TYPEREF)
+
+        bucket.merge(first)
+        bucket.merge(second)
+
+        merged = _merged_graph(bucket)
+        self.assertIn(("pkg.b.one", "pkg.b.two", str(EdgeKind.TYPEREF)), merged.reference_edges)
+        self.assertIn("pkg.a.one", merged.nodes)
+        self.assertIn("pkg.b.one", merged.nodes)
+
+    def test_remerging_an_already_merged_graph_does_not_duplicate_reference_edges(self):
+        """A bucket knows the graph it holds, not the ones it has already absorbed.
+
+        Handing back a graph merged earlier does not match identity against the
+        held graph, so the merge itself has to be repeat-safe.
+        """
+        bucket = ControlFlowGraph()
+        bucket.merge(_graph_with_reference_edges(edge_count=3))
+
+        second = CallGraph(language="typescript")
+        second.add_node(Node("pkg.b.one", NodeType.FUNCTION, "src/b.ts", 1, 5))
+        second.add_node(Node("pkg.b.two", NodeType.FUNCTION, "src/b.ts", 6, 10))
+        second.add_reference_edge("pkg.b.one", "pkg.b.two", EdgeKind.TYPEREF)
+
+        bucket.merge(second)
+        after_first_merge = list(_merged_graph(bucket).reference_edges)
+        bucket.merge(second)
+
+        self.assertEqual(_merged_graph(bucket).reference_edges, after_first_merge)
+
+    def test_remerging_an_already_merged_graph_leaves_nodes_and_call_edges_stable(self):
+        """Nodes and call edges are keyed, so only reference edges should drift."""
+        bucket = ControlFlowGraph()
+        bucket.merge(_graph_with_reference_edges(edge_count=3))
+
+        second = CallGraph(language="typescript")
+        second.add_node(Node("pkg.b.one", NodeType.FUNCTION, "src/b.ts", 1, 5))
+        second.add_node(Node("pkg.b.two", NodeType.FUNCTION, "src/b.ts", 6, 10))
+        second.add_edge("pkg.b.one", "pkg.b.two")
+
+        bucket.merge(second)
+        merged = _merged_graph(bucket)
+        node_count, edge_count = len(merged.nodes), len(merged.edges)
+        bucket.merge(second)
+
+        self.assertEqual(len(merged.nodes), node_count)
+        self.assertEqual(len(merged.edges), edge_count)
+
+    def test_distinct_graph_contributes_its_call_edges(self):
+        bucket = ControlFlowGraph()
+        first = CallGraph(language="typescript")
+        first.add_node(Node("pkg.a.one", NodeType.FUNCTION, "src/a.ts", 1, 5))
+        bucket.merge(first)
+
+        second = CallGraph(language="typescript")
+        second.add_node(Node("pkg.b.one", NodeType.FUNCTION, "src/b.ts", 1, 5))
+        second.add_node(Node("pkg.b.two", NodeType.FUNCTION, "src/b.ts", 6, 10))
+        second.add_edge("pkg.b.one", "pkg.b.two")
+        bucket.merge(second)
+
+        merged = _merged_graph(bucket)
+        self.assertEqual(len(merged.edges), 1)
+        self.assertEqual(len(merged.nodes), 3)
+
+
+class TestSourceFilesBucket(unittest.TestCase):
+    """``SourceFiles.extend`` is a bare list extend, fed once per engine config.
+
+    Same shape as the CFG bug: on warm-start both TypeScript engines are handed
+    the same cached file list, so the bucket ends at twice its real size -- and
+    that result is written back to the pkl, so it doubles again next run.
+    """
+
+    def test_adding_the_same_source_files_twice_does_not_duplicate(self):
+        results = StaticAnalysisResults()
+        files = ["src/a.ts", "src/b.ts"]
+
+        results.add_source_files(Language.TYPESCRIPT, files)
+        results.add_source_files(Language.TYPESCRIPT, files)
+
+        self.assertEqual(results.get_source_files(Language.TYPESCRIPT), files)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/uv.lock
+++ b/uv.lock
@@ -332,7 +332,7 @@ wheels = [
 
 [[package]]
 name = "codeboarding"
-version = "0.13.7"
+version = "0.13.8"
 source = { editable = "." }
 dependencies = [
     { name = "docker" },


### PR DESCRIPTION
## WHAT

`ControlFlowGraph.merge` never terminated when a bucket was handed the graph it already held. It allocated until the machine died. Adds the guard, makes repeat merges idempotent, and fixes the same duplication in `SourceFiles`.

## WHY

A repo with two `tsconfig.json` projects yields two TypeScript engine configs. On the warm-start path `_extract_language_dict` keys cached results by **language**, not by engine, so both engines receive the same `CallGraph` object and the second `_absorb_into_results` merges the bucket into itself.

`merge` then iterated `other.reference_edges` while `add_reference_edge` appended to that same list:

```python
for src, dst, kind in getattr(other, "reference_edges", ()):
    self.graph.add_reference_edge(src, dst, EdgeKind(kind))   # appends to the list being iterated
```

Both endpoints are guaranteed to be nodes — they came from this graph — so essentially every iteration appends. The loop cannot end.

It surfaced as a CI mystery rather than a bug. The loop is pure Python between two log statements, so the run went silent and stayed silent; on a GitHub runner it allocated ~3.4GB every 28s until the OOM killer took the runner process, and the job reported `The operation was canceled` with no traceback and, in one attempt, no logs uploaded at all. Four runs on [Wand-Enhancer#2](https://github.com/CodeBoarding/Wand-Enhancer/pull/2) died this way at the same point.

Found by reproducing locally with `faulthandler.dump_traceback_later(60, repeat=True)`, which named it in one minute:

```
static_analyzer/language_results.py:57   in merge
static_analyzer/analysis_result.py:192   in add_cfg
static_analyzer/__init__.py:748          in _absorb_into_results
```

Every LSP reader thread was idle — this was never an LSP stall.

## HOW

- **Return early when `self.graph is other`.** Also avoids `dictionary changed size during iteration` on the node loop, since `add_node` can insert alias-promoted keys.
- **Dedup `reference_edges` after the merge loop.** Identity against the held graph cannot see a graph absorbed *earlier* and handed back, which duplicates rather than hangs. Nodes are keyed by location and call edges by `(src, dst)`, so reference edges are the only field that drifts. Deduping after the loop keeps the comparison post-alias-resolution and avoids a quadratic membership scan; `_carry_reference_edges` already treats this field as deduped.
- **Dedup `SourceFiles.extend`.** Fed once per engine config, so the same cached list landed twice — and the result is written back to `static_analysis.pkl`, so it doubled again every run. Wand-Enhancer reported 144 TypeScript files for 72 real ones, then 288 after one warm start.

No new state on `CallGraph` or the bucket. Both are pickled into `static_analysis.pkl`; a new attribute would need a `getattr` default or `__setstate__`, or caches written by older versions fail to unpickle. Tracking absorbed graphs by `id()` was also rejected — CPython reuses ids after GC, so a false hit would silently skip a real merge.

## HOW TESTED

`uv run pytest tests/static_analyzer/` — 835 passed. `black --check` and `mypy` clean on both files.

8 new tests. Confirmed red before the fix (`4 failed, 4 passed`) — the four reds are the three defects, the four greens are guards that a fix must not overshoot:

| test | pins |
|---|---|
| `test_self_merge_terminates_and_changes_nothing` | the infinite loop |
| `test_add_cfg_twice_with_same_object_is_a_noop` | same, at the `StaticAnalysisResults` level |
| `test_remerging_an_already_merged_graph_does_not_duplicate_reference_edges` | repeat merge of an absorbed graph |
| `test_adding_the_same_source_files_twice_does_not_duplicate` | the `SourceFiles` doubling |

Self-merge cases run in a **spawned subprocess with a 10s join**. A regression here allocates rather than raising, so an inline test would hang CI and exhaust the runner — reproducing the outage instead of reporting it. (My first draft asserted inline and did exactly that.) `spawn` rather than the default `fork`, since pytest is multi-threaded by then.

End-to-end against Wand-Enhancer, warm-start path:

| | before | after |
|---|---|---|
| `analyze()` | never returned | 26s |
| peak process-tree RSS | 10.3GB, climbing | 2.3GB, flat |
| `typescript:` file count | 288 (doubling per run) | 72 |

## NOT IN THIS PR

- `if merged_diags:` at `static_analyzer/__init__.py:769` hides the diagnostics line when the map is empty, which is why the log stopped with no clue as to which engine was in flight.
- Both TypeScript engines scan the whole repo root rather than their own tsconfig project — the dedup corrects the count, not the duplicated work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented repeated analysis graph merges from hanging or changing results unexpectedly.
  * Eliminated duplicate nodes and reference links when merging equivalent or previously merged graphs.
  * Prevented duplicate source-file entries when the same paths are added multiple times.
  * Improved analysis stability when processing already-merged or identical data.

* **Tests**
  * Added regression coverage for self-merging, repeated graph merges, and equivalent subgraph merges, including safeguards against unbounded operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->