### PR TITLE
feat(cfg): one to_networkx, reference-augmented by default

### DIFF
--- a/agents/abstraction_agent.py
+++ b/agents/abstraction_agent.py
@@ -33,6 +33,7 @@ from agents.validation import (
 )
 from monitoring import trace
 from static_analyzer import StaticAnalysisFatalError
+from static_analyzer.cfg import DEFAULT_REFERENCE_KINDS
 from static_analyzer.analysis_result import StaticAnalysisResults
 from static_analyzer.cluster_helpers import build_all_cluster_results
 from static_analyzer.constants import Language
@@ -89,7 +90,10 @@ class AbstractionAgent(ClusterMethodsMixin, CodeBoardingAgent):
         final-analysis step.
         """
         logger.info(f"[AbstractionAgent] Super-clustering leaf clusters for: {self.project_name}")
-        cfg_graphs = {lang: self.static_analysis.get_cfg(Language(lang)).to_networkx() for lang in cluster_results}
+        cfg_graphs = {
+            lang: self.static_analysis.get_cfg(Language(lang)).to_networkx(DEFAULT_REFERENCE_KINDS)
+            for lang in cluster_results
+        }
         return self.deterministic_cluster_grouping(cluster_results, cfg_graphs)
 
     @trace

--- a/agents/abstraction_agent.py
+++ b/agents/abstraction_agent.py
@@ -89,9 +89,7 @@ class AbstractionAgent(ClusterMethodsMixin, CodeBoardingAgent):
         final-analysis step.
         """
         logger.info(f"[AbstractionAgent] Super-clustering leaf clusters for: {self.project_name}")
-        cfg_graphs = {
-            lang: self.static_analysis.get_cfg(Language(lang)).clustering_networkx() for lang in cluster_results
-        }
+        cfg_graphs = {lang: self.static_analysis.get_cfg(Language(lang)).to_networkx() for lang in cluster_results}
         return self.deterministic_cluster_grouping(cluster_results, cfg_graphs)
 
     @trace

--- a/agents/cluster_methods_mixin.py
+++ b/agents/cluster_methods_mixin.py
@@ -38,7 +38,7 @@ from static_analyzer.cluster_relations import (
     merge_relations,
 )
 from static_analyzer.constants import CALLABLE_TYPES, CLASS_TYPES, Language
-from static_analyzer.cfg import CallGraph
+from static_analyzer.cfg import CallGraph, DEFAULT_REFERENCE_KINDS
 from static_analyzer.clustering import (
     METHOD_LEVEL_STRATEGY,
     ClusteringService,
@@ -349,7 +349,7 @@ class ClusterMethodsMixin:
             )
             if seeded_snapshot:
                 sub_cluster_result = _delta_for_language(
-                    str(lang), sub_cfg.to_networkx(), seeded_snapshot
+                    str(lang), sub_cfg.to_networkx(DEFAULT_REFERENCE_KINDS), seeded_snapshot
                 ).cluster_results
             else:
                 sub_cluster_result = ClusteringService().cluster(sub_cfg)
@@ -404,7 +404,7 @@ class ClusterMethodsMixin:
             cfg = (
                 cfg_graphs[lang] if cfg_graphs and lang in cfg_graphs else self.static_analysis.get_cfg(Language(lang))
             )
-            graphs[lang] = cfg.to_networkx().to_undirected()
+            graphs[lang] = cfg.to_networkx(DEFAULT_REFERENCE_KINDS).to_undirected()
         return graphs
 
     def _find_nearest_cluster(

--- a/agents/cluster_methods_mixin.py
+++ b/agents/cluster_methods_mixin.py
@@ -349,7 +349,7 @@ class ClusterMethodsMixin:
             )
             if seeded_snapshot:
                 sub_cluster_result = _delta_for_language(
-                    str(lang), sub_cfg.clustering_networkx(), seeded_snapshot
+                    str(lang), sub_cfg.to_networkx(), seeded_snapshot
                 ).cluster_results
             else:
                 sub_cluster_result = ClusteringService().cluster(sub_cfg)

--- a/agents/details_agent.py
+++ b/agents/details_agent.py
@@ -100,7 +100,7 @@ class DetailsAgent(ClusterMethodsMixin, CodeBoardingAgent):
         logger.info(f"[DetailsAgent] Super-clustering subgraph for component: {component.name}")
         return self.deterministic_cluster_grouping(
             subgraph_cluster_results,
-            {lang: cfg.clustering_networkx() for lang, cfg in subgraph_cfgs.items()},
+            {lang: cfg.to_networkx() for lang, cfg in subgraph_cfgs.items()},
             SUBCOMPONENTS_MIN,
             SUBCOMPONENTS_MAX,
         )

