### PR TITLE
perf(engine): bound how many LSP servers are resident at once

### DIFF
--- a/static_analyzer/__init__.py
+++ b/static_analyzer/__init__.py
@@ -17,7 +17,7 @@ from static_analyzer.engine.adapters import get_adapter
 from static_analyzer.engine.call_graph_builder import CallGraphBuilder
 from static_analyzer.engine.language_adapter import LanguageAdapter
 from static_analyzer.engine.lsp_client import LSPClient
-from static_analyzer.engine.lsp_recycler import default_memory_budget
+from static_analyzer.engine.lsp_recycler import default_memory_budget, per_engine_memory_budget
 from static_analyzer.engine.result_converter import convert_to_codeboarding_format
 from static_analyzer.engine.source_inspector import SourceInspector
 from static_analyzer.engine.utils import uri_to_path
@@ -309,9 +309,15 @@ class StaticAnalyzer:
                 failed_languages.append(adapter.language)
                 failed_details.append(f"{adapter.language}: {exc}")
 
-        if attempted and max_concurrent_engines():
+        if not attempted:
+            logger.info(f"No source files for any detected language in {self.repository_path}; no LSP clients started.")
+            self._engine_clients = []
+            self._clients_started = True
+            return
+
+        if max_concurrent_engines():
             logger.info(
-                "Deferring %d engine LSP client(s); the full pass keeps at most %d resident.",
+                "%d engine LSP client(s) will start during analysis, at most %d running at a time.",
                 len(attempted),
                 max_concurrent_engines(),
             )
@@ -324,12 +330,6 @@ class StaticAnalyzer:
                     self._prepare_project_once(engine_config)
                 except Exception:
                     logger.exception(f"Failed to prepare {engine_config.project_path}; the full pass will report it")
-            self._engine_clients = []
-            self._clients_started = True
-            return
-
-        if not attempted:
-            logger.info(f"No source files for any detected language in {self.repository_path}; no LSP clients started.")
             self._engine_clients = []
             self._clients_started = True
             return
@@ -725,8 +725,13 @@ class StaticAnalyzer:
         absorb_lock = threading.Lock()
         spawned: list[str] = []
         spawn_failures: list[str] = []
+        # Keyed by position in the engine list so results merge in configuration
+        # order. The merges replace on key collision, and overlapping configs
+        # (nested solution roots) do collide, so completion order would let two
+        # identical runs keep different nodes and produce different component IDs.
+        completed: dict[int, tuple[Language, dict]] = {}
 
-        def run_one(engine_config: EngineConfig, engine_client: LSPClient | None) -> None:
+        def run_one(engine_config: EngineConfig, engine_client: LSPClient | None, order: int = 0) -> None:
             """Analyze one engine. Owns the client's lifetime when given none."""
             adapter, project_path = engine_config.adapter, engine_config.project_path
             language = adapter.language_enum
@@ -748,7 +753,7 @@ class StaticAnalyzer:
                 duration_ms = round((time.monotonic() - t_lang_start) * 1000)
                 logger.info(f"Engine analysis for {adapter.language} completed in {duration_ms / 1000:.1f}s")
                 with absorb_lock:
-                    self._absorb_into_results(results, language, analysis)
+                    completed[order] = (language, analysis)
                     self._collect_diagnostics_for(adapter, engine_client, analysis)
                     track_lsp_result(
                         language=adapter.language_enum.value,
@@ -782,8 +787,8 @@ class StaticAnalyzer:
 
         cap = max_concurrent_engines()
         if not cap:
-            for engine_config, engine_client in self._engine_clients:
-                run_one(engine_config, engine_client)
+            for order, (engine_config, engine_client) in enumerate(self._engine_clients):
+                run_one(engine_config, engine_client, order)
         else:
             pending = [cfg for cfg in self._engine_configs if cfg.source_files]
             logger.info("Running %d engine(s) with at most %d resident at a time", len(pending), cap)
@@ -793,7 +798,8 @@ class StaticAnalyzer:
             # wait so each in-flight ``run_one`` still shuts its own client down.
             pool = ThreadPoolExecutor(max_workers=cap)
             try:
-                for future in as_completed([pool.submit(run_one, cfg, None) for cfg in pending]):
+                futures = [pool.submit(run_one, cfg, None, order) for order, cfg in enumerate(pending)]
+                for future in as_completed(futures):
                     future.result()
             finally:
                 pool.shutdown(wait=True, cancel_futures=True)
@@ -803,6 +809,10 @@ class StaticAnalyzer:
                     "Failed to start any engine LSP client "
                     f"(attempted: {', '.join(cfg.adapter.language for cfg in pending)}){details}"
                 )
+
+        for order in sorted(completed):
+            language, analysis = completed[order]
+            self._absorb_into_results(results, language, analysis)
 
         summaries = []
         for language in results.get_languages():
@@ -954,7 +964,10 @@ class StaticAnalyzer:
                 f"Diagnostics for {adapter.language}: {len(merged_diags)} files, {total} items "
                 f"(cache={len(cache_diags)}, live={len(live_diags)})"
             )
-        self.collected_diagnostics[adapter.language_enum] = merged_diags
+        # Merge, not replace: a monorepo yields several configs per language, and
+        # replacing kept only whichever finished last -- which under the concurrency
+        # bound is a different one run to run.
+        self.collected_diagnostics.setdefault(adapter.language_enum, {}).update(merged_diags)
 
     def _loc_for_adapter(self, adapter: LanguageAdapter) -> int:
         """Return scanner LOC that should have been covered by this adapter."""
@@ -994,7 +1007,12 @@ class StaticAnalyzer:
         logger.info(f"Analyzing {len(source_files)} {adapter.language} files")
 
         t_build_start = time.monotonic()
-        builder = CallGraphBuilder(engine_client, adapter, project_path)
+        builder = CallGraphBuilder(
+            engine_client,
+            adapter,
+            project_path,
+            memory_budget_bytes=per_engine_memory_budget(max(max_concurrent_engines(), 1)),
+        )
         engine_result = builder.build(source_files)
         logger.info(f"CallGraphBuilder.build() for {adapter.language}: {time.monotonic() - t_build_start:.1f}s")
         if adapter.fail_on_empty_symbols is True and not builder.symbol_table.symbols:

--- a/static_analyzer/__init__.py
+++ b/static_analyzer/__init__.py
@@ -2,7 +2,7 @@ import logging
 import os
 import threading
 import time
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -55,58 +55,41 @@ class StaticAnalysisFatalError(RuntimeError):
 MAX_CONCURRENT_ENGINES_ENV_VAR = "CODEBOARDING_MAX_CONCURRENT_ENGINES"
 
 
-# An engine costs about three cores: the server itself peaks near 1.9 (measured
-# from csharp-ls), plus its dotnet children and the tree-sitter parsing the same
-# pass does on the Python side. On a 12-core host that predicts 4, which is where
-# abp actually peaked (612s, against 698s at 6 and 677s at 8).
+# An engine costs ~3 cores: the server's own peak (~1.9, measured on csharp-ls),
+# its dotnet children, and the tree-sitter parsing the same pass runs in Python.
 CORES_PER_ENGINE = 3
 
