### PR TITLE
feat(telemetry): one summary event per run for absorbed failures

### DIFF
--- a/codeboarding_cli/render.py
+++ b/codeboarding_cli/render.py
@@ -4,6 +4,8 @@ import argparse
 import json
 import logging
 import sys
+
+from telemetry.events import already_captured, capture_error
 from pathlib import Path
 
 from logging_config import setup_logging
@@ -65,7 +67,12 @@ def run_from_args(args: argparse.Namespace, parser: argparse.ArgumentParser) -> 
 def main(argv: list[str] | None = None) -> None:
     """Run the standalone rendering CLI."""
     parser = build_parser()
-    run_from_args(parser.parse_args(sys.argv[1:] if argv is None else argv), parser)
+    try:
+        run_from_args(parser.parse_args(sys.argv[1:] if argv is None else argv), parser)
+    except BaseException as exc:
+        if not already_captured(exc):
+            capture_error("cli.render", exc)
+        raise
 
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -1,4 +1,6 @@
 import argparse
+
+from telemetry.events import already_captured, capture_error
 import os
 import sys
 from pathlib import Path
@@ -122,7 +124,14 @@ def main(argv: list[str] | None = None) -> None:
     argv = _inject_default_subcommand(list(argv))
     parser = build_parser()
     args = parser.parse_args(argv)
-    _dispatch(args, parser)
+    try:
+        _dispatch(args, parser)
+    except BaseException as exc:
+        # Last frame before the user sees this. Anything reported deeper is
+        # already marked, so this only catches what nothing else did.
+        if not already_captured(exc):
+            capture_error(f"cli.{getattr(args, 'command', 'unknown')}", exc)
+        raise
 
 
 if __name__ == "__main__":

--- a/static_analyzer/__init__.py
+++ b/static_analyzer/__init__.py
@@ -27,7 +27,7 @@ from static_analyzer.lsp_client.diagnostics import FileDiagnosticsMap
 from static_analyzer.programming_language import ProgrammingLanguage
 from static_analyzer.scanner import ProjectScanner
 from static_analyzer.typescript_config_scanner import TypeScriptConfigScanner
-from telemetry.events import track_lsp_result
+from telemetry.events import flush_degradations, track_lsp_result
 from tool_registry import ensure_node_on_path
 from utils import get_artifact_dir
 
@@ -712,6 +712,15 @@ class StaticAnalyzer:
         self._pending_cache_dir = cache_dir
         # Fresh results this session: flush_cache/stop_clients should write them.
         self._results_need_saving = True
+        # One event for everything this run absorbed, rather than one per batch.
+        degraded = flush_degradations("static_analysis")
+        if degraded:
+            logger.warning(
+                "Analysis completed with %d degradation(s) costing %d item(s): %s",
+                degraded["degraded_events"],
+                degraded["degraded_items"],
+                ", ".join(f"{k}x{v['occurrences']}" for k, v in degraded["by_category"].items()),
+            )
         return results
 
     def _run_full_lsp_pass(self) -> StaticAnalysisResults:

--- a/static_analyzer/engine/edge_builder.py
+++ b/static_analyzer/engine/edge_builder.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 from static_analyzer.engine.edge_build_context import EdgeBuildContext
 from static_analyzer.exceptions import EdgeResolutionError
