### PR TITLE
refactor(prompts): specialize model tool-use policies

### DIFF
--- a/agents/llm_config.py
+++ b/agents/llm_config.py
@@ -271,8 +271,8 @@ LLM_PROVIDERS = {
         chat_class=ChatOpenAI,
         selection_envs=["KIMI_API_KEY", "KIMI_BASE_URL"],
         api_key_env="KIMI_API_KEY",
-        agent_model="kimi-k2.5",
-        parsing_model="kimi-k2.5",
+        agent_model="kimi-k2.6",
+        parsing_model="kimi-k2.6",
         llm_type=LLMType.KIMI,
         extra_args={
             "base_url": lambda: os.getenv("KIMI_BASE_URL", "https://api.moonshot.cn/v1"),

--- a/agents/llm_config.py
+++ b/agents/llm_config.py
@@ -376,8 +376,6 @@ def _initialize_llm(
     if _model_accepts_temperature(model_name):
         kwargs["temperature"] = getattr(config, temperature_attr)
     kwargs.update(config.get_resolved_extra_args())
-    if LLMType.from_model_name(model_name) == LLMType.KIMI:
-        kwargs["streaming"] = True
 
     # ChatBedrockConverse and ChatOllama take no api_key kwarg; their SDKs read
     # AWS_BEARER_TOKEN_BEDROCK / OLLAMA_API_KEY from the environment directly.

--- a/agents/llm_config.py
+++ b/agents/llm_config.py
@@ -376,6 +376,8 @@ def _initialize_llm(
     if _model_accepts_temperature(model_name):
         kwargs["temperature"] = getattr(config, temperature_attr)
     kwargs.update(config.get_resolved_extra_args())
+    if LLMType.from_model_name(model_name) == LLMType.KIMI:
+        kwargs["streaming"] = True
 
     # ChatBedrockConverse and ChatOllama take no api_key kwarg; their SDKs read
     # AWS_BEARER_TOKEN_BEDROCK / OLLAMA_API_KEY from the environment directly.

--- a/agents/prompts/abstract_prompt_factory.py
+++ b/agents/prompts/abstract_prompt_factory.py
@@ -54,45 +54,10 @@ class AbstractPromptFactory(ABC):
     def get_scope_relations_message(self) -> str:
         pass
 
+    @abstractmethod
     def get_api_surfaces_message(self) -> str:
-        return API_SURFACES_MESSAGE
+        pass
 
+    @abstractmethod
     def get_relation_analysis_message(self) -> str:
-        return RELATION_ANALYSIS_MESSAGE
-
-
-API_SURFACES_MESSAGE = """Analyze the component API surfaces.
-
-Components:
-{component_summaries}
-
-Known static call evidence between components (incomplete; do not treat as the full communication model):
-{static_call_evidence}
-
-Identify each component's API surface. For every component, describe:
-- provided_interfaces: important methods/classes/config symbols it exposes or uses as entrypoints
-- consumed_interfaces: important methods/classes/config symbols it calls, configures, imports, or expects from others
-- incoming_api_paths and outgoing_api_paths: how other components enter this component's API, and how this component reaches other components' APIs; include direct calls, runtime dispatch, plugin hooks, REST, queues, files, config, reflection/import, subprocesses, etc.
-
-Static call evidence is incomplete. Reason from component APIs, registries, protocols, runtime dispatch, plugin hooks, configuration, and data flow."""
-
-
-RELATION_ANALYSIS_MESSAGE = """Discover architectural communication relations between the components.
-
-Components:
-{component_summaries}
-
-Component API surfaces:
-{api_surfaces}
-
-Known static call evidence between components (incomplete; use as evidence only):
-{static_call_evidence}
-
-Create the component relations. Do not limit relations to static calls. First reason from component API surfaces, including runtime dispatch, plugin hooks, REST/queues/files/config, reflection/imports, and data flow. Use static calls only as one evidence source.
-
-For each relation:
-- src_name and dst_name must exactly match component names
-- relation should be a short architectural phrase
-- evidence should concisely explain the communication mechanism
-- key_edges should contain 1-3 important source-to-target code references when possible, similar to key_entities
-- avoid generic implementation-only calls and avoid adding relations solely because a static edge exists"""
+        pass

--- a/agents/prompts/claude_prompts.py
+++ b/agents/prompts/claude_prompts.py
@@ -229,6 +229,43 @@ Constraints:
 Justify component choices based on fundamental architectural importance."""
 
 
+API_SURFACES_MESSAGE = """Analyze the component API surfaces.
+
+Components:
+{component_summaries}
+
+Known static call evidence between components (incomplete; do not treat as the full communication model):
+{static_call_evidence}
+
+Identify each component's API surface. For every component, describe:
+- provided_interfaces: important methods/classes/config symbols it exposes or uses as entrypoints
+- consumed_interfaces: important methods/classes/config symbols it calls, configures, imports, or expects from others
+- incoming_api_paths and outgoing_api_paths: how other components enter this component's API, and how this component reaches other components' APIs; include direct calls, runtime dispatch, plugin hooks, REST, queues, files, config, reflection/import, subprocesses, etc.
+
+Static call evidence is incomplete. Reason from component APIs, registries, protocols, runtime dispatch, plugin hooks, configuration, and data flow."""
+
+
+RELATION_ANALYSIS_MESSAGE = """Discover architectural communication relations between the components.
+
+Components:
+{component_summaries}
+
+Component API surfaces:
+{api_surfaces}
+
+Known static call evidence between components (incomplete; use as evidence only):
+{static_call_evidence}
+
+Create the component relations. Do not limit relations to static calls. First reason from component API surfaces, including runtime dispatch, plugin hooks, REST/queues/files/config, reflection/imports, and data flow. Use static calls only as one evidence source.
+
+For each relation:
+- src_name and dst_name must exactly match component names
+- relation should be a short architectural phrase
+- evidence should concisely explain the communication mechanism
+- key_edges should contain 1-3 important source-to-target code references when possible, similar to key_entities
+- avoid generic implementation-only calls and avoid adding relations solely because a static edge exists"""
+
+
 class ClaudePromptFactory(AbstractPromptFactory):
     """Prompt factory for Claude models."""
 
@@ -264,3 +301,9 @@ class ClaudePromptFactory(AbstractPromptFactory):
 
     def get_details_message(self) -> str:
         return DETAILS_MESSAGE
+
+    def get_api_surfaces_message(self) -> str:
+        return API_SURFACES_MESSAGE
+
+    def get_relation_analysis_message(self) -> str:
+        return RELATION_ANALYSIS_MESSAGE

--- a/agents/prompts/deepseek_prompts.py
+++ b/agents/prompts/deepseek_prompts.py
@@ -11,6 +11,8 @@ DeepSeek Prompt Design Principles:
       best with matter-of-fact instructions focused on what to do, not who it is.
     - Avoids XML tags and heavy formatting. DeepSeek doesn't benefit from these structural cues the
       way Claude does; plain markdown hierarchy is sufficient and produces cleaner outputs.
+    - Treats supplied CFG and cluster evidence as authoritative. Tool calls are reserved for a small
+      number of specific gaps so the model does not inventory the repository or grow long transcripts.
 """
 
 from .abstract_prompt_factory import AbstractPromptFactory
@@ -33,6 +35,7 @@ Generate inter-component relationships for the `{scope_name}` scope.
    - **relation**: Short phrase describing the interaction (e.g. "delegates to", "notifies", "provides data to")
 
 # Constraints
+- The supplied components and communication evidence are sufficient; do not call tools
 - Every src_name and dst_name must match an existing component name exactly
 - Maximum 2 relationships per component pair (avoid bidirectional sends/returns pairs like ComponentA sends to ComponentB and ComponentB returns to ComponentA)
 - Only include architecturally significant interactions grounded in the communication evidence
@@ -51,10 +54,17 @@ Analyze Control Flow Graphs (CFG) for `{project_name}` and generate a high-level
 {meta_context}
 
 # Instructions (execute in order)
-1. Analyze the provided CFG data - identify patterns and structures suitable for flow graph representation.
-2. Use tools only when information is missing.
+1. Analyze the provided CFG data first - identify patterns and structures suitable for flow graph representation.
+2. Use tools only to resolve a specific required fact that is absent from the supplied context.
 3. Focus on architectural patterns for {project_type} projects with clear component boundaries.
 4. Consider diagram generation needs - components must have distinct visual boundaries.
+
+# Tool policy
+- Treat the supplied context and CFG as authoritative and normally sufficient
+- Do not inventory the repository, broadly read files, or verify facts already present in the prompt
+- If a required fact is genuinely missing, make one tool round with at most 3 targeted calls
+- Never repeat a tool call, reread a file, read adjacent chunks, or guess a path or qualified name
+- After that tool round, produce the final answer; omit unsupported optional details instead of searching further
 
 # Required outputs
 - Central modules/functions (maximum 20) from CFG data with clear interaction patterns
@@ -81,6 +91,7 @@ Instructions:
 6. Provide a one-paragraph description of the overall main flow and purpose.
 
 Constraints:
+- Use only the supplied cluster analysis; do not call tools to re-verify groups, entities, or files.
 - Keep every group: there must be exactly as many components as groups, each backed by exactly one group.
 - Name components by architectural role (e.g. 'Authentication', 'Data Pipeline', 'Request Handling'), never 'Group N'.
 - Ground the name in the code's own vocabulary: reuse the terms that the group's own modules, classes, and packages already use, and stay close to them rather than inventing a broader abstraction.
@@ -93,8 +104,8 @@ PLANNER_SYSTEM_MESSAGE = """You are a software architecture expert.
 Evaluate component expansion needs.
 
 # Instructions (execute in order)
-1. Use available context (file structure, CFG, source) to assess complexity.
-2. Use getClassHierarchy if component internal structure is unclear.
+1. Use the supplied component context to assess complexity.
+2. Do not call tools; the structural load and component description are sufficient for this decision.
 
 # Evaluation criteria
 - Simple functionality (few classes/functions) = NO expansion
@@ -133,7 +144,9 @@ Analyze software projects to extract high-level architectural metadata for docum
 - Consider both documentation clarity and visual diagram requirements
 
 # Constraints
-- Maximum 2 tool calls for critical information gathering
+- Prefer README/docs and dependency metadata; do not inspect implementation files unless documentation is absent
+- Make at most 2 targeted tool calls total, never repeat a call, then produce the final answer
+- Do not inventory directories or guess paths
 - Focus on architectural significance over implementation details
 - Provide actionable guidance for component identification and organization"""
 
@@ -152,6 +165,9 @@ Analyze project '{project_name}' to extract architectural metadata.
 1. Read project documentation (README, setup files) to understand purpose and domain.
 2. Examine file structure and dependencies to identify technology stack.
 3. Apply architectural expertise to determine patterns and expected component structure.
+
+# Tool limit
+Use at most 2 targeted tool calls total. Do not read implementation files when documentation or dependency metadata already answers the question.
 
 # Focus
 Extract metadata that will guide component identification and architectural analysis."""
@@ -180,6 +196,7 @@ VALIDATION_FEEDBACK_MESSAGE = """# IMPORTANT: CORRECT the output below. Do NOT r
 
 # Correction Instructions
 Address EACH issue listed above. Preserve all correct components, relationships, and assignments. Only modify what the feedback specifically calls out.
+Use the original output and task context as the evidence source. Do not call tools unless an issue explicitly requires one missing reference; in that case make at most 1 targeted call.
 
 # Original Task Context (for reference only — do NOT treat as a new task)
 {original_prompt}"""
@@ -194,7 +211,13 @@ Analyze a subsystem of `{project_name}`.
 
 # Instructions (execute in order)
 1. Start with available project context and CFG data.
-2. Use getClassHierarchy only for the target subsystem.
+2. Use tools only to resolve a specific required fact absent from that context.
+
+# Tool policy
+- Do not inventory the subsystem or broadly read its files
+- Make one tool round with at most 3 targeted calls only when required
+- Never repeat a call, reread a file, read adjacent chunks, or guess a path or qualified name
+- After that round, produce the final answer from the available evidence
 
 # Required outputs
 - Subsystem boundaries from context
@@ -230,12 +253,63 @@ The clusters have already been partitioned into a fixed set of groups by graph c
 - Components: Each with a clear name, a description of what it does, the single named cluster group it encompasses, and 2-5 key entities mentioning their qualified names and source files
 
 # Constraints
+- Use the supplied cluster analysis as authoritative; do not call tools to re-verify it
 - Focus on subsystem-specific functionality
 - Exclude utility/logging sub-components
 - Sub-components must translate well to flow diagram representation
 
 # Justification
 Base component choices on fundamental architectural importance."""
+
+
+API_SURFACES_MESSAGE = """Analyze the component API surfaces.
+
+Components:
+{component_summaries}
+
+Known static call evidence between components (incomplete; do not treat as the full communication model):
+{static_call_evidence}
+
+Identify each component's API surface. For every component, describe:
+- provided_interfaces: important methods/classes/config symbols it exposes or uses as entrypoints
+- consumed_interfaces: important methods/classes/config symbols it calls, configures, imports, or expects from others
+- incoming_api_paths and outgoing_api_paths: how other components enter this component's API, and how this component reaches other components' APIs; include direct calls, runtime dispatch, plugin hooks, REST, queues, files, config, reflection/import, subprocesses, etc.
+
+Evidence and tool policy:
+- Treat the component summaries and static call evidence as the primary source and normally sufficient
+- Infer runtime dispatch, plugin hooks, configuration, and data flow from names and evidence already supplied
+- Do not inventory the repository, broadly read files, or verify interfaces already present in the prompt
+- If a required interface is genuinely missing, make one tool round with at most 3 targeted calls
+- Never repeat a call, reread a file, read adjacent chunks, or guess a path or qualified name
+- After that round, return the complete API surfaces; omit unsupported optional details instead of searching further"""
+
+
+RELATION_ANALYSIS_MESSAGE = """Discover architectural communication relations between the components.
+
+Components:
+{component_summaries}
+
+Component API surfaces:
+{api_surfaces}
+
+Known static call evidence between components (incomplete; use as evidence only):
+{static_call_evidence}
+
+Create the component relations. Reason first from the supplied API surfaces and static evidence, including already-described runtime dispatch, plugin hooks, REST/queues/files/config, reflection/imports, and data flow.
+
+For each relation:
+- src_name and dst_name must exactly match component names
+- relation should be a short architectural phrase
+- evidence should concisely explain the communication mechanism
+- key_edges should contain 1-3 important source-to-target code references when possible, similar to key_entities
+- avoid generic implementation-only calls and avoid adding relations solely because a static edge exists
+
+Evidence and tool policy:
+- The supplied API surfaces and static evidence are normally sufficient. Do not inventory or broadly read the repository
+- Use exact component names, paths, and qualified names already present; never invent or probe alternatives
+- If one required relation cannot be grounded, make one tool round with at most 3 targeted calls
+- Never repeat a call or reread a file; omit an unsupported relation instead of searching further
+- After that round, return the complete relation set immediately"""
 
 
 class DeepSeekPromptFactory(AbstractPromptFactory):
@@ -273,3 +347,9 @@ class DeepSeekPromptFactory(AbstractPromptFactory):
 
     def get_scope_relations_message(self) -> str:
         return SCOPE_RELATIONS_MESSAGE
+
+    def get_api_surfaces_message(self) -> str:
+        return API_SURFACES_MESSAGE
+
+    def get_relation_analysis_message(self) -> str:
+        return RELATION_ANALYSIS_MESSAGE

--- a/agents/prompts/gemini_flash_prompts.py
+++ b/agents/prompts/gemini_flash_prompts.py
@@ -211,6 +211,43 @@ Constraints:
 Justify component choices based on fundamental architectural importance."""
 
 
+API_SURFACES_MESSAGE = """Analyze the component API surfaces.
+
+Components:
+{component_summaries}
+
+Known static call evidence between components (incomplete; do not treat as the full communication model):
+{static_call_evidence}
+
+Identify each component's API surface. For every component, describe:
+- provided_interfaces: important methods/classes/config symbols it exposes or uses as entrypoints
+- consumed_interfaces: important methods/classes/config symbols it calls, configures, imports, or expects from others
+- incoming_api_paths and outgoing_api_paths: how other components enter this component's API, and how this component reaches other components' APIs; include direct calls, runtime dispatch, plugin hooks, REST, queues, files, config, reflection/import, subprocesses, etc.
+
+Static call evidence is incomplete. Reason from component APIs, registries, protocols, runtime dispatch, plugin hooks, configuration, and data flow."""
+
+
+RELATION_ANALYSIS_MESSAGE = """Discover architectural communication relations between the components.
+
+Components:
+{component_summaries}
+
+Component API surfaces:
+{api_surfaces}
+
+Known static call evidence between components (incomplete; use as evidence only):
+{static_call_evidence}
+
+Create the component relations. Do not limit relations to static calls. First reason from component API surfaces, including runtime dispatch, plugin hooks, REST/queues/files/config, reflection/imports, and data flow. Use static calls only as one evidence source.
+
+For each relation:
+- src_name and dst_name must exactly match component names
+- relation should be a short architectural phrase
+- evidence should concisely explain the communication mechanism
+- key_edges should contain 1-3 important source-to-target code references when possible, similar to key_entities
+- avoid generic implementation-only calls and avoid adding relations solely because a static edge exists"""
+
+
 class GeminiFlashPromptFactory(AbstractPromptFactory):
     """Prompt factory for Gemini Flash models."""
 
@@ -246,3 +283,9 @@ class GeminiFlashPromptFactory(AbstractPromptFactory):
 
     def get_scope_relations_message(self) -> str:
         return SCOPE_RELATIONS_MESSAGE
+
+    def get_api_surfaces_message(self) -> str:
+        return API_SURFACES_MESSAGE
+
+    def get_relation_analysis_message(self) -> str:
+        return RELATION_ANALYSIS_MESSAGE

--- a/agents/prompts/glm_prompts.py
+++ b/agents/prompts/glm_prompts.py
@@ -255,6 +255,43 @@ JUSTIFICATION:
 MUST base component choices on fundamental architectural importance."""
 
 
+API_SURFACES_MESSAGE = """Analyze the component API surfaces.
+
+Components:
+{component_summaries}
+
+Known static call evidence between components (incomplete; do not treat as the full communication model):
+{static_call_evidence}
+
+Identify each component's API surface. For every component, describe:
+- provided_interfaces: important methods/classes/config symbols it exposes or uses as entrypoints
+- consumed_interfaces: important methods/classes/config symbols it calls, configures, imports, or expects from others
+- incoming_api_paths and outgoing_api_paths: how other components enter this component's API, and how this component reaches other components' APIs; include direct calls, runtime dispatch, plugin hooks, REST, queues, files, config, reflection/import, subprocesses, etc.
+
+Static call evidence is incomplete. Reason from component APIs, registries, protocols, runtime dispatch, plugin hooks, configuration, and data flow."""
+
+
+RELATION_ANALYSIS_MESSAGE = """Discover architectural communication relations between the components.
+
+Components:
+{component_summaries}
+
+Component API surfaces:
+{api_surfaces}
+
+Known static call evidence between components (incomplete; use as evidence only):
+{static_call_evidence}
+
+Create the component relations. Do not limit relations to static calls. First reason from component API surfaces, including runtime dispatch, plugin hooks, REST/queues/files/config, reflection/imports, and data flow. Use static calls only as one evidence source.
+
+For each relation:
+- src_name and dst_name must exactly match component names
+- relation should be a short architectural phrase
+- evidence should concisely explain the communication mechanism
+- key_edges should contain 1-3 important source-to-target code references when possible, similar to key_entities
+- avoid generic implementation-only calls and avoid adding relations solely because a static edge exists"""
+
+
 class GLMPromptFactory(AbstractPromptFactory):
     """Prompt factory for GLM models optimized for firm directive prompts with strong role-playing."""
 
@@ -290,3 +327,9 @@ class GLMPromptFactory(AbstractPromptFactory):
 
     def get_scope_relations_message(self) -> str:
         return SCOPE_RELATIONS_MESSAGE
+
+    def get_api_surfaces_message(self) -> str:
+        return API_SURFACES_MESSAGE
+
+    def get_relation_analysis_message(self) -> str:
+        return RELATION_ANALYSIS_MESSAGE

--- a/agents/prompts/gpt_prompts.py
+++ b/agents/prompts/gpt_prompts.py
@@ -273,6 +273,43 @@ Guidelines:
 - A component that never calls or is called by another component should not have a relation to it"""
 
 
+API_SURFACES_MESSAGE = """Analyze the component API surfaces.
+
+Components:
+{component_summaries}
+
+Known static call evidence between components (incomplete; do not treat as the full communication model):
+{static_call_evidence}
+
+Identify each component's API surface. For every component, describe:
+- provided_interfaces: important methods/classes/config symbols it exposes or uses as entrypoints
+- consumed_interfaces: important methods/classes/config symbols it calls, configures, imports, or expects from others
+- incoming_api_paths and outgoing_api_paths: how other components enter this component's API, and how this component reaches other components' APIs; include direct calls, runtime dispatch, plugin hooks, REST, queues, files, config, reflection/import, subprocesses, etc.
+
+Static call evidence is incomplete. Reason from component APIs, registries, protocols, runtime dispatch, plugin hooks, configuration, and data flow."""
+
+
+RELATION_ANALYSIS_MESSAGE = """Discover architectural communication relations between the components.
+
+Components:
+{component_summaries}
+
+Component API surfaces:
+{api_surfaces}
+
+Known static call evidence between components (incomplete; use as evidence only):
+{static_call_evidence}
+
+Create the component relations. Do not limit relations to static calls. First reason from component API surfaces, including runtime dispatch, plugin hooks, REST/queues/files/config, reflection/imports, and data flow. Use static calls only as one evidence source.
+
+For each relation:
+- src_name and dst_name must exactly match component names
+- relation should be a short architectural phrase
+- evidence should concisely explain the communication mechanism
+- key_edges should contain 1-3 important source-to-target code references when possible, similar to key_entities
+- avoid generic implementation-only calls and avoid adding relations solely because a static edge exists"""
+
+
 class GPTPromptFactory(AbstractPromptFactory):
     """Prompt factory for GPT-4 models."""
 
@@ -308,3 +345,9 @@ class GPTPromptFactory(AbstractPromptFactory):
 
     def get_scope_relations_message(self) -> str:
         return SCOPE_RELATIONS_MESSAGE
+
+    def get_api_surfaces_message(self) -> str:
+        return API_SURFACES_MESSAGE
+
+    def get_relation_analysis_message(self) -> str:
+        return RELATION_ANALYSIS_MESSAGE

--- a/agents/prompts/kimi_prompts.py
+++ b/agents/prompts/kimi_prompts.py
@@ -5,11 +5,10 @@ Kimi Prompt Design Principles:
     - Every prompt begins with "You are Kimi, an AI assistant created by Moonshot AI." This identity
       anchor is required because Kimi performs significantly better when its own identity is reinforced
       at the start of each message, not just in the system prompt.
-    - Emphasizes explicit chain-of-thought cues ("Reason step-by-step", "Think aloud first",
-      "Decompose tasks into parallel subtasks"). Kimi benefits from being told to reason before
-      acting; without these cues it tends to jump to conclusions or produce shallow analysis.
-    - Includes "Use tools proactively to verify facts" directives because Kimi's default behavior
-      is conservative with tool usage; it needs encouragement to call tools rather than guess.
+    - Requests concise conclusions rather than visible chain-of-thought, keeping outputs focused on
+      the structured architecture result instead of spending tokens narrating intermediate reasoning.
+    - Treats supplied CFG and cluster evidence as authoritative. Tool calls are reserved for a small
+      number of specific gaps so the model does not inventory the repository or grow long transcripts.
     - Prompt structure is conversational but directive, matching Kimi's training style. Overly formal
       or rigid formatting (like strict markdown headers) is less effective than natural task framing.
 """
@@ -26,14 +25,13 @@ Components in this scope:
 Cross-component communication from static analysis:
 {cross_component_calls}
 
-Reason step-by-step. Review the components listed above and the cross-component communication evidence, then produce relationships that describe how these components interact.
-
-Think aloud first about which components actually communicate based on the evidence, then for each relationship provide:
+Review the components and communication evidence, then produce only grounded relationships. For each relationship provide:
 - **src_name**: Source component name
 - **dst_name**: Target component name
 - **relation**: A short phrase describing the relationship (e.g. "delegates to", "notifies", "provides data to")
 
 Constraints:
+- The supplied components and communication evidence are sufficient; do not call tools
 - Every src_name and dst_name must match an existing component name exactly
 - Maximum 2 relationships per component pair, avoiding bidirectional sends/returns pairs (i.e. ComponentA sends to ComponentB and ComponentB returns to ComponentA)
 - Focus on architecturally significant interactions, not implementation details
@@ -48,7 +46,14 @@ Project Context:
 
 Analyze Control Flow Graphs (CFG) for `{project_name}` and generate a high-level data flow overview optimized for diagram generation.
 
-Reason step-by-step. Decompose tasks into parallel subtasks if possible. Use tools to verify facts when information is missing.
+Analyze the supplied CFG and context first.
+
+Tool policy:
+- Treat the supplied context and CFG as authoritative and normally sufficient
+- Do not inventory the repository, broadly read files, or verify facts already present in the prompt
+- If a required fact is genuinely missing, make one tool round with at most 3 targeted calls
+- Never repeat a tool call, reread a file, read adjacent chunks, or guess a path or qualified name
+- After that tool round, produce the final answer; omit unsupported optional details instead of searching further
 
 Your analysis must include:
 - Central modules/functions (maximum 20) from CFG data with clear interaction patterns
@@ -76,6 +81,7 @@ Instructions:
 6. Provide a one-paragraph description of the overall main flow and purpose.
 
 Constraints:
+- Use only the supplied cluster analysis; do not call tools to re-verify groups, entities, or files.
 - Keep every group: there must be exactly as many components as groups, each backed by exactly one group.
 - Name components by architectural role (e.g. 'Authentication', 'Data Pipeline', 'Request Handling'), never 'Group N'.
 - Ground the name in the code's own vocabulary: reuse the terms that the group's own modules, classes, and packages already use, and stay close to them rather than inventing a broader abstraction.
@@ -86,10 +92,7 @@ PLANNER_SYSTEM_MESSAGE = """You are Kimi, an AI assistant created by Moonshot AI
 
 Task: Evaluate component expansion needs.
 
-Reason carefully, then use available tools:
-
-1. Use available context (file structure, CFG, source) to assess complexity.
-2. Use getClassHierarchy if component internal structure is unclear.
+Use the supplied component context to assess complexity. Do not call tools; the structural load and component description are sufficient for this decision.
 
 Evaluation criteria:
 - Simple functionality (few classes/functions) = NO expansion
@@ -100,8 +103,6 @@ Focus on architectural significance, not implementation details."""
 EXPANSION_PROMPT = """You are Kimi, an AI assistant created by Moonshot AI.
 
 Task: Evaluate component expansion necessity for: {component}
-
-Think aloud first (reasoning), then decide:
 
 1. Review component description and source files.
 2. Determine if it represents a complex subsystem worth detailed analysis.
@@ -115,7 +116,7 @@ SYSTEM_META_ANALYSIS_MESSAGE = """You are Kimi, an AI assistant created by Moons
 
 Role: Analyze software projects to extract high-level architectural metadata for documentation and flow diagram generation.
 
-Reason step-by-step. Use tools proactively to verify facts.
+Use project documentation and dependency metadata as the primary evidence.
 
 Core responsibilities:
 1. Identify project type, domain, and architectural patterns from project structure and documentation.
@@ -130,15 +131,15 @@ Analysis approach:
 - Consider both documentation clarity and visual diagram requirements
 
 Constraints:
-- Maximum 2 tool calls for critical information gathering
+- Prefer README/docs and dependency metadata; do not inspect implementation files unless documentation is absent
+- Make at most 2 targeted tool calls total, never repeat a call, then produce the final answer
+- Do not inventory directories or guess paths
 - Focus on architectural significance over implementation details
 - Provide actionable guidance for component identification and organization"""
 
 META_INFORMATION_PROMPT = """You are Kimi, an AI assistant created by Moonshot AI.
 
 Task: Analyze project '{project_name}' to extract architectural metadata.
-
-Think step-by-step. Use tools to verify facts.
 
 Required analysis outputs:
 1. **Project Type**: Classify the project category (web framework, data processing library, ML toolkit, CLI tool, etc.)
@@ -153,6 +154,8 @@ Analysis steps:
 2. Examine file structure and dependencies to identify technology stack.
 3. Apply architectural expertise to determine patterns and expected component structure.
 
+Tool limit: Use at most 2 targeted tool calls total. Do not read implementation files when documentation or dependency metadata already answers the question.
+
 Focus on extracting metadata that will guide component identification and architectural analysis."""
 
 FILE_CLASSIFICATION_MESSAGE = """You are Kimi, an AI assistant created by Moonshot AI.
@@ -161,8 +164,6 @@ Goal: Find which file contains the code reference `{qname}`.
 
 Files to choose from (absolute paths): 
 {files}
-
-Reason carefully, then execute:
 
 1. Select exactly one file path from the list above. Do not invent or modify paths.
 2. If `{qname}` is a function, method, class, or similar:
@@ -181,6 +182,7 @@ IMPORTANT: You must CORRECT the output below. Do NOT regenerate from scratch —
 
 ## Correction Instructions
 Address EACH issue listed above. Preserve all correct components, relationships, and assignments. Only modify what the feedback specifically calls out.
+Use the original output and task context as the evidence source. Do not call tools unless an issue explicitly requires one missing reference; in that case make at most 1 targeted call.
 
 ## Original Task Context (for reference only — do NOT treat as a new task)
 {original_prompt}"""
@@ -192,10 +194,14 @@ Project Context:
 
 Task: Analyze a subsystem of `{project_name}`.
 
-Use tools proactively to verify facts:
-
 1. Start with available project context and CFG data.
-2. Use getClassHierarchy only for the target subsystem.
+2. Use tools only to resolve a specific required fact absent from that context.
+
+Tool policy:
+- Do not inventory the subsystem or broadly read its files
+- Make one tool round with at most 3 targeted calls only when required
+- Never repeat a call, reread a file, read adjacent chunks, or guess a path or qualified name
+- After that round, produce the final answer from the available evidence
 
 Required outputs:
 - Subsystem boundaries from context
@@ -214,8 +220,6 @@ Task: Create final sub-component architecture for the `{component}` subsystem op
 
 The clusters have already been partitioned into a fixed set of groups by graph community detection. Each "Group N" above is exactly one sub-component — the number of groups and their membership are already decided. Do NOT merge, split, or re-group them; only name and describe each group.
 
-Think aloud first (reasoning), then synthesize:
-
 1. Produce EXACTLY one sub-component per named group above (the same number of sub-components as there are groups).
 2. Set each sub-component's source_group_names to the single group it corresponds to (use the exact group name, e.g. "Group 1").
 3. Give each sub-component a descriptive architectural name (its role, not "Group N").
@@ -230,6 +234,7 @@ Guidelines:
 For each sub-component provide a clear name, a description of what it does, the single named cluster group it encompasses, and the 2-5 most important classes/methods with their qualified names and source files. Also provide one paragraph explaining the subsystem's overall main flow and purpose. Do not define relationships yet.
 
 Constraints:
+- Use the supplied cluster analysis as authoritative; do not call tools to re-verify it
 - Focus on subsystem-specific functionality
 - Exclude utility/logging sub-components
 - Sub-components should translate well to flow diagram representation
@@ -237,8 +242,58 @@ Constraints:
 Justify component choices based on fundamental architectural importance."""
 
 
+API_SURFACES_MESSAGE = """Analyze the component API surfaces.
+
+Components:
+{component_summaries}
+
+Known static call evidence between components (incomplete; do not treat as the full communication model):
+{static_call_evidence}
+
+Identify each component's API surface. For every component, describe:
+- provided_interfaces: important methods/classes/config symbols it exposes or uses as entrypoints
+- consumed_interfaces: important methods/classes/config symbols it calls, configures, imports, or expects from others
+- incoming_api_paths and outgoing_api_paths: how other components enter this component's API, and how this component reaches other components' APIs; include direct calls, runtime dispatch, plugin hooks, REST, queues, files, config, reflection/import, subprocesses, etc.
+
+Evidence and tool policy:
+- Treat the component summaries and static call evidence as the primary source and normally sufficient
+- Infer runtime dispatch, plugin hooks, configuration, and data flow from names and evidence already supplied
+- Do not inventory the repository, broadly read files, or verify interfaces already present in the prompt
+- If a required interface is genuinely missing, make one tool round with at most 3 targeted calls
+- Never repeat a call, reread a file, read adjacent chunks, or guess a path or qualified name
+- After that round, return the complete API surfaces; omit unsupported optional details instead of searching further"""
+
+
+RELATION_ANALYSIS_MESSAGE = """Discover architectural communication relations between the components.
+
+Components:
+{component_summaries}
+
+Component API surfaces:
+{api_surfaces}
+
+Known static call evidence between components (incomplete; use as evidence only):
+{static_call_evidence}
+
+Create the component relations. Reason first from the supplied API surfaces and static evidence, including already-described runtime dispatch, plugin hooks, REST/queues/files/config, reflection/imports, and data flow.
+
+For each relation:
+- src_name and dst_name must exactly match component names
+- relation should be a short architectural phrase
+- evidence should concisely explain the communication mechanism
+- key_edges should contain 1-3 important source-to-target code references when possible, similar to key_entities
+- avoid generic implementation-only calls and avoid adding relations solely because a static edge exists
+
+Evidence and tool policy:
+- The supplied API surfaces and static evidence are normally sufficient. Do not inventory or broadly read the repository
+- Use exact component names, paths, and qualified names already present; never invent or probe alternatives
+- If one required relation cannot be grounded, make one tool round with at most 3 targeted calls
+- Never repeat a call or reread a file; omit an unsupported relation instead of searching further
+- After that round, return the complete relation set immediately"""
+
+
 class KimiPromptFactory(AbstractPromptFactory):
-    """Prompt factory for Kimi models optimized for proactive tool use and agent swarms."""
+    """Prompt factory for Kimi models optimized for concise, evidence-first analysis."""
 
     def get_system_message(self) -> str:
         return SYSTEM_MESSAGE
@@ -272,3 +327,9 @@ class KimiPromptFactory(AbstractPromptFactory):
 
     def get_scope_relations_message(self) -> str:
         return SCOPE_RELATIONS_MESSAGE
+
+    def get_api_surfaces_message(self) -> str:
+        return API_SURFACES_MESSAGE
+
+    def get_relation_analysis_message(self) -> str:
+        return RELATION_ANALYSIS_MESSAGE

--- a/tests/agents/prompts/test_prompts.py
+++ b/tests/agents/prompts/test_prompts.py
@@ -30,6 +30,9 @@ class TestAbstractPromptFactory(unittest.TestCase):
             "get_validation_feedback_message",
             "get_system_details_message",
             "get_details_message",
+            "get_scope_relations_message",
+            "get_api_surfaces_message",
+            "get_relation_analysis_message",
         ]
 
         for method_name in expected_methods:
@@ -141,6 +144,48 @@ class TestMetaPromptToolConsistency(unittest.TestCase):
         self.assertNotIn("getPackageDependencies", combined_prompt)
 
 
+class TestBoundedToolUsePrompts(unittest.TestCase):
+    def test_deepseek_and_kimi_use_bounded_evidence_first_tool_policies(self):
+        for llm_type in (LLMType.DEEPSEEK, LLMType.KIMI):
+            factory = PromptFactory(llm_type)._prompt_factory
+            bounded_prompts = [
+                factory.get_system_message(),
+                factory.get_system_details_message(),
+                factory.get_api_surfaces_message(),
+                factory.get_relation_analysis_message(),
+            ]
+
+            for prompt in bounded_prompts:
+                self.assertIn("at most 3 targeted calls", prompt)
+                self.assertIn("Do not inventory", prompt)
+                self.assertIn("Never repeat", prompt)
+
+            self.assertIn("do not call tools", factory.get_final_analysis_message())
+            self.assertIn("do not call tools", factory.get_details_message())
+            self.assertIn("do not call tools", factory.get_scope_relations_message())
+
+    def test_kimi_does_not_request_visible_reasoning_or_proactive_tool_use(self):
+        factory = PromptFactory(LLMType.KIMI)._prompt_factory
+        prompts = [
+            factory.get_system_message(),
+            factory.get_final_analysis_message(),
+            factory.get_planner_system_message(),
+            factory.get_expansion_prompt(),
+            factory.get_system_meta_analysis_message(),
+            factory.get_meta_information_prompt(),
+            factory.get_system_details_message(),
+            factory.get_details_message(),
+            factory.get_api_surfaces_message(),
+            factory.get_relation_analysis_message(),
+        ]
+        combined = "\n".join(prompts)
+
+        self.assertNotIn("Think aloud", combined)
+        self.assertNotIn("Reason step-by-step", combined)
+        self.assertNotIn("Use tools proactively", combined)
+        self.assertNotIn("Decompose tasks into parallel subtasks", combined)
+
+
 class TestGlobalFactory(unittest.TestCase):
     def setUp(self):
         # Reset global factory before each test
@@ -205,6 +250,9 @@ class TestConvenienceFunctions(unittest.TestCase):
             "get_validation_feedback_message",
             "get_system_details_message",
             "get_details_message",
+            "get_scope_relations_message",
+            "get_api_surfaces_message",
+            "get_relation_analysis_message",
         ]
 
         for func_name in convenience_functions:

--- a/tests/agents/test_llm_config.py
+++ b/tests/agents/test_llm_config.py
@@ -88,6 +88,22 @@ class TestProviderSelection:
         assert kimi.agent_model == "kimi-k2.6"
         assert kimi.parsing_model == "kimi-k2.6"
 
+    @patch("agents.prompts.prompt_factory.initialize_global_factory")
+    @patch("agents.agent.MONITORING_CALLBACK")
+    def test_kimi_streams_through_openai_compatible_providers(self, mock_monitoring_callback, mock_init_factory):
+        env = {
+            "OPENAI_API_KEY": "sk-test",
+            "OPENAI_BASE_URL": "https://example.com/v1",
+            "AGENT_MODEL": "Kimi-K2.6",
+            "PARSING_MODEL": "Kimi-K2.6",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            openai = LLM_PROVIDERS["openai"]
+            with patch.object(openai, "chat_class", return_value=MagicMock()) as mock_chat_class:
+                initialize_llms()
+
+        assert all(call.kwargs["streaming"] is True for call in mock_chat_class.call_args_list)
+
     def test_ollama_activates_via_ollama_host(self):
         ollama = LLM_PROVIDERS["ollama"]
         with patch.dict(os.environ, {"OLLAMA_HOST": "127.0.0.1:11434"}, clear=True):

--- a/tests/agents/test_llm_config.py
+++ b/tests/agents/test_llm_config.py
@@ -82,6 +82,12 @@ class TestValidateApiKeyProvided:
 
 
 class TestProviderSelection:
+    def test_kimi_defaults_to_k2_6(self):
+        kimi = LLM_PROVIDERS["kimi"]
+
+        assert kimi.agent_model == "kimi-k2.6"
+        assert kimi.parsing_model == "kimi-k2.6"
+
     def test_ollama_activates_via_ollama_host(self):
         ollama = LLM_PROVIDERS["ollama"]
         with patch.dict(os.environ, {"OLLAMA_HOST": "127.0.0.1:11434"}, clear=True):

--- a/tests/agents/test_llm_config.py
+++ b/tests/agents/test_llm_config.py
@@ -88,22 +88,6 @@ class TestProviderSelection:
         assert kimi.agent_model == "kimi-k2.6"
         assert kimi.parsing_model == "kimi-k2.6"
 
-    @patch("agents.prompts.prompt_factory.initialize_global_factory")
-    @patch("agents.agent.MONITORING_CALLBACK")
-    def test_kimi_streams_through_openai_compatible_providers(self, mock_monitoring_callback, mock_init_factory):
-        env = {
-            "OPENAI_API_KEY": "sk-test",
-            "OPENAI_BASE_URL": "https://example.com/v1",
-            "AGENT_MODEL": "Kimi-K2.6",
-            "PARSING_MODEL": "Kimi-K2.6",
-        }
-        with patch.dict(os.environ, env, clear=True):
-            openai = LLM_PROVIDERS["openai"]
-            with patch.object(openai, "chat_class", return_value=MagicMock()) as mock_chat_class:
-                initialize_llms()
-
-        assert all(call.kwargs["streaming"] is True for call in mock_chat_class.call_args_list)
-
     def test_ollama_activates_via_ollama_host(self):
         ollama = LLM_PROVIDERS["ollama"]
         with patch.dict(os.environ, {"OLLAMA_HOST": "127.0.0.1:11434"}, clear=True):


### PR DESCRIPTION
## Summary
- move API-surface and relation-analysis prompts from the abstract factory into each model-specific factory
- constrain Kimi and DeepSeek to evidence-first, bounded tool use instead of broad repository exploration
- remove visible chain-of-thought and proactive tool-use instructions from Kimi prompts
- default Kimi agent and parsing models to `kimi-k2.6`
- add contract tests for model-specific prompt policies and the Kimi default

## Verification
- `uv run pytest tests/agents/test_llm_config.py tests/agents/prompts/test_prompts.py -q` — 152 passed
- `uv run black --check .` — 329 files clean
- `uv run mypy .` — no issues in 329 files
- full suite — 2,075 passed, 28 skipped, 83.42% coverage; 3 pre-existing macOS `/tmp` vs `/private/tmp` assertion failures in `tests/test_cli_parser.py`

## Evals
Kimi K2.6 full and incremental evals are running serially with judges disabled. Results will be added when complete.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AI-assisted analysis of component interfaces, communication paths, and architectural relationships.
  * Improved analysis prompts to prioritize supplied evidence and targeted tool usage.
  * Added support for Kimi model version `kimi-k2.6`.

* **Improvements**
  * Kimi responses now favor concise, evidence-based results without visible reasoning or unnecessary repository exploration.

* **Tests**
  * Added coverage for new analysis prompts, bounded tool usage, and Kimi model selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->