-# Peak resident set per engine, from abp at cap=4 (7.09GB across four servers).
+# Peak RSS per engine, measured on abp at cap=4 (7.09GB across four servers).
 ENGINE_MEMORY_FOOTPRINT_BYTES = 2 * 1024**3
 
 
 def max_concurrent_engines() -> int:
     """How many engine LSP servers may be resident at once. 0 disables the bound.
 
-    Why bound it: a monorepo emits one engine per sub-project (abp ships 30 C#
-    solutions). Starting them all up front holds every Roslyn workspace in
-    memory while the full pass uses one at a time — peak 12.9GB across 28
-    servers to do strictly sequential work.
-
-    On a 12-core box abp took 1413s at 28 resident, 1394s at 1, 612s at 4 and
-    677s at 8: throughput turns over once the servers oversubscribe the machine,
-    so the useful setting is a function of cores rather than a constant. See
-    ``recommended_engine_concurrency``.
-
-    Still opt-in: the warm-start path in ``_update_cached_results`` reads
-    ``_engine_clients`` directly, so defaulting this on would leave it empty and
-    make an incremental run silently return stale results. Making that path
-    spawn on demand is the prerequisite for flipping the default.
+    Why off by default: the bound hands each client's lifetime to the full pass,
+    so warm-start and the editor-facing file queries have no live client to use.
+    They refuse to run rather than answer emptily — see ``_live_clients``.
     """
     raw = os.environ.get(MAX_CONCURRENT_ENGINES_ENV_VAR, "").strip()
     if not raw:
         return 0
     try:
-        return max(int(raw), 0)
+        value = int(raw)
     except ValueError:
-        logger.warning("Ignoring non-integer %s=%r", MAX_CONCURRENT_ENGINES_ENV_VAR, raw)
+        logger.warning("Ignoring non-integer %s=%r; the bound stays off", MAX_CONCURRENT_ENGINES_ENV_VAR, raw)
         return 0
+    if value < 0:
+        logger.warning("Ignoring negative %s=%r; the bound stays off", MAX_CONCURRENT_ENGINES_ENV_VAR, raw)
+        return 0
+    return value
 
 
 def recommended_engine_concurrency(engine_count: int) -> int:
-    """The smallest of the three limits that actually bind engine concurrency.
+    """Engine concurrency bounded by available work, cores, and memory.
 
-    - Work: never more servers than there are engines. Most repos have one or
-      two; abp's 28 is the outlier this bound exists for.
-    - CPU: ``cores // CORES_PER_ENGINE``, the term the abp sweep measured.
-    - Memory: the recycler's per-server budget divided by what an engine
-      actually occupies. This is the binding term on a large host — 128 cores
-      would allow 42 engines on CPU alone, which no memory budget supports.
-
-    The memory term deliberately reuses ``default_memory_budget()`` so the two
-    mechanisms agree on how much RAM the analysis may hold. Without it the
-    recycler lets every server grow to the full budget while nothing accounts
-    for how many are resident.
+    Why the memory term: ``default_memory_budget()`` is what one server may grow
+    to before the recycler restarts it, so ``cap`` servers are expected to hold
+    about that much between them. It binds well before CPU on a large host.
     """
     cpu_bound = (os.cpu_count() or CORES_PER_ENGINE) // CORES_PER_ENGINE
     memory_bound = default_memory_budget() // ENGINE_MEMORY_FOOTPRINT_BYTES
@@ -240,7 +223,8 @@ class StaticAnalyzer:
         self.programming_langs = ProjectScanner(self.repository_path).scan()
         self._engine_configs = _create_engine_configs(self.programming_langs, self.repository_path, self.ignore_manager)
         self._engine_clients: list[tuple[EngineConfig, LSPClient]] = []
-        self._prepared_projects: set[Path] = set()
+        # (language, project) -> the failure preparation raised, or None.
+        self._prepared_projects: dict[tuple[str, Path], Exception | None] = {}
         self._prepared_lock = threading.Lock()
         self.collected_diagnostics: dict[Language, FileDiagnosticsMap] = {}
         self._clients_started: bool = False
@@ -339,7 +323,7 @@ class StaticAnalyzer:
                 try:
                     self._prepare_project_once(engine_config)
                 except Exception:
-                    logger.exception(f"Failed to prepare {engine_config.project_path}; continuing")
+                    logger.exception(f"Failed to prepare {engine_config.project_path}; the full pass will report it")
             self._engine_clients = []
             self._clients_started = True
             return
@@ -375,12 +359,27 @@ class StaticAnalyzer:
         an engine that runs before its siblings are restored loses cross-project
         edges. Preparing every project before the first server starts keeps the
         bounded pass resolving exactly what the unbounded one does.
+
+        A failure is remembered and re-raised rather than retried: preparation
+        installs SDKs into a shared directory, so several engines retrying it
+        concurrently is worse than one engine reporting it.
         """
+        key = (engine_config.adapter.language, engine_config.project_path)
         with self._prepared_lock:
-            if engine_config.project_path in self._prepared_projects:
+            if key in self._prepared_projects:
+                failure = self._prepared_projects[key]
+                if failure is not None:
+                    raise failure
                 return
-            self._prepared_projects.add(engine_config.project_path)
-        engine_config.adapter.prepare_project(engine_config.project_path)
+        outcome: Exception | None = None
+        try:
+            engine_config.adapter.prepare_project(engine_config.project_path)
+        except Exception as exc:
+            outcome = exc
+            raise
+        finally:
+            with self._prepared_lock:
+                self._prepared_projects[key] = outcome
 
     def _spawn_engine_client(self, engine_config: EngineConfig) -> LSPClient:
         """Start one engine's LSP server and return it ready for queries."""
@@ -468,6 +467,23 @@ class StaticAnalyzer:
         except Exception:
             logger.exception("Failed to persist static analysis pkl during stop_clients; continuing teardown")
 
+    def _live_clients(self, operation: str) -> list[tuple[EngineConfig, LSPClient]]:
+        """The started engine clients, refusing callers the concurrency bound cannot serve.
+
+        Why: under ``CODEBOARDING_MAX_CONCURRENT_ENGINES`` the full pass owns
+        each client's lifetime, so nothing is resident outside it. Every caller
+        below iterates the client list, and an empty one reads as a successful
+        empty answer — for warm-start that answer is then persisted over a good
+        cache, so a loud refusal is the only safe reading of this state.
+        """
+        if self._engine_clients or not any(config.source_files for config in self._engine_configs):
+            return self._engine_clients
+        raise StaticAnalysisFatalError(
+            f"{operation} needs live LSP clients, but {MAX_CONCURRENT_ENGINES_ENV_VAR}="
+            f"{max_concurrent_engines()} defers them to the full pass. Unset it, or run a full "
+            "analysis (skip_cache=True) so the pass owns the servers."
+        )
+
     def collect_fresh_diagnostics(self) -> dict[Language, FileDiagnosticsMap]:
         """Read current diagnostics from all running LSP clients without re-analyzing.
 
@@ -476,7 +492,7 @@ class StaticAnalyzer:
         diagnostics without triggering any new analysis work.
         """
         result: dict[Language, FileDiagnosticsMap] = {}
-        for engine_config, client in self._engine_clients:
+        for engine_config, client in self._live_clients("collect_fresh_diagnostics"):
             diags = client.get_collected_diagnostics()
             if diags:
                 result[engine_config.adapter.language_enum] = diags
@@ -484,7 +500,9 @@ class StaticAnalyzer:
 
     def get_diagnostics_generation(self) -> int:
         """Return the sum of diagnostics generation counters across all LSP clients."""