--- a/agents/details_agent.py
+++ b/agents/details_agent.py
@@ -37,7 +37,7 @@ from agents.validation import (
 from monitoring import trace
 from static_analyzer.analysis_result import StaticAnalysisResults
 from static_analyzer.cluster_helpers import SUBCOMPONENTS_MAX, SUBCOMPONENTS_MIN
-from static_analyzer.cfg import CallGraph
+from static_analyzer.cfg import CallGraph, DEFAULT_REFERENCE_KINDS
 from static_analyzer.clustering import ClusterResult
 
 logger = logging.getLogger(__name__)
@@ -100,7 +100,7 @@ class DetailsAgent(ClusterMethodsMixin, CodeBoardingAgent):
         logger.info(f"[DetailsAgent] Super-clustering subgraph for component: {component.name}")
         return self.deterministic_cluster_grouping(
             subgraph_cluster_results,
-            {lang: cfg.to_networkx() for lang, cfg in subgraph_cfgs.items()},
+            {lang: cfg.to_networkx(DEFAULT_REFERENCE_KINDS) for lang, cfg in subgraph_cfgs.items()},
             SUBCOMPONENTS_MIN,
             SUBCOMPONENTS_MAX,
         )

--- a/diagram_analysis/cluster_delta.py
+++ b/diagram_analysis/cluster_delta.py
@@ -281,7 +281,7 @@ def compute_cluster_delta(
         cfg = new_static.get_cfg(language)
         # Cluster the same reference-augmented graph the full run uses; a call-only graph would
         # re-cluster type-coupled methods differently and drift from what a full analysis produces.
-        nx_graph = cfg.clustering_networkx()
+        nx_graph = cfg.to_networkx()
         old_clusters = old_snapshot.get_language(language)
         language_delta = _delta_for_language(
             language,

--- a/diagram_analysis/cluster_delta.py
+++ b/diagram_analysis/cluster_delta.py
@@ -31,6 +31,7 @@ from agents.scope_ids import ROOT_SCOPE_ID
 from diagram_analysis.cluster_snapshot import ClusterSnapshot, ClusterSnapshotEntry
 from repo_utils.path_utils import normalize_repo_path
 from repo_utils.change_detector import ChangeSet
+from static_analyzer.cfg import DEFAULT_REFERENCE_KINDS
 from static_analyzer.analysis_result import StaticAnalysisResults
 from static_analyzer.clustering import ClusterResult
 from static_analyzer.leiden_utils import find_partition_seeded
@@ -281,7 +282,7 @@ def compute_cluster_delta(
         cfg = new_static.get_cfg(language)
         # Cluster the same reference-augmented graph the full run uses; a call-only graph would
         # re-cluster type-coupled methods differently and drift from what a full analysis produces.
-        nx_graph = cfg.to_networkx()
+        nx_graph = cfg.to_networkx(DEFAULT_REFERENCE_KINDS)
         old_clusters = old_snapshot.get_language(language)
         language_delta = _delta_for_language(
             language,

--- a/diagram_analysis/cluster_snapshot.py
+++ b/diagram_analysis/cluster_snapshot.py
@@ -55,7 +55,7 @@ def snapshot_from_static_analysis(static_analysis: StaticAnalysisResults) -> Clu
         partition = static_analysis.get_clusters(language).result
         if not partition.clusters:
             continue
-        by_language[language] = _entries_from_partition(partition, cfg.to_networkx())
+        by_language[language] = _entries_from_partition(partition, cfg.to_networkx(reference_kinds=()))
     return ClusterSnapshot(by_language=by_language)
 
 

--- a/diagram_analysis/diagram_generator.py
+++ b/diagram_analysis/diagram_generator.py
@@ -72,6 +72,7 @@ from monitoring.paths import get_monitoring_run_dir
 from repo_utils.change_detector import ChangeSet
 from repo_utils.ignore import RepoIgnoreManager
 from static_analyzer import StaticAnalyzer, get_static_analysis
+from static_analyzer.cfg import DEFAULT_REFERENCE_KINDS
 from static_analyzer.analysis_cache import StaticAnalysisCache
 from static_analyzer.analysis_result import StaticAnalysisResults
 from static_analyzer.reference_resolver import StaticReferenceResolver
@@ -665,7 +666,7 @@ class DiagramGenerator:
             # Reference-augmented graph, matching the production split (deterministic_cluster_grouping ->
             # supercluster_by_modularity_peak): a component separable only via CONTAINS/INHERITS edges
             # must not be judged cohesive on a call-only graph.
-            cfg_graphs = {lang: cfg.to_networkx() for lang, cfg in subgraph_cfgs.items()}
+            cfg_graphs = {lang: cfg.to_networkx(DEFAULT_REFERENCE_KINDS) for lang, cfg in subgraph_cfgs.items()}
             separable = component_is_separable(cluster_results, cfg_graphs, load)
         self._separable_cache[key] = separable
         return separable
@@ -1494,7 +1495,7 @@ class DiagramGenerator:
             baseline_membership = _capture_membership_baseline(root_analysis, sub_analyses)
             root_cluster_results = delta.cluster_results()
             root_cfgs = {
-                language: self.static_analysis.get_cfg(Language(language)).to_networkx()
+                language: self.static_analysis.get_cfg(Language(language)).to_networkx(DEFAULT_REFERENCE_KINDS)
                 for language in root_cluster_results
             }
             apply_result = self._apply_incremental_scope_recursively(
@@ -1722,7 +1723,11 @@ def _build_scope_incremental_inputs(
         scope_id=scope_id,
         changed=changed_members,
     )
-    return cluster_results, {lang: cfg.to_networkx() for lang, cfg in subgraph_cfgs.items()}, structural_diff
+    return (
+        cluster_results,
+        {lang: cfg.to_networkx(DEFAULT_REFERENCE_KINDS) for lang, cfg in subgraph_cfgs.items()},
+        structural_diff,
+    )
 
 
 def scoped_snapshot_for_component(

--- a/diagram_analysis/diagram_generator.py
+++ b/diagram_analysis/diagram_generator.py
@@ -665,7 +665,7 @@ class DiagramGenerator:
             # Reference-augmented graph, matching the production split (deterministic_cluster_grouping ->
             # supercluster_by_modularity_peak): a component separable only via CONTAINS/INHERITS edges
             # must not be judged cohesive on a call-only graph.
-            cfg_graphs = {lang: cfg.clustering_networkx() for lang, cfg in subgraph_cfgs.items()}
+            cfg_graphs = {lang: cfg.to_networkx() for lang, cfg in subgraph_cfgs.items()}
             separable = component_is_separable(cluster_results, cfg_graphs, load)
         self._separable_cache[key] = separable
         return separable
@@ -1494,7 +1494,7 @@ class DiagramGenerator:
             baseline_membership = _capture_membership_baseline(root_analysis, sub_analyses)
             root_cluster_results = delta.cluster_results()
             root_cfgs = {
-                language: self.static_analysis.get_cfg(Language(language)).clustering_networkx()
+                language: self.static_analysis.get_cfg(Language(language)).to_networkx()
                 for language in root_cluster_results
             }
             apply_result = self._apply_incremental_scope_recursively(
@@ -1722,7 +1722,7 @@ def _build_scope_incremental_inputs(
         scope_id=scope_id,
         changed=changed_members,
     )
-    return cluster_results, {lang: cfg.clustering_networkx() for lang, cfg in subgraph_cfgs.items()}, structural_diff
+    return cluster_results, {lang: cfg.to_networkx() for lang, cfg in subgraph_cfgs.items()}, structural_diff
 
 
 def scoped_snapshot_for_component(

--- a/health/checks/coupling.py
+++ b/health/checks/coupling.py
@@ -18,7 +18,9 @@ def collect_coupling_values(call_graph: CallGraph) -> tuple[list[float], list[fl
     Returns:
         A tuple of (fan_out_values, fan_in_values).
     """
-    nx_graph = call_graph.to_networkx()
+    # Call edges only: a CONTAINS edge from a class to its methods is not a call, and
+    # folding it in would give every method a phantom +1 fan-in.
+    nx_graph = call_graph.to_networkx(reference_kinds=())
     fan_out_values: list[float] = []
     fan_in_values: list[float] = []
 
@@ -96,7 +98,7 @@ def check_fan_in(call_graph: CallGraph, config: HealthCheckConfig) -> StandardCh
     total_checked = 0
     threshold = config.fan_in_max
 
-    nx_graph = call_graph.to_networkx()
+    nx_graph = call_graph.to_networkx(reference_kinds=())  # call edges only; see collect_coupling_values
     for node_name in nx_graph.nodes:
         node = call_graph.nodes.get(node_name)
         if node and (node.is_class() or node.is_data()):

--- a/health/checks/coupling.py
+++ b/health/checks/coupling.py
@@ -98,7 +98,8 @@ def check_fan_in(call_graph: CallGraph, config: HealthCheckConfig) -> StandardCh
     total_checked = 0
     threshold = config.fan_in_max
 
-    nx_graph = call_graph.to_networkx(reference_kinds=())  # call edges only; see collect_coupling_values
+    # Call edges only: a CONTAINS edge would give every method a phantom +1 fan-in from its class.
+    nx_graph = call_graph.to_networkx(reference_kinds=())
     for node_name in nx_graph.nodes:
         node = call_graph.nodes.get(node_name)
         if node and (node.is_class() or node.is_data()):

--- a/static_analyzer/cfg/__init__.py
+++ b/static_analyzer/cfg/__init__.py
@@ -5,6 +5,6 @@ the physical-location identity used to dedup LSP qualified-name aliases.
 """
 
 from static_analyzer.cfg.call_graph import CallGraph
-from static_analyzer.cfg.edge import Edge, EdgeKind
+from static_analyzer.cfg.edge import DEFAULT_REFERENCE_KINDS, Edge, EdgeKind
 
-__all__ = ["CallGraph", "Edge", "EdgeKind"]
+__all__ = ["DEFAULT_REFERENCE_KINDS", "CallGraph", "Edge", "EdgeKind"]

--- a/static_analyzer/cfg/call_graph.py
+++ b/static_analyzer/cfg/call_graph.py
@@ -6,7 +6,7 @@ from types import MappingProxyType
 
 import networkx as nx
 
-from static_analyzer.cfg.edge import Edge, EdgeKind
+from static_analyzer.cfg.edge import DEFAULT_REFERENCE_KINDS, Edge, EdgeKind
 from static_analyzer.cfg.location_key import LocationKey
 from static_analyzer.constants import ClusteringConfig
 from static_analyzer.node import Node
@@ -43,7 +43,7 @@ class CallGraph:
         self._alias_to_canonical: dict[str, str] = {}
         # Non-call relationship edges (CONTAINS/INHERITS/TYPEREF/IMPORT), kept off
         # ``self.edges`` so relations and ``methods_called_by_me`` stay call-only.
-        # Merged into the graph only for clustering (``clustering_networkx``).
+        # ``to_networkx`` folds them into the export by default.
         # Each entry: (src_qname, dst_qname, EdgeKind value).
         self.reference_edges: list[tuple[str, str, str]] = []
 
@@ -198,7 +198,14 @@ class CallGraph:
         for edge in self.edges:
             edge.visit_paths(fn)
 
-    def to_networkx(self) -> nx.DiGraph:
+    def to_networkx(self, reference_kinds: Collection[str] = DEFAULT_REFERENCE_KINDS) -> nx.DiGraph:
+        """Export to networkx: always call edges, plus reference edges of the given kinds.
+
+        Why: folding in CONTAINS/INHERITS keeps constructors, dunders and interface
+        methods from being graph-isolated, which is what every structural consumer
+        wants. Pass ``()`` for call edges only — degree-counting metrics need that,
+        since a CONTAINS edge is not a call.
+        """
         nx_graph = nx.DiGraph()
         for node in self.nodes.values():
             nx_graph.add_node(
@@ -210,23 +217,13 @@ class CallGraph:
             )
         for edge in self.edges:
             nx_graph.add_edge(edge.get_source(), edge.get_destination())
-        return nx_graph
 
-    def clustering_networkx(self, reference_kinds: Collection[str] | None = None) -> nx.DiGraph:
-        """Graph used for clustering: call edges plus configured reference-edge kinds.
-
-        Reference edges (CONTAINS/INHERITS/TYPEREF/IMPORT) complete the graph so
-        constructors, dunders, DI/reflection-invoked, and interface methods aren't
-        graph-isolated. ``reference_kinds`` defaults to
-        ``ClusteringConfig.CLUSTERING_EDGE_KINDS``; pass an explicit set to analyze
-        a different subset. Call edges are always included.
-        """
-        kinds = set(ClusteringConfig.CLUSTERING_EDGE_KINDS if reference_kinds is None else reference_kinds)
-        nx_graph = self.to_networkx()
-        # getattr: baselines pickled before reference edges existed lack the attribute.
-        # Resolve endpoints through the alias map so an edge stored under a short alias still
-        # lands on the canonical node (matching how add_edge resolves call edges).
-        for src, dst, kind in getattr(self, "reference_edges", ()):
+        kinds = set(reference_kinds)
+        if not kinds:
+            return nx_graph
+        # Resolve endpoints through the alias map so an edge stored under a short alias
+        # still lands on the canonical node (matching how add_edge resolves call edges).
+        for src, dst, kind in self.reference_edges:
             rsrc, rdst = self._resolve_name(src), self._resolve_name(dst)
             if kind in kinds and rsrc in self.nodes and rdst in self.nodes:
                 nx_graph.add_edge(rsrc, rdst)

--- a/static_analyzer/cfg/call_graph.py
+++ b/static_analyzer/cfg/call_graph.py
@@ -133,7 +133,7 @@ class CallGraph:
         seen: set[tuple[str, str, str]] = set()
         carried: list[tuple[str, str, str]] = []
         for source in (self, *extra_sources):
-            for s, d, k in getattr(source, "reference_edges", ()):
+            for s, d, k in source.reference_edges:
                 # Resolve through the SOURCE's alias map: an endpoint stored under a short
                 # alias must map to the canonical name ``out`` promoted it to, or a call edge
                 # (which add_edge resolves) survives while its reference edge is silently dropped.
@@ -198,14 +198,8 @@ class CallGraph:
         for edge in self.edges:
             edge.visit_paths(fn)
 
-    def to_networkx(self, reference_kinds: Collection[str] = DEFAULT_REFERENCE_KINDS) -> nx.DiGraph:
-        """Export to networkx: always call edges, plus reference edges of the given kinds.
-
-        Why: folding in CONTAINS/INHERITS keeps constructors, dunders and interface
-        methods from being graph-isolated, which is what every structural consumer
-        wants. Pass ``()`` for call edges only — degree-counting metrics need that,
-        since a CONTAINS edge is not a call.
-        """
+    def to_networkx(self, reference_kinds: Collection[str]) -> nx.DiGraph:
+        """Export to networkx: call edges, plus reference edges of the given kinds."""
         nx_graph = nx.DiGraph()
         for node in self.nodes.values():
             nx_graph.add_node(

--- a/static_analyzer/cfg/edge.py
+++ b/static_analyzer/cfg/edge.py
@@ -25,6 +25,12 @@ class EdgeKind(StrEnum):
     IMPORT = "import"
 
 
+# Folded in on top of call edges by ``CallGraph.to_networkx`` unless a caller opts out.
+# CONTAINS and INHERITS reconnect the symbols the call graph leaves isolated —
+# constructors, dunders, interface methods. No engine emits TYPEREF/IMPORT yet.
+DEFAULT_REFERENCE_KINDS: tuple[EdgeKind, ...] = (EdgeKind.CONTAINS, EdgeKind.INHERITS)
+
+
 class Edge:
     def __init__(self, src_node: Node, dst_node: Node, call_sites: Sequence[Mapping[str, Hashable]] = ()) -> None:
         self.src_node = src_node

--- a/static_analyzer/cfg/edge.py
+++ b/static_analyzer/cfg/edge.py
@@ -25,9 +25,11 @@ class EdgeKind(StrEnum):
     IMPORT = "import"
 
 
-# Folded in on top of call edges by ``CallGraph.to_networkx`` unless a caller opts out.
-# CONTAINS and INHERITS reconnect the symbols the call graph leaves isolated —
-# constructors, dunders, interface methods. No engine emits TYPEREF/IMPORT yet.
+# What structural consumers fold into ``to_networkx`` on top of call edges. The call graph
+# leaves ~a fifth of symbols isolated (constructors, dunders, DI/interface methods), so
+# completing it with these avoids grab-bag components. TYPEREF and IMPORT are plumbed through
+# ``LanguageAnalysisResult`` but no engine emits them yet, and IMPORT is expected to over-merge
+# (coarse, dense, file-level) when one does.
 DEFAULT_REFERENCE_KINDS: tuple[EdgeKind, ...] = (EdgeKind.CONTAINS, EdgeKind.INHERITS)
 
 

--- a/static_analyzer/clustering/service.py
+++ b/static_analyzer/clustering/service.py
@@ -20,7 +20,7 @@ class ClusteringService:
         self.min_cluster_size = ClusteringConfig.DEFAULT_MIN_CLUSTER_SIZE
 
     def cluster(self, graph: CallGraph) -> ClusterResult:
-        nx_graph = graph.clustering_networkx()
+        nx_graph = graph.to_networkx()
         return cluster_graph(
             nx_graph,
             delimiter=graph.delimiter,

--- a/static_analyzer/clustering/service.py
+++ b/static_analyzer/clustering/service.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from static_analyzer.cfg import CallGraph
+from static_analyzer.cfg import CallGraph, DEFAULT_REFERENCE_KINDS
 from static_analyzer.clustering.engine import cluster_graph
 from static_analyzer.clustering.models import ClusterResult
 from static_analyzer.constants import ClusteringConfig
@@ -20,7 +20,7 @@ class ClusteringService:
         self.min_cluster_size = ClusteringConfig.DEFAULT_MIN_CLUSTER_SIZE
 
     def cluster(self, graph: CallGraph) -> ClusterResult:
-        nx_graph = graph.to_networkx()
+        nx_graph = graph.to_networkx(DEFAULT_REFERENCE_KINDS)
         return cluster_graph(
             nx_graph,
             delimiter=graph.delimiter,

--- a/static_analyzer/constants.py
+++ b/static_analyzer/constants.py
@@ -82,15 +82,6 @@ class ClusteringConfig:
     # Deterministic seed for clustering algorithms
     CLUSTERING_SEED = 42
 
-    # Which reference-edge kinds (beyond call edges) to fold into the graph used
-    # for clustering. The static call graph misses ~a fifth of symbols (isolated
-    # constructors, dunders, DI/interface methods), so completing it with these
-    # relationships avoids grab-bag components. Values are ``graph.EdgeKind`` string
-    # values. TYPEREF and IMPORT are plumbed through ``LanguageAnalysisResult`` but no
-    # engine emits them yet, so listing them here would be a no-op; IMPORT is also
-    # expected to over-merge (coarse, dense, file-level) once it does arrive.
-    CLUSTERING_EDGE_KINDS = ("contains", "inherits")
-
 
 class NodeType(IntEnum):
     """LSP SymbolKind constants as an IntEnum.

--- a/tests/agents/test_abstraction_agent.py
+++ b/tests/agents/test_abstraction_agent.py
@@ -121,7 +121,6 @@ class TestAbstractionAgent(unittest.TestCase):
         agent = self._make_agent()
         cr, graph = self._clustered_graph(range(1, 13))
         self.mock_static_analysis.get_cfg.return_value.to_networkx.return_value = graph
-        self.mock_static_analysis.get_cfg.return_value.to_networkx.return_value = graph
         cluster_results = {"python": cr}
 
         result = agent.step_clusters_grouping(cluster_results)
@@ -141,7 +140,6 @@ class TestAbstractionAgent(unittest.TestCase):
         _, graph = self._clustered_graph(range(1, 13))
         py_cr, _ = self._clustered_graph(range(1, 7))
         js_cr, _ = self._clustered_graph(range(7, 13))
-        self.mock_static_analysis.get_cfg.return_value.to_networkx.return_value = graph
         self.mock_static_analysis.get_cfg.return_value.to_networkx.return_value = graph
         cluster_results = {"python": py_cr, "javascript": js_cr}
 

--- a/tests/agents/test_abstraction_agent.py
+++ b/tests/agents/test_abstraction_agent.py
@@ -121,7 +121,7 @@ class TestAbstractionAgent(unittest.TestCase):
         agent = self._make_agent()
         cr, graph = self._clustered_graph(range(1, 13))
         self.mock_static_analysis.get_cfg.return_value.to_networkx.return_value = graph
-        self.mock_static_analysis.get_cfg.return_value.clustering_networkx.return_value = graph
+        self.mock_static_analysis.get_cfg.return_value.to_networkx.return_value = graph
         cluster_results = {"python": cr}
 
         result = agent.step_clusters_grouping(cluster_results)
@@ -142,7 +142,7 @@ class TestAbstractionAgent(unittest.TestCase):
         py_cr, _ = self._clustered_graph(range(1, 7))
         js_cr, _ = self._clustered_graph(range(7, 13))
         self.mock_static_analysis.get_cfg.return_value.to_networkx.return_value = graph
-        self.mock_static_analysis.get_cfg.return_value.clustering_networkx.return_value = graph
+        self.mock_static_analysis.get_cfg.return_value.to_networkx.return_value = graph
         cluster_results = {"python": py_cr, "javascript": js_cr}
 
         result = agent.step_clusters_grouping(cluster_results)

--- a/tests/agents/test_details_agent.py
+++ b/tests/agents/test_details_agent.py
@@ -202,7 +202,7 @@ class TestDetailsAgent(unittest.TestCase):
         cr, graph = self._clustered_graph(range(1, 11))
         subgraph_cfg = MagicMock()
         subgraph_cfg.to_networkx.return_value = graph
-        subgraph_cfg.clustering_networkx.return_value = graph
+        subgraph_cfg.to_networkx.return_value = graph
         subgraph_cluster_results = {"python": cr}
         subgraph_cfgs = {"python": subgraph_cfg}
 
@@ -399,7 +399,7 @@ class TestDetailsAgent(unittest.TestCase):
         mock_subgraph.cluster.return_value = sub_cluster_result
         mock_subgraph.to_cluster_string.return_value = "Component CFG String"
         mock_subgraph.to_networkx.return_value = subgraph_graph
-        mock_subgraph.clustering_networkx.return_value = subgraph_graph
+        mock_subgraph.to_networkx.return_value = subgraph_graph
 
         mock_cfg = MagicMock()
         mock_cfg.cluster.return_value = mock_cluster_result
@@ -408,7 +408,7 @@ class TestDetailsAgent(unittest.TestCase):
         mock_cfg.to_cluster_string.return_value = "Cluster 1: method_a, method_b"
         # deterministic_cluster_grouping reads the (super-)graph via get_cfg(...).to_networkx()
         mock_cfg.to_networkx.return_value = subgraph_graph
-        mock_cfg.clustering_networkx.return_value = subgraph_graph
+        mock_cfg.to_networkx.return_value = subgraph_graph
 
         self.mock_static_analysis.get_languages.return_value = ["python"]
         self.mock_static_analysis.get_cfg.return_value = mock_cfg

--- a/tests/agents/test_details_agent.py
+++ b/tests/agents/test_details_agent.py
@@ -202,7 +202,6 @@ class TestDetailsAgent(unittest.TestCase):
         cr, graph = self._clustered_graph(range(1, 11))
         subgraph_cfg = MagicMock()
         subgraph_cfg.to_networkx.return_value = graph
-        subgraph_cfg.to_networkx.return_value = graph
         subgraph_cluster_results = {"python": cr}
         subgraph_cfgs = {"python": subgraph_cfg}
 
@@ -399,7 +398,6 @@ class TestDetailsAgent(unittest.TestCase):
         mock_subgraph.cluster.return_value = sub_cluster_result
         mock_subgraph.to_cluster_string.return_value = "Component CFG String"
         mock_subgraph.to_networkx.return_value = subgraph_graph
-        mock_subgraph.to_networkx.return_value = subgraph_graph
 
         mock_cfg = MagicMock()
         mock_cfg.cluster.return_value = mock_cluster_result
@@ -407,7 +405,6 @@ class TestDetailsAgent(unittest.TestCase):
         # _build_cluster_string calls cfg.to_cluster_string on the original cfg
         mock_cfg.to_cluster_string.return_value = "Cluster 1: method_a, method_b"
         # deterministic_cluster_grouping reads the (super-)graph via get_cfg(...).to_networkx()
-        mock_cfg.to_networkx.return_value = subgraph_graph
         mock_cfg.to_networkx.return_value = subgraph_graph
 
         self.mock_static_analysis.get_languages.return_value = ["python"]

--- a/tests/diagram_analysis/test_cluster_delta.py
+++ b/tests/diagram_analysis/test_cluster_delta.py
@@ -20,7 +20,7 @@ from diagram_analysis.cluster_snapshot import ClusterSnapshot, ClusterSnapshotEn
 from repo_utils.change_detector import ChangeSet, FileChange
 from static_analyzer.analysis_result import StaticAnalysisResults
 from static_analyzer.constants import Language, NodeType
-from static_analyzer.cfg import CallGraph
+from static_analyzer.cfg import CallGraph, DEFAULT_REFERENCE_KINDS
 from static_analyzer.clustering import ClusterResult
 from static_analyzer.node import Node
 
@@ -451,7 +451,7 @@ class TestDiffScoping(unittest.TestCase):
 class TestInternalHelpersSmoke(unittest.TestCase):
     def test_flavor_b_handles_empty_universe(self) -> None:
         graph = _build_graph([], [])
-        ld = _flavor_b_seeded("python", graph.to_networkx(), {}, set(), set())
+        ld = _flavor_b_seeded("python", graph.to_networkx(DEFAULT_REFERENCE_KINDS), {}, set(), set())
         self.assertFalse(ld.affected_cluster_ids)
 
 
@@ -558,7 +558,7 @@ class TestSeededLockGuarantee(unittest.TestCase):
             }
         )
         # Build the working subgraph the way _flavor_b_seeded does.
-        nx_g = graph.to_networkx()
+        nx_g = graph.to_networkx(DEFAULT_REFERENCE_KINDS)
         old_clusters = snap.by_language["python"]
         added_nodes = {"added.x"}
         removed_nodes: set[str] = set()

--- a/tests/static_analyzer/test_graph.py
+++ b/tests/static_analyzer/test_graph.py
@@ -6,7 +6,7 @@ import networkx as nx
 from static_analyzer.constants import NodeType
 from static_analyzer.leiden_utils import find_partition
 from static_analyzer.node import Node
-from static_analyzer.cfg import CallGraph, Edge
+from static_analyzer.cfg import CallGraph, DEFAULT_REFERENCE_KINDS, Edge
 from static_analyzer.clustering import ClusterResult, ClusteringService
 
 
@@ -230,7 +230,7 @@ class TestCallGraph(unittest.TestCase):
         graph.add_node(node2)
         graph.add_edge("module.func1", "module.func2")
 
-        nx_graph = graph.to_networkx()
+        nx_graph = graph.to_networkx(DEFAULT_REFERENCE_KINDS)
 
         # Check it's a DiGraph
         self.assertIsInstance(nx_graph, nx.DiGraph)
@@ -470,7 +470,7 @@ class TestCallGraph(unittest.TestCase):
         self.assertNotIn("index.funcA", graph.nodes)
 
         # Edge objects must reflect the promoted name (in-place mutation)
-        nx_graph = graph.to_networkx()
+        nx_graph = graph.to_networkx(DEFAULT_REFERENCE_KINDS)
         self.assertEqual(nx_graph.number_of_edges(), 1)
 
         # filter_by_files must not KeyError on stale edge names

--- a/tests/static_analyzer/test_result_converter.py
+++ b/tests/static_analyzer/test_result_converter.py
@@ -643,7 +643,7 @@ def test_add_reference_edges_contains_and_inherits():
     assert not any(s == "mod.helper" and k == str(EdgeKind.CONTAINS) for s, d, k in cg.reference_edges)
 
 
-def test_clustering_networkx_includes_configured_reference_kinds():
+def test_to_networkx_folds_in_default_reference_kinds():
     from static_analyzer.cfg import CallGraph, EdgeKind
     from static_analyzer.node import Node
 
@@ -661,9 +661,11 @@ def test_clustering_networkx_includes_configured_reference_kinds():
     cg.add_reference_edge("mod.A", "mod.B", EdgeKind.CONTAINS)
 
     # default kinds include contains -> edge present
-    assert cg.clustering_networkx().has_edge("mod.A", "mod.B")
+    assert cg.to_networkx().has_edge("mod.A", "mod.B")
     # restricting to a kind that isn't present -> edge absent (call graph had no edges)
-    assert not cg.clustering_networkx(reference_kinds={"import"}).has_edge("mod.A", "mod.B")
+    assert not cg.to_networkx(reference_kinds={"import"}).has_edge("mod.A", "mod.B")
+    # opting out entirely -> call edges only
+    assert not cg.to_networkx(reference_kinds=()).has_edge("mod.A", "mod.B")
 
 
 class TestIgnoredFilesExcluded:

--- a/tests/static_analyzer/test_result_converter.py
+++ b/tests/static_analyzer/test_result_converter.py
@@ -8,6 +8,7 @@ parameters, and dual-registration aliases are correctly excluded from references
 from pathlib import Path
 from unittest.mock import MagicMock
 
+from static_analyzer.cfg import DEFAULT_REFERENCE_KINDS
 from static_analyzer.constants import NodeType
 from static_analyzer.engine.language_adapter import LanguageAdapter
 from static_analyzer.engine.models import CallFlowGraph, LanguageAnalysisResult, SymbolInfo
@@ -660,8 +661,8 @@ def test_to_networkx_folds_in_default_reference_kinds():
         )
     cg.add_reference_edge("mod.A", "mod.B", EdgeKind.CONTAINS)
 
-    # default kinds include contains -> edge present
-    assert cg.to_networkx().has_edge("mod.A", "mod.B")
+    # the default kinds include contains -> edge present
+    assert cg.to_networkx(DEFAULT_REFERENCE_KINDS).has_edge("mod.A", "mod.B")
     # restricting to a kind that isn't present -> edge absent (call graph had no edges)
     assert not cg.to_networkx(reference_kinds={"import"}).has_edge("mod.A", "mod.B")
     # opting out entirely -> call edges only


### PR DESCRIPTION
**Stack 7 of 9** — base: `stack/6-cfg-package` (#480). ⚠️ **Behaviour change — deliberate.**

`to_networkx` and `clustering_networkx` differed only in which reference kinds they folded in, so they collapse into `to_networkx(reference_kinds=...)` with `DEFAULT_REFERENCE_KINDS` (`CONTAINS`, `INHERITS`) as the default. Every clustering call site drops its explicit argument; the two coupling checks opt out with `()`.

**83 changed lines** across 12 files.

### Two callers change what they see

**`health` fan-in/fan-out are protected.** They pass `()`. Folding `CONTAINS` in would give every method a phantom +1 fan-in from its owning class and corrupt E2/E3.

**`_build_undirected_graphs` in `cluster_methods_mixin` now sees the same graph the partition came from.** It was building orphan-placement graphs from call edges alone, while the clusters it placed nodes *into* were computed on a reference-augmented graph. So constructors and interface methods — exactly the symbols the reference kinds exist to reconnect — resolved as disconnected and never found a nearest cluster.

**This shifts orphan assignments on real repos.** It needs an eval run before merge, and results should be read knowing that I2 membership flips roughly 1 run in 4 from `set[Path]` iteration order, independent of this change.

### Also
The `getattr` guard on `reference_edges` goes away — the tag bump in #475 means no pre-reference-edge pickle can reach this code.

### Checks
`2059 passed, 28 skipped` · mypy clean · black clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency and determinism across graph-based clustering, diagram analysis, and subgraph grouping.
  * Added control over which reference relationships are included in generated graph representations.
  * Ensured coupling analysis focuses on call relationships and avoids unrelated containment links.
  * Prevented reference relationships from being included when rebuilding selected graph snapshots.

* **Tests**
  * Updated clustering and graph conversion coverage for default, filtered, and call-only graph outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->