+from telemetry.degradations import record as record_degradation
 from static_analyzer.engine.progress import ProgressLogger
 from static_analyzer.constants import NodeType
 from static_analyzer.engine.lsp_constants import (
@@ -136,7 +137,8 @@ def build_edges_via_references(
             try:
                 result_list, error_indices = ctx.lsp.send_references_batch(queries, per_query_timeout=per_query_timeout)
             except Exception as e:
-                logger.warning("Batch references failed: %s", e)
+                logger.warning("Batch references failed (%d positions): %s", len(queries), e)
+                record_degradation("references_batch", f"{type(e).__name__}: {e}", items=len(queries))
                 result_list = [[] for _ in queries]
                 error_indices = set()
 
@@ -581,7 +583,8 @@ def _resolve_implementations(
         try:
             impl_results, _ = ctx.lsp.send_implementation_batch(queries)
         except Exception as e:
-            logger.warning("Implementation batch failed: %s", e)
+            logger.warning("Implementation batch failed (%d targets): %s", len(batch_keys), e)
+            record_degradation("implementation_batch", f"{type(e).__name__}: {e}", items=len(batch_keys))
             pbar.update(len(batch_keys))
             continue
 

--- a/static_analyzer/engine/hierarchy_builder.py
+++ b/static_analyzer/engine/hierarchy_builder.py
@@ -12,6 +12,7 @@ from static_analyzer.engine.models import SymbolInfo
 from static_analyzer.engine.source_inspector import SourceInspector
 from static_analyzer.engine.symbol_table import SymbolTable
 from static_analyzer.engine.utils import uri_to_path
+from telemetry.degradations import record as record_degradation
 
 logger = logging.getLogger(__name__)
 
@@ -77,6 +78,7 @@ class HierarchyBuilder:
                     pass
                 except Exception as e:
                     logger.debug("Failed to get supertypes for %s: %s", sym.qualified_name, e)
+                    record_degradation("type_hierarchy_supertypes", f"{sym.qualified_name}: {e}")
 
                 try:
                     subtypes = self._lsp.type_hierarchy_subtypes(item)
@@ -91,6 +93,7 @@ class HierarchyBuilder:
                     pass
                 except Exception as e:
                     logger.debug("Failed to get subtypes for %s: %s", sym.qualified_name, e)
+                    record_degradation("type_hierarchy_subtypes", f"{sym.qualified_name}: {e}")
             except MethodNotFoundError:
                 logger.info("Type hierarchy not supported by server, skipping remaining classes")
                 break

--- a/telemetry/degradations.py
+++ b/telemetry/degradations.py
@@ -1,0 +1,52 @@
+"""One summary event per run for failures the analysis absorbed.
+
+A degradation is a failure that cost output without stopping the run: a batch
+whose edges are gone, a symbol whose supertypes never resolved. Reporting each
+one individually does not scale -- the hierarchy path alone visits ~3,900 class
+symbols in a single abp engine, so a server that cannot answer typeHierarchy
+would emit thousands of identical events and bury everything else in the
+dashboard.
+
+So they accumulate here and leave as a single event carrying counts per
+category plus one worked example, which is what someone reading it actually
+needs: how much was lost, of what kind, and what one instance looked like.
+"""
+
+import threading
+from collections import Counter
+
+_lock = threading.Lock()
+_counts: Counter = Counter()
+_samples: dict[str, str] = {}
+_items: Counter = Counter()
+
+
+def record(category: str, detail: str, *, items: int = 1) -> None:
+    """Note one absorbed failure. ``items`` is what it cost (sites, symbols, edges)."""
+    with _lock:
+        _counts[category] += 1
+        _items[category] += items
+        _samples.setdefault(category, detail)
+
+
+def summary() -> dict:
+    """Counts, costs and one example per category; empty when the run was clean."""
+    with _lock:
+        if not _counts:
+            return {}
+        return {
+            "degraded_categories": len(_counts),
+            "degraded_events": sum(_counts.values()),
+            "degraded_items": sum(_items.values()),
+            "by_category": {
+                category: {"occurrences": count, "items": _items[category], "example": _samples[category]}
+                for category, count in _counts.most_common()
+            },
+        }
+
+
+def reset() -> None:
+    with _lock:
+        _counts.clear()
+        _items.clear()
+        _samples.clear()

--- a/telemetry/events.py
+++ b/telemetry/events.py
@@ -18,6 +18,7 @@ from contextvars import ContextVar
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 
+from telemetry import degradations
 from telemetry.schemas import (
     AnalysisCompleted,
     AnalysisStarted,
@@ -211,15 +212,48 @@ def track_analysis(func):
                     depth_level=depth_level,
                 ).model_dump(exclude_none=True),
             )
-            if exc is not None:
+            if exc is not None and not already_captured(exc):
                 exc_props: dict = {"command": command, "version": _app_version()}
                 if run_id:
                     exc_props["run_id"] = run_id
                 exc_props.update(_exception_properties(exc))
                 telemetry.capture_exception(exc, properties=exc_props)
+                try:
+                    setattr(exc, _CAPTURED_FLAG, True)
+                except AttributeError:
+                    pass
             telemetry.flush()
 
     return wrapper
+
+
+_CAPTURED_FLAG = "__codeboarding_captured__"
+
+
+def already_captured(exc: BaseException) -> bool:
+    """Whether this exception has been reported once already.
+
+    An exception raised deep in the engine passes several frames that could each
+    report it. One user-visible failure should be one ``$exception`` event, so
+    the first reporter marks it and later ones defer.
+    """
+    return getattr(exc, _CAPTURED_FLAG, False)
+
+
+def flush_degradations(command: str) -> dict:
+    """Emit the run's absorbed failures as one event, then reset.
+
+    Separate from ``capture_error``: those are failures that stopped something,
+    these are losses the run carried on through. Sending them individually would
+    scale with the repository rather than with the number of distinct problems.
+    """
+    payload = degradations.summary()
+    degradations.reset()
+    if not payload:
+        return {}
+    telemetry.capture("analysis_degraded", {"command": command, "version": _app_version(), **payload})
+    telemetry.flush()
+    return payload
 
 
 def capture_error(command: str, exc: BaseException, *, extra: dict | None = None) -> None:
@@ -237,6 +271,10 @@ def capture_error(command: str, exc: BaseException, *, extra: dict | None = None
     if extra:
         properties.update(extra)
     telemetry.capture_exception(exc, properties=properties)
+    try:
+        setattr(exc, _CAPTURED_FLAG, True)
+    except AttributeError:
+        pass  # builtins with __slots__ cannot carry the mark; a duplicate event is the lesser cost
     telemetry.flush()
 
 

--- a/tests/test_degradation_summary.py
+++ b/tests/test_degradation_summary.py
@@ -1,0 +1,56 @@
+"""Absorbed failures are summarized, not sent one by one."""
+
+from unittest.mock import patch
+
+from telemetry import degradations
+from telemetry.events import flush_degradations
+
+
+def setup_function():
+    degradations.reset()
+
+
+def test_thousands_of_failures_produce_one_event():
+    """The hierarchy path visits ~3,900 class symbols in a single abp engine.
+
+    One event each would bury every other signal in the dashboard, so volume must
+    scale with the number of distinct problems rather than the repository size.
+    """
+    for i in range(3900):
+        degradations.record("type_hierarchy_supertypes", f"Sym{i}: server closed")
+
+    with patch("telemetry.events.telemetry") as tele:
+        payload = flush_degradations("static_analysis")
+
+    assert tele.capture.call_count == 1
+    assert payload["degraded_events"] == 3900
+    assert payload["by_category"]["type_hierarchy_supertypes"]["occurrences"] == 3900
+    assert payload["by_category"]["type_hierarchy_supertypes"]["example"] == "Sym0: server closed"
+
+
+def test_cost_is_reported_not_just_occurrences():
+    """Ten failed batches of fifty is a different problem from ten failed symbols."""
+    degradations.record("references_batch", "TimeoutError", items=50)
+    degradations.record("references_batch", "TimeoutError", items=50)
+
+    with patch("telemetry.events.telemetry"):
+        payload = flush_degradations("static_analysis")
+
+    assert payload["by_category"]["references_batch"] == {
+        "occurrences": 2,
+        "items": 100,
+        "example": "TimeoutError",
+    }
+
+
+def test_clean_run_sends_nothing():
+    with patch("telemetry.events.telemetry") as tele:
+        assert flush_degradations("static_analysis") == {}
+    assert tele.capture.call_count == 0
+
+
+def test_flush_resets_so_the_next_run_starts_clean():
+    degradations.record("references_batch", "boom")
+    with patch("telemetry.events.telemetry"):
+        flush_degradations("static_analysis")
+        assert flush_degradations("static_analysis") == {}

--- a/tests/test_telemetry_boundary.py
+++ b/tests/test_telemetry_boundary.py
@@ -1,0 +1,37 @@
+"""A user-visible failure must be reported exactly once."""
+
+from unittest.mock import patch
+
+import pytest
+
+from telemetry.events import already_captured, capture_error
+
+
+def test_capture_error_marks_the_exception():
+    exc = RuntimeError("boom")
+    assert not already_captured(exc)
+    with patch("telemetry.events.telemetry"):
+        capture_error("test", exc)
+    assert already_captured(exc)
+
+
+def test_second_reporter_defers_to_the_first():
+    """The engine reports with its context; the CLI must not report again.
+
+    Two events for one failure would double-count every error in the dashboard
+    and hide which frame actually had the useful context.
+    """
+    exc = RuntimeError("boom")
+    with patch("telemetry.events.telemetry") as tele:
+        capture_error("static_analysis.definition_batch", exc, extra={"file": "app.cs"})
+        assert tele.capture_exception.call_count == 1
+        if not already_captured(exc):
+            capture_error("cli.full", exc)
+        assert tele.capture_exception.call_count == 1
+
+
+def test_builtin_without_dict_still_reports():
+    """An exception that cannot carry the mark is reported rather than dropped."""
+    with patch("telemetry.events.telemetry") as tele:
+        capture_error("test", KeyboardInterrupt())
+        assert tele.capture_exception.call_count == 1


### PR DESCRIPTION
Split out of #477, stacked on #492. Neither of those is about telemetry.

## Two gaps

`main()` had no error handling. Anything escaping `_dispatch` — a config error, a scanner
failure, the `EdgeResolutionError` #492 adds — printed a traceback and told us nothing. Only
failures that happened to pass through a `@track_analysis` frame were reported. `codeboarding-render`
was the same.

Separately, the handlers that absorb a failure without stopping reported nothing at all: a
references batch losing its edges, a symbol whose supertypes never resolved.

## Why a summary rather than an event each

The hierarchy path visits every class symbol — **3,884 in a single abp engine**, across 28
engines. A server that cannot answer `typeHierarchy` is *one* problem, but reporting per symbol
would emit thousands of identical events from one run and bury every other signal in the
dashboard.

So they accumulate and leave as one `analysis_degraded` event:

```json
{"degraded_categories": 2, "degraded_events": 3900, "degraded_items": 4100,
 "by_category": {
   "type_hierarchy_supertypes": {"occurrences": 3900, "items": 3900, "example": "Sym0: server closed"},
   "references_batch":          {"occurrences": 2,    "items": 100,  "example": "TimeoutError"}}}
```

Volume scales with the number of distinct problems, not with repository size.

`occurrences` and `items` are counted separately because ten failed batches of fifty sites is a
different problem from ten failed symbols. One example per category is kept, since a count alone
does not tell you what broke.

## Raised errors report once

An exception crossing several frames could be reported by each. The first reporter marks it and
later frames defer, so one failure produces one `$exception` carrying the **most specific**
context — the engine knows the file and site count, the CLI only knows the subcommand.
`track_analysis` honours the same mark, which also fixes a pre-existing double-count.

An exception that cannot carry the mark (builtins with `__slots__`) is reported rather than
dropped; a duplicate is the lesser cost.

A degraded run also logs one warning naming the categories, so it is visible locally with no
telemetry backend at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)