-        return sum(client.get_diagnostics_generation() for _, client in self._engine_clients)
+        return sum(
+            client.get_diagnostics_generation() for _, client in self._live_clients("get_diagnostics_generation")
+        )
 
     def load_cached_analysis(
         self,
@@ -535,7 +553,7 @@ class StaticAnalyzer:
             content:   Full current text content of the file.
         """
         suffix = file_path.suffix
-        for engine_config, client in self._engine_clients:
+        for engine_config, client in self._live_clients("notify_file_changed"):
             adapter = engine_config.adapter
             if suffix in adapter.file_extensions:
                 # Open + change to ensure the server has the latest content
@@ -557,7 +575,7 @@ class StaticAnalyzer:
             Returns an empty list if no matching client is found.
         """
         suffix = file_path.suffix
-        for engine_config, client in self._engine_clients:
+        for engine_config, client in self._live_clients("get_file_symbols"):
             if suffix in engine_config.adapter.file_extensions:
                 try:
                     symbols = client.document_symbol(file_path)
@@ -571,7 +589,7 @@ class StaticAnalyzer:
     def get_adapter_for_file(self, file_path: Path) -> tuple[LanguageAdapter, Path] | None:
         """Return the (adapter, project_root) pair that handles a given file extension."""
         suffix = file_path.suffix
-        for engine_config, _ in self._engine_clients:
+        for engine_config, _ in self._live_clients("get_adapter_for_file"):
             if suffix in engine_config.adapter.file_extensions:
                 return engine_config.adapter, engine_config.project_path
         return None
@@ -594,7 +612,12 @@ class StaticAnalyzer:
         """
         suffix = file_path.suffix
         client = next(
-            (c for engine_config, c in self._engine_clients if suffix in engine_config.adapter.file_extensions), None
+            (
+                c
+                for engine_config, c in self._live_clients("discover_file_dependencies")
+                if suffix in engine_config.adapter.file_extensions
+            ),
+            None,
         )
         if client is None:
             return []
@@ -700,6 +723,8 @@ class StaticAnalyzer:
         """
         results = StaticAnalysisResults()
         absorb_lock = threading.Lock()
+        spawned: list[str] = []
+        spawn_failures: list[str] = []
 
         def run_one(engine_config: EngineConfig, engine_client: LSPClient | None) -> None:
             """Analyze one engine. Owns the client's lifetime when given none."""
@@ -709,7 +734,14 @@ class StaticAnalyzer:
             owned_client: LSPClient | None = None
             try:
                 if engine_client is None:
-                    owned_client = self._spawn_engine_client(engine_config)
+                    try:
+                        owned_client = self._spawn_engine_client(engine_config)
+                    except Exception as exc:
+                        with absorb_lock:
+                            spawn_failures.append(f"{adapter.language}: {exc}")
+                        raise
+                    with absorb_lock:
+                        spawned.append(adapter.language)
                     engine_client = owned_client
                 logger.info(f"Starting engine analysis for {adapter.language} in {project_path}")
                 analysis = self._run_full_analysis(engine_config, engine_client)
@@ -755,9 +787,22 @@ class StaticAnalyzer:
         else:
             pending = [cfg for cfg in self._engine_configs if cfg.source_files]
             logger.info("Running %d engine(s) with at most %d resident at a time", len(pending), cap)
-            with ThreadPoolExecutor(max_workers=cap) as pool:
-                for future in [pool.submit(run_one, cfg, None) for cfg in pending]:
+            # Not ``with``: its ``__exit__`` waits without cancelling, so one
+            # engine's fatal error would still drain every queued engine — a full
+            # pass over a monorepo — before propagating. Cancel the queue, then
+            # wait so each in-flight ``run_one`` still shuts its own client down.
+            pool = ThreadPoolExecutor(max_workers=cap)
+            try:
+                for future in as_completed([pool.submit(run_one, cfg, None) for cfg in pending]):
                     future.result()
+            finally:
+                pool.shutdown(wait=True, cancel_futures=True)
+            if pending and not spawned:
+                details = f"; failures: {'; '.join(spawn_failures)}" if spawn_failures else ""
+                raise RuntimeError(
+                    "Failed to start any engine LSP client "
+                    f"(attempted: {', '.join(cfg.adapter.language for cfg in pending)}){details}"
+                )
 
         summaries = []
         for language in results.get_languages():
@@ -797,7 +842,7 @@ class StaticAnalyzer:
         output.
         """
         results = StaticAnalysisResults()
-        for engine_config, engine_client in self._engine_clients:
+        for engine_config, engine_client in self._live_clients("warm-start"):
             adapter, project_path = engine_config.adapter, engine_config.project_path
             language = adapter.language_enum
             cached_lang_dict = self._extract_language_dict(cached_results, language)

--- a/static_analyzer/__init__.py
+++ b/static_analyzer/__init__.py
@@ -1,5 +1,8 @@
 import logging
+import os
+import threading
 import time
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -46,6 +49,46 @@ class EngineConfig:
 
 class StaticAnalysisFatalError(RuntimeError):
     """Raised when continuing would produce misleading cached analysis."""
+
+
+MAX_CONCURRENT_ENGINES_ENV_VAR = "CODEBOARDING_MAX_CONCURRENT_ENGINES"
+
+
+_CORES_PER_ENGINE = 3  # measured: one csharp-ls peaks around 1.9 cores
+_MAX_ENGINE_CEILING = 8
+
+
+def max_concurrent_engines() -> int:
+    """How many engine LSP servers may be resident at once. 0 disables the bound.
+
+    Why bound it: a monorepo emits one engine per sub-project (abp ships 30 C#
+    solutions). Starting them all up front holds every Roslyn workspace in
+    memory while the full pass uses one at a time — peak 12.9GB across 28
+    servers to do strictly sequential work.
+
+    On a 12-core box abp took 1413s at 28 resident, 1394s at 1, 612s at 4 and
+    677s at 8: throughput turns over once the servers oversubscribe the machine,
+    so the useful setting is a function of cores rather than a constant. See
+    ``recommended_engine_concurrency``.
+
+    Still opt-in: the warm-start path in ``_update_cached_results`` reads
+    ``_engine_clients`` directly, so defaulting this on would leave it empty and
+    make an incremental run silently return stale results. Making that path
+    spawn on demand is the prerequisite for flipping the default.
+    """
+    raw = os.environ.get(MAX_CONCURRENT_ENGINES_ENV_VAR, "").strip()
+    if not raw:
+        return 0
+    try:
+        return max(int(raw), 0)
+    except ValueError:
+        logger.warning("Ignoring non-integer %s=%r", MAX_CONCURRENT_ENGINES_ENV_VAR, raw)
+        return 0
+
+
+def recommended_engine_concurrency() -> int:
+    """The bound the abp measurements point at, given this host's core count."""
+    return max(1, min((os.cpu_count() or 1) // _CORES_PER_ENGINE, _MAX_ENGINE_CEILING))
 
 
 def _create_engine_configs(
@@ -175,6 +218,8 @@ class StaticAnalyzer:
         self.programming_langs = ProjectScanner(self.repository_path).scan()
         self._engine_configs = _create_engine_configs(self.programming_langs, self.repository_path, self.ignore_manager)
         self._engine_clients: list[tuple[EngineConfig, LSPClient]] = []
+        self._prepared_projects: set[Path] = set()
+        self._prepared_lock = threading.Lock()
         self.collected_diagnostics: dict[Language, FileDiagnosticsMap] = {}
         self._clients_started: bool = False
         self._cached_results: StaticAnalysisResults | None = None
@@ -244,47 +289,12 @@ class StaticAnalyzer:
                 continue
 
             attempted.append(adapter.language)
-            engine_client: LSPClient | None = None
+            if max_concurrent_engines():
+                # Deferred: the full pass owns the lifetime so only a bounded
+                # number of servers are resident at once.
+                continue
             try:
-                logger.info(f"Starting engine LSP client for {adapter.language} at {project_path}")
-                t_start = time.monotonic()
-                # Allow adapters to prepare the project before LSP startup
-                # (e.g. ``dotnet restore`` so csharp-ls sees framework refs).
-                adapter.prepare_project(project_path)
-                command = adapter.get_lsp_command(project_path)
-                init_options = adapter.get_lsp_init_options(self.ignore_manager)
-                extra_env = adapter.get_lsp_env(project_path)
-                # Node-based LSPs spawn child ``node`` processes by name; on
-                # a Node-less host the embedded runtime's dir must be on PATH.
-                ensure_node_on_path(command, extra_env)
-                workspace_settings = adapter.get_workspace_settings()
-                extra_capabilities = getattr(adapter, "extra_client_capabilities", {}) or {}
-                engine_client = LSPClient(
-                    command=command,
-                    project_root=project_path,
-                    init_options=init_options,
-                    default_timeout=adapter.get_lsp_default_timeout(),
-                    collect_diagnostics=True,
-                    extra_env=extra_env,
-                    workspace_settings=workspace_settings,
-                    extra_client_capabilities=extra_capabilities,
-                )
-                engine_client.start()
-                t_lsp_started = time.monotonic()
-                logger.info(f"{adapter.language} LSP start: {t_lsp_started - t_start:.1f}s")
-
-                # Some LSP servers (JDTLS, rust-analyzer) load
-                # workspace metadata asynchronously and only respond to
-                # cross-file queries once that's complete. Adapters opt in
-                # via ``wait_for_workspace_ready`` so the language-name
-                # check doesn't keep growing.
-                if adapter.wait_for_workspace_ready:
-                    engine_client.wait_for_server_ready()
-                    adapter.validate_workspace_ready(engine_client)
-                    logger.info(f"{adapter.language} workspace ready: {time.monotonic() - t_lsp_started:.1f}s")
-
-                started.append((engine_config, engine_client))
-
+                started.append((engine_config, self._spawn_engine_client(engine_config)))
             except Exception as exc:
                 logger.exception(
                     f"Failed to start engine LSP client for {adapter.language}; "
@@ -292,13 +302,25 @@ class StaticAnalyzer:
                 )
                 failed_languages.append(adapter.language)
                 failed_details.append(f"{adapter.language}: {exc}")
-                if engine_client is not None:
-                    try:
-                        engine_client.shutdown()
-                    except Exception:
-                        logger.exception(
-                            f"Error shutting down partially-started {adapter.language} client during cleanup"
-                        )
+
+        if attempted and max_concurrent_engines():
+            logger.info(
+                "Deferring %d engine LSP client(s); the full pass keeps at most %d resident.",
+                len(attempted),
+                max_concurrent_engines(),
+            )
+            # Prepare everything now, while nothing is resident: a project must
+            # not be analyzed before its siblings are restored.
+            for engine_config in self._engine_configs:
+                if not engine_config.source_files:
+                    continue
+                try:
+                    self._prepare_project_once(engine_config)
+                except Exception:
+                    logger.exception(f"Failed to prepare {engine_config.project_path}; continuing")
+            self._engine_clients = []
+            self._clients_started = True
+            return
 
         if not attempted:
             logger.info(f"No source files for any detected language in {self.repository_path}; no LSP clients started.")
@@ -322,6 +344,64 @@ class StaticAnalyzer:
 
         self._engine_clients = started
         self._clients_started = True
+
+    def _prepare_project_once(self, engine_config: EngineConfig) -> None:
+        """Let the adapter prepare a project exactly once (e.g. ``dotnet restore``).
+
+        Why once, and why up front under a concurrency cap: restore writes the
+        ``obj/`` artifacts a sibling project's compilation resolves against, so
+        an engine that runs before its siblings are restored loses cross-project
+        edges. Preparing every project before the first server starts keeps the
+        bounded pass resolving exactly what the unbounded one does.
+        """
+        with self._prepared_lock:
+            if engine_config.project_path in self._prepared_projects:
+                return
+            self._prepared_projects.add(engine_config.project_path)
+        engine_config.adapter.prepare_project(engine_config.project_path)
+
+    def _spawn_engine_client(self, engine_config: EngineConfig) -> LSPClient:
+        """Start one engine's LSP server and return it ready for queries."""
+        adapter, project_path = engine_config.adapter, engine_config.project_path
+        logger.info(f"Starting engine LSP client for {adapter.language} at {project_path}")
+        t_start = time.monotonic()
+        self._prepare_project_once(engine_config)
+        command = adapter.get_lsp_command(project_path)
+        init_options = adapter.get_lsp_init_options(self.ignore_manager)
+        extra_env = adapter.get_lsp_env(project_path)
+        # Node-based LSPs spawn child ``node`` processes by name; on
+        # a Node-less host the embedded runtime's dir must be on PATH.
+        ensure_node_on_path(command, extra_env)
+        engine_client = LSPClient(
+            command=command,
+            project_root=project_path,
+            init_options=init_options,
+            default_timeout=adapter.get_lsp_default_timeout(),
+            collect_diagnostics=True,
+            extra_env=extra_env,
+            workspace_settings=adapter.get_workspace_settings(),
+            extra_client_capabilities=getattr(adapter, "extra_client_capabilities", {}) or {},
+        )
+        try:
+            engine_client.start()
+            t_lsp_started = time.monotonic()
+            logger.info(f"{adapter.language} LSP start: {t_lsp_started - t_start:.1f}s")
+
+            # Some LSP servers (JDTLS, rust-analyzer) load workspace metadata
+            # asynchronously and only respond to cross-file queries once that's
+            # complete. Adapters opt in via ``wait_for_workspace_ready`` so the
+            # language-name check doesn't keep growing.
+            if adapter.wait_for_workspace_ready:
+                engine_client.wait_for_server_ready()
+                adapter.validate_workspace_ready(engine_client)
+                logger.info(f"{adapter.language} workspace ready: {time.monotonic() - t_lsp_started:.1f}s")
+        except Exception:
+            try:
+                engine_client.shutdown()
+            except Exception:
+                logger.exception(f"Error shutting down partially-started {adapter.language} client during cleanup")
+            raise
+        return engine_client
 
     def stop_clients(self) -> None:
         """Gracefully shut down all engine LSP server processes. Idempotent.
@@ -597,37 +677,66 @@ class StaticAnalyzer:
         explicitly requested ``skip_cache=True``.
         """
         results = StaticAnalysisResults()
-        for engine_config, engine_client in self._engine_clients:
+        absorb_lock = threading.Lock()
+
+        def run_one(engine_config: EngineConfig, engine_client: LSPClient | None) -> None:
+            """Analyze one engine. Owns the client's lifetime when given none."""
             adapter, project_path = engine_config.adapter, engine_config.project_path
             language = adapter.language_enum
             t_lang_start = time.monotonic()
+            owned_client: LSPClient | None = None
             try:
+                if engine_client is None:
+                    owned_client = self._spawn_engine_client(engine_config)
+                    engine_client = owned_client
                 logger.info(f"Starting engine analysis for {adapter.language} in {project_path}")
                 analysis = self._run_full_analysis(engine_config, engine_client)
-                self._absorb_into_results(results, language, analysis)
                 duration_ms = round((time.monotonic() - t_lang_start) * 1000)
                 logger.info(f"Engine analysis for {adapter.language} completed in {duration_ms / 1000:.1f}s")
-                self._collect_diagnostics_for(adapter, engine_client, analysis)
-                track_lsp_result(
-                    language=adapter.language_enum.value,
-                    loc=self._loc_for_adapter(adapter),
-                    status="success",
-                    duration_ms=duration_ms,
-                    analysis=analysis,
-                    diagnostics=self.collected_diagnostics.get(adapter.language_enum, {}),
-                )
+                with absorb_lock:
+                    self._absorb_into_results(results, language, analysis)
+                    self._collect_diagnostics_for(adapter, engine_client, analysis)
+                    track_lsp_result(
+                        language=adapter.language_enum.value,
+                        loc=self._loc_for_adapter(adapter),
+                        status="success",
+                        duration_ms=duration_ms,
+                        analysis=analysis,
+                        diagnostics=self.collected_diagnostics.get(adapter.language_enum, {}),
+                    )
             except StaticAnalysisFatalError:
                 raise
             except Exception as e:
                 logger.error(f"Error during engine analysis for {adapter.language}: {e}")
-                track_lsp_result(
-                    language=adapter.language_enum.value,
-                    loc=self._loc_for_adapter(adapter),
-                    status="error",
-                    duration_ms=round((time.monotonic() - t_lang_start) * 1000),
-                    analysis={},
-                    diagnostics={},
-                )
+                with absorb_lock:
+                    track_lsp_result(
+                        language=adapter.language_enum.value,
+                        loc=self._loc_for_adapter(adapter),
+                        status="error",
+                        duration_ms=round((time.monotonic() - t_lang_start) * 1000),
+                        analysis={},
+                        diagnostics={},
+                    )
+            finally:
+                # Only shut down what this call started; eagerly-started clients
+                # stay up for the incremental and file-query paths.
+                if owned_client is not None:
+                    try:
+                        owned_client.shutdown()
+                    except Exception:
+                        logger.exception(f"Error shutting down {adapter.language} client for {project_path}")
+
+        cap = max_concurrent_engines()
+        if not cap:
+            for engine_config, engine_client in self._engine_clients:
+                run_one(engine_config, engine_client)
+        else:
+            pending = [cfg for cfg in self._engine_configs if cfg.source_files]
+            logger.info("Running %d engine(s) with at most %d resident at a time", len(pending), cap)
+            with ThreadPoolExecutor(max_workers=cap) as pool:
+                for future in [pool.submit(run_one, cfg, None) for cfg in pending]:
+                    future.result()
+
         summaries = []
         for language in results.get_languages():
             try:
@@ -835,7 +944,9 @@ class StaticAnalyzer:
 
     def _validate_analysis_results(self, results: StaticAnalysisResults) -> None:
         """Reject non-empty language buckets that would otherwise cache zero-symbol output."""
-        for engine_config, _ in self._engine_clients:
+        # Configs, not clients: under a concurrency cap the full pass owns each
+        # client's lifetime, so none are live by the time this runs.
+        for engine_config in self._engine_configs:
             adapter = engine_config.adapter
             if adapter.fail_on_empty_symbols is not True:
                 continue

--- a/static_analyzer/__init__.py
+++ b/static_analyzer/__init__.py
@@ -17,6 +17,7 @@ from static_analyzer.engine.adapters import get_adapter
 from static_analyzer.engine.call_graph_builder import CallGraphBuilder
 from static_analyzer.engine.language_adapter import LanguageAdapter
 from static_analyzer.engine.lsp_client import LSPClient
+from static_analyzer.engine.lsp_recycler import default_memory_budget
 from static_analyzer.engine.result_converter import convert_to_codeboarding_format
 from static_analyzer.engine.source_inspector import SourceInspector
 from static_analyzer.engine.utils import uri_to_path
@@ -54,8 +55,14 @@ class StaticAnalysisFatalError(RuntimeError):
 MAX_CONCURRENT_ENGINES_ENV_VAR = "CODEBOARDING_MAX_CONCURRENT_ENGINES"
 
 
-_CORES_PER_ENGINE = 3  # measured: one csharp-ls peaks around 1.9 cores
-_MAX_ENGINE_CEILING = 8
+# An engine costs about three cores: the server itself peaks near 1.9 (measured
+# from csharp-ls), plus its dotnet children and the tree-sitter parsing the same
+# pass does on the Python side. On a 12-core host that predicts 4, which is where
+# abp actually peaked (612s, against 698s at 6 and 677s at 8).
+CORES_PER_ENGINE = 3
+
+# Peak resident set per engine, from abp at cap=4 (7.09GB across four servers).
+ENGINE_MEMORY_FOOTPRINT_BYTES = 2 * 1024**3
 
 
 def max_concurrent_engines() -> int:
@@ -86,9 +93,24 @@ def max_concurrent_engines() -> int:
         return 0
 
 
-def recommended_engine_concurrency() -> int:
-    """The bound the abp measurements point at, given this host's core count."""
-    return max(1, min((os.cpu_count() or 1) // _CORES_PER_ENGINE, _MAX_ENGINE_CEILING))
+def recommended_engine_concurrency(engine_count: int) -> int:
+    """The smallest of the three limits that actually bind engine concurrency.
+
+    - Work: never more servers than there are engines. Most repos have one or
+      two; abp's 28 is the outlier this bound exists for.
+    - CPU: ``cores // CORES_PER_ENGINE``, the term the abp sweep measured.
+    - Memory: the recycler's per-server budget divided by what an engine
+      actually occupies. This is the binding term on a large host — 128 cores
+      would allow 42 engines on CPU alone, which no memory budget supports.
+
+    The memory term deliberately reuses ``default_memory_budget()`` so the two
+    mechanisms agree on how much RAM the analysis may hold. Without it the
+    recycler lets every server grow to the full budget while nothing accounts
+    for how many are resident.
+    """
+    cpu_bound = (os.cpu_count() or CORES_PER_ENGINE) // CORES_PER_ENGINE
+    memory_bound = default_memory_budget() // ENGINE_MEMORY_FOOTPRINT_BYTES
+    return max(1, min(engine_count, cpu_bound, memory_bound))
 
 
 def _create_engine_configs(

--- a/static_analyzer/engine/adapters/csharp_adapter.py
+++ b/static_analyzer/engine/adapters/csharp_adapter.py
@@ -6,6 +6,7 @@ import logging
 import os
 import shutil
 import subprocess
+import threading
 from pathlib import Path
 
 from repo_utils.ignore import RepoIgnoreManager
@@ -67,7 +68,9 @@ def _write_injected_import(name: str, content: str) -> Path:
     path = get_servers_dir() / name
     path.parent.mkdir(parents=True, exist_ok=True)
     if not path.exists() or path.read_text(encoding="utf-8") != content:
-        temporary_path = path.with_name(f"{path.name}.{os.getpid()}.tmp")
+        # Per thread, not just per process: several engines can publish these
+        # concurrently, and a shared temp name loses the race to os.replace.
+        temporary_path = path.with_name(f"{path.name}.{os.getpid()}.{threading.get_ident()}.tmp")
         temporary_path.write_text(content, encoding="utf-8")
         os.replace(temporary_path, path)
     return path

--- a/static_analyzer/engine/call_graph_builder.py
+++ b/static_analyzer/engine/call_graph_builder.py
@@ -29,10 +29,13 @@ class CallGraphBuilder:
         lsp_client: LSPClient,
         adapter: LanguageAdapter,
         project_root: Path,
+        memory_budget_bytes: int = 0,
     ) -> None:
         self._lsp = lsp_client
         self._adapter = adapter
         self._root = project_root.resolve()
+        # 0 means "one server at a time", so the recycler uses the whole allowance.
+        self._memory_budget_bytes = memory_budget_bytes
 
         self._symbol_table = SymbolTable(adapter)
         self._source_inspector = SourceInspector()
@@ -125,7 +128,12 @@ class CallGraphBuilder:
         """A recycler for servers whose memory the references phase would otherwise grow without bound."""
         if not self._adapter.workspace_owns_documents or not source_files:
             return None
-        return LSPRecycler(self._lsp, source_files[0], self._probe_timeout(len(source_files)))
+        return LSPRecycler(
+            self._lsp,
+            source_files[0],
+            self._probe_timeout(len(source_files)),
+            budget_bytes=self._memory_budget_bytes,
+        )
 
     def _build_edges(self, ctx: EdgeBuildContext, source_files: list[Path]) -> EdgeMap:
         """Dispatch to the edge-building strategy specified by the adapter."""

--- a/static_analyzer/engine/lsp_constants.py
+++ b/static_analyzer/engine/lsp_constants.py
@@ -30,6 +30,9 @@ DID_OPEN_BATCH_SIZE = 50
 MEMORY_BUDGET_FRACTION = 0.4
 MIN_MEMORY_BUDGET = 2 * 1024**3
 MAX_MEMORY_BUDGET = 12 * 1024**3
+# Smallest useful share when several servers are resident: below this a server
+# recycles faster than it can index.
+MIN_ENGINE_MEMORY_BUDGET = 1024**3
 
 # Reduce reference-query concurrency before reaching the recycle threshold.
 PRESSURE_FRACTION = 0.5

--- a/static_analyzer/engine/lsp_recycler.py
+++ b/static_analyzer/engine/lsp_recycler.py
@@ -28,6 +28,7 @@ from static_analyzer.engine.lsp_constants import (
     MIN_MEMORY_BUDGET,
     PRESSURE_FRACTION,
     PRESSURED_BATCH_DIVISOR,
+    MIN_ENGINE_MEMORY_BUDGET,
 )
 from static_analyzer.engine.process_memory import format_bytes, physical_memory_bytes, process_tree_rss
 
@@ -46,6 +47,21 @@ def default_memory_budget() -> int:
     if not physical:
         return MIN_MEMORY_BUDGET
     return int(min(max(physical * MEMORY_BUDGET_FRACTION, MIN_MEMORY_BUDGET), MAX_MEMORY_BUDGET))
+
+
+def per_engine_memory_budget(resident_engines: int) -> int:
+    """Split the allowance across servers that may be resident at the same time.
+
+    ``default_memory_budget`` is what *one* server may reach. Running several
+    concurrently without dividing it lets N servers each grow to the whole
+    allowance, so the concurrency bound would multiply peak memory rather than
+    contain it -- the opposite of its purpose. The floor keeps a share large
+    enough to be worth recycling against; below it a server would thrash.
+    """
+    total = default_memory_budget()
+    if resident_engines <= 1:
+        return total
+    return max(MIN_ENGINE_MEMORY_BUDGET, total // resident_engines)
 
 
 class LSPRecycler:

--- a/tests/static_analyzer/test_max_concurrent_engines.py
+++ b/tests/static_analyzer/test_max_concurrent_engines.py
@@ -37,15 +37,31 @@ class TestMaxConcurrentEngines:
 
 
 class TestRecommendedEngineConcurrency:
-    def test_scales_with_cores(self):
-        for cores, expected in ((1, 1), (2, 1), (12, 4), (24, 8)):
-            with patch("os.cpu_count", return_value=cores):
-                assert recommended_engine_concurrency() == expected
+    """The bound is the smallest of work, CPU and memory. Each test pins one."""
 
-    def test_capped_so_a_big_host_does_not_thrash(self):
-        with patch("os.cpu_count", return_value=128):
-            assert recommended_engine_concurrency() == 8
+    def test_cpu_binds_on_a_modest_host(self):
+        # 12 cores / 3 = 4, which is where the abp sweep actually peaked.
+        with patch("static_analyzer.default_memory_budget", return_value=64 * 1024**3):
+            with patch("os.cpu_count", return_value=12):
+                assert recommended_engine_concurrency(28) == 4
+
+    def test_memory_binds_on_a_large_host(self):
+        # 128 cores would allow 42 on CPU alone; a 12GB budget supports 6.
+        with patch("static_analyzer.default_memory_budget", return_value=12 * 1024**3):
+            with patch("os.cpu_count", return_value=128):
+                assert recommended_engine_concurrency(28) == 6
+
+    def test_available_work_binds_for_an_ordinary_repo(self):
+        with patch("static_analyzer.default_memory_budget", return_value=64 * 1024**3):
+            with patch("os.cpu_count", return_value=128):
+                assert recommended_engine_concurrency(2) == 2
+
+    def test_never_drops_below_one(self):
+        with patch("static_analyzer.default_memory_budget", return_value=1024**3):
+            with patch("os.cpu_count", return_value=2):
+                assert recommended_engine_concurrency(28) == 1
 
     def test_unknown_core_count_still_yields_a_usable_bound(self):
-        with patch("os.cpu_count", return_value=None):
-            assert recommended_engine_concurrency() == 1
+        with patch("static_analyzer.default_memory_budget", return_value=64 * 1024**3):
+            with patch("os.cpu_count", return_value=None):
+                assert recommended_engine_concurrency(28) == 1

--- a/tests/static_analyzer/test_max_concurrent_engines.py
+++ b/tests/static_analyzer/test_max_concurrent_engines.py
@@ -1,0 +1,51 @@
+"""Tests for the engine-concurrency bound.
+
+The bound exists because a monorepo emits one engine per sub-project and
+starting them all at once costs peak memory for work that then runs one engine
+at a time. See ``max_concurrent_engines`` for the measurements behind it.
+"""
+
+from unittest.mock import patch
+
+from static_analyzer import (
+    MAX_CONCURRENT_ENGINES_ENV_VAR,
+    max_concurrent_engines,
+    recommended_engine_concurrency,
+)
+
+
+class TestMaxConcurrentEngines:
+    def test_unset_stays_unbounded(self):
+        with patch.dict("os.environ", {}, clear=True):
+            assert max_concurrent_engines() == 0
+
+    def test_explicit_value_is_honoured(self):
+        with patch.dict("os.environ", {MAX_CONCURRENT_ENGINES_ENV_VAR: "3"}):
+            assert max_concurrent_engines() == 3
+
+    def test_zero_disables_the_bound(self):
+        with patch.dict("os.environ", {MAX_CONCURRENT_ENGINES_ENV_VAR: "0"}):
+            assert max_concurrent_engines() == 0
+
+    def test_negative_is_clamped_to_unbounded(self):
+        with patch.dict("os.environ", {MAX_CONCURRENT_ENGINES_ENV_VAR: "-4"}):
+            assert max_concurrent_engines() == 0
+
+    def test_non_integer_is_treated_as_unset(self):
+        with patch.dict("os.environ", {MAX_CONCURRENT_ENGINES_ENV_VAR: "lots"}):
+            assert max_concurrent_engines() == 0
+
+
+class TestRecommendedEngineConcurrency:
+    def test_scales_with_cores(self):
+        for cores, expected in ((1, 1), (2, 1), (12, 4), (24, 8)):
+            with patch("os.cpu_count", return_value=cores):
+                assert recommended_engine_concurrency() == expected
+
+    def test_capped_so_a_big_host_does_not_thrash(self):
+        with patch("os.cpu_count", return_value=128):
+            assert recommended_engine_concurrency() == 8
+
+    def test_unknown_core_count_still_yields_a_usable_bound(self):
+        with patch("os.cpu_count", return_value=None):
+            assert recommended_engine_concurrency() == 1

--- a/tests/static_analyzer/test_max_concurrent_engines.py
+++ b/tests/static_analyzer/test_max_concurrent_engines.py
@@ -20,6 +20,11 @@ from static_analyzer import (
     max_concurrent_engines,
     recommended_engine_concurrency,
 )
+from static_analyzer.engine.lsp_constants import MIN_ENGINE_MEMORY_BUDGET
+from static_analyzer.engine.lsp_recycler import (
+    default_memory_budget,
+    per_engine_memory_budget,
+)
 
 
 class TestMaxConcurrentEngines:
@@ -211,3 +216,23 @@ class TestBoundedFullPass:
                 analyzer._run_full_lsp_pass()
 
         assert len(analyzed) < 12
+
+
+class TestPerEngineMemoryBudget:
+    """The bound must contain peak memory, not multiply it."""
+
+    def test_single_engine_gets_the_whole_allowance(self):
+        assert per_engine_memory_budget(1) == default_memory_budget()
+        assert per_engine_memory_budget(0) == default_memory_budget()
+
+    def test_concurrent_engines_share_one_allowance(self):
+        total = default_memory_budget()
+        for resident in (2, 3, 4):
+            share = per_engine_memory_budget(resident)
+            assert share * resident <= max(total, MIN_ENGINE_MEMORY_BUDGET * resident)
+            assert share <= total
+
+    def test_share_never_falls_below_a_usable_floor(self):
+        # Below the floor a server recycles faster than it can index, so the
+        # split stops rather than shrinking without limit.
+        assert per_engine_memory_budget(1000) == MIN_ENGINE_MEMORY_BUDGET

--- a/tests/static_analyzer/test_max_concurrent_engines.py
+++ b/tests/static_analyzer/test_max_concurrent_engines.py
@@ -2,13 +2,21 @@
 
 The bound exists because a monorepo emits one engine per sub-project and
 starting them all at once costs peak memory for work that then runs one engine
-at a time. See ``max_concurrent_engines`` for the measurements behind it.
+at a time.
 """
 
-from unittest.mock import patch
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
 
+import pytest
+
+from static_analyzer.constants import Language
 from static_analyzer import (
     MAX_CONCURRENT_ENGINES_ENV_VAR,
+    EngineConfig,
+    StaticAnalysisFatalError,
+    StaticAnalyzer,
     max_concurrent_engines,
     recommended_engine_concurrency,
 )
@@ -27,7 +35,7 @@ class TestMaxConcurrentEngines:
         with patch.dict("os.environ", {MAX_CONCURRENT_ENGINES_ENV_VAR: "0"}):
             assert max_concurrent_engines() == 0
 
-    def test_negative_is_clamped_to_unbounded(self):
+    def test_negative_is_ignored(self):
         with patch.dict("os.environ", {MAX_CONCURRENT_ENGINES_ENV_VAR: "-4"}):
             assert max_concurrent_engines() == 0
 
@@ -65,3 +73,141 @@ class TestRecommendedEngineConcurrency:
         with patch("static_analyzer.default_memory_budget", return_value=64 * 1024**3):
             with patch("os.cpu_count", return_value=None):
                 assert recommended_engine_concurrency(28) == 1
+
+
+class TestLiveClientsGuard:
+    """Under the bound nothing is resident, so callers that need a client must be refused."""
+
+    def _analyzer(self, tmp_path: Path, clients: list) -> StaticAnalyzer:
+        analyzer = StaticAnalyzer.__new__(StaticAnalyzer)
+        analyzer.repository_path = tmp_path
+        adapter = MagicMock()
+        adapter.file_extensions = [".cs"]
+        analyzer._engine_configs = [EngineConfig(adapter, tmp_path, source_files=[tmp_path / "A.cs"])]
+        analyzer._engine_clients = clients
+        return analyzer
+
+    def test_refuses_a_warm_start_with_no_resident_client(self, tmp_path: Path):
+        analyzer = self._analyzer(tmp_path, [])
+        with pytest.raises(StaticAnalysisFatalError, match=MAX_CONCURRENT_ENGINES_ENV_VAR):
+            analyzer._live_clients("warm-start")
+
+    def test_allows_the_ordinary_path(self, tmp_path: Path):
+        clients = [(MagicMock(), MagicMock())]
+        assert self._analyzer(tmp_path, clients)._live_clients("warm-start") == clients
+
+    def test_stays_quiet_when_there_is_genuinely_nothing_to_analyze(self, tmp_path: Path):
+        analyzer = self._analyzer(tmp_path, [])
+        analyzer._engine_configs = [EngineConfig(MagicMock(), tmp_path)]
+        assert analyzer._live_clients("warm-start") == []
+
+
+class TestPrepareProjectOnce:
+    def _analyzer(self, tmp_path: Path) -> StaticAnalyzer:
+        analyzer = StaticAnalyzer.__new__(StaticAnalyzer)
+        analyzer._prepared_projects = {}
+        analyzer._prepared_lock = __import__("threading").Lock()
+        return analyzer
+
+    def test_prepares_once(self, tmp_path: Path):
+        analyzer = self._analyzer(tmp_path)
+        adapter = MagicMock()
+        adapter.language = "CSharp"
+        config = EngineConfig(adapter, tmp_path)
+
+        analyzer._prepare_project_once(config)
+        analyzer._prepare_project_once(config)
+
+        assert adapter.prepare_project.call_count == 1
+
+    def test_a_failure_is_re_raised_rather_than_retried(self, tmp_path: Path):
+        analyzer = self._analyzer(tmp_path)
+        adapter = MagicMock()
+        adapter.language = "CSharp"
+        adapter.prepare_project.side_effect = RuntimeError("no SDK")
+        config = EngineConfig(adapter, tmp_path)
+
+        with pytest.raises(RuntimeError, match="no SDK"):
+            analyzer._prepare_project_once(config)
+        with pytest.raises(RuntimeError, match="no SDK"):
+            analyzer._prepare_project_once(config)
+
+        assert adapter.prepare_project.call_count == 1
+
+    def test_one_language_does_not_suppress_another_at_the_same_root(self, tmp_path: Path):
+        analyzer = self._analyzer(tmp_path)
+        python, csharp = MagicMock(), MagicMock()
+        python.language, csharp.language = "Python", "CSharp"
+
+        analyzer._prepare_project_once(EngineConfig(python, tmp_path))
+        analyzer._prepare_project_once(EngineConfig(csharp, tmp_path))
+
+        assert python.prepare_project.call_count == 1
+        assert csharp.prepare_project.call_count == 1
+
+
+class TestBoundedFullPass:
+    """The bounded pass must keep the eager path's failure behaviour."""
+
+    def _analyzer(self, tmp_path: Path, engines: int) -> StaticAnalyzer:
+        analyzer = StaticAnalyzer.__new__(StaticAnalyzer)
+        analyzer.repository_path = tmp_path
+        analyzer.collected_diagnostics = {}
+        analyzer._engine_clients = []
+        analyzer._engine_configs = []
+        for i in range(engines):
+            adapter = MagicMock()
+            adapter.language = "CSharp"
+            adapter.language_enum = Language.CSHARP
+            analyzer._engine_configs.append(
+                EngineConfig(adapter, tmp_path / f"p{i}", source_files=[tmp_path / f"p{i}" / "A.cs"])
+            )
+        analyzer._loc_for_adapter = MagicMock(return_value=0)
+        analyzer._absorb_into_results = MagicMock()
+        analyzer._collect_diagnostics_for = MagicMock()
+        return analyzer
+
+    def test_every_client_failing_to_start_raises(self, tmp_path: Path):
+        analyzer = self._analyzer(tmp_path, engines=3)
+        analyzer._spawn_engine_client = MagicMock(side_effect=RuntimeError("csharp-ls missing"))
+        analyzer._run_full_analysis = MagicMock()
+
+        with patch.dict("os.environ", {MAX_CONCURRENT_ENGINES_ENV_VAR: "2"}):
+            with pytest.raises(RuntimeError, match="Failed to start any engine LSP client"):
+                analyzer._run_full_lsp_pass()
+
+    def test_one_survivor_is_not_a_total_failure(self, tmp_path: Path):
+        analyzer = self._analyzer(tmp_path, engines=3)
+        calls = {"n": 0}
+
+        def spawn(_config):
+            calls["n"] += 1
+            if calls["n"] > 1:
+                raise RuntimeError("csharp-ls missing")
+            return MagicMock()
+
+        analyzer._spawn_engine_client = spawn
+        analyzer._run_full_analysis = MagicMock(return_value={})
+
+        with patch.dict("os.environ", {MAX_CONCURRENT_ENGINES_ENV_VAR: "1"}):
+            analyzer._run_full_lsp_pass()
+
+    def test_a_fatal_error_cancels_the_engines_still_queued(self, tmp_path: Path):
+        analyzer = self._analyzer(tmp_path, engines=12)
+        analyzer._spawn_engine_client = MagicMock(side_effect=lambda _c: MagicMock())
+        analyzed: list[Path] = []
+
+        def analyse(config, _client):
+            analyzed.append(config.project_path)
+            if len(analyzed) == 1:
+                raise StaticAnalysisFatalError("0 symbols")
+            time.sleep(0.05)
+            return {}
+
+        analyzer._run_full_analysis = analyse
+
+        with patch.dict("os.environ", {MAX_CONCURRENT_ENGINES_ENV_VAR: "2"}):
+            with pytest.raises(StaticAnalysisFatalError):
+                analyzer._run_full_lsp_pass()
+
+        assert len(analyzed) < 12

--- a/tests/static_analyzer/test_static_analyzer_start_clients.py
+++ b/tests/static_analyzer/test_static_analyzer_start_clients.py
@@ -147,7 +147,7 @@ class TestStartClientsGracefulDegradation:
 
     def test_validate_rejects_empty_symbol_csharp_result(self, analyzer: StaticAnalyzer, tmp_path: Path) -> None:
         cs_adapter = _make_adapter("CSharp", language_enum=Language.CSHARP, fail_on_empty_symbols=True)
-        analyzer._engine_clients = [(EngineConfig(cs_adapter, tmp_path), MagicMock())]
+        analyzer._engine_configs = [EngineConfig(cs_adapter, tmp_path)]
 
         results = StaticAnalysisResults()
         results.add_source_files(Language.CSHARP, [str(tmp_path / "Program.cs")])
@@ -157,7 +157,7 @@ class TestStartClientsGracefulDegradation:
 
     def test_validate_ignores_empty_non_opted_language(self, analyzer: StaticAnalyzer, tmp_path: Path) -> None:
         py_adapter = _make_adapter("Python", language_enum=Language.PYTHON, fail_on_empty_symbols=False)
-        analyzer._engine_clients = [(EngineConfig(py_adapter, tmp_path), MagicMock())]
+        analyzer._engine_configs = [EngineConfig(py_adapter, tmp_path)]
 
         results = StaticAnalysisResults()
         results.add_source_files(Language.PYTHON, [str(tmp_path / "app.py")])


### PR DESCRIPTION
> Stacked on #477 — based on `fix/csharp-definitions-edge-strategy` so it shows only the two engine commits. Retargets to `main` once #477 merges.

## The observation

A full run on [abp](https://github.com/abpframework/abp) spawns **28 C# engines**, which looks alarming. It isn't, on its own: abp ships 30 `.sln`/`.slnx` files and the scanner emits one engine per solution. Their file counts sum to **6,297 against 6,284 analyzed** — they partition the repo, nothing is analyzed twice.

The waste is the lifecycle. `start_clients()` starts all 28 up front, and `_run_full_lsp_pass` then walks them **one at a time**. We paid peak memory for full parallelism and got none of the throughput: 12.87GB resident to do strictly sequential work.

## The change

`CODEBOARDING_MAX_CONCURRENT_ENGINES` bounds residency. When set, clients are started inside the full pass and shut down as each engine finishes, with a worker pool sized to the bound. **Unset keeps today's behaviour exactly**, so this is inert until opted into.

## Measured

abp, 6,284 C# files, 12-core host, static analysis only. **Every configuration produced an identical graph** (23,866 nodes / 34,813 edges), so these differ only in cost:

| cap | wall | speedup | peak RSS | servers |
|---|---|---|---|---|
| unbounded (today) | 1,413.3s | 1.00× | 12.87 GB | 28 |
| 1 | 1,394.2s | 1.01× | **4.95 GB** | 1 |
| **4** | **612.1s** | **2.31×** | 7.09 GB | 4 |
| 6 | 697.7s | 2.03× | 7.61 GB | 6 |
| 8 | 676.7s | 2.09× | 8.52 GB | 8 |

cap=1 shows the eager start bought nothing — same wall time, 2.6× less memory. cap=4 is the knee. Past it, summed phase-1 CPU climbs 967s → 1,449s → 1,725s as the servers contend.

## Two bugs the sweep caught

**Restore ordering.** cap=1 first returned **34,806 edges — 7 short of baseline**. `dotnet restore` writes the `obj/` artifacts a *sibling* project's compilation resolves against, so an engine analyzed before its siblings are restored silently loses cross-project edges. Projects are now prepared before any server starts; cap=1 then matched 34,813 exactly. This was only visible because the harness diffed edge counts rather than assuming same-inputs-same-output.

**Validation read live clients.** `_validate_analysis_results` iterated `_engine_clients`, which is empty under a bound — the zero-symbol guard would have silently stopped running. It now reads engine configs.

## Sizing the bound

`recommended_engine_concurrency()` is the smallest of three real limits, not a fitted constant:

- **Work** — never more servers than engines. Most repos have one or two, so this mechanism is inert outside monorepos.
- **CPU** — `cores // 3`. An engine costs about three cores: the server peaks near 1.9 (measured), plus its `dotnet` children and the tree-sitter parsing the same pass runs on the Python side. On 12 cores that predicts 4, which is where abp actually peaked.
- **Memory** — the recycler's own budget divided by observed per-engine footprint. This binds on a large host: 128 cores would allow 42 engines on CPU alone.

The memory term reuses `default_memory_budget()` deliberately. The two mechanisms did not agree before — the recycler lets each server grow to the full budget while nothing accounted for how many were resident, so during the baseline run 28 servers each believed they could reach 12GB.

| host | work | CPU | memory | result | binds on |
|---|---|---|---|---|---|
| 12-core, abp | 28 | 4 | 6 | 4 | CPU |
| 128-core, abp | 28 | 42 | 6 | 6 | memory |
| 128-core, typical repo | 2 | 42 | 6 | 2 | work |
| 2-core CI runner | 28 | 0 | 1 | 1 | floor |

## Why it is not the default yet

`_update_cached_results` — the warm-start path — reads `_engine_clients` directly. Defaulting the bound on would leave that empty, so the loop body would never run and an incremental analysis would **silently return stale results**. That is a worse failure than the problem being solved, so the default flip needs that path to spawn on demand first. `recommended_engine_concurrency()` and its tests are in place for when it does.

2,071 unit tests pass; the 3 `test_cli_parser` failures reproduce on `main` and are unrelated. mypy and black clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable limits for concurrent analysis engines based on environment settings and available system resources.
  - Added per-engine memory budgeting for language servers and call-graph analysis.
  - Improved concurrent analysis startup, cleanup, failure handling, and cancellation.
  - Added clearer errors when live client operations are unavailable.
  - Prevented temporary files from conflicting during parallel C# analysis.

- **Bug Fixes**
  - Improved validation to recognize configured analysis engines even before clients are active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->