### PR TITLE
fix(lsp): barrier after bulk didOpen for workspace-probing servers

### DIFF
--- a/static_analyzer/engine/call_graph_builder.py
+++ b/static_analyzer/engine/call_graph_builder.py
@@ -162,6 +162,10 @@ class CallGraphBuilder:
             probe_result = self._send_sync_probe(source_files, probe_timeout)
             if not interleave_open:
                 self._bulk_did_open(source_files)
+                # Opening every file queues server work proportional to the file
+                # count, and the next request waits behind all of it. The other
+                # ordering below gets that barrier from its post-open probe.
+                probe_result = self._send_sync_probe(source_files, probe_timeout, phase="overlay processing")
         else:
             self._bulk_did_open(source_files)
             probe_result = self._send_sync_probe(source_files, probe_timeout)
@@ -205,10 +209,10 @@ class CallGraphBuilder:
         pbar.finish()
         logger.info("did_open %d files: %.1fs", total, time.monotonic() - t_open_start)
 
-    def _send_sync_probe(self, source_files: list[Path], probe_timeout: int) -> list[dict]:
-        """Send a documentSymbol probe to wait for the LSP server to finish indexing."""
+    def _send_sync_probe(self, source_files: list[Path], probe_timeout: int, phase: str = "indexing") -> list[dict]:
+        """Send a documentSymbol probe to wait for the LSP server to finish a bulk phase."""
         probe_result: list[dict] = []
-        logger.info("Waiting for LSP server indexing (timeout=%ds)...", probe_timeout)
+        logger.info("Waiting for LSP server %s (timeout=%ds)...", phase, probe_timeout)
         t_probe = time.monotonic()
         if source_files:
             probe_result = self._lsp.document_symbol(source_files[0], timeout=probe_timeout)

--- a/tests/static_analyzer/test_call_graph_builder.py
+++ b/tests/static_analyzer/test_call_graph_builder.py
@@ -171,6 +171,25 @@ class TestDiscoverSymbols:
         probe_call = lsp.document_symbol.call_args_list[0]
         assert probe_call.kwargs.get("timeout") == 1800
 
+    def test_probe_before_open_gets_a_barrier_after_bulk_open(self):
+        """Opening every file queues work the next request waits behind."""
+        lsp = _make_lsp()
+        adapter = _make_adapter()
+        adapter.probe_before_open = True
+        builder = CallGraphBuilder(lsp, adapter, Path("/project"))
+
+        files = [Path(f"/project/file_{i}.cs") for i in range(100)]
+        lsp.document_symbol.return_value = []
+
+        builder._discover_symbols(files)
+
+        # Probe, then bulk didOpen, then a second probe on the same scaled budget.
+        probe_timeouts = [
+            call.kwargs.get("timeout") for call in lsp.document_symbol.call_args_list if "timeout" in call.kwargs
+        ]
+        assert probe_timeouts[:2] == [260, 260]
+        assert lsp.did_open.call_count == 100
+
     def test_interleaves_did_open_with_symbol_queries(self):
         lsp = _make_lsp()
         adapter = _make_adapter()


### PR DESCRIPTION
## WHAT

Give adapters that probe *before* the bulk `didOpen` a barrier on the far side of it too. One-line-of-logic change in `_discover_symbols`.

Third in the sequence after #456/#457 and #459. With #457 shipped in 0.13.7 the C# solution *load* works; this is the next wall, and with it the full analysis completes.

## WHY

On 0.13.7, a 286-project / 7605-file C# solution now gets past the load and dies immediately after:

```
Analyzing 7605 CSharp files
Waiting for LSP server indexing (timeout=1800s)...
Sync probe: 56.4s (1 symbols)            <-- load fixed by #457, probe answers
Error during engine analysis for CSharp: Timeout waiting for LSP response to request 3
```

Request 3 is the first Phase 1 `documentSymbol`. Locally the gap is exactly `120.001s`, which is `CSharpAdapter.get_lsp_default_timeout()`:

```
did_open 7605 files: 18.1s
[exactly 120.001s later] Timeout waiting for LSP response to request 3
```

`_bulk_did_open` sends one `didOpen` per file with no barrier. The server must materialize all N overlays before it can answer anything, so the next request waits behind work proportional to the file count — but it runs on the fixed per-request default.

Driving csharp-ls 0.24.0 directly with the engine's exact handshake, then opening all files and timing that next request:

```
PROBE OK in 195.2s              <-- covered by the scaled probe budget
did_open 8740 files in 27.2s
POST-OPEN REQUEST OK in 517.6s  <-- allowed only 120s
```

**517.6s against a 120s budget.** The server is healthy — peak RSS 2.5GB, bounded, publishing diagnostics throughout. Nothing is stuck; the budget is simply the wrong shape. This is not another unbounded-growth bug.

The asymmetry is already visible in the existing code. For `probe_before_open = False` the order is bulk-open → probe, so the probe *is* the drain barrier and it carries `probe_timeout`. For `probe_before_open = True` the probe happens first — covering the workspace load — and nothing covers the far side.

## HOW

Send a second sync probe after `_bulk_did_open` on the same `probe_timeout`, and feed its result to the first file exactly as the first probe's result was fed. `_send_sync_probe` takes a `phase` label so the two waits are distinguishable in logs.

Scope is narrow by construction: only the `probe_before_open and not interleave_open` branch changes. The `interleave_open` adapters already have per-file backpressure, and the probe-after-open adapters already have the barrier.

## HOW TESTED

The whole point — **the C# analysis completes on the solution that has never once completed**:

```
Sync probe: 169.1s (1 symbols)
did_open 7605 files: 17.6s
Waiting for LSP server overlay processing (timeout=1800s)...
Phase 1 (symbols): 100% (7605/7605 files) | symbols=54397
Phase 2 total (build edges): 428.9s, 3821 edges
Phase 3 (hierarchy): 810.6s
Pipeline complete: 7605 files, 54397 symbols, 3821 edges, 8368 hierarchy entries in 2170.0s
Reference edges for CSharp: 14855 ({'contains': 12063, 'inherits': 2792})
Static analysis complete: csharp: 7605 files, 42306 references, 20434 nodes, 3811 edges
```

Non-zero nodes and edges, so `zero nodes despite LOC` and the downstream `No component groups found for <repo>` are both gone. Before this change the same run stopped at `Timeout waiting for LSP response to request 3` with 0 symbols.

Peak csharp-ls RSS ~3.8GB during Phase 2, comfortably under the recycler's budget — the recycler armed and never needed to fire.

`uv run pytest` — 2020 passed, 28 skipped. `uv run mypy .` clean on 313 files, `black --check` clean. One regression test asserting a `probe_before_open` adapter issues two scaled-budget probes around the bulk open.

## Two observations, not changes

- **Phase 3 (hierarchy) cost 810.6s of the 2170s total**, more than Phase 2. I did not touch it — flagging it as the next thing to look at if end-to-end wall clock matters for the action's budget.
- I again did not touch `_PROBE_MAX_TIMEOUT`. 1800s covers the measured 517s with room; the bug was that this request never got the scaled budget at all, not that the cap was too low.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved symbol discovery reliability by synchronizing after files are opened.
  * Preserved existing indexing behavior while adding clearer synchronization phases.

* **Tests**
  * Added coverage confirming all files are opened and a follow-up symbol probe runs with the expected timeout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->