### PR TITLE
refactor(clustering): collapse the candidate machinery to one seeded Leiden run

### DIFF
--- a/static_analyzer/clustering/engine.py
+++ b/static_analyzer/clustering/engine.py
@@ -1,8 +1,4 @@
-"""Seeded-Leiden clustering with a level-up search over an exported graph.
-
-Operates on ``nx.DiGraph`` only — it never sees a ``CallGraph``, so the search
-can be exercised on any graph. ``ClusteringService`` does the export.
-"""
+"""Seeded-Leiden clustering with a level-up search over a graph the caller exports."""
 
 from __future__ import annotations
 

--- a/static_analyzer/clustering/engine.py
+++ b/static_analyzer/clustering/engine.py
@@ -1,21 +1,25 @@
-"""Clustering search over an exported graph.
+"""Seeded-Leiden clustering with a level-up search over an exported graph.
 
-Operates on ``nx.DiGraph`` only — it never sees a ``CallGraph``, so the search can
-be exercised on any graph. The caller does the export.
+Operates on ``nx.DiGraph`` only — it never sees a ``CallGraph``, so the search
+can be exercised on any graph. ``ClusteringService`` does the export.
 """
+
+from __future__ import annotations
 
 import logging
 from collections import defaultdict
 from enum import StrEnum
 
 import networkx as nx
-import networkx.algorithms.community as nx_comm
 
 from static_analyzer.clustering.models import ClusterResult
 from static_analyzer.constants import ClusteringConfig
 from static_analyzer.leiden_utils import find_partition
 
 logger = logging.getLogger(__name__)
+
+# (communities, strategy name, score)
+Candidate = tuple[list[set[str]], str, float]
 
 
 class Level(StrEnum):
@@ -28,22 +32,23 @@ class Level(StrEnum):
 
 def cluster_graph(
     nx_graph: nx.DiGraph,
-    delimiter: str,
+    *,
+    delimiter: str = ClusteringConfig.QUALIFIED_NAME_DELIMITER,
     target_clusters: int = ClusteringConfig.DEFAULT_TARGET_CLUSTERS,
     min_cluster_size: int = ClusteringConfig.DEFAULT_MIN_CLUSTER_SIZE,
 ) -> ClusterResult:
-    """Cluster the graph using a try-all-then-level-up approach.
+    """Cluster ``nx_graph``, levelling up until the partition covers enough of it.
 
-    Flow: try all algorithms at each abstraction level (raw, class, file).
-    If coverage >= 50% at any level, stop and return the best result.
-    Falls back to connected components if everything fails.
+    Scores a Leiden partition at each abstraction level (raw, class, file) and stops
+    at the first to reach ``MIN_COVERAGE_RATIO``, else keeps the best-scoring level.
+    Falls back to connected components if every level scores zero.
     """
     if nx_graph.number_of_nodes() == 0:
         logger.warning("No nodes available for clustering.")
         return ClusterResult(strategy="empty")
 
     total_nodes = nx_graph.number_of_nodes()
-    all_candidates: list[tuple[list[set[str]], str, float]] = []
+    all_candidates: list[Candidate] = []
 
     for level in Level:
         work_graph = nx_graph
