### PR TITLE
fix(agents): drop skipped nodes from rendered call targets

### DIFF
--- a/agents/llm_renderers/call_graph.py
+++ b/agents/llm_renderers/call_graph.py
@@ -30,6 +30,17 @@ def render_call_graph(graph: CallGraph, size_limit: int = DEFAULT_SIZE_LIMIT, sk
     return class_level
 
 
+def _visible_targets(graph: CallGraph, node: Node, skip_set: set[Node]) -> list[str]:
+    """Sorted call targets of ``node``, minus those resolving to a skipped node."""
+    visible = []
+    for name in node.methods_called_by_me:
+        target = graph.nodes.get(name)
+        if target is not None and target in skip_set:
+            continue
+        visible.append(name)
+    return sorted(visible)
+
+
 def _render_detailed(graph: CallGraph, skip_set: set[Node]) -> str:
     """File-grouped, method-level detail with call targets."""
     file_nodes: dict[str, list[Node]] = defaultdict(list)
@@ -49,10 +60,10 @@ def _render_detailed(graph: CallGraph, skip_set: set[Node]) -> str:
     for file_path in sorted(file_nodes):
         nodes = sorted(file_nodes[file_path], key=lambda n: n.fully_qualified_name)
         for node in nodes:
-            if node.methods_called_by_me:
+            targets = _visible_targets(graph, node, skip_set)
+            if targets:
                 label = node.entity_label()
-                targets = ", ".join(sorted(node.methods_called_by_me))
-                result += f"{label} {node.fully_qualified_name} calls: {targets}\n"
+                result += f"{label} {node.fully_qualified_name} calls: {', '.join(targets)}\n"
 
     return result
 
@@ -64,7 +75,10 @@ def _render_class_level(graph: CallGraph, skip_set: set[Node]) -> str:
     function_calls: list[str] = []
 
     for node in graph.nodes.values():
-        if node in skip_set or not node.methods_called_by_me:
+        if node in skip_set:
+            continue
+        targets = _visible_targets(graph, node, skip_set)
+        if not targets:
             continue
 
         parts = node.fully_qualified_name.split(delimiter)
@@ -72,7 +86,7 @@ def _render_class_level(graph: CallGraph, skip_set: set[Node]) -> str:
             class_name = delimiter.join(parts[:-1])
             method_short = parts[-1]
 
-            for called_method in node.methods_called_by_me:
+            for called_method in targets:
                 called_parts = called_method.split(delimiter)
                 if len(called_parts) > 1:
                     called_class = delimiter.join(called_parts[:-1])
@@ -81,8 +95,7 @@ def _render_class_level(graph: CallGraph, skip_set: set[Node]) -> str:
                 else:
                     class_calls[class_name][called_method].append(f"{method_short}->{called_method}")
         else:
-            targets = ", ".join(sorted(node.methods_called_by_me))
-            function_calls.append(f"Function {node.fully_qualified_name} calls: {targets}")
+            function_calls.append(f"Function {node.fully_qualified_name} calls: {', '.join(targets)}")
 
     active_count = sum(1 for n in graph.nodes.values() if n not in skip_set)
     result = f"Control flow graph with {active_count} nodes (class-level summary)\n"

--- a/tests/agents/test_llm_renderers.py
+++ b/tests/agents/test_llm_renderers.py
@@ -52,15 +52,54 @@ class TestRenderCallGraph(unittest.TestCase):
         for node in (node1, node2, node3):
             graph.add_node(node)
         graph.add_edge("module.func1", "module.func2")
+        graph.add_edge("module.func1", "module.func3")
         graph.add_edge("module.func2", "module.func3")
 
-        # func1 still lists func2 as a target (it lives in methods_called_by_me),
-        # but func2's own outgoing call is suppressed and it leaves the node count.
         result = render_call_graph(graph, skip_nodes=[node2])
 
+        # func1 survives on its remaining target; a skipped node leaves the count,
+        # loses its own outgoing call, and is dropped from every other node's targets.
         self.assertIn("module.func1", result)
-        self.assertIn("module.func2", result)
+        self.assertIn("module.func3", result)
+        self.assertNotIn("module.func2", result)
         self.assertIn("2 nodes", result)
+
+    def test_source_with_only_skipped_targets_is_omitted(self):
+        graph = CallGraph()
+        node1 = Node("module.func1", 12, "/file.py", 1, 10)
+        node2 = Node("module.func2", 12, "/file.py", 20, 30)
+        for node in (node1, node2):
+            graph.add_node(node)
+        graph.add_edge("module.func1", "module.func2")
+
+        result = render_call_graph(graph, skip_nodes=[node2])
+
+        self.assertNotIn("calls:", result)
+        self.assertNotIn("module.func2", result)
+
+    def test_unresolved_targets_survive_filtering(self):
+        """External calls have no node in the graph, so they are not 'skipped'."""
+        graph = CallGraph()
+        node1 = Node("module.func1", 12, "/file.py", 1, 10)
+        graph.add_node(node1)
+        node1.methods_called_by_me.add("thirdparty.helper")
+
+        result = render_call_graph(graph, skip_nodes=[])
+
+        self.assertIn("thirdparty.helper", result)
+
+    def test_skipped_targets_are_dropped_at_class_level(self):
+        graph = CallGraph()
+        keep = Node("pkg.ClassA.method1", NodeType.METHOD, "/a.py", 1, 10)
+        skipped = Node("pkg.ClassB.method2", NodeType.METHOD, "/b.py", 1, 10)
+        for node in (keep, skipped):
+            graph.add_node(node)
+        graph.add_edge("pkg.ClassA.method1", "pkg.ClassB.method2")
+
+        result = render_call_graph(graph, size_limit=0, skip_nodes=[skipped])
+
+        self.assertIn("class-level summary", result)
+        self.assertNotIn("pkg.ClassB", result)
 
 
 if __name__ == "__main__":

--- a/tests/agents/tools/test_cfg_tools.py
+++ b/tests/agents/tools/test_cfg_tools.py
@@ -12,9 +12,10 @@ from agents.tools import ComponentBridgeEdgesTool, GetCFGTool, MethodInvocations
 from agents.tools.base import RepoContext
 from repo_utils.ignore import RepoIgnoreManager
 from static_analyzer import StaticAnalyzer
-from static_analyzer.constants import NodeType
+from static_analyzer.analysis_result import StaticAnalysisResults
 from static_analyzer.cfg import CallGraph, Edge
 from static_analyzer.clustering import ClusterResult
+from static_analyzer.constants import Language, NodeType
 from static_analyzer.node import Node
 from utils import get_artifact_dir
 
@@ -194,3 +195,37 @@ class TestComponentBridgeEdgesTool(unittest.TestCase):
         result = tool._run(["Destination Group"], ["Source Group"])
 
         self.assertEqual(result, "No directed static bridge edges found between these component groups.")
+
+
+class TestComponentCFGScoping(unittest.TestCase):
+    """component_cfg must render only the component's own graph, targets included."""
+
+    def _make_tool(self, cfg: CallGraph) -> GetCFGTool:
+        static_analysis = StaticAnalysisResults()
+        static_analysis.add_cfg(Language.PYTHON, cfg)
+        context = RepoContext(
+            repo_dir=Path("."),
+            ignore_manager=RepoIgnoreManager(Path(".")),
+            static_analysis=static_analysis,
+        )
+        return GetCFGTool(context=context)
+
+    def test_out_of_component_call_target_is_absent(self):
+        cfg = CallGraph()
+        cfg.add_node(Node("pkg.inside.caller", NodeType.FUNCTION, "/inside.py", 1, 10))
+        cfg.add_node(Node("pkg.inside.helper", NodeType.FUNCTION, "/inside.py", 20, 30))
+        cfg.add_node(Node("pkg.outside.secret", NodeType.FUNCTION, "/outside.py", 1, 10))
+        cfg.add_edge("pkg.inside.caller", "pkg.inside.helper")
+        cfg.add_edge("pkg.inside.caller", "pkg.outside.secret")
+
+        component = Component(
+            name="InsideComponent",
+            description="Spans /inside.py only",
+            key_entities=[],
+            file_methods=[FileMethodGroup(file_path="/inside.py")],
+        )
+        result = self._make_tool(cfg).component_cfg(component)
+
+        self.assertIn("pkg.inside.caller", result)
+        self.assertIn("pkg.inside.helper", result)
+        self.assertNotIn("pkg.outside.secret", result)


### PR DESCRIPTION
**Stack 8 of 9** — base: `stack/7-to-networkx` (#481). ⚠️ **Behaviour change — deliberate.**

Both renderers filtered skipped nodes as *sources* but emitted `methods_called_by_me` wholesale, so a skipped node's fully qualified name still appeared as a call target. `component_cfg` passes every out-of-component node as `skip_nodes`, so **a component-scoped render leaked names from other components into the prompt.**

The header already disagreed with the body: it counts only edges whose endpoints both survive, while the body listed every target.

**113 changed lines.**

### The fix

One `_visible_targets` helper, used by both renderers. A target is dropped only when it resolves to a skipped node — a name that resolves to nothing is an *external* call, not a filtered one, so it stays. Sources left with no visible targets are omitted, which also fixes an empty `Function X calls: ` line at class level.

### Why this doesn't lose cross-component evidence

That evidence comes from `build_scope_cfg_string` → `build_component_relations`, a separate renderer built for exactly that purpose and feeding `static_call_evidence`. `component_cfg` is scoped to a component's own graph.

### Tests

Four new, all of which fail against the previous renderer: per-target filtering, source omission when nothing survives, unresolved targets surviving, and class-level filtering. Plus the component-scoped test asserting the out-of-component FQN is absent — built self-contained rather than in `TestCFGTools`, which skips without the `test-vscode-repo` fixture.

One existing test asserted the leak (`assertIn("module.func2", ...)`) with a comment describing it. Its subject is the header count, so I gave `func1` a surviving second target and flipped the assertion.

### Checks
`2063 passed, 28 skipped` · mypy clean · black clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Call-graph output now excludes skipped nodes and sources that only reference skipped targets.
  * External or unresolved call targets remain visible.
  * Class-level call-graph summaries now consistently omit skipped targets.
  * Component control-flow results now include only nodes within the selected component.

* **Tests**
  * Added coverage for skipped-node filtering, unresolved targets, class-level summaries, and component scoping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->