### PR TITLE
refactor(clustering): move the partition off CallGraph onto LanguageResults

### DIFF
--- a/agents/cluster_methods_mixin.py
+++ b/agents/cluster_methods_mixin.py
@@ -39,7 +39,12 @@ from static_analyzer.cluster_relations import (
 )
 from static_analyzer.constants import CALLABLE_TYPES, CLASS_TYPES, Language
 from static_analyzer.graph import CallGraph
-from static_analyzer.clustering import ClusterResult, METHOD_LEVEL_STRATEGY
+from static_analyzer.clustering import (
+    METHOD_LEVEL_STRATEGY,
+    ClusteringService,
+    ClusterResult,
+    MethodClusterPaths,
+)
 from static_analyzer.node import Node
 
 logger = logging.getLogger(__name__)
@@ -74,13 +79,15 @@ def _fallback_component(group: ClustersComponent, node_lookup: dict[int, set[str
     return Component(name=name, description=group.description, key_entities=[])
 
 
-def scoped_snapshot_from_lineage(cfg: CallGraph, scope_id: str) -> dict[int, ClusterSnapshotEntry]:
+def scoped_snapshot_from_lineage(
+    cfg: CallGraph, method_paths: MethodClusterPaths, scope_id: str
+) -> dict[int, ClusterSnapshotEntry]:
     """Build a scoped snapshot from each method's recorded cluster ancestry/path."""
     if not scope_id:
         return {}
     prefix = f"{scope_id}."
     entries: dict[int, ClusterSnapshotEntry] = {}
-    for qname, cluster_ids in cfg.method_cluster_paths_snapshot():
+    for qname, cluster_ids in method_paths.snapshot():
         if qname not in cfg.nodes:
             continue
         for cluster_id in cluster_ids:
@@ -337,13 +344,15 @@ class ClusterMethodsMixin:
                 continue
             subgraph_cfgs[lang] = sub_cfg
 
-            seeded_snapshot = scoped_snapshot_from_lineage(sub_cfg, source_cluster_id_prefix)
+            seeded_snapshot = scoped_snapshot_from_lineage(
+                sub_cfg, self.static_analysis.get_clusters(lang).method_paths, source_cluster_id_prefix
+            )
             if seeded_snapshot:
                 sub_cluster_result = _delta_for_language(
                     str(lang), sub_cfg.clustering_networkx(), seeded_snapshot
                 ).cluster_results
             else:
-                sub_cluster_result = sub_cfg.cluster()
+                sub_cluster_result = ClusteringService().cluster(sub_cfg)
 
             cluster_results[lang] = self._expand_to_method_level_clusters(sub_cfg, sub_cluster_result)
 
@@ -351,9 +360,7 @@ class ClusterMethodsMixin:
 
         if source_cluster_id_prefix:
             for lang, cluster_result in cluster_results.items():
-                self.static_analysis.get_cfg(Language(lang)).record_cluster_paths(
-                    cluster_result, source_cluster_id_prefix
-                )
+                self.static_analysis.get_clusters(Language(lang)).record_scope(cluster_result, source_cluster_id_prefix)
 
         return cluster_results, subgraph_cfgs
 

--- a/diagram_analysis/cluster_snapshot.py
+++ b/diagram_analysis/cluster_snapshot.py
@@ -1,10 +1,9 @@
 """In-memory cluster snapshot of the prior clustering, used by ``cluster_delta``.
 
-The partition is sourced exclusively from each per-language CFG's
-``CallGraph._cluster_cache``, populated by the previous run's
-``DiagramGenerator._persist_pkl_with_cluster_cache`` and round-tripped
-through the SHA-tagged pkl. When the cache is absent (legacy pkl, first run
-on a fresh repo) ``snapshot_from_static_analysis`` returns an empty snapshot;
+The partition is sourced exclusively from each language's ``ClusterCache``,
+populated by the previous run and round-tripped through the SHA-tagged pkl.
+When the cache is absent (first run on a fresh repo)
+``snapshot_from_static_analysis`` returns an empty snapshot;
 ``DiagramGenerator.generate_analysis_incremental`` then falls back to a
 full run, which warms the pkl for every subsequent incremental.
 """
@@ -38,10 +37,10 @@ class ClusterSnapshot:
 
 
 def snapshot_from_static_analysis(static_analysis: StaticAnalysisResults) -> ClusterSnapshot:
-    """Reconstruct a ``ClusterSnapshot`` from each per-language CFG's ``_cluster_cache``.
+    """Reconstruct a ``ClusterSnapshot`` from each language's ``ClusterCache``.
 
-    Languages whose CFG carries no ``_cluster_cache`` (legacy pkl or first-ever
-    run on a fresh repo) contribute nothing; the resulting snapshot's
+    Languages whose cache holds an empty partition (first-ever run on a fresh repo)
+    contribute nothing; the resulting snapshot's
     ``all_cluster_ids()`` will be empty for those languages, which causes
     ``DiagramGenerator.generate_analysis_incremental`` to fall back to a full
     run. After that full run the pkl is re-saved with a populated cache and
@@ -53,23 +52,24 @@ def snapshot_from_static_analysis(static_analysis: StaticAnalysisResults) -> Clu
             cfg = static_analysis.get_cfg(language)
         except ValueError:
             continue
-        if cfg._cluster_cache is None:
+        partition = static_analysis.get_clusters(language).result
+        if not partition.clusters:
             continue
-        by_language[language] = _entries_from_cfg_cache(cfg._cluster_cache, cfg.to_networkx())
+        by_language[language] = _entries_from_partition(partition, cfg.to_networkx())
     return ClusterSnapshot(by_language=by_language)
 
 
-def _entries_from_cfg_cache(
-    cluster_cache: ClusterResult,
+def _entries_from_partition(
+    partition: ClusterResult,
     nx_graph,
 ) -> dict[int, ClusterSnapshotEntry]:
-    """Build ``{cluster_id -> ClusterSnapshotEntry}`` from a CFG's ``_cluster_cache``.
+    """Build ``{cluster_id -> ClusterSnapshotEntry}`` from a language's partition.
 
     File paths come straight off the CFG node attributes — authoritative for
     every qname Leiden actually placed into a cluster.
     """
     entries: dict[int, ClusterSnapshotEntry] = {}
-    for cid, members in cluster_cache.clusters.items():
+    for cid, members in partition.clusters.items():
         entry = ClusterSnapshotEntry(members=set(members))
         for qname in members:
             attrs = nx_graph.nodes.get(qname)

--- a/diagram_analysis/diagram_generator.py
+++ b/diagram_analysis/diagram_generator.py
@@ -867,7 +867,7 @@ class DiagramGenerator:
         )
 
     def _seed_incremental_cluster_cache(self, cluster_results: dict[str, ClusterResult]) -> None:
-        """Write post-delta ``cluster_results`` into each language CFG's ``_cluster_cache``.
+        """Write post-delta ``cluster_results`` into each language's ``ClusterCache``.
 
         On the incremental path the abstraction agent doesn't run, so the live
         partition has to be plumbed in explicitly before ``stop_clients`` saves
@@ -877,11 +877,9 @@ class DiagramGenerator:
             return
         for language, cr in cluster_results.items():
             try:
-                cfg = self.static_analysis.get_cfg(Language(language))
+                self.static_analysis.get_clusters(Language(language)).adopt(cr)
             except (ValueError, KeyError):
                 continue
-            cfg._cluster_cache = cr
-            cfg.record_cluster_paths(cr)
 
     def _persist_static_analysis_artifact(self) -> None:
         """Persist the post-clustering static-analysis artifact."""
@@ -1219,12 +1217,12 @@ class DiagramGenerator:
         # Absorption must not erase the evidence of an invalid parent-child boundary.
         assert_scope_containment(root_analysis, sub_analyses)
         self.rebuild_global_relations(root_analysis, sub_analyses)
-        cfgs = (
-            [self.static_analysis.get_cfg(lang) for lang in self.static_analysis.get_languages()]
+        cluster_caches = (
+            [self.static_analysis.get_clusters(lang) for lang in self.static_analysis.get_languages()]
             if self.static_analysis
             else []
         )
-        absorb_single_child_components(root_analysis, sub_analyses, cfgs)
+        absorb_single_child_components(root_analysis, sub_analyses, cluster_caches)
         assert_scope_containment(root_analysis, sub_analyses)
 
     def finalize_and_save(
@@ -1740,7 +1738,9 @@ def scoped_snapshot_for_component(
         cfg = incremental_agent.static_analysis.get_cfg(language)
         sub_cfg = cfg.filter_by_nodes(assigned_qnames)
         if sub_cfg.nodes:
-            by_language[str(language)] = scoped_snapshot_from_lineage(sub_cfg, scope_id)
+            by_language[str(language)] = scoped_snapshot_from_lineage(
+                sub_cfg, incremental_agent.static_analysis.get_clusters(language).method_paths, scope_id
+            )
     return ClusterSnapshot(by_language=by_language)
 
 

--- a/diagram_analysis/exceptions.py
+++ b/diagram_analysis/exceptions.py
@@ -8,19 +8,10 @@ from static_analyzer.analysis_cache import STATIC_ANALYSIS_PKL, STATIC_ANALYSIS_
 class IncrementalCacheMissingError(RuntimeError):
     """Raised when ``generate_analysis_incremental`` finds no usable warm cache.
 
-    The incremental path requires a populated ``ClusterCache`` on the cached
-    ``LanguageResults`` (sourced from the SHA-tagged ``static_analysis.pkl``).
-    When absent we
-    used to silently fall back to a full analysis, which discarded the
-    existing analysis.json's depth and component IDs. Callers must
-    explicitly opt into a full run instead.
-
-    The constructor inspects ``artifact_dir`` to produce a specific
-    diagnostic depending on which piece is missing — pkl absent, sha
-    absent (so the warm-start cannot SHA-gate), or pkl present but no
-    cluster baseline inside it. Without that distinction, every variant
-    of this failure surfaced as "no warm static_analysis.pkl", which
-    misled callers when the pkl was actually present.
+    Needs a populated ``ClusterCache`` on the cached ``LanguageResults``, from the
+    SHA-tagged ``static_analysis.pkl``. Why raise: falling back to a full analysis
+    discarded analysis.json's depth and component IDs. The message names which
+    piece is missing — pkl, sha, or cluster baseline.
     """
 
     def __init__(self, artifact_dir: Path):

--- a/diagram_analysis/exceptions.py
+++ b/diagram_analysis/exceptions.py
@@ -8,8 +8,9 @@ from static_analyzer.analysis_cache import STATIC_ANALYSIS_PKL, STATIC_ANALYSIS_
 class IncrementalCacheMissingError(RuntimeError):
     """Raised when ``generate_analysis_incremental`` finds no usable warm cache.
 
-    The incremental path requires a populated ``CallGraph._cluster_cache``
-    (sourced from the SHA-tagged ``static_analysis.pkl``). When absent we
+    The incremental path requires a populated ``ClusterCache`` on the cached
+    ``LanguageResults`` (sourced from the SHA-tagged ``static_analysis.pkl``).
+    When absent we
     used to silently fall back to a full analysis, which discarded the
     existing analysis.json's depth and component IDs. Callers must
     explicitly opt into a full run instead.

--- a/diagram_analysis/tree_shape.py
+++ b/diagram_analysis/tree_shape.py
@@ -4,7 +4,7 @@ import logging
 from collections.abc import Sequence
 
 from agents.agent_responses import AnalysisInsights, Relation
-from static_analyzer.graph import CallGraph
+from static_analyzer.clustering import ClusterCache
 
 logger = logging.getLogger(__name__)
 
@@ -14,12 +14,12 @@ ROOT_SCOPE = ""
 def absorb_single_child_components(
     root_analysis: AnalysisInsights,
     sub_analyses: dict[str, AnalysisInsights],
-    cfgs: Sequence[CallGraph] = (),
+    cluster_caches: Sequence[ClusterCache] = (),
 ) -> list[str]:
     """Collapse all single-child scopes to a fixpoint."""
     absorbed: list[str] = []
     while scopes := single_child_scopes(root_analysis, sub_analyses):
-        absorbed.append(_absorb(scopes[0], root_analysis, sub_analyses, cfgs))
+        absorbed.append(_absorb(scopes[0], root_analysis, sub_analyses, cluster_caches))
     return absorbed
 
 
@@ -45,7 +45,7 @@ def _absorb(
     parent_id: str,
     root_analysis: AnalysisInsights,
     sub_analyses: dict[str, AnalysisInsights],
-    cfgs: Sequence[CallGraph] = (),
+    cluster_caches: Sequence[ClusterCache] = (),
 ) -> str:
     scope = root_analysis if parent_id == ROOT_SCOPE else sub_analyses[parent_id]
     child = scope.components[0]
@@ -60,8 +60,8 @@ def _absorb(
             scope.components_relations = grandchildren.components_relations
     sub_analyses.pop(child_id, None)
     _reroot_tree(root_analysis, sub_analyses, child_id, parent_id)
-    for cfg in cfgs:
-        cfg.method_cluster_paths.reroot_scope(child_id, parent_id)
+    for cache in cluster_caches:
+        cache.method_paths.reroot_scope(child_id, parent_id)
     logger.info(f"[TreeShape] Absorbed '{child.name}' ({child_id}) into {parent_id or 'the root'}")
     return child_id
 

--- a/health/checks/cohesion.py
+++ b/health/checks/cohesion.py
@@ -2,6 +2,7 @@ import logging
 
 from health.models import FindingEntity, FindingGroup, HealthCheckConfig, Severity, StandardCheckSummary
 from static_analyzer.graph import CallGraph
+from static_analyzer.clustering import ClusteringService
 
 logger = logging.getLogger(__name__)
 
@@ -16,15 +17,13 @@ def check_component_cohesion(call_graph: CallGraph, config: HealthCheckConfig) -
     cluster than inside it, suggesting the grouping may not reflect
     actual code organization.
 
-    NOT wired into ``health.runner`` today: the ``cluster()`` call below seeds
-    ``CallGraph._cluster_cache`` with a current-graph partition, which would
-    masquerade as a historical snapshot in the next incremental delta. Before
-    re-enabling, either reset ``_cluster_cache`` after the call or compute the
-    partition without touching the cache.
+    Not wired into ``health.runner`` today, but clustering here is now free of
+    side effects: ``ClusteringService`` returns a partition without touching any
+    language's ``ClusterCache``.
     """
     warning_entities: list[FindingEntity] = []
 
-    cluster_result = call_graph.cluster()
+    cluster_result = ClusteringService().cluster(call_graph)
     if not cluster_result.clusters:
         return StandardCheckSummary(
             check_name="component_cohesion",

--- a/health/runner.py
+++ b/health/runner.py
@@ -100,13 +100,12 @@ def _collect_checks_for_language(
         summaries.append(check_circular_dependencies(package_deps, config))
         summaries.append(check_package_instability(package_deps, config))
 
-    # Component-cohesion check intentionally not run here. It's the only health
-    # check that calls ``CallGraph.cluster()``, which would seed
-    # ``_cluster_cache`` with a current-graph partition and let it masquerade
-    # as a historical snapshot in the next incremental delta. Re-enable via
-    # ``health.checks.cohesion.check_component_cohesion`` only after addressing
-    # that side effect.
-    # use_cache=False
+    # Component-cohesion check still not wired in here, but the side effect that
+    # justified skipping it is gone: ``ClusteringService`` returns a partition
+    # without touching any language's ``ClusterCache``, so it can no longer
+    # masquerade as a historical snapshot in the next incremental delta.
+    # Enabling ``health.checks.cohesion.check_component_cohesion`` is now only a
+    # question of what a clustering pass costs per health run.
 
     # Run LSP-based unused code detection
     exclude_patterns = config.health_exclude_patterns

--- a/health/runner.py
+++ b/health/runner.py
@@ -100,12 +100,8 @@ def _collect_checks_for_language(
         summaries.append(check_circular_dependencies(package_deps, config))
         summaries.append(check_package_instability(package_deps, config))
 
-    # Component-cohesion check still not wired in here, but the side effect that
-    # justified skipping it is gone: ``ClusteringService`` returns a partition
-    # without touching any language's ``ClusterCache``, so it can no longer
-    # masquerade as a historical snapshot in the next incremental delta.
-    # Enabling ``health.checks.cohesion.check_component_cohesion`` is now only a
-    # question of what a clustering pass costs per health run.
+    # check_component_cohesion is not wired in: ClusteringService has no side effects
+    # now, so enabling it is only a cost question.
 
     # Run LSP-based unused code detection
     exclude_patterns = config.health_exclude_patterns

--- a/static_analyzer/__init__.py
+++ b/static_analyzer/__init__.py
@@ -327,7 +327,7 @@ class StaticAnalyzer:
         """Gracefully shut down all engine LSP server processes. Idempotent.
 
         Persists the latest ``_cached_results`` to the pkl on the way down so
-        downstream mutations (``CallGraph._cluster_cache`` populated by the
+        downstream mutations (the language's ``ClusterCache``, populated by the
         abstraction agent) reach disk in one save instead of two. Save errors
         are logged but never block teardown.
         """
@@ -657,8 +657,9 @@ class StaticAnalyzer:
         ``update_cfg_for_changed_files`` along with the language's portion of the
         cached state, and put the merged result back into a fresh
         ``StaticAnalysisResults``. Merging (rather than a full re-LSP) is what
-        preserves the cached CFG's ``_cluster_cache``, so the next incremental
-        run still finds a cluster baseline.
+        preserves the language's ``ClusterCache`` (carried across by ``select``,
+        keeping only surviving nodes), so the next incremental run still finds a
+        cluster baseline.
 
         Changed-file source: ``self.changed_files`` when set at construction
         (git-free — e.g. the wrapper's fingerprint diff), else ``git diff`` via

--- a/static_analyzer/__init__.py
+++ b/static_analyzer/__init__.py
@@ -691,7 +691,7 @@ class StaticAnalyzer:
                 surviving = results.get_cfg(language).nodes
             except ValueError:
                 surviving = {}
-            results.set_clusters(language, cached_results.get_clusters(language).prune(surviving))
+            results.set_clusters(language, cached_results.get_clusters(language).select(surviving))
             self._collect_diagnostics_for(adapter, engine_client, analysis)
             track_lsp_result(
                 language=adapter.language_enum.value,

--- a/static_analyzer/__init__.py
+++ b/static_analyzer/__init__.py
@@ -326,10 +326,9 @@ class StaticAnalyzer:
     def stop_clients(self) -> None:
         """Gracefully shut down all engine LSP server processes. Idempotent.
 
-        Persists the latest ``_cached_results`` to the pkl on the way down so
-        downstream mutations (the language's ``ClusterCache``, populated by the
-        abstraction agent) reach disk in one save instead of two. Save errors
-        are logged but never block teardown.
+        Persists ``_cached_results`` on the way down so the abstraction agent's
+        ``ClusterCache`` writes reach disk in one save. Save errors are logged
+        but never block teardown.
         """
         if not self._clients_started:
             return
@@ -656,10 +655,8 @@ class StaticAnalyzer:
         Per language: determine the changed-file list, hand it to
         ``update_cfg_for_changed_files`` along with the language's portion of the
         cached state, and put the merged result back into a fresh
-        ``StaticAnalysisResults``. Merging (rather than a full re-LSP) is what
-        preserves the language's ``ClusterCache`` (carried across by ``select``,
-        keeping only surviving nodes), so the next incremental run still finds a
-        cluster baseline.
+        ``StaticAnalysisResults``. The cached ``ClusterCache`` is grafted on either
+        way, so a language that fell back to a full re-LSP still leaves a baseline.
 
         Changed-file source: ``self.changed_files`` when set at construction
         (git-free — e.g. the wrapper's fingerprint diff), else ``git diff`` via
@@ -685,9 +682,9 @@ class StaticAnalyzer:
                 )
 
             self._absorb_into_results(results, language, analysis)
-            # Carry the cached partition onto the merged graph — nodes the re-LSP dropped
-            # fall out of the pruned copy. Without this the warm start would hand the next
-            # incremental run an empty cluster baseline.
+            # Both branches, including the full re-LSP: the partition describes cached_sha,
+            # which stays a valid delta baseline however the graph was rebuilt. select()
+            # drops whatever the re-LSP no longer has.
             try:
                 surviving = results.get_cfg(language).nodes
             except ValueError:

--- a/static_analyzer/__init__.py
+++ b/static_analyzer/__init__.py
@@ -684,6 +684,14 @@ class StaticAnalyzer:
                 )
 
             self._absorb_into_results(results, language, analysis)
+            # Carry the cached partition onto the merged graph — nodes the re-LSP dropped
+            # fall out of the pruned copy. Without this the warm start would hand the next
+            # incremental run an empty cluster baseline.
+            try:
+                surviving = results.get_cfg(language).nodes
+            except ValueError:
+                surviving = {}
+            results.set_clusters(language, cached_results.get_clusters(language).prune(surviving))
             self._collect_diagnostics_for(adapter, engine_client, analysis)
             track_lsp_result(
                 language=adapter.language_enum.value,

--- a/static_analyzer/analysis_result.py
+++ b/static_analyzer/analysis_result.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from static_analyzer.clustering import ClusterCache
 from static_analyzer.constants import Language
 from static_analyzer.graph import CallGraph
 from static_analyzer.language_results import LanguageResults
@@ -209,6 +210,18 @@ class StaticAnalysisResults:
         if bucket is not None and bucket.cfg.graph is not None:
             return bucket.cfg.graph
         raise ValueError(f"Control flow graph for language '{language}' not found in results.")
+
+    def get_clusters(self, language: Language) -> ClusterCache:
+        """Return the clustering state for ``language``, creating an empty one if absent.
+
+        Unlike ``get_cfg`` this never raises: an unclustered language has an empty
+        cache, and callers write their partition straight into it.
+        """
+        return self._bucket(language).clusters
+
+    def set_clusters(self, language: Language, clusters: ClusterCache) -> None:
+        """Replace the clustering state for ``language`` wholesale."""
+        self._bucket(language).clusters = clusters
 
     def available_cfgs(self) -> dict[str, CallGraph]:
         """Return every language CFG that is already present."""

--- a/static_analyzer/cluster_helpers.py
+++ b/static_analyzer/cluster_helpers.py
@@ -23,7 +23,7 @@ import networkx.algorithms.community as nx_comm
 from static_analyzer.analysis_result import StaticAnalysisResults
 from static_analyzer.constants import ClusteringConfig, Language
 from static_analyzer.leiden_utils import find_partition
-from static_analyzer.clustering import ClusterResult
+from static_analyzer.clustering import ClusterResult, ClusteringService
 
 logger = logging.getLogger(__name__)
 
@@ -52,10 +52,11 @@ def build_all_cluster_results(static_analysis: StaticAnalysisResults) -> dict[st
     Downstream code maps ``cluster_id -> component`` in a single dict, so IDs must
     not collide across languages.
     """
+    cluster_service = ClusteringService()
     cluster_results: dict[str, ClusterResult] = {}
     offset = 0
     for lang in static_analysis.get_languages():
-        result = static_analysis.get_cfg(lang).cluster()
+        result = cluster_service.cluster(static_analysis.get_cfg(lang))
         if offset:
             result = reindex_cluster_result(result, offset)
             logger.info(f"[Cluster] {lang}: offset IDs by +{offset} ({len(result.clusters)} clusters)")
@@ -67,14 +68,12 @@ def build_all_cluster_results(static_analysis: StaticAnalysisResults) -> dict[st
 
 
 def _sync_cluster_cache(static_analysis: StaticAnalysisResults, cluster_results: dict[str, ClusterResult]) -> None:
-    """Keep each CFG cache aligned with returned cluster IDs."""
+    """Store each language's partition (with its final, offset IDs) on its cluster cache."""
     for lang, result in cluster_results.items():
         try:
-            cfg = static_analysis.get_cfg(Language(lang))
-            cfg._cluster_cache = result
-            cfg.record_cluster_paths(result)
+            static_analysis.get_clusters(Language(lang)).adopt(result)
         except ValueError:
-            logger.warning("Could not sync cluster cache for missing language %s", lang)
+            logger.warning("Could not sync cluster cache for unknown language %s", lang)
 
 
 def reindex_across_languages(cluster_results: dict[str, ClusterResult]) -> None:

--- a/static_analyzer/clustering/__init__.py
+++ b/static_analyzer/clustering/__init__.py
@@ -1,14 +1,19 @@
-"""Clustering of call graphs: the search, the result types, and method lineage.
+"""Clustering of call graphs: the search, the result types, and where results are kept.
 
-``engine`` is the search over an exported ``nx.DiGraph``; ``models`` holds the
-result types; ``method_cluster_paths`` tracks each method's scoped cluster ancestry.
+``service`` is the entry point; ``engine`` is the search over an exported
+``nx.DiGraph``; ``models`` holds the result types; ``cache`` holds the per-language
+state that ``LanguageResults`` owns.
 """
 
+from static_analyzer.clustering.cache import ClusterCache
 from static_analyzer.clustering.method_cluster_paths import MethodClusterPaths
 from static_analyzer.clustering.models import METHOD_LEVEL_STRATEGY, ClusterResult
+from static_analyzer.clustering.service import ClusteringService
 
 __all__ = [
     "METHOD_LEVEL_STRATEGY",
+    "ClusterCache",
     "ClusterResult",
+    "ClusteringService",
     "MethodClusterPaths",
 ]

--- a/static_analyzer/clustering/cache.py
+++ b/static_analyzer/clustering/cache.py
@@ -36,11 +36,11 @@ class ClusterCache:
         """
         self.method_paths.record(cluster_result, scope_id)
 
-    def prune(self, surviving_nodes: Mapping[str, Node]) -> ClusterCache:
-        """Return a copy restricted to ``surviving_nodes``, for filter/union of the graph."""
+    def select(self, surviving_nodes: Mapping[str, Node]) -> ClusterCache:
+        """Return a copy keeping only ``surviving_nodes``, for filter/union of the graph."""
         return ClusterCache(
-            result=self.result.prune(surviving_nodes),
-            method_paths=self.method_paths.prune(surviving_nodes),
+            result=self.result.select(surviving_nodes),
+            method_paths=self.method_paths.select(surviving_nodes),
         )
 
     def visit_paths(self, fn: Callable[[str], str]) -> None:

--- a/static_analyzer/clustering/cache.py
+++ b/static_analyzer/clustering/cache.py
@@ -1,0 +1,47 @@
+"""Per-language clustering state, owned by ``LanguageResults``.
+
+Kept off ``CallGraph`` so the graph stays pure structure: a partition is a
+*result* about a graph, not part of it, and the same graph can be re-clustered
+at a different scope without disturbing what an earlier run recorded.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+
+from static_analyzer.clustering.method_cluster_paths import MethodClusterPaths
+from static_analyzer.clustering.models import ClusterResult
+from static_analyzer.node import Node
+
+
+@dataclass
+class ClusterCache:
+    """The partition of a language's call graph, plus each method's scoped cluster path."""
+
+    result: ClusterResult = field(default_factory=ClusterResult)
+    method_paths: MethodClusterPaths = field(default_factory=MethodClusterPaths)
+
+    def adopt(self, cluster_result: ClusterResult) -> None:
+        """Make ``cluster_result`` this language's partition and record it at root scope."""
+        self.result = cluster_result
+        self.method_paths.record(cluster_result)
+
+    def record_scope(self, cluster_result: ClusterResult, scope_id: str) -> None:
+        """Record a nested scope's partition in the method lineage only.
+
+        Why: sub-clustering a component produces a partition of that scope, not of
+        the language — adopting it would overwrite the top-level partition that
+        ``cluster_snapshot`` reads.
+        """
+        self.method_paths.record(cluster_result, scope_id)
+
+    def prune(self, surviving_nodes: Mapping[str, Node]) -> ClusterCache:
+        """Return a copy restricted to ``surviving_nodes``, for filter/union of the graph."""
+        return ClusterCache(
+            result=self.result.prune(surviving_nodes),
+            method_paths=self.method_paths.prune(surviving_nodes),
+        )
+
+    def visit_paths(self, fn: Callable[[str], str]) -> None:
+        self.result.visit_paths(fn)

--- a/static_analyzer/clustering/engine.py
+++ b/static_analyzer/clustering/engine.py
@@ -139,9 +139,7 @@ def _abstract_at_level(graph: nx.DiGraph, level: Level, delimiter: str) -> nx.Di
         if abstract_name not in abstracted:
             abstracted.add_node(abstract_name)
 
-    # These weights are recorded but never read: _leiden_candidate calls find_partition
-    # without ``weight=``, so class and file levels cluster unweighted. Passing them would
-    # change every existing partition, so it needs its own change.
+    # Never read: find_partition is called without ``weight=``. Passing it moves every partition.
     edge_weights: dict[tuple[str, str], int] = defaultdict(int)
     for src, dst in graph.edges():
         a_src, a_dst = node_map[src], node_map[dst]
@@ -164,8 +162,6 @@ def _leiden_candidate(graph: nx.DiGraph, level: Level, min_cluster_size: int, to
     try:
         communities = find_partition(graph, seed=ClusteringConfig.CLUSTERING_SEED)
     except Exception:
-        # Warn, not debug: if every level throws we ship connected components, which
-        # looks like an ordinary result with nothing explaining it.
         logger.warning(f"Leiden failed at level {level or 'raw'}; scoring 0", exc_info=True)
     score = _score_clustering(communities, min_cluster_size, total_nodes)
     logger.debug(f"leiden: score={score:.3f}, clusters={len(communities)}")

--- a/static_analyzer/clustering/method_cluster_paths.py
+++ b/static_analyzer/clustering/method_cluster_paths.py
@@ -21,7 +21,7 @@ class MethodClusterPaths:
             for qname, cluster_ids in other.snapshot():
                 self._paths.setdefault(qname, set()).update(cluster_ids)
 
-    def prune(self, surviving_nodes: Mapping[str, object]) -> "MethodClusterPaths":
+    def select(self, surviving_nodes: Mapping[str, object]) -> "MethodClusterPaths":
         with self._lock:
             return MethodClusterPaths(
                 {qname: set(cluster_ids) for qname, cluster_ids in self._paths.items() if qname in surviving_nodes}

--- a/static_analyzer/clustering/models.py
+++ b/static_analyzer/clustering/models.py
@@ -1,8 +1,12 @@
 """Clustering output types."""
 
+from __future__ import annotations
+
 from collections import defaultdict
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
+
+from static_analyzer.node import Node
 
 # Marker on a ClusterResult whose clusters are synthetic one-method-per-cluster
 # groups, produced when a subgraph had too few natural clusters to assign methods
@@ -12,7 +16,7 @@ METHOD_LEVEL_STRATEGY = "method_level_expansion"
 
 @dataclass
 class ClusterResult:
-    """Result of clustering a CallGraph. Provides deterministic cluster IDs and file mappings."""
+    """A partition of a CallGraph. Provides deterministic cluster IDs and file mappings."""
 
     clusters: dict[int, set[str]] = field(default_factory=dict)  # cluster_id -> node names
     cluster_to_files: dict[int, set[str]] = field(default_factory=dict)  # cluster_id -> file_paths
@@ -37,3 +41,28 @@ class ClusterResult:
         for path, cluster_ids in self.file_to_clusters.items():
             remapped_file_to_clusters[fn(path)].update(cluster_ids)
         self.file_to_clusters = dict(remapped_file_to_clusters)
+
+    def prune(self, surviving_nodes: Mapping[str, Node]) -> ClusterResult:
+        """Drop qnames not in ``surviving_nodes`` and recompute the file mappings."""
+        pruned_clusters: dict[int, set[str]] = {}
+        pruned_cluster_to_files: dict[int, set[str]] = {}
+        pruned_file_to_clusters: dict[str, set[int]] = {}
+        for cid, members in self.clusters.items():
+            kept = {m for m in members if m in surviving_nodes}
+            if not kept:
+                continue
+            pruned_clusters[cid] = kept
+            files: set[str] = set()
+            for qname in kept:
+                file_path = surviving_nodes[qname].file_path
+                if file_path:
+                    files.add(file_path)
+                    pruned_file_to_clusters.setdefault(file_path, set()).add(cid)
+            if files:
+                pruned_cluster_to_files[cid] = files
+        return ClusterResult(
+            clusters=pruned_clusters,
+            cluster_to_files=pruned_cluster_to_files,
+            file_to_clusters=pruned_file_to_clusters,
+            strategy=self.strategy,
+        )

--- a/static_analyzer/clustering/models.py
+++ b/static_analyzer/clustering/models.py
@@ -42,27 +42,27 @@ class ClusterResult:
             remapped_file_to_clusters[fn(path)].update(cluster_ids)
         self.file_to_clusters = dict(remapped_file_to_clusters)
 
-    def prune(self, surviving_nodes: Mapping[str, Node]) -> ClusterResult:
-        """Drop qnames not in ``surviving_nodes`` and recompute the file mappings."""
-        pruned_clusters: dict[int, set[str]] = {}
-        pruned_cluster_to_files: dict[int, set[str]] = {}
-        pruned_file_to_clusters: dict[str, set[int]] = {}
+    def select(self, surviving_nodes: Mapping[str, Node]) -> ClusterResult:
+        """Return a copy keeping only qnames in ``surviving_nodes``, with file mappings recomputed."""
+        kept_clusters: dict[int, set[str]] = {}
+        kept_cluster_to_files: dict[int, set[str]] = {}
+        kept_file_to_clusters: dict[str, set[int]] = {}
         for cid, members in self.clusters.items():
             kept = {m for m in members if m in surviving_nodes}
             if not kept:
                 continue
-            pruned_clusters[cid] = kept
+            kept_clusters[cid] = kept
             files: set[str] = set()
             for qname in kept:
                 file_path = surviving_nodes[qname].file_path
                 if file_path:
                     files.add(file_path)
-                    pruned_file_to_clusters.setdefault(file_path, set()).add(cid)
+                    kept_file_to_clusters.setdefault(file_path, set()).add(cid)
             if files:
-                pruned_cluster_to_files[cid] = files
+                kept_cluster_to_files[cid] = files
         return ClusterResult(
-            clusters=pruned_clusters,
-            cluster_to_files=pruned_cluster_to_files,
-            file_to_clusters=pruned_file_to_clusters,
+            clusters=kept_clusters,
+            cluster_to_files=kept_cluster_to_files,
+            file_to_clusters=kept_file_to_clusters,
             strategy=self.strategy,
         )

--- a/static_analyzer/clustering/service.py
+++ b/static_analyzer/clustering/service.py
@@ -15,13 +15,9 @@ class ClusteringService:
     keep a partition store it in the ``ClusterCache`` on their ``LanguageResults``.
     """
 
-    def __init__(
-        self,
-        target_clusters: int = ClusteringConfig.DEFAULT_TARGET_CLUSTERS,
-        min_cluster_size: int = ClusteringConfig.DEFAULT_MIN_CLUSTER_SIZE,
-    ) -> None:
-        self.target_clusters = target_clusters
-        self.min_cluster_size = min_cluster_size
+    def __init__(self) -> None:
+        self.target_clusters = ClusteringConfig.DEFAULT_TARGET_CLUSTERS
+        self.min_cluster_size = ClusteringConfig.DEFAULT_MIN_CLUSTER_SIZE
 
     def cluster(self, graph: CallGraph) -> ClusterResult:
         nx_graph = graph.clustering_networkx()

--- a/static_analyzer/clustering/service.py
+++ b/static_analyzer/clustering/service.py
@@ -1,0 +1,33 @@
+"""Entry point for clustering a call graph."""
+
+from __future__ import annotations
+
+from static_analyzer.graph import CallGraph
+from static_analyzer.clustering.engine import cluster_graph
+from static_analyzer.clustering.models import ClusterResult
+from static_analyzer.constants import ClusteringConfig
+
+
+class ClusteringService:
+    """Clusters a ``CallGraph``.
+
+    Pure: it neither mutates the graph nor caches anything. Callers that want to
+    keep a partition store it in the ``ClusterCache`` on their ``LanguageResults``.
+    """
+
+    def __init__(
+        self,
+        target_clusters: int = ClusteringConfig.DEFAULT_TARGET_CLUSTERS,
+        min_cluster_size: int = ClusteringConfig.DEFAULT_MIN_CLUSTER_SIZE,
+    ) -> None:
+        self.target_clusters = target_clusters
+        self.min_cluster_size = min_cluster_size
+
+    def cluster(self, graph: CallGraph) -> ClusterResult:
+        nx_graph = graph.clustering_networkx()
+        return cluster_graph(
+            nx_graph,
+            delimiter=graph.delimiter,
+            target_clusters=self.target_clusters,
+            min_cluster_size=self.min_cluster_size,
+        )

--- a/static_analyzer/graph.py
+++ b/static_analyzer/graph.py
@@ -6,9 +6,6 @@ from types import MappingProxyType
 
 import networkx as nx
 
-from static_analyzer.clustering.engine import cluster_graph
-from static_analyzer.clustering.method_cluster_paths import MethodClusterPaths
-from static_analyzer.clustering.models import ClusterResult
 from static_analyzer.constants import ClusteringConfig
 from static_analyzer.node import Node
 
@@ -107,10 +104,6 @@ class CallGraph:
         # Every adapter currently emits ``.``-separated qualified names; see
         # ``constants.QUALIFIED_NAME_DELIMITER`` for the language-switch caveat.
         self.delimiter = ClusteringConfig.QUALIFIED_NAME_DELIMITER
-        # Cache for cluster result
-        self._cluster_cache: ClusterResult | None = None
-        # qname -> scoped cluster ids it belongs to, e.g. ["1", "1.3", "1.3.6"].
-        self.method_cluster_paths = MethodClusterPaths()
         # Location-based dedup: (file_path, line_start, line_end, type) -> canonical qualified name.
         # When the LSP produces multiple qualified-name aliases for the same
         # physical symbol (e.g. ``src.index.funcA`` vs
@@ -228,10 +221,9 @@ class CallGraph:
     ) -> "CallGraph":
         """Return a new CallGraph keeping only nodes matching ``keep_node`` and connecting edges.
 
-        ``_cluster_cache`` is preserved and pruned to the surviving qnames so
-        a warm-start invalidation/filter step doesn't silently drop the prior
-        clustering. Edges whose endpoints both survive are re-added; edges
-        with a dropped endpoint are cascaded out and optionally collected.
+        Edges whose endpoints both survive are re-added; edges with a dropped
+        endpoint are cascaded out and optionally collected. Any partition over
+        this graph lives in a ``ClusterCache`` and is pruned by its owner.
         """
         out = CallGraph(language=self.language)
         for node in self.nodes.values():
@@ -246,19 +238,11 @@ class CallGraph:
                     logger.warning(f"Failed to add edge {src} -> {dst} during filter: {e}")
             else:
                 on_dropped_edge(edge)
-        out._cluster_cache = self._prune_cluster_cache(out.nodes)
-        out.method_cluster_paths = self._prune_method_cluster_paths(out.nodes)
         self._carry_reference_edges(out)
         return out
 
     def union(self, other: "CallGraph") -> "CallGraph":
-        """Return a new CallGraph unioning ``self`` (cached) with ``other`` (fresh).
-
-        ``_cluster_cache`` comes from ``self`` (the cached side that was
-        clustered in a prior run), pruned to the merged-node set. ``other``'s
-        nodes are new and unclustered until the next clustering pass; that's
-        the intended cluster_delta input — new files appear unassigned.
-        """
+        """Return a new CallGraph unioning ``self`` (cached) with ``other`` (fresh)."""
         out = CallGraph(language=self.language)
         for node in self.nodes.values():
             out.add_node(node)
@@ -274,57 +258,16 @@ class CallGraph:
                 out.add_edge(edge.get_source(), edge.get_destination(), call_sites=edge.call_sites)
             except ValueError:
                 pass
-        out._cluster_cache = self._prune_cluster_cache(out.nodes)
-        out.method_cluster_paths = self._prune_method_cluster_paths(out.nodes)
         # Carry reference edges from BOTH sides: ``other`` holds the fresh reference edges for
         # changed/added files, which would otherwise be lost and revert those files to call-only.
         self._carry_reference_edges(out, other)
         return out
-
-    def _prune_cluster_cache(self, surviving_nodes: dict[str, Node]) -> "ClusterResult | None":
-        """Drop qnames not in ``surviving_nodes`` from ``_cluster_cache``; recompute file maps."""
-        if self._cluster_cache is None:
-            return None
-        pruned_clusters: dict[int, set[str]] = {}
-        pruned_cluster_to_files: dict[int, set[str]] = {}
-        pruned_file_to_clusters: dict[str, set[int]] = {}
-        for cid, members in self._cluster_cache.clusters.items():
-            kept = {m for m in members if m in surviving_nodes}
-            if not kept:
-                continue
-            pruned_clusters[cid] = kept
-            files: set[str] = set()
-            for qname in kept:
-                fp = surviving_nodes[qname].file_path
-                if fp:
-                    files.add(fp)
-                    pruned_file_to_clusters.setdefault(fp, set()).add(cid)
-            if files:
-                pruned_cluster_to_files[cid] = files
-        return ClusterResult(
-            clusters=pruned_clusters,
-            cluster_to_files=pruned_cluster_to_files,
-            file_to_clusters=pruned_file_to_clusters,
-            strategy=self._cluster_cache.strategy,
-        )
-
-    def _prune_method_cluster_paths(self, surviving_nodes: dict[str, Node]) -> MethodClusterPaths:
-        return self.method_cluster_paths.prune(surviving_nodes)
 
     def visit_paths(self, fn: Callable[[str], str]) -> None:
         for node in self.nodes.values():
             node.file_path = fn(node.file_path)
         for edge in self.edges:
             edge.visit_paths(fn)
-        if self._cluster_cache is not None:
-            self._cluster_cache.visit_paths(fn)
-
-    def record_cluster_paths(self, cluster_result: ClusterResult, scope_id: str = "") -> None:
-        """Record each member's current cluster id for this scope."""
-        self.method_cluster_paths.record(cluster_result, scope_id)
-
-    def method_cluster_paths_snapshot(self) -> list[tuple[str, set[str]]]:
-        return self.method_cluster_paths.snapshot()
 
     def to_networkx(self) -> nx.DiGraph:
         nx_graph = nx.DiGraph()
@@ -360,22 +303,6 @@ class CallGraph:
                 nx_graph.add_edge(rsrc, rdst)
         return nx_graph
 
-    def cluster(
-        self,
-        target_clusters: int = ClusteringConfig.DEFAULT_TARGET_CLUSTERS,
-        min_cluster_size: int = ClusteringConfig.DEFAULT_MIN_CLUSTER_SIZE,
-    ) -> ClusterResult:
-        """Cluster the graph, caching the partition on first call."""
-        if self._cluster_cache is not None:
-            return self._cluster_cache
-        self._cluster_cache = cluster_graph(
-            self.clustering_networkx(),
-            delimiter=self.delimiter,
-            target_clusters=target_clusters,
-            min_cluster_size=min_cluster_size,
-        )
-        return self._cluster_cache
-
     def filter_by_files(self, file_paths: set[str]) -> "CallGraph":
         """
         Create a new CallGraph containing only nodes from the specified files.
@@ -400,7 +327,6 @@ class CallGraph:
 
         # Create new graph, preserving the source language
         sub_graph = CallGraph(nodes=relevant_nodes, edges=filtered_edges, language=self.language)
-        sub_graph.method_cluster_paths = self._prune_method_cluster_paths(relevant_nodes)
         self._carry_reference_edges(sub_graph)
 
         return sub_graph
@@ -424,7 +350,6 @@ class CallGraph:
                 )
 
         sub_graph = CallGraph(nodes=relevant_nodes, edges=filtered_edges, language=self.language)
-        sub_graph.method_cluster_paths = self._prune_method_cluster_paths(relevant_nodes)
         self._carry_reference_edges(sub_graph)
         return sub_graph
 

--- a/static_analyzer/language_results.py
+++ b/static_analyzer/language_results.py
@@ -11,6 +11,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 import logging
 
+from static_analyzer.clustering import ClusterCache
 from static_analyzer.graph import CallGraph, EdgeKind
 from static_analyzer.node import Node
 
@@ -65,7 +66,6 @@ class ControlFlowGraph:
         # tuple is post-alias-resolution, and a membership scan per edge is quadratic.
         # getattr for the same reason as above: pre-reference-edge caches lack the field.
         self.graph.reference_edges = list(dict.fromkeys(getattr(self.graph, "reference_edges", ())))
-        self.graph.method_cluster_paths.merge(other.method_cluster_paths)
 
     def visit_paths(self, fn: Callable[[str], str]) -> None:
         if self.graph is None:
@@ -162,6 +162,7 @@ class LanguageResults:
     references: References = field(default_factory=References)
     dependencies: PackageDependencies = field(default_factory=PackageDependencies)
     source_files: SourceFiles = field(default_factory=SourceFiles)
+    clusters: ClusterCache = field(default_factory=ClusterCache)
 
     def visit_paths(self, fn: Callable[[str], str]) -> None:
         self.cfg.visit_paths(fn)
@@ -169,3 +170,4 @@ class LanguageResults:
         self.references.visit_paths(fn)
         self.dependencies.visit_paths(fn)
         self.source_files.visit_paths(fn)
+        self.clusters.visit_paths(fn)

--- a/tests/agents/test_details_agent.py
+++ b/tests/agents/test_details_agent.py
@@ -22,7 +22,7 @@ from diagram_analysis.file_index import build_files_index
 from static_analyzer.analysis_result import StaticAnalysisResults
 from static_analyzer.constants import NodeType
 from static_analyzer.graph import CallGraph
-from static_analyzer.clustering import ClusterResult
+from static_analyzer.clustering import ClusterCache, ClusterResult, ClusteringService
 from static_analyzer.node import Node
 
 
@@ -178,29 +178,30 @@ class TestDetailsAgent(unittest.TestCase):
 
         mock_subgraph = MagicMock()
         mock_subgraph.nodes = {"n1": mock_node}
-        mock_subgraph.cluster.return_value = mock_sub_cluster_result
-        mock_subgraph.method_cluster_paths_snapshot.return_value = []
 
         mock_cfg = MagicMock()
         mock_cfg.filter_by_nodes.return_value = mock_subgraph
 
         self.mock_static_analysis.get_languages.return_value = ["python"]
         self.mock_static_analysis.get_cfg.return_value = mock_cfg
+        self.mock_static_analysis.get_clusters.return_value = ClusterCache()
 
-        subgraph_cluster_results, subgraph_cfgs = agent._create_strict_component_subgraph(self.test_component)
+        with patch.object(ClusteringService, "cluster", return_value=mock_sub_cluster_result) as mock_cluster:
+            subgraph_cluster_results, subgraph_cfgs = agent._create_strict_component_subgraph(self.test_component)
 
         self.assertIs(subgraph_cluster_results["python"], mock_sub_cluster_result)
         self.assertIn("python", subgraph_cfgs)
         self.assertIs(subgraph_cfgs["python"], mock_subgraph)
         self.mock_static_analysis.get_cfg.assert_called_with("python")
         mock_cfg.filter_by_nodes.assert_called_with(expected_qnames)
-        mock_subgraph.cluster.assert_called_once()
+        mock_cluster.assert_called_once_with(mock_subgraph)
 
     def test_step_clusters_grouping(self):
         # Grouping is deterministic (resolution-tuned Leiden on the subgraph), no LLM call.
         agent = self._make_agent()
         cr, graph = self._clustered_graph(range(1, 11))
         subgraph_cfg = MagicMock()
+        subgraph_cfg.to_networkx.return_value = graph
         subgraph_cfg.clustering_networkx.return_value = graph
         subgraph_cluster_results = {"python": cr}
         subgraph_cfgs = {"python": subgraph_cfg}
@@ -398,6 +399,7 @@ class TestDetailsAgent(unittest.TestCase):
         mock_subgraph.cluster.return_value = sub_cluster_result
         mock_subgraph.to_cluster_string.return_value = "Component CFG String"
         mock_subgraph.to_networkx.return_value = subgraph_graph
+        mock_subgraph.clustering_networkx.return_value = subgraph_graph
 
         mock_cfg = MagicMock()
         mock_cfg.cluster.return_value = mock_cluster_result
@@ -406,6 +408,7 @@ class TestDetailsAgent(unittest.TestCase):
         mock_cfg.to_cluster_string.return_value = "Cluster 1: method_a, method_b"
         # deterministic_cluster_grouping reads the (super-)graph via get_cfg(...).to_networkx()
         mock_cfg.to_networkx.return_value = subgraph_graph
+        mock_cfg.clustering_networkx.return_value = subgraph_graph
 
         self.mock_static_analysis.get_languages.return_value = ["python"]
         self.mock_static_analysis.get_cfg.return_value = mock_cfg

--- a/tests/diagram_analysis/test_cluster_snapshot.py
+++ b/tests/diagram_analysis/test_cluster_snapshot.py
@@ -1,10 +1,9 @@
 """Tests for ``diagram_analysis.cluster_snapshot``.
 
-The snapshot is sourced exclusively from each per-language CFG's
-``CallGraph._cluster_cache`` (the partition is round-tripped through the
-SHA-tagged pkl). Languages without a populated cache contribute nothing,
-which is what triggers the full-analysis fallback in
-``DiagramGenerator.generate_analysis_incremental``.
+The snapshot is sourced exclusively from each language's ``ClusterCache``
+(the partition is round-tripped through the SHA-tagged pkl). Languages
+without a populated cache contribute nothing, which is what triggers the
+full-analysis fallback in ``DiagramGenerator.generate_analysis_incremental``.
 """
 
 import unittest
@@ -38,22 +37,24 @@ def _build_graph(node_specs: list[tuple[str, str]]) -> CallGraph:
     return graph
 
 
-def _build_static(graphs: dict[str, CallGraph]) -> StaticAnalysisResults:
+def _build_static(graphs: dict[str, CallGraph], partitions: dict[str, ClusterResult] = {}) -> StaticAnalysisResults:
     results = StaticAnalysisResults()
     for language, graph in graphs.items():
         results.add_cfg(Language(language), graph)
+        if language in partitions:
+            results.get_clusters(Language(language)).adopt(partitions[language])
     return results
 
 
 class TestSnapshotFromStaticAnalysis(unittest.TestCase):
-    def test_partition_read_from_cfg_cache(self) -> None:
+    def test_partition_read_from_cluster_cache(self) -> None:
         graph = _build_graph([("a.foo", "a.py"), ("a.bar", "a.py"), ("b.baz", "b.py")])
-        graph._cluster_cache = ClusterResult(
+        partition = ClusterResult(
             clusters={5: {"a.foo", "a.bar"}, 6: {"b.baz"}},
             cluster_to_files={5: {"a.py"}, 6: {"b.py"}},
             file_to_clusters={"a.py": {5}, "b.py": {6}},
         )
-        static = _build_static({"python": graph})
+        static = _build_static({"python": graph}, {"python": partition})
 
         snap = snapshot_from_static_analysis(static)
 
@@ -66,10 +67,14 @@ class TestSnapshotFromStaticAnalysis(unittest.TestCase):
 
     def test_partitions_each_language_independently(self) -> None:
         py_graph = _build_graph([("a.foo", "a.py"), ("b.baz", "b.py")])
-        py_graph._cluster_cache = ClusterResult(clusters={1: {"a.foo"}, 2: {"b.baz"}})
         go_graph = _build_graph([("c.qux", "c.go")])
-        go_graph._cluster_cache = ClusterResult(clusters={3: {"c.qux"}})
-        static = _build_static({"python": py_graph, "go": go_graph})
+        static = _build_static(
+            {"python": py_graph, "go": go_graph},
+            {
+                "python": ClusterResult(clusters={1: {"a.foo"}, 2: {"b.baz"}}),
+                "go": ClusterResult(clusters={3: {"c.qux"}}),
+            },
+        )
 
         snap = snapshot_from_static_analysis(static)
 
@@ -79,12 +84,12 @@ class TestSnapshotFromStaticAnalysis(unittest.TestCase):
         self.assertEqual(snap.by_language["go"][3].members, {"c.qux"})
 
     def test_language_without_cluster_cache_is_skipped(self) -> None:
-        # Why: legacy pkl / first-ever run leaves ``_cluster_cache`` as None.
+        # Why: a first-ever run leaves the ``ClusterCache`` partition as None.
         # ``generate_analysis_incremental`` checks ``all_cluster_ids()`` and
         # falls back to a full run, which then warms the pkl. The empty
         # snapshot here is the explicit "I have nothing to compare against"
         # signal, not an error.
-        graph = _build_graph([("a.foo", "a.py")])  # _cluster_cache is None
+        graph = _build_graph([("a.foo", "a.py")])  # no partition recorded
         static = _build_static({"python": graph})
 
         snap = snapshot_from_static_analysis(static)
@@ -92,13 +97,12 @@ class TestSnapshotFromStaticAnalysis(unittest.TestCase):
         self.assertEqual(snap.all_cluster_ids(), set())
 
     def test_qnames_outside_cfg_are_dropped_from_member_files(self) -> None:
-        # A qname can appear in the cluster cache without a corresponding CFG
+        # A qname can appear in the partition without a corresponding CFG
         # node when the cache was saved before a node-level mutation. Such
         # qnames have no authoritative file_path, so they're absorbed into
         # ``members`` but contribute nothing to ``files`` / ``member_files``.
         graph = _build_graph([("a.foo", "a.py")])
-        graph._cluster_cache = ClusterResult(clusters={1: {"a.foo", "ghost.fn"}})
-        static = _build_static({"python": graph})
+        static = _build_static({"python": graph}, {"python": ClusterResult(clusters={1: {"a.foo", "ghost.fn"}})})
 
         snap = snapshot_from_static_analysis(static)
 

--- a/tests/diagram_analysis/test_cluster_snapshot.py
+++ b/tests/diagram_analysis/test_cluster_snapshot.py
@@ -37,7 +37,7 @@ def _build_graph(node_specs: list[tuple[str, str]]) -> CallGraph:
     return graph
 
 
-def _build_static(graphs: dict[str, CallGraph], partitions: dict[str, ClusterResult] = {}) -> StaticAnalysisResults:
+def _build_static(graphs: dict[str, CallGraph], partitions: dict[str, ClusterResult]) -> StaticAnalysisResults:
     results = StaticAnalysisResults()
     for language, graph in graphs.items():
         results.add_cfg(Language(language), graph)
@@ -90,7 +90,7 @@ class TestSnapshotFromStaticAnalysis(unittest.TestCase):
         # snapshot here is the explicit "I have nothing to compare against"
         # signal, not an error.
         graph = _build_graph([("a.foo", "a.py")])  # no partition recorded
-        static = _build_static({"python": graph})
+        static = _build_static({"python": graph}, {})
 
         snap = snapshot_from_static_analysis(static)
 

--- a/tests/diagram_analysis/test_diagram_analysis.py
+++ b/tests/diagram_analysis/test_diagram_analysis.py
@@ -1779,14 +1779,16 @@ class TestDiagramGenerator(unittest.TestCase):
                 line_end=1,
             )
         )
-        cfg._cluster_cache = ClusterResult(
-            clusters={1: {"test.fn"}},
-            cluster_to_files={1: {str(self.repo_location / "test.py")}},
-            file_to_clusters={str(self.repo_location / "test.py"): {1}},
-            strategy="test",
-        )
         results = StaticAnalysisResults()
         results.add_cfg(Language.PYTHON, cfg)
+        results.get_clusters(Language.PYTHON).adopt(
+            ClusterResult(
+                clusters={1: {"test.fn"}},
+                cluster_to_files={1: {str(self.repo_location / "test.py")}},
+                file_to_clusters={str(self.repo_location / "test.py"): {1}},
+                strategy="test",
+            )
+        )
         gen.static_analysis = results
 
         gen._persist_static_analysis_artifact()
@@ -1797,7 +1799,7 @@ class TestDiagramGenerator(unittest.TestCase):
             return
         loaded_results, cached_sha = loaded
         self.assertEqual(cached_sha, "sha-current")
-        self.assertIsNotNone(loaded_results.get_cfg(Language.PYTHON)._cluster_cache)
+        self.assertTrue(loaded_results.get_clusters(Language.PYTHON).result.clusters)
 
     def _finalize_gen(self):
         gen = DiagramGenerator(

--- a/tests/diagram_analysis/test_tree_shape.py
+++ b/tests/diagram_analysis/test_tree_shape.py
@@ -11,7 +11,7 @@ from diagram_analysis.analysis_json import build_unified_analysis_json, parse_un
 from diagram_analysis.diagram_generator import DiagramGenerator, _member_keys, _reconcile_child_scope
 from diagram_analysis.exceptions import ScopeContainmentError
 from static_analyzer.graph import CallGraph
-from static_analyzer.clustering.method_cluster_paths import MethodClusterPaths
+from static_analyzer.clustering import ClusterCache, MethodClusterPaths
 from diagram_analysis.tree_shape import absorb_single_child_components
 
 
@@ -409,12 +409,11 @@ class TestClusterLineageMovesWithTheTree(unittest.TestCase):
                 component("1.1.1", "G", {"a.py": ["a.one"]}), component("1.1.2", "G2", {"a.py": ["a.one"]})
             ),
         }
-        cfg = CallGraph()
-        cfg.method_cluster_paths = MethodClusterPaths({"a.one": {"1.0", "1.1.4"}})
+        clusters = ClusterCache(method_paths=MethodClusterPaths({"a.one": {"1.0", "1.1.4"}}))
 
-        absorb_single_child_components(root, subs, [cfg])
+        absorb_single_child_components(root, subs, [clusters])
 
-        self.assertEqual(cfg.method_cluster_paths.snapshot_dict(), {"a.one": {"1.4"}})
+        self.assertEqual(clusters.method_paths.snapshot_dict(), {"a.one": {"1.4"}})
 
 
 class TestAbsorptionKeepsTheDocumentRenderable(unittest.TestCase):

--- a/tests/static_analyzer/test_analysis_cache_inmem.py
+++ b/tests/static_analyzer/test_analysis_cache_inmem.py
@@ -212,9 +212,9 @@ class TestClusterCachePreservation(unittest.TestCase):
         cached = _result(self._cg(), source_files=["a.py", "b.py"])
 
         updated = invalidate_files(cached, {Path("a.py")}).analysis
-        pruned = self._cache().prune(updated.call_graph.nodes)
+        kept = self._cache().select(updated.call_graph.nodes)
 
-        cc = pruned.result
+        cc = kept.result
         # Cluster 1 had only a.py members -> dropped entirely.
         # Cluster 2 keeps b.qux from b.py.
         self.assertNotIn(1, cc.clusters)
@@ -229,7 +229,7 @@ class TestClusterCachePreservation(unittest.TestCase):
         # cluster 2 (b.qux only) drops.
         updated = invalidate_files(cached, {Path("b.py")}).analysis
 
-        cc = self._cache().prune(updated.call_graph.nodes).result
+        cc = self._cache().select(updated.call_graph.nodes).result
 
         self.assertEqual(cc.clusters[1], {"a.foo", "a.bar"})
         self.assertNotIn(2, cc.clusters)
@@ -241,7 +241,7 @@ class TestClusterCachePreservation(unittest.TestCase):
         new = _result(new_cg, source_files=["c.py"])
 
         merged = merge_results(_analysis_data(cached), new)
-        cc = self._cache().prune(merged.call_graph.nodes).result
+        cc = self._cache().select(merged.call_graph.nodes).result
 
         # Cached clusters survive; new node 'c.new' is unclustered (intentional —
         # cluster_delta will pick it up as drift on the next run).
@@ -274,7 +274,7 @@ class TestClusterCachePreservation(unittest.TestCase):
         new.add_node(_node("c.new", "c.py"))
 
         unioned = self._cg().union(new)
-        cc = self._cache().prune(unioned.nodes).result
+        cc = self._cache().select(unioned.nodes).result
 
         self.assertEqual(cc.clusters, {1: {"a.foo", "a.bar"}, 2: {"b.qux"}})
         # New node from `other` participates in the graph but not yet in any cluster.

--- a/tests/static_analyzer/test_analysis_cache_inmem.py
+++ b/tests/static_analyzer/test_analysis_cache_inmem.py
@@ -8,8 +8,9 @@ the cached analysis-dict up to date in memory before saving a new pkl.
 import unittest
 import tempfile
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
+from static_analyzer import EngineConfig, StaticAnalyzer
 from static_analyzer.analysis_cache import StaticAnalysisCache, invalidate_files, merge_results
 from static_analyzer.analysis_result import AnalysisData, StaticAnalysisResults
 from static_analyzer.constants import Language, NodeType
@@ -331,6 +332,74 @@ class TestClusterCachePreservation(unittest.TestCase):
             loaded_partition = loaded.get_clusters(Language.PYTHON).result
             self.assertEqual(loaded_partition.cluster_to_files, {1: {expected_file}})
             self.assertEqual(loaded_partition.file_to_clusters, {expected_file: {1}})
+
+
+class TestUpdateCachedResultsCarriesPartition(unittest.TestCase):
+    """Binds the graft in ``_update_cached_results``; delete that line and these fail.
+
+    The classes above exercise ``ClusterCache.select`` directly, so they stay green
+    whether or not the warm start actually wires it up.
+    """
+
+    def _analyzer(self, project: Path, changed_files: set[Path] | None) -> StaticAnalyzer:
+        analyzer = object.__new__(StaticAnalyzer)
+        adapter = MagicMock()
+        adapter.language = "Python"
+        adapter.language_enum = Language.PYTHON
+        analyzer._engine_clients = [(EngineConfig(adapter=adapter, project_path=project), MagicMock())]
+        analyzer.collected_diagnostics = {}
+        analyzer.ignore_manager = MagicMock()
+        analyzer._loc_for_adapter = MagicMock(return_value=0)
+        analyzer.changed_files = changed_files
+        return analyzer
+
+    def _cached(self) -> StaticAnalysisResults:
+        cg = CallGraph(language="python")
+        cg.add_node(_node("a.foo", "a.py"))
+        cg.add_node(_node("b.qux", "b.py"))
+        cached = StaticAnalysisResults()
+        cached.add_cfg(Language.PYTHON, cg)
+        clusters = ClusterCache()
+        clusters.adopt(ClusterResult(clusters={1: {"a.foo"}, 2: {"b.qux"}}, strategy="leiden"))
+        cached.set_clusters(Language.PYTHON, clusters)
+        return cached
+
+    def _surviving_graph(self) -> CallGraph:
+        """What the re-LSP hands back: a.foo is gone, b.qux survives."""
+        cg = CallGraph(language="python")
+        cg.add_node(_node("b.qux", "b.py"))
+        return cg
+
+    def test_merge_branch_carries_the_partition_pruned_to_survivors(self) -> None:
+        project = Path("/proj").resolve()
+        analyzer = self._analyzer(project, changed_files={project / "a.py"})
+
+        with (
+            patch(
+                "static_analyzer.update_cfg_for_changed_files",
+                return_value={"call_graph": self._surviving_graph()},
+            ),
+            patch.object(analyzer, "_collect_diagnostics_for"),
+            patch("static_analyzer.track_lsp_result"),
+        ):
+            results = analyzer._update_cached_results(self._cached(), cached_sha="deadbeef")
+
+        self.assertEqual(results.get_clusters(Language.PYTHON).result.clusters, {2: {"b.qux"}})
+
+    def test_full_relsp_branch_also_carries_the_partition(self) -> None:
+        """Git detection failing is not a reason to hand the next run an empty baseline."""
+        project = Path("/proj").resolve()
+        analyzer = self._analyzer(project, changed_files=None)
+
+        with (
+            patch("static_analyzer.get_changed_files_since", side_effect=RuntimeError("not a git repo")),
+            patch.object(analyzer, "_run_full_analysis", return_value={"call_graph": self._surviving_graph()}),
+            patch.object(analyzer, "_collect_diagnostics_for"),
+            patch("static_analyzer.track_lsp_result"),
+        ):
+            results = analyzer._update_cached_results(self._cached(), cached_sha="deadbeef")
+
+        self.assertEqual(results.get_clusters(Language.PYTHON).result.clusters, {2: {"b.qux"}})
 
 
 class TestWarmStartDeletion(unittest.TestCase):

--- a/tests/static_analyzer/test_analysis_cache_inmem.py
+++ b/tests/static_analyzer/test_analysis_cache_inmem.py
@@ -13,8 +13,8 @@ from unittest.mock import MagicMock
 from static_analyzer.analysis_cache import StaticAnalysisCache, invalidate_files, merge_results
 from static_analyzer.analysis_result import AnalysisData, StaticAnalysisResults
 from static_analyzer.constants import Language, NodeType
-from static_analyzer.graph import CallGraph, Edge
-from static_analyzer.clustering import ClusterResult
+from static_analyzer.graph import CallGraph
+from static_analyzer.clustering import ClusterCache, ClusterResult
 from static_analyzer.node import Node
 from static_analyzer.incremental_orchestrator import (
     _definition_nodes,
@@ -187,32 +187,34 @@ class TestMergeResults(unittest.TestCase):
 
 
 class TestClusterCachePreservation(unittest.TestCase):
-    """``_cluster_cache`` must survive warm-start invalidation/merge.
+    """The partition must survive warm-start invalidation/merge, pruned to the survivors."""
 
-    Regression: dropping it caused ``IncrementalCacheMissingError`` even
-    when the pkl on disk had a populated cache.
-    """
-
-    def _cg_with_cluster_cache(self) -> CallGraph:
+    def _cg(self) -> CallGraph:
         cg = CallGraph(language="python")
         cg.add_node(_node("a.foo", "a.py", line_start=1))
         cg.add_node(_node("a.bar", "a.py", line_start=10))
         cg.add_node(_node("b.qux", "b.py", line_start=1))
-        cg._cluster_cache = ClusterResult(
-            clusters={1: {"a.foo", "a.bar"}, 2: {"b.qux"}},
-            cluster_to_files={1: {"a.py"}, 2: {"b.py"}},
-            file_to_clusters={"a.py": {1}, "b.py": {2}},
-            strategy="leiden",
-        )
         return cg
 
-    def test_invalidate_files_preserves_cluster_cache_for_kept_files(self) -> None:
-        cached = _result(self._cg_with_cluster_cache(), source_files=["a.py", "b.py"])
+    def _cache(self) -> ClusterCache:
+        cache = ClusterCache()
+        cache.adopt(
+            ClusterResult(
+                clusters={1: {"a.foo", "a.bar"}, 2: {"b.qux"}},
+                cluster_to_files={1: {"a.py"}, 2: {"b.py"}},
+                file_to_clusters={"a.py": {1}, "b.py": {2}},
+                strategy="leiden",
+            )
+        )
+        return cache
+
+    def test_invalidate_files_then_prune_keeps_surviving_clusters(self) -> None:
+        cached = _result(self._cg(), source_files=["a.py", "b.py"])
 
         updated = invalidate_files(cached, {Path("a.py")}).analysis
+        pruned = self._cache().prune(updated.call_graph.nodes)
 
-        cc = updated.call_graph._cluster_cache
-        assert cc is not None
+        cc = pruned.result
         # Cluster 1 had only a.py members -> dropped entirely.
         # Cluster 2 keeps b.qux from b.py.
         self.assertNotIn(1, cc.clusters)
@@ -221,68 +223,59 @@ class TestClusterCachePreservation(unittest.TestCase):
         self.assertEqual(cc.file_to_clusters, {"b.py": {2}})
         self.assertEqual(cc.strategy, "leiden")
 
-    def test_invalidate_files_preserves_partial_cluster(self) -> None:
-        cached = _result(self._cg_with_cluster_cache(), source_files=["a.py", "b.py"])
+    def test_invalidate_files_then_prune_keeps_whole_untouched_cluster(self) -> None:
+        cached = _result(self._cg(), source_files=["a.py", "b.py"])
         # Only invalidate b.py; cluster 1 (members in a.py) survives whole;
         # cluster 2 (b.qux only) drops.
         updated = invalidate_files(cached, {Path("b.py")}).analysis
 
-        cc = updated.call_graph._cluster_cache
-        assert cc is not None
+        cc = self._cache().prune(updated.call_graph.nodes).result
+
         self.assertEqual(cc.clusters[1], {"a.foo", "a.bar"})
         self.assertNotIn(2, cc.clusters)
 
-    def test_merge_results_preserves_cached_cluster_cache(self) -> None:
-        cached = _result(self._cg_with_cluster_cache(), source_files=["a.py", "b.py"])
+    def test_merge_results_then_prune_keeps_cached_clusters(self) -> None:
+        cached = _result(self._cg(), source_files=["a.py", "b.py"])
         new_cg = CallGraph(language="python")
         new_cg.add_node(_node("c.new", "c.py"))
         new = _result(new_cg, source_files=["c.py"])
 
         merged = merge_results(_analysis_data(cached), new)
+        cc = self._cache().prune(merged.call_graph.nodes).result
 
-        cc = merged.call_graph._cluster_cache
-        assert cc is not None
         # Cached clusters survive; new node 'c.new' is unclustered (intentional —
         # cluster_delta will pick it up as drift on the next run).
         self.assertEqual(cc.clusters[1], {"a.foo", "a.bar"})
         self.assertEqual(cc.clusters[2], {"b.qux"})
+        self.assertNotIn("c.new", {m for members in cc.clusters.values() for m in members})
 
     def test_filter_returns_independent_call_graph(self) -> None:
-        # Ensure CallGraph.filter does not mutate the source.
-        cg = self._cg_with_cluster_cache()
+        cg = self._cg()
         original_node_count = len(cg.nodes)
-        assert cg._cluster_cache is not None
-        original_cluster_ids = set(cg._cluster_cache.clusters.keys())
 
-        cg.filter(lambda n: n.file_path != "a.py", on_dropped_edge=lambda _edge: None)
+        cg.filter(lambda n: n.file_path != "a.py", lambda _edge: None)
 
         self.assertEqual(len(cg.nodes), original_node_count)
-        assert cg._cluster_cache is not None
-        self.assertEqual(set(cg._cluster_cache.clusters.keys()), original_cluster_ids)
 
     def test_filter_drops_edges_with_dropped_endpoint(self) -> None:
         cg = CallGraph(language="python")
         cg.add_node(_node("a.foo", "a.py"))
         cg.add_node(_node("b.bar", "b.py"))
         cg.add_edge("a.foo", "b.bar")
-        dropped_edges: list[Edge] = []
 
-        filtered = cg.filter(lambda n: n.file_path != "a.py", on_dropped_edge=dropped_edges.append)
+        filtered = cg.filter(lambda n: n.file_path != "a.py", lambda _edge: None)
 
         self.assertEqual(len(filtered.edges), 0)
         self.assertNotIn("a.foo", filtered.nodes)
         self.assertIn("b.bar", filtered.nodes)
-        self.assertEqual([(edge.get_source(), edge.get_destination()) for edge in dropped_edges], [("a.foo", "b.bar")])
 
-    def test_union_preserves_cached_side_cluster_cache(self) -> None:
-        cached = self._cg_with_cluster_cache()
+    def test_union_then_prune_leaves_new_nodes_unclustered(self) -> None:
         new = CallGraph(language="python")
         new.add_node(_node("c.new", "c.py"))
 
-        unioned = cached.union(new)
+        unioned = self._cg().union(new)
+        cc = self._cache().prune(unioned.nodes).result
 
-        cc = unioned._cluster_cache
-        assert cc is not None
         self.assertEqual(cc.clusters, {1: {"a.foo", "a.bar"}, 2: {"b.qux"}})
         # New node from `other` participates in the graph but not yet in any cluster.
         self.assertIn("c.new", unioned.nodes)
@@ -292,7 +285,7 @@ class TestClusterCachePreservation(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
             result = StaticAnalysisResults()
-            result.add_cfg(Language.PYTHON, self._cg_with_cluster_cache())
+            result.add_cfg(Language.PYTHON, self._cg())
             base_results = StaticAnalysisResults()
             result.incremental_base_results = base_results
 
@@ -304,7 +297,7 @@ class TestClusterCachePreservation(unittest.TestCase):
             self.assertIsNone(loaded.incremental_base_results)
             self.assertIs(result.incremental_base_results, base_results)
 
-    def test_static_analysis_cache_round_trips_cluster_cache_paths_between_repo_roots(self) -> None:
+    def test_static_analysis_cache_round_trips_cluster_paths_between_repo_roots(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_path = Path(temp_dir)
             repo_a = temp_path / "repo-a"
@@ -316,25 +309,28 @@ class TestClusterCachePreservation(unittest.TestCase):
             source_file = repo_a / "pkg" / "a.py"
             cg = CallGraph(language="python")
             cg.add_node(_node("pkg.a.foo", str(source_file)))
-            cg._cluster_cache = ClusterResult(
-                clusters={1: {"pkg.a.foo"}},
-                cluster_to_files={1: {str(source_file)}},
-                file_to_clusters={str(source_file): {1}},
-                strategy="leiden",
+            clusters = ClusterCache()
+            clusters.adopt(
+                ClusterResult(
+                    clusters={1: {"pkg.a.foo"}},
+                    cluster_to_files={1: {str(source_file)}},
+                    file_to_clusters={str(source_file): {1}},
+                    strategy="leiden",
+                )
             )
             result = StaticAnalysisResults()
             result.add_cfg(Language.PYTHON, cg)
+            result.set_clusters(Language.PYTHON, clusters)
 
             StaticAnalysisCache(artifact_dir, repo_a).save(result, source_sha="sha")
             loaded = StaticAnalysisCache(artifact_dir, repo_b).get(expected_sha="sha")
 
             assert loaded is not None
-            loaded_cfg = loaded.get_cfg(Language.PYTHON)
             expected_file = str(repo_b.resolve() / "pkg" / "a.py")
-            self.assertEqual(loaded_cfg.nodes["pkg.a.foo"].file_path, expected_file)
-            assert loaded_cfg._cluster_cache is not None
-            self.assertEqual(loaded_cfg._cluster_cache.cluster_to_files, {1: {expected_file}})
-            self.assertEqual(loaded_cfg._cluster_cache.file_to_clusters, {expected_file: {1}})
+            self.assertEqual(loaded.get_cfg(Language.PYTHON).nodes["pkg.a.foo"].file_path, expected_file)
+            loaded_partition = loaded.get_clusters(Language.PYTHON).result
+            self.assertEqual(loaded_partition.cluster_to_files, {1: {expected_file}})
+            self.assertEqual(loaded_partition.file_to_clusters, {expected_file: {1}})
 
 
 class TestWarmStartDeletion(unittest.TestCase):

--- a/tests/static_analyzer/test_cluster_helpers.py
+++ b/tests/static_analyzer/test_cluster_helpers.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import networkx as nx
 
@@ -13,7 +13,7 @@ from static_analyzer.cluster_helpers import (
     supercluster_by_modularity_peak,
     supercluster_leaf_ids,
 )
-from static_analyzer.clustering import ClusterResult
+from static_analyzer.clustering import ClusterCache, ClusterResult, ClusteringService
 
 
 def _make_cluster_result(prefix: str, count: int) -> ClusterResult:
@@ -35,14 +35,19 @@ class TestClusterHelpers(unittest.TestCase):
 
         python_cfg = MagicMock()
         typescript_cfg = MagicMock()
-        python_cfg.cluster.return_value = _make_cluster_result("py", 40)
-        typescript_cfg.cluster.return_value = _make_cluster_result("ts", 40)
         analysis.get_cfg.side_effect = lambda language: {
             "python": python_cfg,
             "typescript": typescript_cfg,
         }[language]
+        partitions = {python_cfg: _make_cluster_result("py", 40), typescript_cfg: _make_cluster_result("ts", 40)}
+        python_clusters, typescript_clusters = ClusterCache(), ClusterCache()
+        analysis.get_clusters.side_effect = lambda language: {
+            "python": python_clusters,
+            "typescript": typescript_clusters,
+        }[language]
 
-        result = build_all_cluster_results(analysis)
+        with patch.object(ClusteringService, "cluster", side_effect=lambda graph: partitions[graph]):
+            result = build_all_cluster_results(analysis)
 
         python_ids = set(result["python"].clusters.keys())
         typescript_ids = set(result["typescript"].clusters.keys())
@@ -52,18 +57,18 @@ class TestClusterHelpers(unittest.TestCase):
 
         shifted_ts_ids = set().union(*result["typescript"].file_to_clusters.values())
         self.assertEqual(shifted_ts_ids, typescript_ids)
-        self.assertIs(python_cfg._cluster_cache, result["python"])
-        self.assertIs(typescript_cfg._cluster_cache, result["typescript"])
+        self.assertIs(python_clusters.result, result["python"])
+        self.assertIs(typescript_clusters.result, result["typescript"])
 
     def test_all_clusters_survive_grouping(self):
         """Every leaf cluster keeps its members — nothing is merged away before grouping."""
         analysis = MagicMock(spec=StaticAnalysisResults)
         analysis.get_languages.return_value = ["python"]
-        cfg = MagicMock()
-        cfg.cluster.return_value = _make_cluster_result("py", 120)
-        analysis.get_cfg.return_value = cfg
+        analysis.get_cfg.return_value = MagicMock()
+        analysis.get_clusters.return_value = ClusterCache()
 
-        result = build_all_cluster_results(analysis)
+        with patch.object(ClusteringService, "cluster", return_value=_make_cluster_result("py", 120)):
+            result = build_all_cluster_results(analysis)
 
         self.assertEqual(len(result["python"].clusters), 120)
 

--- a/tests/static_analyzer/test_graph.py
+++ b/tests/static_analyzer/test_graph.py
@@ -7,7 +7,7 @@ from static_analyzer.constants import NodeType
 from static_analyzer.leiden_utils import find_partition
 from static_analyzer.node import Node
 from static_analyzer.graph import CallGraph, Edge
-from static_analyzer.clustering import ClusterResult
+from static_analyzer.clustering import ClusterResult, ClusteringService
 
 
 class TestNode(unittest.TestCase):
@@ -290,7 +290,7 @@ class TestCallGraph(unittest.TestCase):
         for i in range(9):
             graph.add_edge(f"module.func{i}", f"module.func{i+1}")
 
-        result = graph.cluster()
+        result = ClusteringService().cluster(graph)
 
         self.assertIsInstance(result, ClusterResult)
         self.assertIsInstance(result.clusters, dict)
@@ -298,24 +298,24 @@ class TestCallGraph(unittest.TestCase):
         self.assertIsInstance(result.cluster_to_files, dict)
         self.assertIsInstance(result.strategy, str)
 
-    def test_cluster_is_cached(self):
-        """Test that cluster() results are cached."""
+    def test_clustering_does_not_mutate_the_graph(self):
+        """The service is pure — the same graph clusters twice to an equal, fresh result."""
         graph = CallGraph()
 
         for i in range(5):
             node = Node(f"module.func{i}", 12, "/file.py", i * 10, i * 10 + 5)
             graph.add_node(node)
 
-        result1 = graph.cluster()
-        result2 = graph.cluster()
+        result1 = ClusteringService().cluster(graph)
+        result2 = ClusteringService().cluster(graph)
 
-        # Should be the same object (cached)
-        self.assertIs(result1, result2)
+        self.assertIsNot(result1, result2)
+        self.assertEqual(result1.clusters, result2.clusters)
 
     def test_cluster_empty_graph(self):
         """Test cluster() on empty graph."""
         graph = CallGraph()
-        result = graph.cluster()
+        result = ClusteringService().cluster(graph)
 
         self.assertEqual(result.clusters, {})
         self.assertEqual(result.strategy, "empty")
@@ -338,7 +338,7 @@ class TestCallGraph(unittest.TestCase):
         graph.add_edge("module.func1", "module.func2")
         graph.add_edge("module.func3", "module.func4")
 
-        result = graph.cluster()
+        result = ClusteringService().cluster(graph)
 
         # Check that file_to_clusters and cluster_to_files are populated
         self.assertTrue(len(result.file_to_clusters) > 0 or result.strategy in ("empty", "none"))
@@ -354,7 +354,7 @@ class TestCallGraph(unittest.TestCase):
         for i in range(9):
             graph.add_edge(f"module.func{i}", f"module.func{i+1}")
 
-        cluster_result = graph.cluster()
+        cluster_result = ClusteringService().cluster(graph)
         if cluster_result.clusters:
             first_cluster_id = next(iter(cluster_result.clusters.keys()))
             file_paths = cluster_result.cluster_to_files.get(first_cluster_id, set())
@@ -391,7 +391,7 @@ class TestCallGraph(unittest.TestCase):
         graph.add_edge("module.func1", "module.func2")
         graph.add_edge("module.func2", "module.func3")
 
-        cluster_result = graph.cluster()
+        cluster_result = ClusteringService().cluster(graph)
         if cluster_result.clusters:
             # Get a cluster and create filter_by_files
             first_cluster_id = next(iter(cluster_result.clusters.keys()))
@@ -414,14 +414,14 @@ class TestCallGraph(unittest.TestCase):
         for i in range(19):
             graph.add_edge(f"module.func{i}", f"module.func{i+1}")
 
-        cluster_result = graph.cluster()
+        cluster_result = ClusteringService().cluster(graph)
         if cluster_result.clusters:
             first_cluster_id = next(iter(cluster_result.clusters.keys()))
             file_paths = cluster_result.cluster_to_files.get(first_cluster_id, set())
             sub_graph = graph.filter_by_files(file_paths)
 
             # Subgraph should be clusterable
-            sub_result = sub_graph.cluster()
+            sub_result = ClusteringService().cluster(sub_graph)
             self.assertIsInstance(sub_result, ClusterResult)
 
             # Should only include the specified cluster
@@ -441,8 +441,8 @@ class TestCallGraph(unittest.TestCase):
         graph1 = create_graph()
         graph2 = create_graph()
 
-        result1 = graph1.cluster()
-        result2 = graph2.cluster()
+        result1 = ClusteringService().cluster(graph1)
+        result2 = ClusteringService().cluster(graph2)
 
         # Cluster IDs and contents should be identical
         self.assertEqual(result1.clusters.keys(), result2.clusters.keys())


### PR DESCRIPTION
**Stack 5 of ~9** — base: `stack/4-clustering-collapse` (#478). **The behavioural one; read this one slowly.**

A partition is a *result about* a graph, not part of it. `_cluster_cache` and `method_cluster_paths` become a `ClusterCache` owned by `LanguageResults`, reached through `StaticAnalysisResults.get_clusters` / `set_clusters`. `ClusteringService.cluster()` replaces `CallGraph.cluster()` and is pure — it neither mutates the graph nor caches.

**324 insertions / 250 deletions across 21 files.**

### Three consequences worth reviewing

**`filter`/`union` no longer silently prune a partition.** The warm-start path in `_run_warm_start` now carries and prunes it in one visible place. Losing a cluster baseline would be a visible deletion rather than an invisible one.

**`ControlFlowGraph.merge` stops merging lineage**, for the same reason — that work moved into the explicit prune above. Note this leaves `MethodClusterPaths.merge` with no callers; I've left it rather than widen this PR, and it belongs in the API cleanup.

**`check_component_cohesion` loses the side effect that kept it switched off.** `cluster()` used to seed `_cluster_cache` with a current-graph partition, which would masquerade as a historical snapshot in the next incremental delta. The service cannot do that. Still left unwired — turning a health check back on is a behaviour change, not a refactor.

### One inverted test

`test_cluster_is_cached` becomes `test_clustering_does_not_mutate_the_graph`. The guarantee genuinely inverted: from "the second call returns the same object" to "the second call returns an equal, freshly built one".

`graph.py`: 447 → 392 lines.

### Checks
`2059 passed, 28 skipped` · mypy clean · black clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved clustering consistency across languages and analysis scopes.
  * Preserved cached clustering results more reliably during incremental updates and warm starts.
  * Enhanced snapshot generation to handle empty or partially available clustering data gracefully.
  * Improved component grouping and lineage handling after analysis changes.
* **Documentation**
  * Clarified cache requirements, fallback behavior, and clustering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->