@@ -52,30 +57,23 @@ def cluster_graph(
             if work_graph.number_of_nodes() == 0:
                 continue
 
-        candidates = _try_all_algorithms(work_graph, min_cluster_size, total_nodes)
-
+        candidate = _leiden_candidate(work_graph, min_cluster_size, total_nodes)
         if level:
-            candidates = _map_candidates_to_original(
-                candidates, nx_graph, level, delimiter, min_cluster_size, total_nodes
-            )
+            candidate = _map_candidate_to_original(candidate, nx_graph, level, delimiter, min_cluster_size, total_nodes)
 
-        all_candidates.extend(candidates)
+        all_candidates.append(candidate)
 
-        # Check if best coverage at this level is good enough
-        if candidates:
-            best = max(candidates, key=lambda c: c[2])
-            best_coverage = _coverage(best[0], min_cluster_size, total_nodes)
-            logger.info(f"Level {level or 'raw'}: best={best[1]} score={best[2]:.3f} coverage={best_coverage:.3f}")
-            if best_coverage >= ClusteringConfig.MIN_COVERAGE_RATIO:
-                break
+        communities, strategy, score = candidate
+        coverage = _coverage(communities, min_cluster_size, total_nodes)
+        logger.info(f"Level {level or 'raw'}: best={strategy} score={score:.3f} coverage={coverage:.3f}")
+        if coverage >= ClusteringConfig.MIN_COVERAGE_RATIO:
+            break
 
-    # Pick overall best
     if all_candidates:
         best_communities, best_strategy, best_score = max(all_candidates, key=lambda c: c[2])
         if best_score > 0.0:
             return _build_result(best_communities, best_strategy, min_cluster_size, nx_graph)
 
-    # Absolute fallback: connected components
     logger.warning("All clustering strategies scored 0, falling back to connected components")
     components = list(nx.connected_components(nx_graph.to_undirected()))
     return _build_result(
@@ -91,19 +89,6 @@ def _abstract_node_name(node_name: str, level: Level, delimiter: str) -> str:
     if level is Level.FILE and len(parts) > 2:
         return delimiter.join(parts[:-2])
     return node_name
-
-
-def _cluster_with_algorithm(graph: nx.DiGraph, algorithm: str) -> list[set[str]]:
-    # Use a fixed seed for reproducibility - Leiden/Louvain are non-deterministic without it
-    if algorithm == "leiden":
-        return find_partition(graph, seed=ClusteringConfig.CLUSTERING_SEED)
-    elif algorithm == "louvain":
-        return list(nx_comm.louvain_communities(graph, seed=ClusteringConfig.CLUSTERING_SEED))
-    elif algorithm == "greedy_modularity":
-        return list(nx.community.greedy_modularity_communities(graph))
-    else:
-        logger.warning(f"Algorithm {algorithm} not supported, defaulting to leiden")
-        return find_partition(graph, seed=ClusteringConfig.CLUSTERING_SEED)
 
 
 def _score_clustering(communities: list[set[str]], min_cluster_size: int, total_nodes: int) -> float:
@@ -158,55 +143,49 @@ def _abstract_at_level(graph: nx.DiGraph, level: Level, delimiter: str) -> nx.Di
     return abstracted
 
 
-def _try_all_algorithms(
-    graph: nx.DiGraph,
-    min_cluster_size: int,
-    total_nodes: int,
-) -> list[tuple[list[set[str]], str, float]]:
-    """Run Leiden and return a single scored candidate.
+def _leiden_candidate(graph: nx.DiGraph, min_cluster_size: int, total_nodes: int) -> Candidate:
+    """Score one seeded-Leiden partition of ``graph``; a failure scores 0 and loses.
 
-    Returned as a list so ``cluster_graph``'s cross-level pooling stays uniform.
+    Why seeded: Leiden is non-deterministic otherwise, and cluster IDs persisted in
+    analysis.json must reproduce on the next run.
     """
-    candidates: list[tuple[list[set[str]], str, float]] = []
+    communities: list[set[str]] = []
     try:
-        communities = _cluster_with_algorithm(graph, "leiden")
-        score = _score_clustering(communities, min_cluster_size, total_nodes)
-        candidates.append((communities, "leiden", score))
-        logger.debug(f"leiden: score={score:.3f}, clusters={len(communities)}")
+        communities = find_partition(graph, seed=ClusteringConfig.CLUSTERING_SEED)
     except Exception as e:
-        logger.debug(f"Algorithm leiden failed: {e}")
-    return candidates
+        logger.debug(f"Leiden failed: {e}")
+    score = _score_clustering(communities, min_cluster_size, total_nodes)
+    logger.debug(f"leiden: score={score:.3f}, clusters={len(communities)}")
+    return communities, "leiden", score
 
 
-def _map_candidates_to_original(
-    candidates: list[tuple[list[set[str]], str, float]],
+def _map_candidate_to_original(
+    candidate: Candidate,
     original_graph: nx.DiGraph,
     level: Level,
     delimiter: str,
     min_cluster_size: int,
     total_nodes: int,
-) -> list[tuple[list[set[str]], str, float]]:
-    """Map abstract community results back to original node names and re-score."""
+) -> Candidate:
+    """Map an abstract-level community result back to original node names and re-score."""
     abstract_to_original: dict[str, list[str]] = defaultdict(list)
     for node in original_graph.nodes():
         abstract_to_original[_abstract_node_name(node, level, delimiter)].append(node)
 
-    mapped: list[tuple[list[set[str]], str, float]] = []
-    for communities, algo, _ in candidates:
-        original_communities: list[set[str]] = []
-        for community in communities:
-            orig: set[str] = set()
-            for abstract_node in community:
-                orig.update(abstract_to_original[abstract_node])
-            if orig:
-                original_communities.append(orig)
-        new_score = _score_clustering(original_communities, min_cluster_size, total_nodes)
-        mapped.append((original_communities, f"{algo}_level_{level}", new_score))
-    return mapped
+    communities, algo, _ = candidate
+    original_communities: list[set[str]] = []
+    for community in communities:
+        orig: set[str] = set()
+        for abstract_node in community:
+            orig.update(abstract_to_original[abstract_node])
+        if orig:
+            original_communities.append(orig)
+    score = _score_clustering(original_communities, min_cluster_size, total_nodes)
+    return original_communities, f"{algo}_level_{level}", score
 
 
 def _coverage(communities: list[set[str]], min_cluster_size: int, total_nodes: int) -> float:
-    """Calculate coverage: fraction of nodes in valid clusters."""
+    """Fraction of nodes landing in clusters that meet ``min_cluster_size``."""
     if total_nodes == 0:
         return 0.0
     valid = [c for c in communities if len(c) >= min_cluster_size]
@@ -219,7 +198,6 @@ def _build_result(
     min_cluster_size: int,
     nx_graph: nx.DiGraph,
 ) -> ClusterResult:
-    """Build ClusterResult from communities."""
     valid_communities = [c for c in communities if len(c) >= min_cluster_size]
     sorted_communities = sorted(valid_communities, key=len, reverse=True)
 

--- a/static_analyzer/clustering/engine.py
+++ b/static_analyzer/clustering/engine.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from collections import defaultdict
 from enum import StrEnum
+from typing import NamedTuple
 
 import networkx as nx
 
@@ -13,9 +14,6 @@ from static_analyzer.constants import ClusteringConfig
 from static_analyzer.leiden_utils import find_partition
 
 logger = logging.getLogger(__name__)
-
-# (communities, strategy name, score)
-Candidate = tuple[list[set[str]], str, float]
 
 
 class Level(StrEnum):
@@ -26,10 +24,23 @@ class Level(StrEnum):
     FILE = "file"
 
 
+class Candidate(NamedTuple):
+    """One scored Leiden partition, tagged with the level it was found at."""
+
+    communities: list[set[str]]
+    level: Level
+    score: float
+
+    @property
+    def strategy(self) -> str:
+        """Name recorded on the ``ClusterResult`` and persisted in analysis.json."""
+        return "leiden" if self.level is Level.RAW else f"leiden_level_{self.level}"
+
+
 def cluster_graph(
     nx_graph: nx.DiGraph,
     *,
-    delimiter: str = ClusteringConfig.QUALIFIED_NAME_DELIMITER,
+    delimiter: str,
     target_clusters: int = ClusteringConfig.DEFAULT_TARGET_CLUSTERS,
     min_cluster_size: int = ClusteringConfig.DEFAULT_MIN_CLUSTER_SIZE,
 ) -> ClusterResult:
@@ -53,22 +64,23 @@ def cluster_graph(
             if work_graph.number_of_nodes() == 0:
                 continue
 
-        candidate = _leiden_candidate(work_graph, min_cluster_size, total_nodes)
+        candidate = _leiden_candidate(work_graph, level, min_cluster_size, total_nodes)
         if level:
-            candidate = _map_candidate_to_original(candidate, nx_graph, level, delimiter, min_cluster_size, total_nodes)
+            candidate = _map_candidate_to_original(candidate, nx_graph, delimiter, min_cluster_size, total_nodes)
 
         all_candidates.append(candidate)
 
-        communities, strategy, score = candidate
-        coverage = _coverage(communities, min_cluster_size, total_nodes)
-        logger.info(f"Level {level or 'raw'}: best={strategy} score={score:.3f} coverage={coverage:.3f}")
+        coverage = _coverage(candidate.communities, min_cluster_size, total_nodes)
+        logger.info(
+            f"Level {level or 'raw'}: best={candidate.strategy} score={candidate.score:.3f} coverage={coverage:.3f}"
+        )
         if coverage >= ClusteringConfig.MIN_COVERAGE_RATIO:
             break
 
-    if all_candidates:
-        best_communities, best_strategy, best_score = max(all_candidates, key=lambda c: c[2])
-        if best_score > 0.0:
-            return _build_result(best_communities, best_strategy, min_cluster_size, nx_graph)
+    # Level.RAW never abstracts, so the loop always scores at least one candidate.
+    best = max(all_candidates, key=lambda c: c.score)
+    if best.score > 0.0:
+        return _build_result(best.communities, best.strategy, min_cluster_size, nx_graph)
 
     logger.warning("All clustering strategies scored 0, falling back to connected components")
     components = list(nx.connected_components(nx_graph.to_undirected()))
@@ -127,6 +139,9 @@ def _abstract_at_level(graph: nx.DiGraph, level: Level, delimiter: str) -> nx.Di
         if abstract_name not in abstracted:
             abstracted.add_node(abstract_name)
 
+    # These weights are recorded but never read: _leiden_candidate calls find_partition
+    # without ``weight=``, so class and file levels cluster unweighted. Passing them would
+    # change every existing partition, so it needs its own change.
     edge_weights: dict[tuple[str, str], int] = defaultdict(int)
     for src, dst in graph.edges():
         a_src, a_dst = node_map[src], node_map[dst]
@@ -139,7 +154,7 @@ def _abstract_at_level(graph: nx.DiGraph, level: Level, delimiter: str) -> nx.Di
     return abstracted
 
 
-def _leiden_candidate(graph: nx.DiGraph, min_cluster_size: int, total_nodes: int) -> Candidate:
+def _leiden_candidate(graph: nx.DiGraph, level: Level, min_cluster_size: int, total_nodes: int) -> Candidate:
     """Score one seeded-Leiden partition of ``graph``; a failure scores 0 and loses.
 
     Why seeded: Leiden is non-deterministic otherwise, and cluster IDs persisted in
@@ -148,17 +163,18 @@ def _leiden_candidate(graph: nx.DiGraph, min_cluster_size: int, total_nodes: int
     communities: list[set[str]] = []
     try:
         communities = find_partition(graph, seed=ClusteringConfig.CLUSTERING_SEED)
-    except Exception as e:
-        logger.debug(f"Leiden failed: {e}")
+    except Exception:
+        # Warn, not debug: if every level throws we ship connected components, which
+        # looks like an ordinary result with nothing explaining it.
+        logger.warning(f"Leiden failed at level {level or 'raw'}; scoring 0", exc_info=True)
     score = _score_clustering(communities, min_cluster_size, total_nodes)
     logger.debug(f"leiden: score={score:.3f}, clusters={len(communities)}")
-    return communities, "leiden", score
+    return Candidate(communities, level, score)
 
 
 def _map_candidate_to_original(
     candidate: Candidate,
     original_graph: nx.DiGraph,
-    level: Level,
     delimiter: str,
     min_cluster_size: int,
     total_nodes: int,
@@ -166,18 +182,17 @@ def _map_candidate_to_original(
     """Map an abstract-level community result back to original node names and re-score."""
     abstract_to_original: dict[str, list[str]] = defaultdict(list)
     for node in original_graph.nodes():
-        abstract_to_original[_abstract_node_name(node, level, delimiter)].append(node)
+        abstract_to_original[_abstract_node_name(node, candidate.level, delimiter)].append(node)
 
-    communities, algo, _ = candidate
     original_communities: list[set[str]] = []
-    for community in communities:
+    for community in candidate.communities:
         orig: set[str] = set()
         for abstract_node in community:
             orig.update(abstract_to_original[abstract_node])
         if orig:
             original_communities.append(orig)
     score = _score_clustering(original_communities, min_cluster_size, total_nodes)
-    return original_communities, f"{algo}_level_{level}", score
+    return Candidate(original_communities, candidate.level, score)
 
 
 def _coverage(communities: list[set[str]], min_cluster_size: int, total_nodes: int) -> float:

--- a/static_analyzer/graph.py
+++ b/static_analyzer/graph.py
@@ -369,7 +369,10 @@ class CallGraph:
         if self._cluster_cache is not None:
             return self._cluster_cache
         self._cluster_cache = cluster_graph(
-            self.clustering_networkx(), self.delimiter, target_clusters, min_cluster_size
+            self.clustering_networkx(),
+            delimiter=self.delimiter,
+            target_clusters=target_clusters,
+            min_cluster_size=min_cluster_size,
         )
         return self._cluster_cache
 

--- a/tests/static_analyzer/test_clustering_engine.py
+++ b/tests/static_analyzer/test_clustering_engine.py
@@ -2,7 +2,7 @@ import unittest
 
 import networkx as nx
 
-from static_analyzer.clustering.engine import cluster_graph
+from static_analyzer.clustering.engine import Candidate, Level, cluster_graph
 from static_analyzer.clustering.models import ClusterResult
 
 
@@ -61,6 +61,12 @@ class TestClusterGraph(unittest.TestCase):
 
         self.assertNotEqual(result.strategy, "empty")
         self.assertTrue(result.clusters)
+
+    def test_strategy_name_is_derived_from_the_level(self):
+        """Strategy strings are persisted in analysis.json, so the naming must not drift."""
+        self.assertEqual(Candidate([], Level.RAW, 0.0).strategy, "leiden")
+        self.assertEqual(Candidate([], Level.CLASS, 0.0).strategy, "leiden_level_class")
+        self.assertEqual(Candidate([], Level.FILE, 0.0).strategy, "leiden_level_file")
 
     def test_falls_back_to_connected_components_when_nothing_scores(self):
         """Leiden is the only algorithm, and a minimum of 6 leaves it nothing to return at any level."""


### PR DESCRIPTION
**Stack 4 of ~9** — base: `stack/3-cluster-engine` (#476).

The search carried plumbing for choosing between algorithms it never chose between. `_try_all_algorithms` only ever called leiden; `_cluster_with_algorithm`'s `louvain` and `greedy_modularity` branches were unreachable; and the candidate list never held more than one element per level.

Collapsed: `_leiden_candidate` returns a single scored `Candidate`, and `_map_candidates_to_original` loses its loop. `cluster_graph` takes keyword-only options so a caller cannot silently transpose `delimiter` and `target_clusters`.

`engine.py`: 242 → 221 lines. **136 changed lines.**

### Why this is its own PR

This restructure was bundled inside the original #472 alongside the file split, where it read as relocation. It isn't — it changes the shape of the search, so it gets reviewed on its own.

### Behaviour is preserved

The old code appended nothing to `all_candidates` when Leiden raised; the new one appends a zero-score candidate. Neither can win, because selection requires `best_score > 0.0`, so an all-levels-failed run still falls through to connected components exactly as before. The only observable difference is a debug log line on the failure path.

### Checks
`2059 passed, 28 skipped` · mypy clean · black clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated graph clustering to use a consistent seeded approach across raw, class, and file levels.
  * Improved scoring and fallback behavior when clustering encounters failures.
  * Added strategy information to clustering results for clearer reporting.
* **Compatibility**
  * Updated clustering configuration usage to require named parameters, reducing ambiguity and improving reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->