### PR TITLE
feat(clustering): add scope results with communication

### DIFF
--- a/agents/agent_responses.py
+++ b/agents/agent_responses.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, get_origin
 from pydantic import BaseModel, Field
 from pydantic.fields import FieldInfo
 
-from agents.cluster_ids import CodeBoardingClusterId, GraphClusterId
+from clustering_ids import ClusterId, ComponentId
 from agents.file_index_models import FileEntry, FileMethodGroup
 from agents.scope_ids import ROOT_SCOPE_ID
 
@@ -383,7 +383,7 @@ class ClustersComponent(LLMBaseModel):
     name: str = Field(
         description="Short, descriptive name for this cluster group (e.g., 'Authentication', 'Data Pipeline', 'Request Handling')"
     )
-    cluster_ids: list[GraphClusterId] = Field(
+    cluster_ids: list[ClusterId] = Field(
         description="List of cluster IDs from the CFG analysis that are grouped together (e.g., [1, 3, 5])"
     )
     description: str = Field(
@@ -459,7 +459,7 @@ class Component(LLMBaseModel):
         default_factory=list,
     )
 
-    source_cluster_ids: list[CodeBoardingClusterId] = Field(
+    source_cluster_ids: list[ComponentId] = Field(
         description="List of cluster IDs from CFG analysis that this component encompasses (populated deterministically from source_group_names).",
         default_factory=list,
         exclude=True,

--- a/agents/cluster_ids.py
+++ b/agents/cluster_ids.py
@@ -1,46 +1,44 @@
 from agents.scope_ids import ROOT_SCOPE_ID
-from clustering_ids import CodeBoardingClusterId, GraphClusterId
+from clustering_ids import ClusterId, ComponentId, ScopeId
 
 
 class GraphClusterIds:
     @classmethod
-    def sort(cls, cluster_ids: set[GraphClusterId]) -> list[GraphClusterId]:
+    def sort(cls, cluster_ids: set[ClusterId]) -> list[ClusterId]:
         return sorted(cluster_ids)
 
 
 class CodeBoardingClusterIds:
     @classmethod
-    def prefix_for_scope(cls, scope_id: str) -> CodeBoardingClusterId:
+    def prefix_for_scope(cls, scope_id: ScopeId) -> ComponentId:
         return "" if scope_id == ROOT_SCOPE_ID else scope_id
 
     @classmethod
-    def sort(cls, cluster_ids: set[CodeBoardingClusterId]) -> list[CodeBoardingClusterId]:
+    def sort(cls, cluster_ids: set[ComponentId]) -> list[ComponentId]:
         # Sort by depth first, then naturally within a level: ["1", "2", "10", "2.1", "3.4"].
         return sorted(cluster_ids, key=_cluster_id_sort_key)
 
     @classmethod
-    def from_graph_id(cls, cluster_id: GraphClusterId) -> CodeBoardingClusterId:
+    def from_graph_id(cls, cluster_id: ClusterId) -> ComponentId:
         return str(cluster_id)
 
     @classmethod
-    def from_graph_ids(cls, cluster_ids: set[GraphClusterId]) -> list[CodeBoardingClusterId]:
+    def from_graph_ids(cls, cluster_ids: set[ClusterId]) -> list[ComponentId]:
         return [cls.from_graph_id(cluster_id) for cluster_id in GraphClusterIds.sort(cluster_ids)]
 
     @classmethod
-    def qualify_local_id(
-        cls, local_cluster_id: CodeBoardingClusterId, source_cluster_id_prefix: str = ""
-    ) -> CodeBoardingClusterId:
+    def qualify_local_id(cls, local_cluster_id: ComponentId, source_cluster_id_prefix: str = "") -> ComponentId:
         if not source_cluster_id_prefix:
             return local_cluster_id
         return f"{source_cluster_id_prefix}.{local_cluster_id}"
 
     @classmethod
     def qualify_local_ids(
-        cls, local_cluster_ids: list[CodeBoardingClusterId], source_cluster_id_prefix: str = ""
-    ) -> list[CodeBoardingClusterId]:
+        cls, local_cluster_ids: list[ComponentId], source_cluster_id_prefix: str = ""
+    ) -> list[ComponentId]:
         return [cls.qualify_local_id(cluster_id, source_cluster_id_prefix) for cluster_id in local_cluster_ids]
 
 
-def _cluster_id_sort_key(cluster_id: CodeBoardingClusterId) -> tuple[tuple[int, int | str], ...]:
+def _cluster_id_sort_key(cluster_id: ComponentId) -> tuple[tuple[int, int | str], ...]:
     parts = tuple((0, int(part)) if part.isdigit() else (1, part) for part in cluster_id.split("."))
     return ((0, len(parts)), *parts)

--- a/agents/cluster_ids.py
+++ b/agents/cluster_ids.py
@@ -1,8 +1,5 @@
 from agents.scope_ids import ROOT_SCOPE_ID
-
-
-type GraphClusterId = int
-type CodeBoardingClusterId = str
+from clustering_ids import CodeBoardingClusterId, GraphClusterId
 
 
 class GraphClusterIds:

--- a/agents/cluster_methods_mixin.py
+++ b/agents/cluster_methods_mixin.py
@@ -17,7 +17,8 @@ from agents.content_hash import (
     hash_method_body,
     read_source_lines,
 )
-from agents.cluster_ids import CodeBoardingClusterId, CodeBoardingClusterIds, GraphClusterId
+from agents.cluster_ids import CodeBoardingClusterIds
+from clustering_ids import ClusterId, ComponentId
 from constants import MIN_CLUSTERS_THRESHOLD
 from diagram_analysis.cluster_delta import _delta_for_language
 from diagram_analysis.cluster_snapshot import ClusterSnapshotEntry
@@ -245,7 +246,7 @@ class ClusterMethodsMixin:
 
     def _resolve_cluster_ids_from_groups(self, analysis: AnalysisInsights, cluster_analysis: ClusterAnalysis) -> None:
         """Resolve source_cluster_ids deterministically from source_group_names via case-insensitive lookup."""
-        group_name_to_ids: dict[str, list[GraphClusterId]] = {
+        group_name_to_ids: dict[str, list[ClusterId]] = {
             cc.name.lower(): cc.cluster_ids for cc in cluster_analysis.cluster_components
         }
 
@@ -504,9 +505,9 @@ class ClusterMethodsMixin:
             groups.append(FileMethodGroup(file_path=file_path, methods=methods))
         return groups
 
-    def _build_cluster_to_component_map(self, analysis: AnalysisInsights) -> dict[CodeBoardingClusterId, Component]:
+    def _build_cluster_to_component_map(self, analysis: AnalysisInsights) -> dict[ComponentId, Component]:
         """Build cluster_id -> Component mapping from source_cluster_ids."""
-        cluster_to_component: dict[CodeBoardingClusterId, Component] = {}
+        cluster_to_component: dict[ComponentId, Component] = {}
         for comp in analysis.components:
             for cid in comp.source_cluster_ids:
                 cluster_to_component[cid] = comp
@@ -514,10 +515,10 @@ class ClusterMethodsMixin:
 
     def _build_node_to_cluster_map(
         self, cluster_results: dict[str, ClusterResult], source_cluster_id_prefix: str = ""
-    ) -> tuple[dict[str, CodeBoardingClusterId], set[CodeBoardingClusterId]]:
+    ) -> tuple[dict[str, ComponentId], set[ComponentId]]:
         """Build node_name (qualified name) -> cluster_id mapping and collect all cluster IDs."""
-        all_cluster_ids: set[CodeBoardingClusterId] = set()
-        node_to_cluster: dict[str, CodeBoardingClusterId] = {}
+        all_cluster_ids: set[ComponentId] = set()
+        node_to_cluster: dict[str, ComponentId] = {}
         for cr in cluster_results.values():
             for cid, members in cr.clusters.items():
                 cluster_id = CodeBoardingClusterIds.qualify_local_id(
@@ -529,7 +530,7 @@ class ClusterMethodsMixin:
         return node_to_cluster, all_cluster_ids
 
     def _validate_cluster_coverage(
-        self, cluster_to_component: dict[CodeBoardingClusterId, Component], all_cluster_ids: set[CodeBoardingClusterId]
+        self, cluster_to_component: dict[ComponentId, Component], all_cluster_ids: set[ComponentId]
     ) -> None:
         """Log an error if any cluster IDs are not mapped to a component."""
         unmapped_cluster_ids = sorted(all_cluster_ids - set(cluster_to_component.keys()))

--- a/clustering_ids.py
+++ b/clustering_ids.py
@@ -1,0 +1,5 @@
+"""Identifier types shared across clustering layers."""
+
+type GraphClusterId = int
+type CodeBoardingClusterId = str
+type ComponentId = str

--- a/clustering_ids.py
+++ b/clustering_ids.py
@@ -1,5 +1,6 @@
 """Identifier types shared across clustering layers."""
 
-type GraphClusterId = int
-type CodeBoardingClusterId = str
+type ClusterId = int
+type ScopeId = str
+type GroupId = str
 type ComponentId = str

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,7 @@ packages = [
     "telemetry",
 ]
 py-modules = [
+    "clustering_ids",
     "constants",
     "utils",
     "vscode_constants",

--- a/static_analyzer/analysis_result.py
+++ b/static_analyzer/analysis_result.py
@@ -1,11 +1,11 @@
 import logging
 import re
-from collections.abc import Hashable, Iterator
+from collections.abc import Iterator
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from static_analyzer.cfg import CallGraph
+from static_analyzer.cfg import CallGraph, CallSiteLocation
 from static_analyzer.clustering import ClusterCache
 from static_analyzer.config import Language
 from static_analyzer.language_results import LanguageResults
@@ -36,7 +36,7 @@ _WORD_RE = re.compile(r"\b([a-z]+)\b")
 _STANDALONE_SINGLE_LETTER_RE = re.compile(r"(?<![a-z])([a-z])(?!\w)")
 
 # (source name, destination name, source node, destination node, cached call sites)
-InvalidatedEdge = tuple[str, str, Node, Node, list[dict[str, Hashable]]]
+InvalidatedEdge = tuple[str, str, Node, Node, list[CallSiteLocation]]
 
 
 @dataclass

--- a/static_analyzer/cfg/__init__.py
+++ b/static_analyzer/cfg/__init__.py
@@ -5,6 +5,6 @@ the physical-location identity used to dedup LSP qualified-name aliases.
 """
 
 from static_analyzer.cfg.call_graph import CallGraph
-from static_analyzer.cfg.edge import DEFAULT_REFERENCE_KINDS, Edge, EdgeKind, ReferenceEdge
+from static_analyzer.cfg.edge import CallSiteLocation, DEFAULT_REFERENCE_KINDS, Edge, EdgeKind, ReferenceEdge
 
-__all__ = ["DEFAULT_REFERENCE_KINDS", "CallGraph", "Edge", "EdgeKind", "ReferenceEdge"]
+__all__ = ["DEFAULT_REFERENCE_KINDS", "CallGraph", "CallSiteLocation", "Edge", "EdgeKind", "ReferenceEdge"]

--- a/static_analyzer/cfg/edge.py
+++ b/static_analyzer/cfg/edge.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable, Hashable, Mapping, Sequence
 from dataclasses import dataclass
 from enum import StrEnum
+from typing import NotRequired, TypedDict
 
 from static_analyzer.node import Node
 
@@ -40,18 +41,26 @@ class ReferenceEdge:
     kind: EdgeKind
 
 
+class CallSiteLocation(TypedDict):
+    """A one-based source location where a call occurs."""
+
+    line: int
+    file: NotRequired[str]
+    column: NotRequired[int]
+
+
 class Edge:
     def __init__(self, src_node: Node, dst_node: Node, call_sites: Sequence[Mapping[str, Hashable]] = ()) -> None:
         self.src_node = src_node
         self.dst_node = dst_node
-        self._call_sites: list[dict[str, Hashable]] = []
+        self._call_sites: list[CallSiteLocation] = []
         self._call_site_keys: set[tuple[tuple[str, Hashable], ...]] = set()
         for site in call_sites:
             self.add_call_site(site)
 
     @property
-    def call_sites(self) -> list[dict[str, Hashable]]:
-        return [dict(site) for site in self._call_sites]
+    def call_sites(self) -> list[CallSiteLocation]:
+        return [site.copy() for site in self._call_sites]
 
     def get_source(self) -> str:
         return self.src_node.fully_qualified_name
@@ -76,8 +85,22 @@ class Edge:
         self._call_site_keys = {tuple(sorted(site.items())) for site in self._call_sites}
 
     @staticmethod
-    def _normalize_call_site(call_site: Mapping[str, Hashable]) -> dict[str, Hashable]:
+    def _normalize_call_site(call_site: Mapping[str, Hashable]) -> CallSiteLocation:
         normalized = dict(call_site)
         if "file" not in normalized and "file_path" in normalized:
             normalized["file"] = normalized.pop("file_path")
-        return normalized
+        file = normalized.get("file")
+        line = normalized.get("line")
+        column = normalized.get("column")
+        if not isinstance(line, int):
+            raise ValueError("Call sites require a one-based integer line")
+        location = CallSiteLocation(line=line)
+        if file is not None:
+            if not isinstance(file, str):
+                raise ValueError("Call-site files must be strings")
+            location["file"] = file
+        if column is not None:
+            if not isinstance(column, int):
+                raise ValueError("Call-site columns must be one-based integers")
+            location["column"] = column
+        return location

--- a/static_analyzer/cluster_helpers.py
+++ b/static_analyzer/cluster_helpers.py
@@ -1,12 +1,12 @@
 """Compatibility imports for clustering helpers moved into the clustering package."""
 
 from static_analyzer.clustering.grouping import (
-    build_all_cluster_results,
     combine_cluster_results,
     group_symbols,
     reindex_across_languages,
     reindex_cluster_result,
 )
+from static_analyzer.clustering.orchestration import build_all_cluster_results
 
 __all__ = [
     "build_all_cluster_results",

--- a/static_analyzer/clustering/__init__.py
+++ b/static_analyzer/clustering/__init__.py
@@ -7,7 +7,7 @@ state that ``LanguageResults`` owns.
 
 from static_analyzer.clustering.cache import ClusterCache
 from static_analyzer.config import DEFAULT_GROUPING_CONFIG, SUBCOMPONENT_GROUPING_CONFIG, GroupingConfig
-from clustering_ids import ComponentId, GraphClusterId
+from clustering_ids import ClusterId, ComponentId, GroupId, ScopeId
 from static_analyzer.clustering.method_cluster_paths import MethodClusterPaths
 from static_analyzer.clustering.models import (
     METHOD_LEVEL_STRATEGY,
@@ -18,7 +18,7 @@ from static_analyzer.clustering.models import (
     ClusterScopeResult,
     GroupConnection,
 )
-from static_analyzer.clustering.service import ClusteringService
+from static_analyzer.clustering.service import ClusteringService, LeafClustersUnavailableError
 
 __all__ = [
     "DEFAULT_GROUPING_CONFIG",
@@ -31,9 +31,12 @@ __all__ = [
     "ClusterResult",
     "ClusterScopeResult",
     "ClusteringService",
+    "ClusterId",
     "ComponentId",
-    "GraphClusterId",
+    "GroupId",
     "GroupConnection",
     "GroupingConfig",
+    "LeafClustersUnavailableError",
     "MethodClusterPaths",
+    "ScopeId",
 ]

--- a/static_analyzer/clustering/__init__.py
+++ b/static_analyzer/clustering/__init__.py
@@ -8,7 +8,15 @@ state that ``LanguageResults`` owns.
 from static_analyzer.clustering.cache import ClusterCache
 from static_analyzer.config import DEFAULT_GROUPING_CONFIG, SUBCOMPONENT_GROUPING_CONFIG, GroupingConfig
 from static_analyzer.clustering.method_cluster_paths import MethodClusterPaths
-from static_analyzer.clustering.models import METHOD_LEVEL_STRATEGY, AnchoredGrouping, ClusterResult
+from static_analyzer.clustering.models import (
+    METHOD_LEVEL_STRATEGY,
+    AnchoredGrouping,
+    ClusterConnection,
+    ClusterConnectionEdge,
+    ClusterGroup,
+    ClusterResult,
+    ClusterScopeResult,
+)
 from static_analyzer.clustering.service import ClusteringService
 
 __all__ = [
@@ -17,7 +25,11 @@ __all__ = [
     "SUBCOMPONENT_GROUPING_CONFIG",
     "AnchoredGrouping",
     "ClusterCache",
+    "ClusterConnection",
+    "ClusterConnectionEdge",
+    "ClusterGroup",
     "ClusterResult",
+    "ClusterScopeResult",
     "ClusteringService",
     "GroupingConfig",
     "MethodClusterPaths",

--- a/static_analyzer/clustering/__init__.py
+++ b/static_analyzer/clustering/__init__.py
@@ -7,15 +7,16 @@ state that ``LanguageResults`` owns.
 
 from static_analyzer.clustering.cache import ClusterCache
 from static_analyzer.config import DEFAULT_GROUPING_CONFIG, SUBCOMPONENT_GROUPING_CONFIG, GroupingConfig
+from clustering_ids import ComponentId, GraphClusterId
 from static_analyzer.clustering.method_cluster_paths import MethodClusterPaths
 from static_analyzer.clustering.models import (
     METHOD_LEVEL_STRATEGY,
     AnchoredGrouping,
-    ClusterConnection,
     ClusterConnectionEdge,
     ClusterGroup,
     ClusterResult,
     ClusterScopeResult,
+    GroupConnection,
 )
 from static_analyzer.clustering.service import ClusteringService
 
@@ -25,12 +26,14 @@ __all__ = [
     "SUBCOMPONENT_GROUPING_CONFIG",
     "AnchoredGrouping",
     "ClusterCache",
-    "ClusterConnection",
     "ClusterConnectionEdge",
     "ClusterGroup",
     "ClusterResult",
     "ClusterScopeResult",
     "ClusteringService",
+    "ComponentId",
+    "GraphClusterId",
+    "GroupConnection",
     "GroupingConfig",
     "MethodClusterPaths",
 ]

--- a/static_analyzer/clustering/grouping.py
+++ b/static_analyzer/clustering/grouping.py
@@ -7,15 +7,12 @@ from collections import Counter, defaultdict, deque
 import networkx as nx
 import networkx.algorithms.community as nx_comm
 
-from static_analyzer.analysis_result import StaticAnalysisResults
 from static_analyzer.config import (
     DEFAULT_GROUPING_CONFIG,
     SUBCOMPONENT_GROUPING_CONFIG,
     GroupingConfig,
-    Language,
 )
 from static_analyzer.clustering.models import AnchoredGrouping, ClusterResult
-from static_analyzer.clustering.service import ClusteringService
 from static_analyzer.leiden_utils import find_partition
 
 logger = logging.getLogger(__name__)
@@ -50,32 +47,6 @@ class GroupingService:
         combined = combine_cluster_results(cluster_results)
         combined_cfg: nx.DiGraph = nx.compose_all(list(cfg_graphs.values())) if cfg_graphs else nx.DiGraph()
         return _anchored_group(combined, combined_cfg, previous_owner, config)
-
-
-def build_all_cluster_results(static_analysis: StaticAnalysisResults) -> dict[str, ClusterResult]:
-    """Cluster every detected language in one shared cluster-ID namespace."""
-    cluster_service = ClusteringService()
-    cluster_results: dict[str, ClusterResult] = {}
-    offset = 0
-    for lang in static_analysis.get_languages():
-        result = cluster_service.cluster(static_analysis.get_cfg(lang))
-        if offset:
-            result = reindex_cluster_result(result, offset)
-            logger.info(f"[Cluster] {lang}: offset IDs by +{offset} ({len(result.clusters)} clusters)")
-        cluster_results[str(lang)] = result
-        offset += max(result.clusters, default=0) + 1
-
-    _sync_cluster_cache(static_analysis, cluster_results)
-    return cluster_results
-
-
-def _sync_cluster_cache(static_analysis: StaticAnalysisResults, cluster_results: dict[str, ClusterResult]) -> None:
-    """Store each language's partition (with its final, offset IDs) on its cluster cache."""
-    for lang, result in cluster_results.items():
-        try:
-            static_analysis.get_clusters(Language(lang)).adopt(result)
-        except ValueError:
-            logger.warning("Could not sync cluster cache for unknown language %s", lang)
 
 
 def reindex_across_languages(cluster_results: dict[str, ClusterResult]) -> None:
@@ -317,6 +288,11 @@ def _method_counts(cluster_result: ClusterResult) -> dict[int, int]:
 def _modularity(meta_graph: nx.DiGraph, groups: list[set[int]]) -> float:
     """0.0 on an edgeless meta-graph — there is nothing to separate."""
     return nx_comm.modularity(meta_graph, groups, weight="weight") if meta_graph.number_of_edges() else 0.0
+
+
+def score_grouping(cluster_result: ClusterResult, cfg_graph: nx.DiGraph, groups: list[set[int]]) -> float:
+    """Score a concrete grouping against its inter-cluster meta-graph."""
+    return _modularity(_build_meta_graph(cluster_result, cfg_graph), groups)
 
 
 def _optimize_grouping(

--- a/static_analyzer/clustering/grouping.py
+++ b/static_analyzer/clustering/grouping.py
@@ -89,30 +89,6 @@ def reindex_cluster_result(cluster_result: ClusterResult, offset: int) -> Cluste
     )
 
 
-def _build_meta_graph(cluster_result: ClusterResult, cfg_graph: nx.DiGraph) -> nx.DiGraph:
-    """Build a weighted directed graph of calls between clusters."""
-    node_to_cluster: dict[str, int] = {}
-    for cluster_id, nodes in cluster_result.clusters.items():
-        for node in nodes:
-            node_to_cluster[node] = cluster_id
-
-    meta_graph = nx.DiGraph()
-    for cid in cluster_result.clusters:
-        meta_graph.add_node(cid)
-
-    edge_weights: dict[tuple[int, int], int] = defaultdict(int)
-    for src, dst in cfg_graph.edges():
-        src_cid = node_to_cluster.get(src)
-        dst_cid = node_to_cluster.get(dst)
-        if src_cid is not None and dst_cid is not None and src_cid != dst_cid:
-            edge_weights[(src_cid, dst_cid)] += 1
-
-    for (src_cid, dst_cid), weight in edge_weights.items():
-        meta_graph.add_edge(src_cid, dst_cid, weight=weight)
-
-    return meta_graph
-
-
 def group_symbols(cluster_ids: list[int], node_lookup: dict[int, set[str]]) -> list[str]:
     """Qualified names in a group, most top-level first (fewest name segments)."""
     names = {qname for cid in cluster_ids for qname in node_lookup.get(cid, set())}
@@ -135,6 +111,35 @@ def combine_cluster_results(cluster_results: dict[str, ClusterResult]) -> Cluste
         file_to_clusters=dict(file_to_clusters),
         strategy="combined",
     )
+
+
+def score_grouping(cluster_result: ClusterResult, cfg_graph: nx.DiGraph, groups: list[set[int]]) -> float:
+    """Score a concrete grouping against its inter-cluster meta-graph."""
+    return _modularity(_build_meta_graph(cluster_result, cfg_graph), groups)
+
+
+def _build_meta_graph(cluster_result: ClusterResult, cfg_graph: nx.DiGraph) -> nx.DiGraph:
+    """Build a weighted directed graph of calls between clusters."""
+    node_to_cluster: dict[str, int] = {}
+    for cluster_id, nodes in cluster_result.clusters.items():
+        for node in nodes:
+            node_to_cluster[node] = cluster_id
+
+    meta_graph = nx.DiGraph()
+    for cid in cluster_result.clusters:
+        meta_graph.add_node(cid)
+
+    edge_weights: dict[tuple[int, int], int] = defaultdict(int)
+    for src, dst in cfg_graph.edges():
+        src_cid = node_to_cluster.get(src)
+        dst_cid = node_to_cluster.get(dst)
+        if src_cid is not None and dst_cid is not None and src_cid != dst_cid:
+            edge_weights[(src_cid, dst_cid)] += 1
+
+    for (src_cid, dst_cid), weight in edge_weights.items():
+        meta_graph.add_edge(src_cid, dst_cid, weight=weight)
+
+    return meta_graph
 
 
 def _pick_peak_partition(
@@ -288,11 +293,6 @@ def _method_counts(cluster_result: ClusterResult) -> dict[int, int]:
 def _modularity(meta_graph: nx.DiGraph, groups: list[set[int]]) -> float:
     """0.0 on an edgeless meta-graph — there is nothing to separate."""
     return nx_comm.modularity(meta_graph, groups, weight="weight") if meta_graph.number_of_edges() else 0.0
-
-
-def score_grouping(cluster_result: ClusterResult, cfg_graph: nx.DiGraph, groups: list[set[int]]) -> float:
-    """Score a concrete grouping against its inter-cluster meta-graph."""
-    return _modularity(_build_meta_graph(cluster_result, cfg_graph), groups)
 
 
 def _optimize_grouping(

--- a/static_analyzer/clustering/models.py
+++ b/static_analyzer/clustering/models.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 
-from clustering_ids import ComponentId, GraphClusterId
+from clustering_ids import ClusterId, ComponentId, GroupId, ScopeId
 from static_analyzer.cfg.edge import CallSiteLocation
 from static_analyzer.node import Node
 
@@ -20,35 +20,35 @@ METHOD_LEVEL_STRATEGY = "method_level_expansion"
 class ClusterResult:
     """Leaf clusters from one language's call graph, with deterministic IDs and file mappings."""
 
-    clusters: dict[GraphClusterId, set[str]] = field(default_factory=dict)  # cluster_id -> node names
-    cluster_to_files: dict[GraphClusterId, set[str]] = field(default_factory=dict)  # cluster_id -> file_paths
-    file_to_clusters: dict[str, set[GraphClusterId]] = field(default_factory=dict)  # file_path -> cluster_ids
+    clusters: dict[ClusterId, set[str]] = field(default_factory=dict)  # cluster_id -> node names
+    cluster_to_files: dict[ClusterId, set[str]] = field(default_factory=dict)  # cluster_id -> file_paths
+    file_to_clusters: dict[str, set[ClusterId]] = field(default_factory=dict)  # file_path -> cluster_ids
     strategy: str = ""  # which algorithm was used
 
-    def get_cluster_ids(self) -> set[GraphClusterId]:
+    def get_cluster_ids(self) -> set[ClusterId]:
         return set(self.clusters.keys())
 
-    def get_files_for_cluster(self, cluster_id: GraphClusterId) -> set[str]:
+    def get_files_for_cluster(self, cluster_id: ClusterId) -> set[str]:
         return self.cluster_to_files.get(cluster_id, set())
 
-    def get_clusters_for_file(self, file_path: str) -> set[GraphClusterId]:
+    def get_clusters_for_file(self, file_path: str) -> set[ClusterId]:
         return self.file_to_clusters.get(file_path, set())
 
-    def get_nodes_for_cluster(self, cluster_id: GraphClusterId) -> set[str]:
+    def get_nodes_for_cluster(self, cluster_id: ClusterId) -> set[str]:
         return self.clusters.get(cluster_id, set())
 
     def visit_paths(self, fn: Callable[[str], str]) -> None:
         self.cluster_to_files = {cid: {fn(path) for path in paths} for cid, paths in self.cluster_to_files.items()}
-        remapped_file_to_clusters: dict[str, set[GraphClusterId]] = defaultdict(set)
+        remapped_file_to_clusters: dict[str, set[ClusterId]] = defaultdict(set)
         for path, cluster_ids in self.file_to_clusters.items():
             remapped_file_to_clusters[fn(path)].update(cluster_ids)
         self.file_to_clusters = dict(remapped_file_to_clusters)
 
     def select(self, surviving_nodes: Mapping[str, Node]) -> ClusterResult:
         """Return a copy keeping only qnames in ``surviving_nodes``, with file mappings recomputed."""
-        kept_clusters: dict[GraphClusterId, set[str]] = {}
-        kept_cluster_to_files: dict[GraphClusterId, set[str]] = {}
-        kept_file_to_clusters: dict[str, set[GraphClusterId]] = {}
+        kept_clusters: dict[ClusterId, set[str]] = {}
+        kept_cluster_to_files: dict[ClusterId, set[str]] = {}
+        kept_file_to_clusters: dict[str, set[ClusterId]] = {}
         for cid, members in self.clusters.items():
             kept = {m for m in members if m in surviving_nodes}
             if not kept:
@@ -74,7 +74,7 @@ class ClusterResult:
 class AnchoredGrouping:
     """A grouping carried forward from the previous run."""
 
-    groups: list[set[GraphClusterId]]
+    groups: list[set[ClusterId]]
     owners: list[ComponentId]
     regrouped: bool
 
@@ -91,8 +91,8 @@ class ClusterConnectionEdge:
 class GroupConnection:
     """All concrete calls from one sibling group to another."""
 
-    source_group_id: ComponentId
-    target_group_id: ComponentId
+    source_group_id: GroupId
+    target_group_id: GroupId
     edges: list[ClusterConnectionEdge] = field(default_factory=list)
 
 
@@ -100,8 +100,8 @@ class GroupConnection:
 class ClusterGroup:
     """One deterministic architectural group inside a clustered scope."""
 
-    group_id: ComponentId
-    cluster_ids: list[GraphClusterId]
+    group_id: GroupId
+    cluster_ids: list[ClusterId]
     symbol_members_by_language: dict[str, set[str]] = field(default_factory=dict)
     previous_component_id: ComponentId = ""
     children: ClusterScopeResult | None = None
@@ -119,7 +119,7 @@ class ClusterGroup:
 class ClusterScopeResult:
     """The leaf clusters, architectural groups, and communication for one graph scope."""
 
-    scope_id: str
+    scope_id: ScopeId
     leaf_clusters_by_language: dict[str, ClusterResult] = field(default_factory=dict)
     groups: list[ClusterGroup] = field(default_factory=list)
     connections: list[GroupConnection] = field(default_factory=list)

--- a/static_analyzer/clustering/models.py
+++ b/static_analyzer/clustering/models.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Hashable, Mapping
 from dataclasses import dataclass, field
 
 from static_analyzer.node import Node
@@ -75,3 +75,49 @@ class AnchoredGrouping:
     groups: list[set[int]]
     owners: list[str]
     regrouped: bool
+
+
+@dataclass
+class ClusterConnectionEdge:
+    """One concrete call crossing between two structural groups."""
+
+    language: str
+    source: str
+    target: str
+    call_sites: list[dict[str, Hashable]] = field(default_factory=list)
+
+
+@dataclass
+class ClusterConnection:
+    """All concrete calls from one sibling group to another."""
+
+    source_group_id: str
+    target_group_id: str
+    edges: list[ClusterConnectionEdge] = field(default_factory=list)
+
+
+@dataclass
+class ClusterGroup:
+    """One deterministic architectural group inside a clustered scope."""
+
+    group_id: str
+    cluster_ids: list[int]
+    members: dict[str, set[str]] = field(default_factory=dict)
+    previous_component_id: str = ""
+    children: ClusterScopeResult | None = None
+
+    @property
+    def qualified_names(self) -> set[str]:
+        return {qualified_name for language_members in self.members.values() for qualified_name in language_members}
+
+
+@dataclass
+class ClusterScopeResult:
+    """The complete partition, grouping, and communication for one graph scope."""
+
+    scope_id: str
+    partitions: dict[str, ClusterResult] = field(default_factory=dict)
+    groups: list[ClusterGroup] = field(default_factory=list)
+    connections: list[ClusterConnection] = field(default_factory=list)
+    modularity: float = 0.0
+    regrouped: bool = False

--- a/static_analyzer/clustering/models.py
+++ b/static_analyzer/clustering/models.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from collections.abc import Callable, Hashable, Mapping
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 
+from clustering_ids import ComponentId, GraphClusterId
+from static_analyzer.cfg.edge import CallSiteLocation
 from static_analyzer.node import Node
 
 # Marker on a ClusterResult whose clusters are synthetic one-method-per-cluster
@@ -16,37 +18,37 @@ METHOD_LEVEL_STRATEGY = "method_level_expansion"
 
 @dataclass
 class ClusterResult:
-    """A partition of a CallGraph. Provides deterministic cluster IDs and file mappings."""
+    """Leaf clusters from one language's call graph, with deterministic IDs and file mappings."""
 
-    clusters: dict[int, set[str]] = field(default_factory=dict)  # cluster_id -> node names
-    cluster_to_files: dict[int, set[str]] = field(default_factory=dict)  # cluster_id -> file_paths
-    file_to_clusters: dict[str, set[int]] = field(default_factory=dict)  # file_path -> cluster_ids
+    clusters: dict[GraphClusterId, set[str]] = field(default_factory=dict)  # cluster_id -> node names
+    cluster_to_files: dict[GraphClusterId, set[str]] = field(default_factory=dict)  # cluster_id -> file_paths
+    file_to_clusters: dict[str, set[GraphClusterId]] = field(default_factory=dict)  # file_path -> cluster_ids
     strategy: str = ""  # which algorithm was used
 
-    def get_cluster_ids(self) -> set[int]:
+    def get_cluster_ids(self) -> set[GraphClusterId]:
         return set(self.clusters.keys())
 
-    def get_files_for_cluster(self, cluster_id: int) -> set[str]:
+    def get_files_for_cluster(self, cluster_id: GraphClusterId) -> set[str]:
         return self.cluster_to_files.get(cluster_id, set())
 
-    def get_clusters_for_file(self, file_path: str) -> set[int]:
+    def get_clusters_for_file(self, file_path: str) -> set[GraphClusterId]:
         return self.file_to_clusters.get(file_path, set())
 
-    def get_nodes_for_cluster(self, cluster_id: int) -> set[str]:
+    def get_nodes_for_cluster(self, cluster_id: GraphClusterId) -> set[str]:
         return self.clusters.get(cluster_id, set())
 
     def visit_paths(self, fn: Callable[[str], str]) -> None:
         self.cluster_to_files = {cid: {fn(path) for path in paths} for cid, paths in self.cluster_to_files.items()}
-        remapped_file_to_clusters: dict[str, set[int]] = defaultdict(set)
+        remapped_file_to_clusters: dict[str, set[GraphClusterId]] = defaultdict(set)
         for path, cluster_ids in self.file_to_clusters.items():
             remapped_file_to_clusters[fn(path)].update(cluster_ids)
         self.file_to_clusters = dict(remapped_file_to_clusters)
 
     def select(self, surviving_nodes: Mapping[str, Node]) -> ClusterResult:
         """Return a copy keeping only qnames in ``surviving_nodes``, with file mappings recomputed."""
-        kept_clusters: dict[int, set[str]] = {}
-        kept_cluster_to_files: dict[int, set[str]] = {}
-        kept_file_to_clusters: dict[str, set[int]] = {}
+        kept_clusters: dict[GraphClusterId, set[str]] = {}
+        kept_cluster_to_files: dict[GraphClusterId, set[str]] = {}
+        kept_file_to_clusters: dict[str, set[GraphClusterId]] = {}
         for cid, members in self.clusters.items():
             kept = {m for m in members if m in surviving_nodes}
             if not kept:
@@ -72,27 +74,25 @@ class ClusterResult:
 class AnchoredGrouping:
     """A grouping carried forward from the previous run."""
 
-    groups: list[set[int]]
-    owners: list[str]
+    groups: list[set[GraphClusterId]]
+    owners: list[ComponentId]
     regrouped: bool
 
 
 @dataclass
 class ClusterConnectionEdge:
-    """One concrete call crossing between two structural groups."""
-
     language: str
-    source: str
-    target: str
-    call_sites: list[dict[str, Hashable]] = field(default_factory=list)
+    source_qualified_name: str
+    target_qualified_name: str
+    call_sites: list[CallSiteLocation] = field(default_factory=list)
 
 
 @dataclass
-class ClusterConnection:
+class GroupConnection:
     """All concrete calls from one sibling group to another."""
 
-    source_group_id: str
-    target_group_id: str
+    source_group_id: ComponentId
+    target_group_id: ComponentId
     edges: list[ClusterConnectionEdge] = field(default_factory=list)
 
 
@@ -100,24 +100,28 @@ class ClusterConnection:
 class ClusterGroup:
     """One deterministic architectural group inside a clustered scope."""
 
-    group_id: str
-    cluster_ids: list[int]
-    members: dict[str, set[str]] = field(default_factory=dict)
-    previous_component_id: str = ""
+    group_id: ComponentId
+    cluster_ids: list[GraphClusterId]
+    symbol_members_by_language: dict[str, set[str]] = field(default_factory=dict)
+    previous_component_id: ComponentId = ""
     children: ClusterScopeResult | None = None
 
     @property
     def qualified_names(self) -> set[str]:
-        return {qualified_name for language_members in self.members.values() for qualified_name in language_members}
+        return {
+            qualified_name
+            for language_qualified_names in self.symbol_members_by_language.values()
+            for qualified_name in language_qualified_names
+        }
 
 
 @dataclass
 class ClusterScopeResult:
-    """The complete partition, grouping, and communication for one graph scope."""
+    """The leaf clusters, architectural groups, and communication for one graph scope."""
 
     scope_id: str
-    partitions: dict[str, ClusterResult] = field(default_factory=dict)
+    leaf_clusters_by_language: dict[str, ClusterResult] = field(default_factory=dict)
     groups: list[ClusterGroup] = field(default_factory=list)
-    connections: list[ClusterConnection] = field(default_factory=list)
+    connections: list[GroupConnection] = field(default_factory=list)
     modularity: float = 0.0
     regrouped: bool = False

--- a/static_analyzer/clustering/orchestration.py
+++ b/static_analyzer/clustering/orchestration.py
@@ -1,0 +1,42 @@
+"""Root-scope clustering orchestration and cache synchronization."""
+
+import logging
+
+from static_analyzer.analysis_result import StaticAnalysisResults
+from static_analyzer.config import Language
+from static_analyzer.clustering.grouping import reindex_cluster_result
+from static_analyzer.clustering.models import ClusterResult
+from static_analyzer.clustering.service import ClusteringService
+
+logger = logging.getLogger(__name__)
+
+
+def build_all_cluster_results(static_analysis: StaticAnalysisResults) -> dict[str, ClusterResult]:
+    """Cluster every detected language in one shared cluster-ID namespace."""
+    cluster_service = ClusteringService()
+    cluster_results: dict[str, ClusterResult] = {}
+    offset = 0
+    for language in static_analysis.get_languages():
+        result = cluster_service.cluster(static_analysis.get_cfg(language))
+        if offset:
+            result = reindex_cluster_result(result, offset)
+            logger.info(
+                "[Cluster] %s: offset IDs by +%d (%d clusters)",
+                language,
+                offset,
+                len(result.clusters),
+            )
+        cluster_results[str(language)] = result
+        offset += max(result.clusters, default=0) + 1
+
+    _sync_cluster_cache(static_analysis, cluster_results)
+    return cluster_results
+
+
+def _sync_cluster_cache(static_analysis: StaticAnalysisResults, cluster_results: dict[str, ClusterResult]) -> None:
+    """Store each language's final partition on its cluster cache."""
+    for language, result in cluster_results.items():
+        try:
+            static_analysis.get_clusters(Language(language)).adopt(result)
+        except ValueError:
+            logger.warning("Could not sync cluster cache for unknown language %s", language)

--- a/static_analyzer/clustering/service.py
+++ b/static_analyzer/clustering/service.py
@@ -8,6 +8,7 @@ from types import MappingProxyType
 
 import networkx as nx
 
+from clustering_ids import ComponentId, GraphClusterId
 from constants import MIN_CLUSTERS_THRESHOLD
 from static_analyzer.cfg import CallGraph, DEFAULT_REFERENCE_KINDS
 from static_analyzer.config import CALLABLE_TYPES, CLASS_TYPES
@@ -20,23 +21,23 @@ from static_analyzer.clustering.grouping import (
 )
 from static_analyzer.clustering.models import (
     METHOD_LEVEL_STRATEGY,
-    ClusterConnection,
     ClusterConnectionEdge,
     ClusterGroup,
     ClusterResult,
     ClusterScopeResult,
+    GroupConnection,
 )
 
 _ROOT_SCOPE_ID = "root"
-_EMPTY_PARTITIONS: Mapping[str, ClusterResult] = MappingProxyType({})
-_EMPTY_OWNERS: Mapping[int, str] = MappingProxyType({})
+_EMPTY_LEAF_CLUSTERS: Mapping[str, ClusterResult] = MappingProxyType({})
+_EMPTY_OWNERS: Mapping[GraphClusterId, ComponentId] = MappingProxyType({})
 
 
 class ClusteringService:
     """Clusters a ``CallGraph``.
 
     Pure: it neither mutates the graph nor caches anything. Callers that want to
-    keep a partition store it in the ``ClusterCache`` on their ``LanguageResults``.
+    keep a result store it in the ``ClusterCache`` on their ``LanguageResults``.
     """
 
     def cluster(self, graph: CallGraph) -> ClusterResult:
@@ -47,33 +48,35 @@ class ClusteringService:
         graphs: Mapping[str, CallGraph],
         *,
         scope_id: str = _ROOT_SCOPE_ID,
-        partitions: Mapping[str, ClusterResult] = _EMPTY_PARTITIONS,
-        previous_owner: Mapping[int, str] = _EMPTY_OWNERS,
+        leaf_clusters_by_language: Mapping[str, ClusterResult] = _EMPTY_LEAF_CLUSTERS,
+        previous_owner: Mapping[GraphClusterId, ComponentId] = _EMPTY_OWNERS,
         method_level_fallback: bool = False,
     ) -> ClusterScopeResult:
         """Cluster and group one exact graph scope, retaining sibling communication."""
-        scope_partitions: dict[str, ClusterResult] = {}
+        scope_leaf_clusters: dict[str, ClusterResult] = {}
         for language, graph in graphs.items():
-            scope_partitions[language] = partitions[language] if language in partitions else self.cluster(graph)
+            scope_leaf_clusters[language] = (
+                leaf_clusters_by_language[language] if language in leaf_clusters_by_language else self.cluster(graph)
+            )
         if method_level_fallback:
-            scope_partitions = {
-                language: self._expand_to_method_level(graphs[language], partition)
-                for language, partition in scope_partitions.items()
+            scope_leaf_clusters = {
+                language: self._expand_to_method_level(graphs[language], cluster_result)
+                for language, cluster_result in scope_leaf_clusters.items()
             }
-        reindex_across_languages(scope_partitions)
+        reindex_across_languages(scope_leaf_clusters)
 
         nx_graphs = {language: graph.to_networkx(DEFAULT_REFERENCE_KINDS) for language, graph in graphs.items()}
         grouping_service = GroupingService()
         if previous_owner:
-            grouping = grouping_service.anchored_group(scope_partitions, nx_graphs, dict(previous_owner))
+            grouping = grouping_service.anchored_group(scope_leaf_clusters, nx_graphs, dict(previous_owner))
             raw_groups = grouping.groups
             owners = grouping.owners
-            combined = combine_cluster_results(scope_partitions)
+            combined = combine_cluster_results(scope_leaf_clusters)
             combined_cfg = nx.compose_all(list(nx_graphs.values())) if nx_graphs else nx.DiGraph()
             modularity = score_grouping(combined, combined_cfg, raw_groups)
             regrouped = grouping.regrouped
         else:
-            raw_groups, modularity = grouping_service.group(scope_partitions, nx_graphs)
+            raw_groups, modularity = grouping_service.group(scope_leaf_clusters, nx_graphs)
             owners = [""] * len(raw_groups)
             regrouped = False
 
@@ -86,11 +89,11 @@ class ClusteringService:
             )
             for group_id, cluster_ids, owner in zip(group_ids, raw_groups, owners, strict=True)
         ]
-        self._assign_members(graphs, scope_partitions, groups)
+        self._assign_symbol_members(graphs, scope_leaf_clusters, groups)
         connections = self._build_connections(graphs, groups)
         return ClusterScopeResult(
             scope_id=scope_id,
-            partitions=scope_partitions,
+            leaf_clusters_by_language=scope_leaf_clusters,
             groups=groups,
             connections=connections,
             modularity=modularity,
@@ -98,9 +101,9 @@ class ClusteringService:
         )
 
     @staticmethod
-    def _allocate_group_ids(scope_id: str, owners: list[str]) -> list[str]:
+    def _allocate_group_ids(scope_id: str, owners: list[ComponentId]) -> list[ComponentId]:
         allocated = set(owners) - {""}
-        result: list[str] = []
+        result: list[ComponentId] = []
         next_index = 1
         for owner in owners:
             if owner:
@@ -116,13 +119,13 @@ class ClusteringService:
         return result
 
     @staticmethod
-    def _expand_to_method_level(graph: CallGraph, partition: ClusterResult) -> ClusterResult:
-        if len(partition.clusters) >= MIN_CLUSTERS_THRESHOLD:
-            return partition
+    def _expand_to_method_level(graph: CallGraph, cluster_result: ClusterResult) -> ClusterResult:
+        if len(cluster_result.clusters) >= MIN_CLUSTERS_THRESHOLD:
+            return cluster_result
 
-        clusters: dict[int, set[str]] = {}
-        cluster_to_files: dict[int, set[str]] = {}
-        file_to_clusters: dict[str, set[int]] = defaultdict(set)
+        clusters: dict[GraphClusterId, set[str]] = {}
+        cluster_to_files: dict[GraphClusterId, set[str]] = {}
+        file_to_clusters: dict[str, set[GraphClusterId]] = defaultdict(set)
         included: set[str] = set()
 
         for qualified_name, node in sorted(graph.nodes.items()):
@@ -150,46 +153,46 @@ class ClusteringService:
             strategy=METHOD_LEVEL_STRATEGY,
         )
 
-    def _assign_members(
+    def _assign_symbol_members(
         self,
         graphs: Mapping[str, CallGraph],
-        partitions: dict[str, ClusterResult],
+        leaf_clusters_by_language: dict[str, ClusterResult],
         groups: list[ClusterGroup],
     ) -> None:
         if not groups:
             return
         group_by_cluster = {cluster_id: group for group in groups for cluster_id in group.cluster_ids}
         for language, graph in graphs.items():
-            partition = partitions.get(language, ClusterResult())
-            cluster_by_member = {
+            cluster_result = leaf_clusters_by_language.get(language, ClusterResult())
+            cluster_by_qualified_name = {
                 qualified_name: cluster_id
-                for cluster_id, members in partition.clusters.items()
+                for cluster_id, members in cluster_result.clusters.items()
                 for qualified_name in members
             }
             undirected = graph.to_networkx(reference_kinds=()).to_undirected()
             for qualified_name, node in graph.nodes.items():
                 if node.type not in CALLABLE_TYPES | CLASS_TYPES:
                     continue
-                cluster_id = cluster_by_member.get(qualified_name)
+                cluster_id = cluster_by_qualified_name.get(qualified_name)
                 if cluster_id not in group_by_cluster:
-                    cluster_id = self._cluster_for_file(node.file_path, partition)
+                    cluster_id = self._cluster_for_file(node.file_path, cluster_result)
                 if cluster_id not in group_by_cluster:
-                    cluster_id = self._nearest_cluster(qualified_name, partition, undirected)
+                    cluster_id = self._nearest_cluster(qualified_name, cluster_result, undirected)
                 group = group_by_cluster[cluster_id] if cluster_id is not None else groups[0]
-                group.members.setdefault(language, set()).add(qualified_name)
+                group.symbol_members_by_language.setdefault(language, set()).add(qualified_name)
 
     @staticmethod
-    def _cluster_for_file(file_path: str, partition: ClusterResult) -> int | None:
-        return next(iter(partition.get_clusters_for_file(file_path)), None)
+    def _cluster_for_file(file_path: str, cluster_result: ClusterResult) -> GraphClusterId | None:
+        return next(iter(cluster_result.get_clusters_for_file(file_path)), None)
 
     @staticmethod
-    def _nearest_cluster(qualified_name: str, partition: ClusterResult, graph: nx.Graph) -> int | None:
+    def _nearest_cluster(qualified_name: str, cluster_result: ClusterResult, graph: nx.Graph) -> GraphClusterId | None:
         if qualified_name not in graph:
             return None
         distances = nx.single_source_shortest_path_length(graph, qualified_name)
-        nearest: int | None = None
+        nearest: GraphClusterId | None = None
         nearest_distance = float("inf")
-        for cluster_id, members in partition.clusters.items():
+        for cluster_id, members in cluster_result.clusters.items():
             for member in members:
                 distance = distances.get(member)
                 if distance is not None and distance < nearest_distance:
@@ -198,32 +201,32 @@ class ClusteringService:
         return nearest
 
     @staticmethod
-    def _build_connections(graphs: Mapping[str, CallGraph], groups: list[ClusterGroup]) -> list[ClusterConnection]:
-        group_by_member = {
+    def _build_connections(graphs: Mapping[str, CallGraph], groups: list[ClusterGroup]) -> list[GroupConnection]:
+        group_id_by_qualified_name = {
             (language, qualified_name): group.group_id
             for group in groups
-            for language, members in group.members.items()
-            for qualified_name in members
+            for language, qualified_names in group.symbol_members_by_language.items()
+            for qualified_name in qualified_names
         }
-        by_pair: dict[tuple[str, str], ClusterConnection] = {}
+        by_pair: dict[tuple[ComponentId, ComponentId], GroupConnection] = {}
         for language, graph in graphs.items():
             for edge in graph.edges:
                 source = edge.get_source()
                 target = edge.get_destination()
-                source_group = group_by_member.get((language, source), "")
-                target_group = group_by_member.get((language, target), "")
+                source_group = group_id_by_qualified_name.get((language, source), "")
+                target_group = group_id_by_qualified_name.get((language, target), "")
                 if not source_group or not target_group or source_group == target_group:
                     continue
                 pair = (source_group, target_group)
                 connection = by_pair.setdefault(
                     pair,
-                    ClusterConnection(source_group_id=source_group, target_group_id=target_group),
+                    GroupConnection(source_group_id=source_group, target_group_id=target_group),
                 )
                 connection.edges.append(
                     ClusterConnectionEdge(
                         language=language,
-                        source=source,
-                        target=target,
+                        source_qualified_name=source,
+                        target_qualified_name=target,
                         call_sites=edge.call_sites,
                     )
                 )

--- a/static_analyzer/clustering/service.py
+++ b/static_analyzer/clustering/service.py
@@ -2,9 +2,34 @@
 
 from __future__ import annotations
 
+from collections import defaultdict
+from collections.abc import Mapping
+from types import MappingProxyType
+
+import networkx as nx
+
+from constants import MIN_CLUSTERS_THRESHOLD
 from static_analyzer.cfg import CallGraph, DEFAULT_REFERENCE_KINDS
+from static_analyzer.config import CALLABLE_TYPES, CLASS_TYPES
 from static_analyzer.clustering.engine import cluster_graph
-from static_analyzer.clustering.models import ClusterResult
+from static_analyzer.clustering.grouping import (
+    GroupingService,
+    combine_cluster_results,
+    reindex_across_languages,
+    score_grouping,
+)
+from static_analyzer.clustering.models import (
+    METHOD_LEVEL_STRATEGY,
+    ClusterConnection,
+    ClusterConnectionEdge,
+    ClusterGroup,
+    ClusterResult,
+    ClusterScopeResult,
+)
+
+_ROOT_SCOPE_ID = "root"
+_EMPTY_PARTITIONS: Mapping[str, ClusterResult] = MappingProxyType({})
+_EMPTY_OWNERS: Mapping[int, str] = MappingProxyType({})
 
 
 class ClusteringService:
@@ -16,3 +41,190 @@ class ClusteringService:
 
     def cluster(self, graph: CallGraph) -> ClusterResult:
         return cluster_graph(graph.to_networkx(DEFAULT_REFERENCE_KINDS), delimiter=graph.delimiter)
+
+    def cluster_scope(
+        self,
+        graphs: Mapping[str, CallGraph],
+        *,
+        scope_id: str = _ROOT_SCOPE_ID,
+        partitions: Mapping[str, ClusterResult] = _EMPTY_PARTITIONS,
+        previous_owner: Mapping[int, str] = _EMPTY_OWNERS,
+        method_level_fallback: bool = False,
+    ) -> ClusterScopeResult:
+        """Cluster and group one exact graph scope, retaining sibling communication."""
+        scope_partitions: dict[str, ClusterResult] = {}
+        for language, graph in graphs.items():
+            scope_partitions[language] = partitions[language] if language in partitions else self.cluster(graph)
+        if method_level_fallback:
+            scope_partitions = {
+                language: self._expand_to_method_level(graphs[language], partition)
+                for language, partition in scope_partitions.items()
+            }
+        reindex_across_languages(scope_partitions)
+
+        nx_graphs = {language: graph.to_networkx(DEFAULT_REFERENCE_KINDS) for language, graph in graphs.items()}
+        grouping_service = GroupingService()
+        if previous_owner:
+            grouping = grouping_service.anchored_group(scope_partitions, nx_graphs, dict(previous_owner))
+            raw_groups = grouping.groups
+            owners = grouping.owners
+            combined = combine_cluster_results(scope_partitions)
+            combined_cfg = nx.compose_all(list(nx_graphs.values())) if nx_graphs else nx.DiGraph()
+            modularity = score_grouping(combined, combined_cfg, raw_groups)
+            regrouped = grouping.regrouped
+        else:
+            raw_groups, modularity = grouping_service.group(scope_partitions, nx_graphs)
+            owners = [""] * len(raw_groups)
+            regrouped = False
+
+        group_ids = self._allocate_group_ids(scope_id, owners)
+        groups = [
+            ClusterGroup(
+                group_id=group_id,
+                cluster_ids=sorted(cluster_ids),
+                previous_component_id=owner,
+            )
+            for group_id, cluster_ids, owner in zip(group_ids, raw_groups, owners, strict=True)
+        ]
+        self._assign_members(graphs, scope_partitions, groups)
+        connections = self._build_connections(graphs, groups)
+        return ClusterScopeResult(
+            scope_id=scope_id,
+            partitions=scope_partitions,
+            groups=groups,
+            connections=connections,
+            modularity=modularity,
+            regrouped=regrouped,
+        )
+
+    @staticmethod
+    def _allocate_group_ids(scope_id: str, owners: list[str]) -> list[str]:
+        allocated = set(owners) - {""}
+        result: list[str] = []
+        next_index = 1
+        for owner in owners:
+            if owner:
+                result.append(owner)
+                continue
+            while True:
+                candidate = str(next_index) if scope_id == _ROOT_SCOPE_ID else f"{scope_id}.{next_index}"
+                next_index += 1
+                if candidate not in allocated:
+                    allocated.add(candidate)
+                    result.append(candidate)
+                    break
+        return result
+
+    @staticmethod
+    def _expand_to_method_level(graph: CallGraph, partition: ClusterResult) -> ClusterResult:
+        if len(partition.clusters) >= MIN_CLUSTERS_THRESHOLD:
+            return partition
+
+        clusters: dict[int, set[str]] = {}
+        cluster_to_files: dict[int, set[str]] = {}
+        file_to_clusters: dict[str, set[int]] = defaultdict(set)
+        included: set[str] = set()
+
+        for qualified_name, node in sorted(graph.nodes.items()):
+            if node.type not in CALLABLE_TYPES:
+                continue
+            cluster_id = len(clusters)
+            clusters[cluster_id] = {qualified_name}
+            cluster_to_files[cluster_id] = {node.file_path}
+            file_to_clusters[node.file_path].add(cluster_id)
+            included.add(qualified_name)
+
+        if len(clusters) < MIN_CLUSTERS_THRESHOLD:
+            for qualified_name, node in sorted(graph.nodes.items()):
+                if node.type not in CLASS_TYPES or qualified_name in included:
+                    continue
+                cluster_id = len(clusters)
+                clusters[cluster_id] = {qualified_name}
+                cluster_to_files[cluster_id] = {node.file_path}
+                file_to_clusters[node.file_path].add(cluster_id)
+
+        return ClusterResult(
+            clusters=clusters,
+            cluster_to_files=cluster_to_files,
+            file_to_clusters=dict(file_to_clusters),
+            strategy=METHOD_LEVEL_STRATEGY,
+        )
+
+    def _assign_members(
+        self,
+        graphs: Mapping[str, CallGraph],
+        partitions: dict[str, ClusterResult],
+        groups: list[ClusterGroup],
+    ) -> None:
+        if not groups:
+            return
+        group_by_cluster = {cluster_id: group for group in groups for cluster_id in group.cluster_ids}
+        for language, graph in graphs.items():
+            partition = partitions.get(language, ClusterResult())
+            cluster_by_member = {
+                qualified_name: cluster_id
+                for cluster_id, members in partition.clusters.items()
+                for qualified_name in members
+            }
+            undirected = graph.to_networkx(reference_kinds=()).to_undirected()
+            for qualified_name, node in graph.nodes.items():
+                if node.type not in CALLABLE_TYPES | CLASS_TYPES:
+                    continue
+                cluster_id = cluster_by_member.get(qualified_name)
+                if cluster_id not in group_by_cluster:
+                    cluster_id = self._cluster_for_file(node.file_path, partition)
+                if cluster_id not in group_by_cluster:
+                    cluster_id = self._nearest_cluster(qualified_name, partition, undirected)
+                group = group_by_cluster[cluster_id] if cluster_id is not None else groups[0]
+                group.members.setdefault(language, set()).add(qualified_name)
+
+    @staticmethod
+    def _cluster_for_file(file_path: str, partition: ClusterResult) -> int | None:
+        return next(iter(partition.get_clusters_for_file(file_path)), None)
+
+    @staticmethod
+    def _nearest_cluster(qualified_name: str, partition: ClusterResult, graph: nx.Graph) -> int | None:
+        if qualified_name not in graph:
+            return None
+        distances = nx.single_source_shortest_path_length(graph, qualified_name)
+        nearest: int | None = None
+        nearest_distance = float("inf")
+        for cluster_id, members in partition.clusters.items():
+            for member in members:
+                distance = distances.get(member)
+                if distance is not None and distance < nearest_distance:
+                    nearest = cluster_id
+                    nearest_distance = distance
+        return nearest
+
+    @staticmethod
+    def _build_connections(graphs: Mapping[str, CallGraph], groups: list[ClusterGroup]) -> list[ClusterConnection]:
+        group_by_member = {
+            (language, qualified_name): group.group_id
+            for group in groups
+            for language, members in group.members.items()
+            for qualified_name in members
+        }
+        by_pair: dict[tuple[str, str], ClusterConnection] = {}
+        for language, graph in graphs.items():
+            for edge in graph.edges:
+                source = edge.get_source()
+                target = edge.get_destination()
+                source_group = group_by_member.get((language, source), "")
+                target_group = group_by_member.get((language, target), "")
+                if not source_group or not target_group or source_group == target_group:
+                    continue
+                pair = (source_group, target_group)
+                connection = by_pair.setdefault(
+                    pair,
+                    ClusterConnection(source_group_id=source_group, target_group_id=target_group),
+                )
+                connection.edges.append(
+                    ClusterConnectionEdge(
+                        language=language,
+                        source=source,
+                        target=target,
+                        call_sites=edge.call_sites,
+                    )
+                )
+        return [by_pair[pair] for pair in sorted(by_pair)]

--- a/static_analyzer/clustering/service.py
+++ b/static_analyzer/clustering/service.py
@@ -8,7 +8,7 @@ from types import MappingProxyType
 
 import networkx as nx
 
-from clustering_ids import ComponentId, GraphClusterId
+from clustering_ids import ClusterId, ComponentId, GroupId, ScopeId
 from constants import MIN_CLUSTERS_THRESHOLD
 from static_analyzer.cfg import CallGraph, DEFAULT_REFERENCE_KINDS
 from static_analyzer.config import CALLABLE_TYPES, CLASS_TYPES
@@ -28,9 +28,20 @@ from static_analyzer.clustering.models import (
     GroupConnection,
 )
 
-_ROOT_SCOPE_ID = "root"
+_ROOT_SCOPE_ID: ScopeId = "root"
 _EMPTY_LEAF_CLUSTERS: Mapping[str, ClusterResult] = MappingProxyType({})
-_EMPTY_OWNERS: Mapping[GraphClusterId, ComponentId] = MappingProxyType({})
+_EMPTY_OWNERS: Mapping[ClusterId, ComponentId] = MappingProxyType({})
+
+
+class LeafClustersUnavailableError(RuntimeError):
+    """Raised when a language has symbols but no leaf clusters to own them."""
+
+    def __init__(self, language: str):
+        super().__init__(
+            f"Language {language!r} has callable or class symbols but no leaf clusters; "
+            "enable method-level fallback or provide a usable cluster result."
+        )
+        self.language = language
 
 
 class ClusteringService:
@@ -47,9 +58,9 @@ class ClusteringService:
         self,
         graphs: Mapping[str, CallGraph],
         *,
-        scope_id: str = _ROOT_SCOPE_ID,
+        scope_id: ScopeId = _ROOT_SCOPE_ID,
         leaf_clusters_by_language: Mapping[str, ClusterResult] = _EMPTY_LEAF_CLUSTERS,
-        previous_owner: Mapping[GraphClusterId, ComponentId] = _EMPTY_OWNERS,
+        previous_owner: Mapping[ClusterId, ComponentId] = _EMPTY_OWNERS,
         method_level_fallback: bool = False,
     ) -> ClusterScopeResult:
         """Cluster and group one exact graph scope, retaining sibling communication."""
@@ -63,6 +74,11 @@ class ClusteringService:
                 language: self._expand_to_method_level(graphs[language], cluster_result)
                 for language, cluster_result in scope_leaf_clusters.items()
             }
+        for language, graph in graphs.items():
+            if not scope_leaf_clusters[language].clusters and any(
+                node.type in CALLABLE_TYPES | CLASS_TYPES for node in graph.nodes.values()
+            ):
+                raise LeafClustersUnavailableError(language)
         reindex_across_languages(scope_leaf_clusters)
 
         nx_graphs = {language: graph.to_networkx(DEFAULT_REFERENCE_KINDS) for language, graph in graphs.items()}
@@ -101,10 +117,15 @@ class ClusteringService:
         )
 
     @staticmethod
-    def _allocate_group_ids(scope_id: str, owners: list[ComponentId]) -> list[ComponentId]:
+    def _allocate_group_ids(scope_id: ScopeId, owners: list[ComponentId]) -> list[GroupId]:
         allocated = set(owners) - {""}
-        result: list[ComponentId] = []
-        next_index = 1
+        used_indices = {
+            int(group_id.rsplit(".", maxsplit=1)[-1])
+            for group_id in allocated
+            if group_id.rsplit(".", maxsplit=1)[-1].isdigit()
+        }
+        result: list[GroupId] = []
+        next_index = max(used_indices, default=0) + 1
         for owner in owners:
             if owner:
                 result.append(owner)
@@ -123,9 +144,9 @@ class ClusteringService:
         if len(cluster_result.clusters) >= MIN_CLUSTERS_THRESHOLD:
             return cluster_result
 
-        clusters: dict[GraphClusterId, set[str]] = {}
-        cluster_to_files: dict[GraphClusterId, set[str]] = {}
-        file_to_clusters: dict[str, set[GraphClusterId]] = defaultdict(set)
+        clusters: dict[ClusterId, set[str]] = {}
+        cluster_to_files: dict[ClusterId, set[str]] = {}
+        file_to_clusters: dict[str, set[ClusterId]] = defaultdict(set)
         included: set[str] = set()
 
         for qualified_name, node in sorted(graph.nodes.items()):
@@ -182,15 +203,15 @@ class ClusteringService:
                 group.symbol_members_by_language.setdefault(language, set()).add(qualified_name)
 
     @staticmethod
-    def _cluster_for_file(file_path: str, cluster_result: ClusterResult) -> GraphClusterId | None:
+    def _cluster_for_file(file_path: str, cluster_result: ClusterResult) -> ClusterId | None:
         return next(iter(cluster_result.get_clusters_for_file(file_path)), None)
 
     @staticmethod
-    def _nearest_cluster(qualified_name: str, cluster_result: ClusterResult, graph: nx.Graph) -> GraphClusterId | None:
+    def _nearest_cluster(qualified_name: str, cluster_result: ClusterResult, graph: nx.Graph) -> ClusterId | None:
         if qualified_name not in graph:
             return None
         distances = nx.single_source_shortest_path_length(graph, qualified_name)
-        nearest: GraphClusterId | None = None
+        nearest: ClusterId | None = None
         nearest_distance = float("inf")
         for cluster_id, members in cluster_result.clusters.items():
             for member in members:
@@ -208,7 +229,7 @@ class ClusteringService:
             for language, qualified_names in group.symbol_members_by_language.items()
             for qualified_name in qualified_names
         }
-        by_pair: dict[tuple[ComponentId, ComponentId], GroupConnection] = {}
+        by_pair: dict[tuple[GroupId, GroupId], GroupConnection] = {}
         for language, graph in graphs.items():
             for edge in graph.edges:
                 source = edge.get_source()

--- a/tests/static_analyzer/test_clustering_scope.py
+++ b/tests/static_analyzer/test_clustering_scope.py
@@ -1,0 +1,121 @@
+import unittest
+
+from static_analyzer.cfg import CallGraph
+from static_analyzer.config import NodeType
+from static_analyzer.clustering import ClusterResult, ClusteringService, METHOD_LEVEL_STRATEGY
+from static_analyzer.clustering.grouping import GroupingService
+from static_analyzer.node import Node
+
+
+def graph_for(language: str, names: list[str], edges: list[tuple[str, str]] = ()) -> CallGraph:
+    graph = CallGraph(language=language)
+    for index, name in enumerate(names):
+        graph.add_node(Node(name, NodeType.FUNCTION, f"/repo/{language}/{name}.py", index + 1, index + 2))
+    for source, target in edges:
+        graph.add_edge(source, target, call_sites=[{"file": f"{language}.py", "line": 10}])
+    return graph
+
+
+def partition_for(graph: CallGraph, clusters: dict[int, set[str]]) -> ClusterResult:
+    cluster_to_files = {
+        cluster_id: {graph.nodes[name].file_path for name in members} for cluster_id, members in clusters.items()
+    }
+    file_to_clusters: dict[str, set[int]] = {}
+    for cluster_id, files in cluster_to_files.items():
+        for file_path in files:
+            file_to_clusters.setdefault(file_path, set()).add(cluster_id)
+    return ClusterResult(
+        clusters=clusters,
+        cluster_to_files=cluster_to_files,
+        file_to_clusters=file_to_clusters,
+        strategy="test",
+    )
+
+
+class TestClusteringScope(unittest.TestCase):
+    def test_grouping_matches_the_existing_supercluster_result(self):
+        graph = graph_for("python", ["a", "b", "c"], [("a", "b"), ("b", "c")])
+        partition = partition_for(graph, {1: {"a"}, 2: {"b"}, 3: {"c"}})
+
+        expected, expected_modularity = GroupingService().group(
+            {"python": partition}, {"python": graph.to_networkx(reference_kinds=())}
+        )
+        result = ClusteringService().cluster_scope({"python": graph}, partitions={"python": partition})
+
+        self.assertEqual(
+            sorted(sorted(group.cluster_ids) for group in result.groups),
+            sorted(sorted(group) for group in expected),
+        )
+        self.assertEqual(result.modularity, expected_modularity)
+
+    def test_members_are_a_complete_disjoint_cover_including_orphans(self):
+        graph = graph_for("python", ["a", "b", "orphan"], [("a", "orphan"), ("orphan", "b")])
+        partition = partition_for(graph, {1: {"a"}, 2: {"b"}})
+
+        result = ClusteringService().cluster_scope({"python": graph}, partitions={"python": partition})
+
+        assigned = [name for group in result.groups for name in group.members.get("python", set())]
+        self.assertEqual(set(assigned), set(graph.nodes))
+        self.assertEqual(len(assigned), len(set(assigned)))
+
+    def test_connections_retain_direction_and_concrete_call_evidence(self):
+        graph = graph_for("python", ["caller", "callee"], [("caller", "callee")])
+        partition = partition_for(graph, {1: {"caller"}, 2: {"callee"}})
+
+        result = ClusteringService().cluster_scope({"python": graph}, partitions={"python": partition})
+
+        self.assertEqual(len(result.connections), 1)
+        connection = result.connections[0]
+        self.assertNotEqual(connection.source_group_id, connection.target_group_id)
+        self.assertEqual(len(connection.edges), 1)
+        self.assertEqual(connection.edges[0].source, "caller")
+        self.assertEqual(connection.edges[0].target, "callee")
+        self.assertEqual(connection.edges[0].call_sites, [{"file": "python.py", "line": 10}])
+
+    def test_language_partitions_receive_disjoint_cluster_ids(self):
+        python = graph_for("python", ["py.a"])
+        typescript = graph_for("typescript", ["ts.a"])
+
+        result = ClusteringService().cluster_scope(
+            {"python": python, "typescript": typescript},
+            partitions={
+                "python": partition_for(python, {1: {"py.a"}}),
+                "typescript": partition_for(typescript, {1: {"ts.a"}}),
+            },
+        )
+
+        python_ids = set(result.partitions["python"].clusters)
+        typescript_ids = set(result.partitions["typescript"].clusters)
+        self.assertTrue(python_ids.isdisjoint(typescript_ids))
+
+    def test_previous_owners_become_stable_group_ids(self):
+        graph = graph_for("python", ["a", "b", "c"])
+        partition = partition_for(graph, {1: {"a"}, 2: {"b"}, 3: {"c"}})
+
+        result = ClusteringService().cluster_scope(
+            {"python": graph},
+            partitions={"python": partition},
+            previous_owner={1: "2", 2: "4", 3: "7"},
+        )
+
+        self.assertEqual([group.group_id for group in result.groups], ["2", "4", "7"])
+        self.assertFalse(result.regrouped)
+
+    def test_method_level_fallback_is_available_for_child_scopes(self):
+        graph = graph_for("python", ["a", "b", "c", "d", "e"])
+        partition = partition_for(graph, {1: set(graph.nodes)})
+
+        result = ClusteringService().cluster_scope(
+            {"python": graph},
+            partitions={"python": partition},
+            method_level_fallback=True,
+        )
+
+        expanded = result.partitions["python"]
+        self.assertEqual(expanded.strategy, METHOD_LEVEL_STRATEGY)
+        self.assertEqual(len(expanded.clusters), 5)
+        self.assertTrue(all(len(members) == 1 for members in expanded.clusters.values()))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/static_analyzer/test_clustering_scope.py
+++ b/tests/static_analyzer/test_clustering_scope.py
@@ -16,7 +16,7 @@ def graph_for(language: str, names: list[str], edges: list[tuple[str, str]] = ()
     return graph
 
 
-def partition_for(graph: CallGraph, clusters: dict[int, set[str]]) -> ClusterResult:
+def cluster_result_for(graph: CallGraph, clusters: dict[int, set[str]]) -> ClusterResult:
     cluster_to_files = {
         cluster_id: {graph.nodes[name].file_path for name in members} for cluster_id, members in clusters.items()
     }
@@ -35,12 +35,14 @@ def partition_for(graph: CallGraph, clusters: dict[int, set[str]]) -> ClusterRes
 class TestClusteringScope(unittest.TestCase):
     def test_grouping_matches_the_existing_supercluster_result(self):
         graph = graph_for("python", ["a", "b", "c"], [("a", "b"), ("b", "c")])
-        partition = partition_for(graph, {1: {"a"}, 2: {"b"}, 3: {"c"}})
+        cluster_result = cluster_result_for(graph, {1: {"a"}, 2: {"b"}, 3: {"c"}})
 
         expected, expected_modularity = GroupingService().group(
-            {"python": partition}, {"python": graph.to_networkx(reference_kinds=())}
+            {"python": cluster_result}, {"python": graph.to_networkx(reference_kinds=())}
         )
-        result = ClusteringService().cluster_scope({"python": graph}, partitions={"python": partition})
+        result = ClusteringService().cluster_scope(
+            {"python": graph}, leaf_clusters_by_language={"python": cluster_result}
+        )
 
         self.assertEqual(
             sorted(sorted(group.cluster_ids) for group in result.groups),
@@ -48,53 +50,57 @@ class TestClusteringScope(unittest.TestCase):
         )
         self.assertEqual(result.modularity, expected_modularity)
 
-    def test_members_are_a_complete_disjoint_cover_including_orphans(self):
+    def test_symbol_members_are_a_complete_disjoint_cover_including_orphans(self):
         graph = graph_for("python", ["a", "b", "orphan"], [("a", "orphan"), ("orphan", "b")])
-        partition = partition_for(graph, {1: {"a"}, 2: {"b"}})
+        cluster_result = cluster_result_for(graph, {1: {"a"}, 2: {"b"}})
 
-        result = ClusteringService().cluster_scope({"python": graph}, partitions={"python": partition})
+        result = ClusteringService().cluster_scope(
+            {"python": graph}, leaf_clusters_by_language={"python": cluster_result}
+        )
 
-        assigned = [name for group in result.groups for name in group.members.get("python", set())]
+        assigned = [name for group in result.groups for name in group.symbol_members_by_language.get("python", set())]
         self.assertEqual(set(assigned), set(graph.nodes))
         self.assertEqual(len(assigned), len(set(assigned)))
 
     def test_connections_retain_direction_and_concrete_call_evidence(self):
         graph = graph_for("python", ["caller", "callee"], [("caller", "callee")])
-        partition = partition_for(graph, {1: {"caller"}, 2: {"callee"}})
+        cluster_result = cluster_result_for(graph, {1: {"caller"}, 2: {"callee"}})
 
-        result = ClusteringService().cluster_scope({"python": graph}, partitions={"python": partition})
+        result = ClusteringService().cluster_scope(
+            {"python": graph}, leaf_clusters_by_language={"python": cluster_result}
+        )
 
         self.assertEqual(len(result.connections), 1)
         connection = result.connections[0]
         self.assertNotEqual(connection.source_group_id, connection.target_group_id)
         self.assertEqual(len(connection.edges), 1)
-        self.assertEqual(connection.edges[0].source, "caller")
-        self.assertEqual(connection.edges[0].target, "callee")
+        self.assertEqual(connection.edges[0].source_qualified_name, "caller")
+        self.assertEqual(connection.edges[0].target_qualified_name, "callee")
         self.assertEqual(connection.edges[0].call_sites, [{"file": "python.py", "line": 10}])
 
-    def test_language_partitions_receive_disjoint_cluster_ids(self):
+    def test_language_leaf_clusters_receive_disjoint_cluster_ids(self):
         python = graph_for("python", ["py.a"])
         typescript = graph_for("typescript", ["ts.a"])
 
         result = ClusteringService().cluster_scope(
             {"python": python, "typescript": typescript},
-            partitions={
-                "python": partition_for(python, {1: {"py.a"}}),
-                "typescript": partition_for(typescript, {1: {"ts.a"}}),
+            leaf_clusters_by_language={
+                "python": cluster_result_for(python, {1: {"py.a"}}),
+                "typescript": cluster_result_for(typescript, {1: {"ts.a"}}),
             },
         )
 
-        python_ids = set(result.partitions["python"].clusters)
-        typescript_ids = set(result.partitions["typescript"].clusters)
+        python_ids = set(result.leaf_clusters_by_language["python"].clusters)
+        typescript_ids = set(result.leaf_clusters_by_language["typescript"].clusters)
         self.assertTrue(python_ids.isdisjoint(typescript_ids))
 
     def test_previous_owners_become_stable_group_ids(self):
         graph = graph_for("python", ["a", "b", "c"])
-        partition = partition_for(graph, {1: {"a"}, 2: {"b"}, 3: {"c"}})
+        cluster_result = cluster_result_for(graph, {1: {"a"}, 2: {"b"}, 3: {"c"}})
 
         result = ClusteringService().cluster_scope(
             {"python": graph},
-            partitions={"python": partition},
+            leaf_clusters_by_language={"python": cluster_result},
             previous_owner={1: "2", 2: "4", 3: "7"},
         )
 
@@ -103,15 +109,15 @@ class TestClusteringScope(unittest.TestCase):
 
     def test_method_level_fallback_is_available_for_child_scopes(self):
         graph = graph_for("python", ["a", "b", "c", "d", "e"])
-        partition = partition_for(graph, {1: set(graph.nodes)})
+        cluster_result = cluster_result_for(graph, {1: set(graph.nodes)})
 
         result = ClusteringService().cluster_scope(
             {"python": graph},
-            partitions={"python": partition},
+            leaf_clusters_by_language={"python": cluster_result},
             method_level_fallback=True,
         )
 
-        expanded = result.partitions["python"]
+        expanded = result.leaf_clusters_by_language["python"]
         self.assertEqual(expanded.strategy, METHOD_LEVEL_STRATEGY)
         self.assertEqual(len(expanded.clusters), 5)
         self.assertTrue(all(len(members) == 1 for members in expanded.clusters.values()))

--- a/tests/static_analyzer/test_clustering_scope.py
+++ b/tests/static_analyzer/test_clustering_scope.py
@@ -2,7 +2,12 @@ import unittest
 
 from static_analyzer.cfg import CallGraph
 from static_analyzer.config import NodeType
-from static_analyzer.clustering import ClusterResult, ClusteringService, METHOD_LEVEL_STRATEGY
+from static_analyzer.clustering import (
+    METHOD_LEVEL_STRATEGY,
+    ClusterResult,
+    ClusteringService,
+    LeafClustersUnavailableError,
+)
 from static_analyzer.clustering.grouping import GroupingService
 from static_analyzer.node import Node
 
@@ -106,6 +111,30 @@ class TestClusteringScope(unittest.TestCase):
 
         self.assertEqual([group.group_id for group in result.groups], ["2", "4", "7"])
         self.assertFalse(result.regrouped)
+
+    def test_new_group_ids_follow_the_highest_surviving_sibling(self):
+        group_ids = ClusteringService._allocate_group_ids("root", ["2", ""])
+
+        self.assertEqual(group_ids, ["2", "3"])
+
+    def test_default_clustering_raises_when_nonempty_scope_has_no_leaf_clusters(self):
+        graph = graph_for("python", ["a", "b"])
+
+        with self.assertRaisesRegex(LeafClustersUnavailableError, "python"):
+            ClusteringService().cluster_scope({"python": graph})
+
+    def test_empty_leaf_clusters_for_a_nonempty_language_raise(self):
+        python = graph_for("python", ["py.a"])
+        typescript = graph_for("typescript", ["ts.a"])
+
+        with self.assertRaisesRegex(LeafClustersUnavailableError, "typescript"):
+            ClusteringService().cluster_scope(
+                {"python": python, "typescript": typescript},
+                leaf_clusters_by_language={
+                    "python": cluster_result_for(python, {1: {"py.a"}}),
+                    "typescript": ClusterResult(),
+                },
+            )
 
     def test_method_level_fallback_is_available_for_child_scopes(self):
         graph = graph_for("python", ["a", "b", "c", "d", "e"])

--- a/tests/test_pyproject_packages.py
+++ b/tests/test_pyproject_packages.py
@@ -28,7 +28,18 @@ def _declared_packages() -> set[str]:
     return set(data["tool"]["setuptools"]["packages"])
 
 
+def _declared_modules() -> set[str]:
+    """Return the modules listed in pyproject.toml [tool.setuptools] py-modules."""
+    pyproject_path = REPO_ROOT / "pyproject.toml"
+    with open(pyproject_path, "rb") as f:
+        data = tomllib.load(f)
+    return set(data["tool"]["setuptools"]["py-modules"])
+
+
 class TestPyprojectPackages(unittest.TestCase):
+    def test_shared_clustering_ids_module_is_packaged(self):
+        self.assertIn("clustering_ids", _declared_modules())
+
     def test_all_packages_declared_in_pyproject(self):
         on_disk = _find_packages_on_disk()
         declared = _declared_packages()


### PR DESCRIPTION
## Goal

Introduce the structural result that the rest of this stack can consume: cluster one exact graph scope once, and retain its per-language leaf clusters, architectural groups, symbol ownership, and cross-group communication together.

This is the contract-building PR. It moves clustering from “a set of helpers whose consumers reconstruct context” toward “one service call that returns the complete structural view of a scope.”

## Behavioral impact (upfront)

This PR adds a new scope-level result and service API. It does **not** yet make the existing full or incremental analysis paths consume that result; those integrations remain in the follow-up PRs in the stack.

| Area | Impact |
|---|---|
| Existing full/incremental analysis | **No intended runtime change.** Existing agents still use their current grouping and recursion paths in this PR. |
| Grouping algorithm | **No new algorithm.** `cluster_scope()` delegates to the `GroupingService` introduced by #494 for fresh or ownership-anchored grouping. |
| Root cluster construction | **No intended result change.** `build_all_cluster_results` and cache synchronization move from `clustering/grouping.py` to `clustering/orchestration.py`; the existing offset and cache-adoption behavior is retained. |
| Scope result | **Intentional new API.** `ClusteringService.cluster_scope(...)` returns one `ClusterScopeResult` containing leaf clusters, groups, complete symbol membership, directed sibling connections, modularity, and regrouping state. |
| Empty leaf clustering | **Fail-fast, matching the previous surface behavior.** A populated language that produces no leaf clusters raises `LeafClustersUnavailableError` instead of returning a successful empty scope. Callers that explicitly request method-level fallback receive synthetic callable/class clusters first. |
| Group IDs | **Preserves established incremental allocation behavior.** Anchored groups retain their previous component IDs; new groups append after the highest surviving sibling index instead of filling retired numeric gaps. |
| Identifier vocabulary | **Intentional type-name cleanup.** Shared `ClusterId`, `ScopeId`, `GroupId`, and `ComponentId` aliases replace overlapping graph/CodeBoarding ID names. |
| Call-site evidence | **Intentional contract tightening.** Connection edges retain normalized `file`, `line`, and optional `column` locations through the shared `CallSiteLocation` type; malformed call-site values fail validation rather than flowing through as arbitrary mappings. |

## Result contract and API mapping

| Before | After | Contract / reason |
|---|---|---|
| `ClusteringService.cluster(graph)` returns one language's `ClusterResult` | Existing method remains; new `cluster_scope(graphs, ...)` returns `ClusterScopeResult` | Keeps leaf clustering available while adding one complete scope-level operation. |
| Consumers separately hold per-language cluster results, grouping output, and CFG evidence | `ClusterScopeResult.leaf_clusters_by_language`, `.groups`, `.connections`, `.modularity`, and `.regrouped` | One result owns the complete structural view needed by hierarchy builders and analysis consumers. |
| Grouping output is `list[set[int]]` plus separately reconstructed members | `ClusterGroup(group_id, cluster_ids, symbol_members_by_language, previous_component_id, children)` | Makes group identity, language → qualified-symbol membership, prior ownership, and future child scope explicit. |
| No typed sibling-communication model | `GroupConnection` contains concrete `ClusterConnectionEdge` calls between `source_group_id` and `target_group_id` | Preserves direction and exact qualified source/target names with call-site evidence. |
| Agent-local `GraphClusterId` / `CodeBoardingClusterId` aliases | Shared top-level `ClusterId`, `ScopeId`, `GroupId`, and `ComponentId` | Gives the static-analysis and agent layers one vocabulary without importing the agent layer from the analyzer. The module is explicitly included in built wheels. |
| Root clustering orchestration lives in `clustering/grouping.py` | `clustering/orchestration.py` | Separates root analysis/cache synchronization from the grouping algorithm while preserving the `cluster_helpers` compatibility export. |
| Generic call-site dictionaries | `CallSiteLocation` (`line`, optional `file`, optional `column`) | Documents and validates the source-location evidence retained on inter-group calls. |

`cluster_scope()` accepts the language graphs for one exact scope and optional precomputed leaf clusters. It gives languages disjoint cluster-ID ranges, applies fresh or previous-ownership-anchored grouping, assigns deterministic group IDs, assigns every callable/class symbol to one group (including symbols omitted by the leaf clustering), and records directed calls crossing sibling groups.

## Compatibility boundary

`ClusteringService.cluster()` and the existing agent flows remain available. General cluster-building/reindexing imports exposed through `static_analyzer.cluster_helpers` continue to resolve after root orchestration moves.

This PR computes **one scope only**. It does not recursively build the component hierarchy and does not yet replace agent-side grouping. #497 owns recursive hierarchy construction; #498 and #499 switch fresh and incremental analysis to consume that hierarchy; #500 removes the superseded paths.

## Validation

- `uv run pytest --cov=. --cov-report=term --cov-fail-under=80` — **2,149 passed, 28 skipped**, **83.05% coverage**.
- Focused scope suite — **9 passed**.
- `uv run mypy .` — passed across 334 source files.
- `uv run black --check ...` — passed for all changed Python files.
- Wheel build inspection — `clustering_ids.py` is present in the built distribution.
- `git diff --check` — passed.

## Stack roadmap

| Position | PR | Responsibility |
|---|---|---|
| Foundation | [#494](https://github.com/CodeBoarding/CodeBoarding/pull/494) | Move the existing grouping algorithms behind the stateless `GroupingService` API without intentionally changing grouping behavior. |
| **This PR** | **#495** | Define and compute a complete structural result for one graph scope, including groups, members, and sibling communication. |
| Next | [#497](https://github.com/CodeBoarding/CodeBoarding/pull/497) | Recursively build those scope results into a deterministic hierarchy using exact induced subgraphs and centralized expansion rules. |
| Follow-up | [#498](https://github.com/CodeBoarding/CodeBoarding/pull/498) | Make fresh/full analysis consume the precomputed hierarchy instead of regrouping inside agents. |
| Follow-up | [#499](https://github.com/CodeBoarding/CodeBoarding/pull/499) | Make incremental analysis build and consume an ownership-anchored hierarchy while preserving stable member ownership. |
| Final cleanup | [#500](https://github.com/CodeBoarding/CodeBoarding/pull/500) | Remove the legacy agent-side grouping and recursive incremental orchestration once both analysis paths use the hierarchy. |

Amp-Thread-ID: https://ampcode.com/threads/T-01a01478-33f2-70cf-8a11-9475c7d3a4cd
Co-authored-by: Amp <amp@ampcode.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>