### PR TITLE
refactor(cfg): graph.py becomes the cfg package

### DIFF
--- a/agents/cluster_methods_mixin.py
+++ b/agents/cluster_methods_mixin.py
@@ -38,7 +38,7 @@ from static_analyzer.cluster_relations import (
     merge_relations,
 )
 from static_analyzer.constants import CALLABLE_TYPES, CLASS_TYPES, Language
-from static_analyzer.graph import CallGraph
+from static_analyzer.cfg import CallGraph
 from static_analyzer.clustering import (
     METHOD_LEVEL_STRATEGY,
     ClusteringService,

--- a/agents/details_agent.py
+++ b/agents/details_agent.py
@@ -37,7 +37,7 @@ from agents.validation import (
 from monitoring import trace
 from static_analyzer.analysis_result import StaticAnalysisResults
 from static_analyzer.cluster_helpers import SUBCOMPONENTS_MAX, SUBCOMPONENTS_MIN
-from static_analyzer.graph import CallGraph
+from static_analyzer.cfg import CallGraph
 from static_analyzer.clustering import ClusterResult
 
 logger = logging.getLogger(__name__)

--- a/agents/incremental_agent.py
+++ b/agents/incremental_agent.py
@@ -52,7 +52,7 @@ from monitoring import trace
 from repo_utils.change_detector import ChangeSet
 from static_analyzer.analysis_result import StaticAnalysisResults
 from static_analyzer.constants import Language
-from static_analyzer.graph import CallGraph
+from static_analyzer.cfg import CallGraph
 from static_analyzer.clustering import ClusterResult
 
 logger = logging.getLogger(__name__)

--- a/agents/incremental_results.py
+++ b/agents/incremental_results.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field
 
-from static_analyzer.graph import CallGraph
+from static_analyzer.cfg import CallGraph
 from static_analyzer.clustering import ClusterResult
 
 

--- a/agents/llm_renderers/call_graph.py
+++ b/agents/llm_renderers/call_graph.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from collections.abc import Sequence
 
 from static_analyzer.constants import NodeType
-from static_analyzer.graph import CallGraph
+from static_analyzer.cfg import CallGraph
 from static_analyzer.node import Node
 
 logger = logging.getLogger(__name__)

--- a/agents/tools/base.py
+++ b/agents/tools/base.py
@@ -7,7 +7,7 @@ from agents.agent_responses import ClusterAnalysis
 from repo_utils.ignore import RepoIgnoreManager
 from repo_utils.change_detector import ChangeSet
 from static_analyzer.analysis_result import StaticAnalysisResults
-from static_analyzer.graph import CallGraph
+from static_analyzer.cfg import CallGraph
 from static_analyzer.clustering import ClusterResult
 
 

--- a/agents/validation.py
+++ b/agents/validation.py
@@ -15,7 +15,7 @@ from agents.agent_responses import (
 )
 from repo_utils import normalize_path
 from static_analyzer.analysis_result import StaticAnalysisResults
-from static_analyzer.graph import CallGraph
+from static_analyzer.cfg import CallGraph
 from static_analyzer.clustering import ClusterResult
 from static_analyzer.reference_resolver import StaticReferenceResolver
 

--- a/health/checks/cohesion.py
+++ b/health/checks/cohesion.py
@@ -1,7 +1,7 @@
 import logging
 
 from health.models import FindingEntity, FindingGroup, HealthCheckConfig, Severity, StandardCheckSummary
-from static_analyzer.graph import CallGraph
+from static_analyzer.cfg import CallGraph
 from static_analyzer.clustering import ClusteringService
 
 logger = logging.getLogger(__name__)

--- a/health/checks/coupling.py
+++ b/health/checks/coupling.py
@@ -7,7 +7,7 @@ from health.models import (
     Severity,
     StandardCheckSummary,
 )
-from static_analyzer.graph import CallGraph
+from static_analyzer.cfg import CallGraph
 
 logger = logging.getLogger(__name__)
 

--- a/health/checks/function_size.py
+++ b/health/checks/function_size.py
@@ -9,7 +9,7 @@ from health.models import (
     StandardCheckSummary,
 )
 from repo_utils.ignore import RepoIgnoreManager
-from static_analyzer.graph import CallGraph
+from static_analyzer.cfg import CallGraph
 
 logger = logging.getLogger(__name__)
 

--- a/health/checks/god_class.py
+++ b/health/checks/god_class.py
@@ -8,7 +8,7 @@ from health.models import (
     Severity,
     StandardCheckSummary,
 )
-from static_analyzer.graph import CallGraph
+from static_analyzer.cfg import CallGraph
 
 logger = logging.getLogger(__name__)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ packages = [
     "output_generators",
     "repo_utils",
     "static_analyzer",
+    "static_analyzer.cfg",
     "static_analyzer.clustering",
     "static_analyzer.engine",
     "static_analyzer.engine.adapters",

--- a/static_analyzer/__init__.py
+++ b/static_analyzer/__init__.py
@@ -16,7 +16,7 @@ from static_analyzer.engine.lsp_client import LSPClient
 from static_analyzer.engine.result_converter import convert_to_codeboarding_format
 from static_analyzer.engine.source_inspector import SourceInspector
 from static_analyzer.engine.utils import uri_to_path
-from static_analyzer.graph import CallGraph
+from static_analyzer.cfg import CallGraph
 from static_analyzer.incremental_orchestrator import update_cfg_for_changed_files
 from static_analyzer.java_config_scanner import JavaConfigScanner
 from static_analyzer.lsp_client.diagnostics import FileDiagnosticsMap

--- a/static_analyzer/__init__.py
+++ b/static_analyzer/__init__.py
@@ -7,6 +7,7 @@ from repo_utils.git_ops import get_changed_files_since
 from repo_utils.ignore import RepoIgnoreManager
 from static_analyzer.analysis_cache import StaticAnalysisCache
 from static_analyzer.analysis_result import StaticAnalysisResults
+from static_analyzer.cfg import CallGraph
 from static_analyzer.constants import Language
 from static_analyzer.csharp_config_scanner import CSharpConfigScanner
 from static_analyzer.engine.adapters import get_adapter
@@ -16,7 +17,6 @@ from static_analyzer.engine.lsp_client import LSPClient
 from static_analyzer.engine.result_converter import convert_to_codeboarding_format
 from static_analyzer.engine.source_inspector import SourceInspector
 from static_analyzer.engine.utils import uri_to_path
-from static_analyzer.cfg import CallGraph
 from static_analyzer.incremental_orchestrator import update_cfg_for_changed_files
 from static_analyzer.java_config_scanner import JavaConfigScanner
 from static_analyzer.lsp_client.diagnostics import FileDiagnosticsMap

--- a/static_analyzer/analysis_cache.py
+++ b/static_analyzer/analysis_cache.py
@@ -32,7 +32,7 @@ from filelock import FileLock
 from constants import STATIC_ANALYSIS_PKL, STATIC_ANALYSIS_SHA
 from repo_utils.path_utils import to_absolute_path, to_relative_path
 from static_analyzer.analysis_result import AnalysisData, InvalidatedAnalysis, InvalidatedEdge
-from static_analyzer.graph import CallGraph, Edge, EdgeKind
+from static_analyzer.cfg import CallGraph, Edge, EdgeKind
 from static_analyzer.lsp_client.diagnostics import FileDiagnosticsMap
 from static_analyzer.node import Node
 

--- a/static_analyzer/analysis_cache.py
+++ b/static_analyzer/analysis_cache.py
@@ -53,8 +53,8 @@ _LEGACY_CACHE_SUBDIR = "cache"
 # Tag file format prefix; bump if the on-disk pickle layout changes.
 # v2: StaticAnalysisResults switched from dict-of-dicts to LanguageResults
 # dataclass storage.
-# v3: MethodClusterPaths moved to static_analyzer.clustering. Older pickles are
-# treated as cache misses and re-run.
+# v3: MethodClusterPaths moved to static_analyzer.clustering, then CallGraph and the
+# edge types to static_analyzer.cfg. Older pickles are treated as cache misses and re-run.
 _TAG_VERSION = "v3"
 
 

--- a/static_analyzer/analysis_result.py
+++ b/static_analyzer/analysis_result.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from static_analyzer.clustering import ClusterCache
 from static_analyzer.constants import Language
-from static_analyzer.graph import CallGraph
+from static_analyzer.cfg import CallGraph
 from static_analyzer.language_results import LanguageResults
 from static_analyzer.lsp_client.diagnostics import FileDiagnosticsMap
 from static_analyzer.node import Node

--- a/static_analyzer/cfg/__init__.py
+++ b/static_analyzer/cfg/__init__.py
@@ -1,0 +1,11 @@
+"""Call-graph structure: nodes, call edges, reference edges and subgraph derivation.
+
+``call_graph`` holds the graph itself, ``edge`` the edge types, and ``location_key``
+the physical-location identity used to dedup LSP qualified-name aliases.
+"""
+
+from static_analyzer.cfg.call_graph import CallGraph
+from static_analyzer.cfg.edge import Edge, EdgeKind
+from static_analyzer.cfg.location_key import LocationKey
+
+__all__ = ["CallGraph", "Edge", "EdgeKind", "LocationKey"]

--- a/static_analyzer/cfg/__init__.py
+++ b/static_analyzer/cfg/__init__.py
@@ -6,6 +6,5 @@ the physical-location identity used to dedup LSP qualified-name aliases.
 
 from static_analyzer.cfg.call_graph import CallGraph
 from static_analyzer.cfg.edge import Edge, EdgeKind
-from static_analyzer.cfg.location_key import LocationKey
 
-__all__ = ["CallGraph", "Edge", "EdgeKind", "LocationKey"]
+__all__ = ["CallGraph", "Edge", "EdgeKind"]

--- a/static_analyzer/cfg/call_graph.py
+++ b/static_analyzer/cfg/call_graph.py
@@ -1,90 +1,19 @@
+"""The call graph: nodes, call edges, reference edges, and derivation of subgraphs."""
+
 import logging
 from collections.abc import Callable, Collection, Hashable, Mapping, Sequence
-from dataclasses import dataclass
-from enum import StrEnum
 from types import MappingProxyType
 
 import networkx as nx
 
+from static_analyzer.cfg.edge import Edge, EdgeKind
+from static_analyzer.cfg.location_key import LocationKey
 from static_analyzer.constants import ClusteringConfig
 from static_analyzer.node import Node
 
 logger = logging.getLogger(__name__)
 
 _EMPTY_NODES: Mapping[str, Node] = MappingProxyType({})
-
-
-class EdgeKind(StrEnum):
-    """Kind of relationship an edge represents.
-
-    ``CALL`` edges live in ``CallGraph.edges`` and drive component *relations*.
-    The rest are *reference edges* (``CallGraph.reference_edges``): structural
-    relationships the pure call graph misses — a method belongs to its class
-    (CONTAINS), a class extends another (INHERITS), code names a type (TYPEREF),
-    a module imports another (IMPORT). They complete the graph for *clustering*
-    (so constructors/dunders/DI/interface methods aren't graph-isolated) without
-    polluting the call-relation semantics.
-    """
-
-    CALL = "call"
-    CONTAINS = "contains"
-    INHERITS = "inherits"
-    TYPEREF = "typeref"
-    IMPORT = "import"
-
-
-@dataclass(frozen=True)
-class LocationKey:
-    """Hashable key identifying a symbol's physical location in the source tree."""
-
-    file_path: str
-    line_start: int
-    line_end: int
-    node_type: int
-    col_start: int = 0
-
-
-class Edge:
-    def __init__(self, src_node: Node, dst_node: Node, call_sites: Sequence[Mapping[str, Hashable]] = ()) -> None:
-        self.src_node = src_node
-        self.dst_node = dst_node
-        self._call_sites: list[dict[str, Hashable]] = []
-        self._call_site_keys: set[tuple[tuple[str, Hashable], ...]] = set()
-        for site in call_sites:
-            self.add_call_site(site)
-
-    @property
-    def call_sites(self) -> list[dict[str, Hashable]]:
-        return [dict(site) for site in self._call_sites]
-
-    def get_source(self) -> str:
-        return self.src_node.fully_qualified_name
-
-    def get_destination(self) -> str:
-        return self.dst_node.fully_qualified_name
-
-    def __repr__(self) -> str:
-        return f"Edge({self.src_node.fully_qualified_name} -> {self.dst_node.fully_qualified_name})"
-
-    def add_call_site(self, call_site: Mapping[str, Hashable]) -> None:
-        call_site = self._normalize_call_site(call_site)
-        call_site_key = tuple(sorted(call_site.items()))
-        if call_site_key not in self._call_site_keys:
-            self._call_site_keys.add(call_site_key)
-            self._call_sites.append(call_site)
-
-    @staticmethod
-    def _normalize_call_site(call_site: Mapping[str, Hashable]) -> dict[str, Hashable]:
-        normalized = dict(call_site)
-        if "file" not in normalized and "file_path" in normalized:
-            normalized["file"] = normalized.pop("file_path")
-        return normalized
-
-    def visit_paths(self, fn: Callable[[str], str]) -> None:
-        for site in self._call_sites:
-            if "file" in site:
-                site["file"] = fn(str(site["file"]))
-        self._call_site_keys = {tuple(sorted(site.items())) for site in self._call_sites}
 
 
 class CallGraph:

--- a/static_analyzer/cfg/edge.py
+++ b/static_analyzer/cfg/edge.py
@@ -1,0 +1,68 @@
+"""Call-graph edge types: call edges and the kinds a reference edge can carry."""
+
+from collections.abc import Callable, Hashable, Mapping, Sequence
+from enum import StrEnum
+
+from static_analyzer.node import Node
+
+
+class EdgeKind(StrEnum):
+    """Kind of relationship an edge represents.
+
+    ``CALL`` edges live in ``CallGraph.edges`` and drive component *relations*.
+    The rest are *reference edges* (``CallGraph.reference_edges``): structural
+    relationships the pure call graph misses — a method belongs to its class
+    (CONTAINS), a class extends another (INHERITS), code names a type (TYPEREF),
+    a module imports another (IMPORT). They complete the graph for *clustering*
+    (so constructors/dunders/DI/interface methods aren't graph-isolated) without
+    polluting the call-relation semantics.
+    """
+
+    CALL = "call"
+    CONTAINS = "contains"
+    INHERITS = "inherits"
+    TYPEREF = "typeref"
+    IMPORT = "import"
+
+
+class Edge:
+    def __init__(self, src_node: Node, dst_node: Node, call_sites: Sequence[Mapping[str, Hashable]] = ()) -> None:
+        self.src_node = src_node
+        self.dst_node = dst_node
+        self._call_sites: list[dict[str, Hashable]] = []
+        self._call_site_keys: set[tuple[tuple[str, Hashable], ...]] = set()
+        for site in call_sites:
+            self.add_call_site(site)
+
+    @property
+    def call_sites(self) -> list[dict[str, Hashable]]:
+        return [dict(site) for site in self._call_sites]
+
+    def get_source(self) -> str:
+        return self.src_node.fully_qualified_name
+
+    def get_destination(self) -> str:
+        return self.dst_node.fully_qualified_name
+
+    def __repr__(self) -> str:
+        return f"Edge({self.src_node.fully_qualified_name} -> {self.dst_node.fully_qualified_name})"
+
+    def add_call_site(self, call_site: Mapping[str, Hashable]) -> None:
+        call_site = self._normalize_call_site(call_site)
+        call_site_key = tuple(sorted(call_site.items()))
+        if call_site_key not in self._call_site_keys:
+            self._call_site_keys.add(call_site_key)
+            self._call_sites.append(call_site)
+
+    @staticmethod
+    def _normalize_call_site(call_site: Mapping[str, Hashable]) -> dict[str, Hashable]:
+        normalized = dict(call_site)
+        if "file" not in normalized and "file_path" in normalized:
+            normalized["file"] = normalized.pop("file_path")
+        return normalized
+
+    def visit_paths(self, fn: Callable[[str], str]) -> None:
+        for site in self._call_sites:
+            if "file" in site:
+                site["file"] = fn(str(site["file"]))
+        self._call_site_keys = {tuple(sorted(site.items())) for site in self._call_sites}

--- a/static_analyzer/cfg/location_key.py
+++ b/static_analyzer/cfg/location_key.py
@@ -1,0 +1,15 @@
+"""Physical-location identity, used to dedup the several qualified names the LSP
+can emit for one symbol. Issue #471 moves the canonicalization itself here."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class LocationKey:
+    """Hashable key identifying a symbol's physical location in the source tree."""
+
+    file_path: str
+    line_start: int
+    line_end: int
+    node_type: int
+    col_start: int = 0

--- a/static_analyzer/cfg/location_key.py
+++ b/static_analyzer/cfg/location_key.py
@@ -1,5 +1,5 @@
 """Physical-location identity, used to dedup the several qualified names the LSP
-can emit for one symbol. Issue #471 moves the canonicalization itself here."""
+can emit for one symbol."""
 
 from dataclasses import dataclass
 

--- a/static_analyzer/cfg/location_key.py
+++ b/static_analyzer/cfg/location_key.py
@@ -1,6 +1,3 @@
-"""Physical-location identity, used to dedup the several qualified names the LSP
-can emit for one symbol."""
-
 from dataclasses import dataclass
 
 

--- a/static_analyzer/cluster_relations.py
+++ b/static_analyzer/cluster_relations.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass, field
 from constants import DEFAULT_STATIC_RELATION_LABEL
 from agents.agent_responses import AnalysisInsights, Relation, RelationEdge, SourceCodeReference
 from agents.relation_edges import append_or_merge_relation, drop_internal_self_relations
-from static_analyzer.graph import CallGraph
+from static_analyzer.cfg import CallGraph
 
 logger = logging.getLogger(__name__)
 

--- a/static_analyzer/clustering/service.py
+++ b/static_analyzer/clustering/service.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from static_analyzer.graph import CallGraph
+from static_analyzer.cfg import CallGraph
 from static_analyzer.clustering.engine import cluster_graph
 from static_analyzer.clustering.models import ClusterResult
 from static_analyzer.constants import ClusteringConfig

--- a/static_analyzer/engine/result_converter.py
+++ b/static_analyzer/engine/result_converter.py
@@ -12,7 +12,7 @@ from static_analyzer.constants import CLASS_TYPES, GRAPH_NODE_TYPES, NodeType
 from static_analyzer.engine.language_adapter import LanguageAdapter
 from static_analyzer.engine.models import LanguageAnalysisResult
 from static_analyzer.engine.symbol_table import SymbolTable
-from static_analyzer.graph import CallGraph, EdgeKind
+from static_analyzer.cfg import CallGraph, EdgeKind
 from static_analyzer.node import Node
 
 logger = logging.getLogger(__name__)

--- a/static_analyzer/incremental_orchestrator.py
+++ b/static_analyzer/incremental_orchestrator.py
@@ -26,7 +26,7 @@ from static_analyzer.engine.lsp_constants import EdgeStrategy
 from static_analyzer.engine.result_converter import convert_to_codeboarding_format
 from static_analyzer.engine.source_inspector import SourceInspector
 from static_analyzer.engine.utils import definition_location, uri_to_path
-from static_analyzer.graph import CallGraph
+from static_analyzer.cfg import CallGraph
 from static_analyzer.internal_references import parent_qualified_name
 from static_analyzer.node import Node
 

--- a/static_analyzer/language_results.py
+++ b/static_analyzer/language_results.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass, field
 import logging
 
 from static_analyzer.clustering import ClusterCache
-from static_analyzer.graph import CallGraph, EdgeKind
+from static_analyzer.cfg import CallGraph, EdgeKind
 from static_analyzer.node import Node
 
 logger = logging.getLogger(__name__)

--- a/tests/agents/test_cluster_methods_mixin.py
+++ b/tests/agents/test_cluster_methods_mixin.py
@@ -12,7 +12,7 @@ from agents.agent_responses import (
     SourceCodeReference,
 )
 from agents.file_index_models import FileMethodGroup, MethodEntry
-from static_analyzer.graph import CallGraph
+from static_analyzer.cfg import CallGraph
 from static_analyzer.clustering import ClusterResult
 from static_analyzer.constants import Language, NodeType
 from static_analyzer.node import Node

--- a/tests/agents/test_details_agent.py
+++ b/tests/agents/test_details_agent.py
@@ -21,7 +21,7 @@ from agents.file_index_models import FileMethodGroup, MethodEntry
 from diagram_analysis.file_index import build_files_index
 from static_analyzer.analysis_result import StaticAnalysisResults
 from static_analyzer.constants import NodeType
-from static_analyzer.graph import CallGraph
+from static_analyzer.cfg import CallGraph
 from static_analyzer.clustering import ClusterCache, ClusterResult, ClusteringService
 from static_analyzer.node import Node
 

--- a/tests/agents/test_incremental_agent.py
+++ b/tests/agents/test_incremental_agent.py
@@ -27,7 +27,7 @@ from agents.incremental_agent import (
 from agents.incremental_results import ScopeRelationContext
 from static_analyzer.analysis_result import StaticAnalysisResults
 from static_analyzer.constants import NodeType
-from static_analyzer.graph import CallGraph
+from static_analyzer.cfg import CallGraph
 from static_analyzer.clustering import ClusterResult
 from static_analyzer.node import Node
 

--- a/tests/agents/test_llm_renderers.py
+++ b/tests/agents/test_llm_renderers.py
@@ -2,7 +2,7 @@ import unittest
 
 from agents.llm_renderers import render_call_graph
 from static_analyzer.constants import NodeType
-from static_analyzer.graph import CallGraph
+from static_analyzer.cfg import CallGraph
 from static_analyzer.node import Node
 
 

--- a/tests/agents/test_method_uniqueness.py
+++ b/tests/agents/test_method_uniqueness.py
@@ -38,7 +38,7 @@ from agents.file_index_models import FileEntry, FileMethodGroup, MethodEntry
 from diagram_analysis.diagram_generator import DiagramGenerator, assert_scope_containment
 from diagram_analysis.exceptions import ScopeContainmentError
 from static_analyzer.constants import Language, NodeType
-from static_analyzer.graph import CallGraph
+from static_analyzer.cfg import CallGraph
 from static_analyzer.clustering import ClusterResult
 from static_analyzer.node import Node
 

--- a/tests/agents/test_validation.py
+++ b/tests/agents/test_validation.py
@@ -24,7 +24,7 @@ from agents.agent_responses import (
     ComponentFiles,
     FileClassification,
 )
-from static_analyzer.graph import CallGraph
+from static_analyzer.cfg import CallGraph
 from static_analyzer.clustering import ClusterResult
 from static_analyzer.node import Node
 from static_analyzer.constants import NodeType

--- a/tests/agents/tools/test_cfg_tools.py
+++ b/tests/agents/tools/test_cfg_tools.py
@@ -13,7 +13,7 @@ from agents.tools.base import RepoContext
 from repo_utils.ignore import RepoIgnoreManager
 from static_analyzer import StaticAnalyzer
 from static_analyzer.constants import NodeType
-from static_analyzer.graph import CallGraph, Edge
+from static_analyzer.cfg import CallGraph, Edge
 from static_analyzer.clustering import ClusterResult
 from static_analyzer.node import Node
 from utils import get_artifact_dir

--- a/tests/diagram_analysis/test_cluster_delta.py
+++ b/tests/diagram_analysis/test_cluster_delta.py
@@ -20,7 +20,7 @@ from diagram_analysis.cluster_snapshot import ClusterSnapshot, ClusterSnapshotEn
 from repo_utils.change_detector import ChangeSet, FileChange
 from static_analyzer.analysis_result import StaticAnalysisResults
 from static_analyzer.constants import Language, NodeType
-from static_analyzer.graph import CallGraph
+from static_analyzer.cfg import CallGraph
 from static_analyzer.clustering import ClusterResult
 from static_analyzer.node import Node
 

--- a/tests/diagram_analysis/test_cluster_snapshot.py
+++ b/tests/diagram_analysis/test_cluster_snapshot.py
@@ -16,7 +16,7 @@ from diagram_analysis.cluster_snapshot import (
 )
 from static_analyzer.analysis_result import StaticAnalysisResults
 from static_analyzer.constants import Language, NodeType
-from static_analyzer.graph import CallGraph
+from static_analyzer.cfg import CallGraph
 from static_analyzer.clustering import ClusterResult
 from static_analyzer.node import Node
 

--- a/tests/diagram_analysis/test_diagram_analysis.py
+++ b/tests/diagram_analysis/test_diagram_analysis.py
@@ -46,7 +46,7 @@ from repo_utils.change_detector import ChangeSet
 from static_analyzer.analysis_cache import StaticAnalysisCache
 from static_analyzer.analysis_result import StaticAnalysisResults
 from static_analyzer.constants import Language, NodeType
-from static_analyzer.graph import CallGraph
+from static_analyzer.cfg import CallGraph
 from static_analyzer.clustering import ClusterResult
 from static_analyzer.node import Node
 

--- a/tests/diagram_analysis/test_file_index.py
+++ b/tests/diagram_analysis/test_file_index.py
@@ -7,7 +7,7 @@ from agents.file_index_models import FileMethodGroup, MethodEntry
 from diagram_analysis.file_index import build_files_index, refresh_method_spans_from_cfg
 from static_analyzer.analysis_result import StaticAnalysisResults
 from static_analyzer.constants import NodeType
-from static_analyzer.graph import CallGraph
+from static_analyzer.cfg import CallGraph
 from static_analyzer.node import Node
 
 

--- a/tests/diagram_analysis/test_tree_shape.py
+++ b/tests/diagram_analysis/test_tree_shape.py
@@ -10,7 +10,7 @@ from agents.file_index_models import FileMethodGroup, MethodEntry
 from diagram_analysis.analysis_json import build_unified_analysis_json, parse_unified_analysis
 from diagram_analysis.diagram_generator import DiagramGenerator, _member_keys, _reconcile_child_scope
 from diagram_analysis.exceptions import ScopeContainmentError
-from static_analyzer.graph import CallGraph
+from static_analyzer.cfg import CallGraph
 from static_analyzer.clustering import ClusterCache, MethodClusterPaths
 from diagram_analysis.tree_shape import absorb_single_child_components
 

--- a/tests/health/test_health_checks.py
+++ b/tests/health/test_health_checks.py
@@ -11,7 +11,7 @@ from health.checks.inheritance import check_inheritance_depth
 from health.checks.instability import check_package_instability
 from health.models import HealthCheckConfig, Severity
 from repo_utils.ignore import RepoIgnoreManager
-from static_analyzer.graph import CallGraph
+from static_analyzer.cfg import CallGraph
 from static_analyzer.constants import NodeType
 from static_analyzer.node import Node
 

--- a/tests/health/test_runner.py
+++ b/tests/health/test_runner.py
@@ -5,7 +5,7 @@ from health.models import HealthCheckConfig, StandardCheckSummary
 from health.runner import run_health_checks
 from static_analyzer.analysis_result import StaticAnalysisResults
 from static_analyzer.constants import Language
-from static_analyzer.graph import CallGraph
+from static_analyzer.cfg import CallGraph
 from static_analyzer.node import Node
 
 

--- a/tests/static_analyzer/scripts/diagnose_relations.py
+++ b/tests/static_analyzer/scripts/diagnose_relations.py
@@ -23,7 +23,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
 
 from static_analyzer import get_static_analysis
 from static_analyzer.cluster_relations import build_component_relations
-from static_analyzer.graph import CallGraph
+from static_analyzer.cfg import CallGraph
 from utils import get_artifact_dir
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")

--- a/tests/static_analyzer/scripts/dropped_edges_diagnostic.py
+++ b/tests/static_analyzer/scripts/dropped_edges_diagnostic.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 dropped_edges: list[tuple[str, str, bool, bool]] = []
 
-from static_analyzer.graph import CallGraph
+from static_analyzer.cfg import CallGraph
 
 original_add_edge = CallGraph.add_edge
 

--- a/tests/static_analyzer/scripts/edge_recovery_diagnostic.py
+++ b/tests/static_analyzer/scripts/edge_recovery_diagnostic.py
@@ -7,7 +7,7 @@ from pathlib import Path
 dropped_edges: list[tuple[str, str, bool, bool]] = []
 all_node_names: set[str] = set()
 
-from static_analyzer.graph import CallGraph
+from static_analyzer.cfg import CallGraph
 
 original_add_edge = CallGraph.add_edge
 original_add_node = CallGraph.add_node

--- a/tests/static_analyzer/test_analysis_cache_inmem.py
+++ b/tests/static_analyzer/test_analysis_cache_inmem.py
@@ -14,7 +14,7 @@ from static_analyzer import EngineConfig, StaticAnalyzer
 from static_analyzer.analysis_cache import StaticAnalysisCache, invalidate_files, merge_results
 from static_analyzer.analysis_result import AnalysisData, StaticAnalysisResults
 from static_analyzer.constants import Language, NodeType
-from static_analyzer.graph import CallGraph
+from static_analyzer.cfg import CallGraph
 from static_analyzer.clustering import ClusterCache, ClusterResult
 from static_analyzer.node import Node
 from static_analyzer.incremental_orchestrator import (

--- a/tests/static_analyzer/test_analysis_result.py
+++ b/tests/static_analyzer/test_analysis_result.py
@@ -3,7 +3,7 @@ import unittest
 from static_analyzer.analysis_result import StaticAnalysisResults
 from static_analyzer.constants import Language, NodeType
 from static_analyzer.node import Node
-from static_analyzer.graph import CallGraph
+from static_analyzer.cfg import CallGraph
 
 
 class TestStaticAnalysisResults(unittest.TestCase):

--- a/tests/static_analyzer/test_call_site_locations.py
+++ b/tests/static_analyzer/test_call_site_locations.py
@@ -1,7 +1,7 @@
 """Tests for preserving call-site locations on static-analysis edges."""
 
 from static_analyzer.constants import NodeType
-from static_analyzer.graph import CallGraph, Edge
+from static_analyzer.cfg import CallGraph, Edge
 from static_analyzer.node import Node
 
 

--- a/tests/static_analyzer/test_cluster_relations.py
+++ b/tests/static_analyzer/test_cluster_relations.py
@@ -24,7 +24,7 @@ from static_analyzer.cluster_relations import (
     prune_ungrounded_edges,
 )
 from static_analyzer.constants import NodeType
-from static_analyzer.graph import CallGraph, Edge
+from static_analyzer.cfg import CallGraph, Edge
 from static_analyzer.node import Node
 
 

--- a/tests/static_analyzer/test_global_relations.py
+++ b/tests/static_analyzer/test_global_relations.py
@@ -53,7 +53,7 @@ from static_analyzer.cluster_relations import (
     build_global_relations,
 )
 from static_analyzer.constants import NodeType
-from static_analyzer.graph import CallGraph, Edge
+from static_analyzer.cfg import CallGraph, Edge
 from static_analyzer.node import Node
 
 

--- a/tests/static_analyzer/test_graph.py
+++ b/tests/static_analyzer/test_graph.py
@@ -6,7 +6,7 @@ import networkx as nx
 from static_analyzer.constants import NodeType
 from static_analyzer.leiden_utils import find_partition
 from static_analyzer.node import Node
-from static_analyzer.graph import CallGraph, Edge
+from static_analyzer.cfg import CallGraph, Edge
 from static_analyzer.clustering import ClusterResult, ClusteringService
 
 

--- a/tests/static_analyzer/test_language_results.py
+++ b/tests/static_analyzer/test_language_results.py
@@ -8,7 +8,7 @@ import multiprocessing
 import unittest
 
 from static_analyzer.constants import NodeType
-from static_analyzer.graph import CallGraph, EdgeKind
+from static_analyzer.cfg import CallGraph, EdgeKind
 from static_analyzer.language_results import ControlFlowGraph
 from static_analyzer.node import Node
 

--- a/tests/static_analyzer/test_reference_resolver.py
+++ b/tests/static_analyzer/test_reference_resolver.py
@@ -7,7 +7,7 @@ from agents.agent_responses import AnalysisInsights, Component, Relation, Relati
 from agents.file_index_models import FileMethodGroup, MethodEntry
 from static_analyzer.analysis_result import StaticAnalysisResults
 from static_analyzer.constants import NodeType
-from static_analyzer.graph import Edge
+from static_analyzer.cfg import Edge
 from static_analyzer.node import Node
 from static_analyzer.reference_resolver import StaticReferenceResolver
 

--- a/tests/static_analyzer/test_result_converter.py
+++ b/tests/static_analyzer/test_result_converter.py
@@ -600,7 +600,7 @@ class TestOutputStructure:
 def test_add_reference_edges_contains_and_inherits():
     """CONTAINS from the qualified-name hierarchy; INHERITS from the class hierarchy."""
     from static_analyzer.engine.result_converter import _add_reference_edges
-    from static_analyzer.graph import CallGraph, EdgeKind
+    from static_analyzer.cfg import CallGraph, EdgeKind
     from static_analyzer.node import Node
 
     cg = CallGraph(language="python")
@@ -644,7 +644,7 @@ def test_add_reference_edges_contains_and_inherits():
 
 
 def test_clustering_networkx_includes_configured_reference_kinds():
-    from static_analyzer.graph import CallGraph, EdgeKind
+    from static_analyzer.cfg import CallGraph, EdgeKind
     from static_analyzer.node import Node
 
     cg = CallGraph(language="python")


### PR DESCRIPTION
**Stack 6 of 9** — retargeted to `main`; #479 is merged.

What's left of `graph.py` is graph structure, so it moves to `static_analyzer/cfg` and splits along its three concerns: `call_graph.py` holds `CallGraph`, `edge.py` the edge types, `location_key.py` the physical-location identity used to dedup LSP aliases.

**50 files, 266 changed lines** — 47 of those files are a one-line import update. Git sees `call_graph.py` as a rename of `graph.py`, so the diff shows what actually moved rather than 300 lines deleted and 300 added.

### Checks
`2068 passed, 28 skipped` · mypy clean (328 files) · black clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a dedicated control-flow graph package with public support for call graphs, edges, edge types, and source-location identifiers.
  - Improved edge handling with call-site metadata, endpoint access, deduplication, and path transformation.
  - Included the new graph package in distributed builds.

- **Refactor**
  - Updated analysis tools, health checks, agents, diagnostics, and tests to use the reorganized graph interfaces without changing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
