### PR TITLE
feat(clustering): build recursive scope hierarchy

### DIFF
--- a/agents/planner_agent.py
+++ b/agents/planner_agent.py
@@ -19,6 +19,14 @@ import networkx as nx
 
 from agents.agent_responses import AnalysisInsights, Component
 from static_analyzer.clustering import METHOD_LEVEL_STRATEGY, ClusterResult
+from static_analyzer.clustering.expansion import (
+    EXPAND_MODULARITY_THRESHOLD,
+    MAX_LEAF_FILES,
+    MAX_LEAF_METHODS,
+    MIN_METHODS_TO_EXPAND,
+    scope_is_separable,
+    scope_load,
+)
 from static_analyzer.clustering.grouping import GroupingService
 
 logger = logging.getLogger(__name__)
@@ -26,27 +34,11 @@ logger = logging.getLogger(__name__)
 # Default thresholds
 DEFAULT_MIN_FILES = 1  # Need at least 1 file to have content
 
-# Below this a component holds too little to be worth sub-dividing at all.
-MIN_METHODS_TO_EXPAND = 30
-
-# The size at which a component stops being readable as one box and must be split
-# whatever its call structure says. Measured across the eval corpus: at 12 files /
-# 120 methods every repo's tree comes out with no oversized leaf, while small repos
-# are untouched (they stop at the modularity gate long before this).
-MAX_LEAF_FILES = 12
-MAX_LEAF_METHODS = 120
-
-# Modularity a *small* component's split must reach to be worth making. The bar
-# ramps linearly to zero as the component approaches the leaf ceiling: a large
-# component gets split on weaker structural evidence, because leaving it whole
-# costs the reader more than an imperfect boundary does.
-EXPAND_MODULARITY_THRESHOLD = 0.15
-
 
 def leaf_load(component: Component) -> float:
     """How full a component is against the leaf ceiling; >= 1.0 means too big to leave whole."""
     methods = sum(len(group.methods) for group in component.file_methods)
-    return max(methods / MAX_LEAF_METHODS, len(component.file_methods) / MAX_LEAF_FILES)
+    return scope_load(methods, len(component.file_methods))
 
 
 def component_is_separable(
@@ -74,7 +66,7 @@ def component_is_separable(
         return False
     _groups, modularity = GroupingService().group(cluster_results, cfg_graphs, subcomponents=True)
     required = EXPAND_MODULARITY_THRESHOLD * max(0.0, 1.0 - load)
-    separable = modularity >= required
+    separable = scope_is_separable(cluster_results, modularity, load, min_methods)
     logger.debug(
         f"[Planner] subgraph modularity={modularity:.4f} (load={load:.2f}, required {required:.4f}) "
         f"-> separable={separable}"

--- a/agents/planner_agent.py
+++ b/agents/planner_agent.py
@@ -19,15 +19,9 @@ import networkx as nx
 
 from agents.agent_responses import AnalysisInsights, Component
 from static_analyzer.clustering import METHOD_LEVEL_STRATEGY, ClusterResult
-from static_analyzer.clustering.expansion import (
-    EXPAND_MODULARITY_THRESHOLD,
-    MAX_LEAF_FILES,
-    MAX_LEAF_METHODS,
-    MIN_METHODS_TO_EXPAND,
-    scope_is_separable,
-    scope_load,
-)
+from static_analyzer.clustering.expansion import scope_is_separable, scope_load
 from static_analyzer.clustering.grouping import GroupingService
+from static_analyzer.config import ClusteringConfig
 
 logger = logging.getLogger(__name__)
 
@@ -45,7 +39,7 @@ def component_is_separable(
     cluster_results: dict[str, ClusterResult],
     cfg_graphs: dict[str, nx.DiGraph],
     load: float,
-    min_methods: int = MIN_METHODS_TO_EXPAND,
+    min_methods: int = ClusteringConfig.MIN_METHODS_TO_EXPAND,
 ) -> bool:
     """Whether a component's own call structure justifies splitting it into sub-components.
 
@@ -65,8 +59,8 @@ def component_is_separable(
         logger.debug("[Planner] subgraph has no natural cluster structure; keeping as leaf")
         return False
     _groups, modularity = GroupingService().group(cluster_results, cfg_graphs, subcomponents=True)
-    required = EXPAND_MODULARITY_THRESHOLD * max(0.0, 1.0 - load)
-    separable = scope_is_separable(cluster_results, modularity, load, min_methods)
+    required = ClusteringConfig.EXPAND_MODULARITY_THRESHOLD * max(0.0, 1.0 - load)
+    separable = scope_is_separable(cluster_results, modularity, load, total_methods, min_methods)
     logger.debug(
         f"[Planner] subgraph modularity={modularity:.4f} (load={load:.2f}, required {required:.4f}) "
         f"-> separable={separable}"

--- a/static_analyzer/clustering/__init__.py
+++ b/static_analyzer/clustering/__init__.py
@@ -15,6 +15,7 @@ from static_analyzer.clustering.models import (
     ClusterConnectionEdge,
     ClusterGroup,
     ClusterResult,
+    ClusterScopeInput,
     ClusterScopeResult,
     GroupConnection,
 )
@@ -29,6 +30,7 @@ __all__ = [
     "ClusterConnectionEdge",
     "ClusterGroup",
     "ClusterResult",
+    "ClusterScopeInput",
     "ClusterScopeResult",
     "ClusteringService",
     "ClusterId",

--- a/static_analyzer/clustering/expansion.py
+++ b/static_analyzer/clustering/expansion.py
@@ -1,0 +1,35 @@
+"""Deterministic rules for deciding whether a clustered scope should split."""
+
+from collections.abc import Mapping
+
+from static_analyzer.clustering.models import METHOD_LEVEL_STRATEGY, ClusterResult
+
+MIN_METHODS_TO_EXPAND = 30
+MAX_LEAF_FILES = 12
+MAX_LEAF_METHODS = 120
+EXPAND_MODULARITY_THRESHOLD = 0.15
+
+
+def scope_load(method_count: int, file_count: int) -> float:
+    """How full a scope is against the leaf ceiling."""
+    return max(method_count / MAX_LEAF_METHODS, file_count / MAX_LEAF_FILES)
+
+
+def scope_is_separable(
+    leaf_clusters_by_language: Mapping[str, ClusterResult],
+    modularity: float,
+    load: float,
+    min_methods: int = MIN_METHODS_TO_EXPAND,
+) -> bool:
+    """Whether a scope's natural clustering and modularity justify a split."""
+    total_methods = sum(
+        len(members)
+        for cluster_result in leaf_clusters_by_language.values()
+        for members in cluster_result.clusters.values()
+    )
+    if total_methods < min_methods:
+        return False
+    if all(cluster_result.strategy == METHOD_LEVEL_STRATEGY for cluster_result in leaf_clusters_by_language.values()):
+        return False
+    required = EXPAND_MODULARITY_THRESHOLD * max(0.0, 1.0 - load)
+    return modularity >= required

--- a/static_analyzer/clustering/expansion.py
+++ b/static_analyzer/clustering/expansion.py
@@ -2,34 +2,29 @@
 
 from collections.abc import Mapping
 
+from static_analyzer.config import ClusteringConfig
 from static_analyzer.clustering.models import METHOD_LEVEL_STRATEGY, ClusterResult
-
-MIN_METHODS_TO_EXPAND = 30
-MAX_LEAF_FILES = 12
-MAX_LEAF_METHODS = 120
-EXPAND_MODULARITY_THRESHOLD = 0.15
 
 
 def scope_load(method_count: int, file_count: int) -> float:
     """How full a scope is against the leaf ceiling."""
-    return max(method_count / MAX_LEAF_METHODS, file_count / MAX_LEAF_FILES)
+    return max(
+        method_count / ClusteringConfig.MAX_LEAF_METHODS,
+        file_count / ClusteringConfig.MAX_LEAF_FILES,
+    )
 
 
 def scope_is_separable(
     leaf_clusters_by_language: Mapping[str, ClusterResult],
     modularity: float,
     load: float,
-    min_methods: int = MIN_METHODS_TO_EXPAND,
+    method_count: int,
+    min_methods: int = ClusteringConfig.MIN_METHODS_TO_EXPAND,
 ) -> bool:
     """Whether a scope's natural clustering and modularity justify a split."""
-    total_methods = sum(
-        len(members)
-        for cluster_result in leaf_clusters_by_language.values()
-        for members in cluster_result.clusters.values()
-    )
-    if total_methods < min_methods:
+    if method_count < min_methods:
         return False
     if all(cluster_result.strategy == METHOD_LEVEL_STRATEGY for cluster_result in leaf_clusters_by_language.values()):
         return False
-    required = EXPAND_MODULARITY_THRESHOLD * max(0.0, 1.0 - load)
+    required = ClusteringConfig.EXPAND_MODULARITY_THRESHOLD * max(0.0, 1.0 - load)
     return modularity >= required

--- a/static_analyzer/clustering/grouping.py
+++ b/static_analyzer/clustering/grouping.py
@@ -384,17 +384,17 @@ def _anchored_group(
             carried[owner].add(cid)
     if not carried:
         # A first run or unrelated baseline has no ownership to preserve.
-        fresh, fresh_modularity = _optimize_grouping(
+        fresh, unanchored_modularity = _optimize_grouping(
             meta_graph,
             cluster_result,
             method_count,
             config,
         )
-        return AnchoredGrouping(fresh, [""] * len(fresh), True, fresh_modularity)
+        return AnchoredGrouping(fresh, [""] * len(fresh), True, unanchored_modularity)
 
     owners = sorted(carried)
     groups = [carried[owner] for owner in owners]
-    fresh_groups, fresh_modularity = _optimize_grouping(
+    fresh_groups, unanchored_modularity = _optimize_grouping(
         meta_graph,
         cluster_result,
         method_count,
@@ -412,21 +412,21 @@ def _anchored_group(
         _absorb_leftovers(groups, absorbed, meta_graph, cluster_result, method_count)
 
     modularity = _modularity(meta_graph, groups)
-    if fresh_modularity - modularity > config.drift_budget:
+    if unanchored_modularity - modularity > config.drift_budget:
         logger.info(
-            f"[Anchored] carried grouping scores {modularity:.4f} vs {fresh_modularity:.4f} fresh "
+            f"[Anchored] carried grouping scores {modularity:.4f} vs {unanchored_modularity:.4f} unanchored "
             f"(> {config.drift_budget} budget); re-deriving structure from scratch"
         )
         return AnchoredGrouping(
             fresh_groups,
             _inherit_ids(fresh_groups, previous_owner, method_count),
             True,
-            fresh_modularity,
+            unanchored_modularity,
         )
 
     logger.info(
         f"[Anchored] {len(live)} leaf clusters -> {len(groups)} components carried forward "
         f"({len(new_subsystems)} new component(s), {len(absorbed)} clusters absorbed, "
-        f"modularity={modularity:.4f} vs {fresh_modularity:.4f} fresh)"
+        f"modularity={modularity:.4f} vs {unanchored_modularity:.4f} unanchored)"
     )
-    return AnchoredGrouping(groups, owners, False, fresh_modularity)
+    return AnchoredGrouping(groups, owners, False, unanchored_modularity)

--- a/static_analyzer/clustering/grouping.py
+++ b/static_analyzer/clustering/grouping.py
@@ -373,7 +373,7 @@ def _anchored_group(
     meta_graph = _build_meta_graph(cluster_result, cfg_graph)
     live = set(meta_graph.nodes)
     if not live:
-        return AnchoredGrouping([], [], False)
+        return AnchoredGrouping([], [], False, 0.0)
     method_count = _method_counts(cluster_result)
 
     # Keep one stable group per surviving component.
@@ -384,13 +384,13 @@ def _anchored_group(
             carried[owner].add(cid)
     if not carried:
         # A first run or unrelated baseline has no ownership to preserve.
-        fresh, _ = _optimize_grouping(
+        fresh, fresh_modularity = _optimize_grouping(
             meta_graph,
             cluster_result,
             method_count,
             config,
         )
-        return AnchoredGrouping(fresh, [""] * len(fresh), True)
+        return AnchoredGrouping(fresh, [""] * len(fresh), True, fresh_modularity)
 
     owners = sorted(carried)
     groups = [carried[owner] for owner in owners]
@@ -417,11 +417,16 @@ def _anchored_group(
             f"[Anchored] carried grouping scores {modularity:.4f} vs {fresh_modularity:.4f} fresh "
             f"(> {config.drift_budget} budget); re-deriving structure from scratch"
         )
-        return AnchoredGrouping(fresh_groups, _inherit_ids(fresh_groups, previous_owner, method_count), True)
+        return AnchoredGrouping(
+            fresh_groups,
+            _inherit_ids(fresh_groups, previous_owner, method_count),
+            True,
+            fresh_modularity,
+        )
 
     logger.info(
         f"[Anchored] {len(live)} leaf clusters -> {len(groups)} components carried forward "
         f"({len(new_subsystems)} new component(s), {len(absorbed)} clusters absorbed, "
         f"modularity={modularity:.4f} vs {fresh_modularity:.4f} fresh)"
     )
-    return AnchoredGrouping(groups, owners, False)
+    return AnchoredGrouping(groups, owners, False, fresh_modularity)

--- a/static_analyzer/clustering/models.py
+++ b/static_analyzer/clustering/models.py
@@ -77,7 +77,7 @@ class AnchoredGrouping:
     groups: list[set[ClusterId]]
     owners: list[ComponentId]
     regrouped: bool
-    fresh_modularity: float
+    unanchored_modularity: float
 
 
 @dataclass
@@ -132,6 +132,6 @@ class ClusterScopeResult:
     leaf_clusters_by_language: dict[str, ClusterResult] = field(default_factory=dict)
     groups: list[ClusterGroup] = field(default_factory=list)
     connections: list[GroupConnection] = field(default_factory=list)
-    modularity: float = 0.0
-    fresh_modularity: float = 0.0
+    modularity: float = 0.0  # Score of the actual groups, including ownership anchors.
+    unanchored_modularity: float = 0.0  # Best score without previous ownership anchors.
     regrouped: bool = False

--- a/static_analyzer/clustering/models.py
+++ b/static_analyzer/clustering/models.py
@@ -77,6 +77,7 @@ class AnchoredGrouping:
     groups: list[set[ClusterId]]
     owners: list[ComponentId]
     regrouped: bool
+    fresh_modularity: float
 
 
 @dataclass
@@ -94,6 +95,14 @@ class GroupConnection:
     source_group_id: GroupId
     target_group_id: GroupId
     edges: list[ClusterConnectionEdge] = field(default_factory=list)
+
+
+@dataclass
+class ClusterScopeInput:
+    """Optional precomputed leaf clusters and ownership anchors for one scope."""
+
+    leaf_clusters_by_language: Mapping[str, ClusterResult] = field(default_factory=dict)
+    previous_owner: Mapping[ClusterId, ComponentId] = field(default_factory=dict)
 
 
 @dataclass
@@ -124,4 +133,5 @@ class ClusterScopeResult:
     groups: list[ClusterGroup] = field(default_factory=list)
     connections: list[GroupConnection] = field(default_factory=list)
     modularity: float = 0.0
+    fresh_modularity: float = 0.0
     regrouped: bool = False

--- a/static_analyzer/clustering/service.py
+++ b/static_analyzer/clustering/service.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections import defaultdict
+from collections import Counter, defaultdict
 from collections.abc import Callable, Mapping
 from types import MappingProxyType
 
@@ -75,6 +75,15 @@ class ClusteringService:
             scope_leaf_clusters[language] = (
                 leaf_clusters_by_language[language] if language in leaf_clusters_by_language else self.cluster(graph)
             )
+        previous_owner_by_language_member = {
+            language: {
+                qualified_name: previous_owner[cluster_id]
+                for cluster_id, members in cluster_result.clusters.items()
+                if previous_owner.get(cluster_id)
+                for qualified_name in members
+            }
+            for language, cluster_result in scope_leaf_clusters.items()
+        }
         if method_level_fallback:
             scope_leaf_clusters = {
                 language: self._expand_to_method_level(graphs[language], cluster_result)
@@ -86,6 +95,16 @@ class ClusteringService:
             ):
                 raise LeafClustersUnavailableError(language)
         reindex_across_languages(scope_leaf_clusters)
+        scope_previous_owner: dict[ClusterId, ComponentId] = {}
+        for language, cluster_result in scope_leaf_clusters.items():
+            owner_by_member = previous_owner_by_language_member[language]
+            for cluster_id, members in cluster_result.clusters.items():
+                owner_counts = Counter(owner_by_member[member] for member in members if member in owner_by_member)
+                if owner_counts:
+                    scope_previous_owner[cluster_id] = min(
+                        owner_counts.items(),
+                        key=lambda claim: (-claim[1], claim[0]),
+                    )[0]
 
         nx_graphs = {language: graph.to_networkx(DEFAULT_REFERENCE_KINDS) for language, graph in graphs.items()}
         grouping_service = GroupingService()
@@ -94,7 +113,7 @@ class ClusteringService:
             grouping = grouping_service.anchored_group(
                 scope_leaf_clusters,
                 nx_graphs,
-                dict(previous_owner),
+                scope_previous_owner,
                 subcomponents=subcomponents,
             )
             raw_groups = grouping.groups
@@ -102,7 +121,7 @@ class ClusteringService:
             combined = combine_cluster_results(scope_leaf_clusters)
             combined_cfg = nx.compose_all(list(nx_graphs.values())) if nx_graphs else nx.DiGraph()
             modularity = score_grouping(combined, combined_cfg, raw_groups)
-            fresh_modularity = grouping.fresh_modularity
+            unanchored_modularity = grouping.unanchored_modularity
             regrouped = grouping.regrouped
         else:
             raw_groups, modularity = grouping_service.group(
@@ -111,7 +130,7 @@ class ClusteringService:
                 subcomponents=subcomponents,
             )
             owners = [""] * len(raw_groups)
-            fresh_modularity = modularity
+            unanchored_modularity = modularity
             regrouped = False
 
         group_ids = self._allocate_group_ids(scope_id, owners)
@@ -131,7 +150,7 @@ class ClusteringService:
             groups=groups,
             connections=connections,
             modularity=modularity,
-            fresh_modularity=fresh_modularity,
+            unanchored_modularity=unanchored_modularity,
             regrouped=regrouped,
         )
 
@@ -165,7 +184,7 @@ class ClusteringService:
             return
         for group in scope.groups:
             child_graphs = self._induced_graphs(group, graphs)
-            method_count, file_count = self._group_size(group, graphs)
+            method_count, file_count = self._scope_size(child_graphs)
             if not child_graphs or not file_count:
                 continue
             child_input = scope_input(group.group_id, child_graphs)
@@ -176,11 +195,14 @@ class ClusteringService:
                 previous_owner=child_input.previous_owner,
                 method_level_fallback=True,
             )
+            if sum(bool(child_group.qualified_names) for child_group in child.groups) < 2:
+                continue
             load = scope_load(method_count, file_count)
             if load < 1.0 and not scope_is_separable(
                 child.leaf_clusters_by_language,
-                child.fresh_modularity,
+                child.unanchored_modularity,
                 load,
+                method_count,
             ):
                 continue
             group.children = child
@@ -199,15 +221,14 @@ class ClusteringService:
         return child_graphs
 
     @staticmethod
-    def _group_size(group: ClusterGroup, graphs: Mapping[str, CallGraph]) -> tuple[int, int]:
+    def _scope_size(graphs: Mapping[str, CallGraph]) -> tuple[int, int]:
         files: set[str] = set()
         method_count = 0
-        for language, members in group.symbol_members_by_language.items():
-            graph = graphs[language]
-            for qualified_name in members:
-                node = graph.nodes[qualified_name]
+        for graph in graphs.values():
+            for node in graph.nodes.values():
                 files.add(node.file_path)
-                method_count += 1
+                if node.type in CALLABLE_TYPES:
+                    method_count += 1
         return method_count, len(files)
 
     @staticmethod

--- a/static_analyzer/clustering/service.py
+++ b/static_analyzer/clustering/service.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from types import MappingProxyType
 
 import networkx as nx
@@ -13,6 +13,7 @@ from constants import MIN_CLUSTERS_THRESHOLD
 from static_analyzer.cfg import CallGraph, DEFAULT_REFERENCE_KINDS
 from static_analyzer.config import CALLABLE_TYPES, CLASS_TYPES
 from static_analyzer.clustering.engine import cluster_graph
+from static_analyzer.clustering.expansion import scope_is_separable, scope_load
 from static_analyzer.clustering.grouping import (
     GroupingService,
     combine_cluster_results,
@@ -24,6 +25,7 @@ from static_analyzer.clustering.models import (
     ClusterConnectionEdge,
     ClusterGroup,
     ClusterResult,
+    ClusterScopeInput,
     ClusterScopeResult,
     GroupConnection,
 )
@@ -42,6 +44,10 @@ class LeafClustersUnavailableError(RuntimeError):
             "enable method-level fallback or provide a usable cluster result."
         )
         self.language = language
+
+
+def _unseeded_scope(_scope_id: ScopeId, _graphs: Mapping[str, CallGraph]) -> ClusterScopeInput:
+    return ClusterScopeInput()
 
 
 class ClusteringService:
@@ -83,17 +89,29 @@ class ClusteringService:
 
         nx_graphs = {language: graph.to_networkx(DEFAULT_REFERENCE_KINDS) for language, graph in graphs.items()}
         grouping_service = GroupingService()
+        subcomponents = scope_id != _ROOT_SCOPE_ID
         if previous_owner:
-            grouping = grouping_service.anchored_group(scope_leaf_clusters, nx_graphs, dict(previous_owner))
+            grouping = grouping_service.anchored_group(
+                scope_leaf_clusters,
+                nx_graphs,
+                dict(previous_owner),
+                subcomponents=subcomponents,
+            )
             raw_groups = grouping.groups
             owners = grouping.owners
             combined = combine_cluster_results(scope_leaf_clusters)
             combined_cfg = nx.compose_all(list(nx_graphs.values())) if nx_graphs else nx.DiGraph()
             modularity = score_grouping(combined, combined_cfg, raw_groups)
+            fresh_modularity = grouping.fresh_modularity
             regrouped = grouping.regrouped
         else:
-            raw_groups, modularity = grouping_service.group(scope_leaf_clusters, nx_graphs)
+            raw_groups, modularity = grouping_service.group(
+                scope_leaf_clusters,
+                nx_graphs,
+                subcomponents=subcomponents,
+            )
             owners = [""] * len(raw_groups)
+            fresh_modularity = modularity
             regrouped = False
 
         group_ids = self._allocate_group_ids(scope_id, owners)
@@ -113,8 +131,84 @@ class ClusteringService:
             groups=groups,
             connections=connections,
             modularity=modularity,
+            fresh_modularity=fresh_modularity,
             regrouped=regrouped,
         )
+
+    def cluster_hierarchy(
+        self,
+        graphs: Mapping[str, CallGraph],
+        max_depth: int,
+        scope_input: Callable[[ScopeId, Mapping[str, CallGraph]], ClusterScopeInput] = _unseeded_scope,
+    ) -> ClusterScopeResult:
+        """Recursively cluster every expandable exact subgraph up to ``max_depth``."""
+        if max_depth < 1:
+            raise ValueError("max_depth must be at least 1")
+        root_input = scope_input(_ROOT_SCOPE_ID, graphs)
+        root = self.cluster_scope(
+            graphs,
+            leaf_clusters_by_language=root_input.leaf_clusters_by_language,
+            previous_owner=root_input.previous_owner,
+        )
+        self._cluster_children(root, graphs, 1, max_depth, scope_input)
+        return root
+
+    def _cluster_children(
+        self,
+        scope: ClusterScopeResult,
+        graphs: Mapping[str, CallGraph],
+        depth: int,
+        max_depth: int,
+        scope_input: Callable[[ScopeId, Mapping[str, CallGraph]], ClusterScopeInput],
+    ) -> None:
+        if depth >= max_depth:
+            return
+        for group in scope.groups:
+            child_graphs = self._induced_graphs(group, graphs)
+            method_count, file_count = self._group_size(group, graphs)
+            if not child_graphs or not file_count:
+                continue
+            child_input = scope_input(group.group_id, child_graphs)
+            child = self.cluster_scope(
+                child_graphs,
+                scope_id=group.group_id,
+                leaf_clusters_by_language=child_input.leaf_clusters_by_language,
+                previous_owner=child_input.previous_owner,
+                method_level_fallback=True,
+            )
+            load = scope_load(method_count, file_count)
+            if load < 1.0 and not scope_is_separable(
+                child.leaf_clusters_by_language,
+                child.fresh_modularity,
+                load,
+            ):
+                continue
+            group.children = child
+            self._cluster_children(child, child_graphs, depth + 1, max_depth, scope_input)
+
+    @staticmethod
+    def _induced_graphs(group: ClusterGroup, graphs: Mapping[str, CallGraph]) -> dict[str, CallGraph]:
+        child_graphs: dict[str, CallGraph] = {}
+        for language, graph in graphs.items():
+            members = group.symbol_members_by_language.get(language, set())
+            if not members:
+                continue
+            child = graph.filter_by_nodes(members)
+            if child.nodes:
+                child_graphs[language] = child
+        return child_graphs
+
+    @staticmethod
+    def _group_size(group: ClusterGroup, graphs: Mapping[str, CallGraph]) -> tuple[int, int]:
+        files: set[str] = set()
+        method_count = 0
+        for language, members in group.symbol_members_by_language.items():
+            graph = graphs[language]
+            for qualified_name in members:
+                node = graph.nodes[qualified_name]
+                files.add(node.file_path)
+                method_count += 1
+        return method_count, len(files)
 
     @staticmethod
     def _allocate_group_ids(scope_id: ScopeId, owners: list[ComponentId]) -> list[GroupId]:

--- a/static_analyzer/config.py
+++ b/static_analyzer/config.py
@@ -73,6 +73,12 @@ class ClusteringConfig:
     # Display limits
     MAX_DISPLAY_CLUSTERS = 55  # Maximum clusters to show in output (readability limit)
 
+    # Recursive hierarchy expansion thresholds
+    MIN_METHODS_TO_EXPAND = 30
+    MAX_LEAF_FILES = 12
+    MAX_LEAF_METHODS = 120
+    EXPAND_MODULARITY_THRESHOLD = 0.15
+
     # Separator used by every ``LanguageAdapter.build_qualified_name``.
     # A future per-language switch (e.g. Rust to ``::``) would need both a
     # per-adapter override and updates to consumers that hardcode

--- a/tests/agents/test_planner_agent.py
+++ b/tests/agents/test_planner_agent.py
@@ -5,8 +5,6 @@ import unittest
 import networkx as nx
 
 from agents.planner_agent import (
-    MAX_LEAF_FILES,
-    MAX_LEAF_METHODS,
     component_is_separable,
     get_expandable_components,
     leaf_load,
@@ -19,6 +17,7 @@ from agents.agent_responses import (
 )
 from agents.file_index_models import FileMethodGroup, MethodEntry
 from static_analyzer.clustering import ClusterResult, METHOD_LEVEL_STRATEGY
+from static_analyzer.config import ClusteringConfig
 
 
 class TestShouldExpandComponent(unittest.TestCase):
@@ -419,10 +418,14 @@ class TestLeafLoad(unittest.TestCase):
 
     def test_file_count_alone_can_exceed_the_ceiling(self):
         # One method each, but spread over more files than a single box should hold.
-        self.assertGreaterEqual(leaf_load(self._component(files=MAX_LEAF_FILES + 1, methods_per_file=1)), 1.0)
+        self.assertGreaterEqual(
+            leaf_load(self._component(files=ClusteringConfig.MAX_LEAF_FILES + 1, methods_per_file=1)), 1.0
+        )
 
     def test_method_count_alone_can_exceed_the_ceiling(self):
-        self.assertGreaterEqual(leaf_load(self._component(files=2, methods_per_file=MAX_LEAF_METHODS)), 1.0)
+        self.assertGreaterEqual(
+            leaf_load(self._component(files=2, methods_per_file=ClusteringConfig.MAX_LEAF_METHODS)), 1.0
+        )
 
     def test_empty_component_has_zero_load(self):
         self.assertEqual(leaf_load(self._component(files=0, methods_per_file=0)), 0.0)

--- a/tests/static_analyzer/test_clustering_hierarchy.py
+++ b/tests/static_analyzer/test_clustering_hierarchy.py
@@ -1,0 +1,115 @@
+import unittest
+from collections.abc import Mapping
+
+from static_analyzer.cfg import CallGraph
+from static_analyzer.clustering import ClusterResult, ClusterScopeInput, ClusteringService
+from static_analyzer.config import NodeType
+from static_analyzer.node import Node
+
+
+def graph_for(names: list[str], *, one_file: bool = False, edges: list[tuple[str, str]] = ()) -> CallGraph:
+    graph = CallGraph(language="python")
+    for index, name in enumerate(names):
+        file_name = "scope.py" if one_file else f"{name}.py"
+        graph.add_node(Node(name, NodeType.FUNCTION, f"/repo/{file_name}", index + 1, index + 2))
+    for source, target in edges:
+        graph.add_edge(source, target, call_sites=[{"file": "scope.py", "line": 10}])
+    return graph
+
+
+def partition_for(graph: CallGraph, clusters: dict[int, set[str]], strategy: str = "test") -> ClusterResult:
+    cluster_to_files = {
+        cluster_id: {graph.nodes[name].file_path for name in members} for cluster_id, members in clusters.items()
+    }
+    file_to_clusters: dict[str, set[int]] = {}
+    for cluster_id, files in cluster_to_files.items():
+        for file_path in files:
+            file_to_clusters.setdefault(file_path, set()).add(cluster_id)
+    return ClusterResult(
+        clusters=clusters,
+        cluster_to_files=cluster_to_files,
+        file_to_clusters=file_to_clusters,
+        strategy=strategy,
+    )
+
+
+def split_partition(graph: CallGraph, count: int = 5) -> ClusterResult:
+    names = sorted(graph.nodes)
+    clusters = {index + 1: set(names[index::count]) for index in range(count)}
+    return partition_for(graph, {cluster_id: members for cluster_id, members in clusters.items() if members})
+
+
+class TestClusteringHierarchy(unittest.TestCase):
+    def test_each_child_uses_its_exact_induced_graph(self):
+        members_a = {f"a{index}" for index in range(13)}
+        members_b = {"b1", "b2"}
+        graph = graph_for(sorted(members_a | members_b), edges=[("a1", "b1")])
+        seen_nodes: dict[str, set[str]] = {}
+        seen_edges: dict[str, set[tuple[str, str]]] = {}
+
+        def scope_input(scope_id: str, graphs: Mapping[str, CallGraph]) -> ClusterScopeInput:
+            current = graphs["python"]
+            seen_nodes[scope_id] = set(current.nodes)
+            seen_edges[scope_id] = {(edge.get_source(), edge.get_destination()) for edge in current.edges}
+            if scope_id == "root":
+                partition = partition_for(current, {1: members_a, 2: members_b})
+            else:
+                partition = split_partition(current)
+            return ClusterScopeInput(leaf_clusters_by_language={"python": partition})
+
+        result = ClusteringService().cluster_hierarchy({"python": graph}, max_depth=2, scope_input=scope_input)
+
+        group_a = next(group for group in result.groups if group.qualified_names == members_a)
+        group_b = next(group for group in result.groups if group.qualified_names == members_b)
+        self.assertEqual(seen_nodes[group_a.group_id], members_a)
+        self.assertEqual(seen_nodes[group_b.group_id], members_b)
+        self.assertEqual(seen_edges[group_a.group_id], set())
+        self.assertEqual(seen_edges[group_b.group_id], set())
+        self.assertIsNotNone(group_a.children)
+        self.assertIsNone(group_b.children)
+
+    def test_recurses_with_new_local_partitions_until_the_depth_cap(self):
+        graph = graph_for([f"n{index:02d}" for index in range(65)])
+        seen_nodes: dict[str, set[str]] = {}
+
+        def scope_input(scope_id: str, graphs: Mapping[str, CallGraph]) -> ClusterScopeInput:
+            current = graphs["python"]
+            seen_nodes[scope_id] = set(current.nodes)
+            partition = (
+                partition_for(current, {1: set(current.nodes)}) if scope_id == "root" else split_partition(current)
+            )
+            return ClusterScopeInput(leaf_clusters_by_language={"python": partition})
+
+        result = ClusteringService().cluster_hierarchy({"python": graph}, max_depth=3, scope_input=scope_input)
+
+        root_group = result.groups[0]
+        self.assertIsNotNone(root_group.children)
+        assert root_group.children is not None
+        self.assertTrue(root_group.children.groups)
+        for child_group in root_group.children.groups:
+            self.assertEqual(seen_nodes[child_group.group_id], child_group.qualified_names)
+            self.assertIsNotNone(child_group.children)
+            assert child_group.children is not None
+            self.assertTrue(all(grandchild.children is None for grandchild in child_group.children.groups))
+
+    def test_small_scope_stops_at_the_existing_size_gate(self):
+        graph = graph_for([f"n{index}" for index in range(10)], one_file=True)
+
+        def scope_input(scope_id: str, graphs: Mapping[str, CallGraph]) -> ClusterScopeInput:
+            current = graphs["python"]
+            partition = (
+                partition_for(current, {1: set(current.nodes)}) if scope_id == "root" else split_partition(current)
+            )
+            return ClusterScopeInput(leaf_clusters_by_language={"python": partition})
+
+        result = ClusteringService().cluster_hierarchy({"python": graph}, max_depth=3, scope_input=scope_input)
+
+        self.assertIsNone(result.groups[0].children)
+
+    def test_rejects_a_depth_below_the_root_level(self):
+        with self.assertRaisesRegex(ValueError, "max_depth must be at least 1"):
+            ClusteringService().cluster_hierarchy({}, max_depth=0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/static_analyzer/test_clustering_hierarchy.py
+++ b/tests/static_analyzer/test_clustering_hierarchy.py
@@ -1,5 +1,6 @@
 import unittest
 from collections.abc import Mapping
+from unittest.mock import patch
 
 from static_analyzer.cfg import CallGraph
 from static_analyzer.clustering import ClusterResult, ClusterScopeInput, ClusteringService
@@ -105,6 +106,41 @@ class TestClusteringHierarchy(unittest.TestCase):
         result = ClusteringService().cluster_hierarchy({"python": graph}, max_depth=3, scope_input=scope_input)
 
         self.assertIsNone(result.groups[0].children)
+
+    def test_one_group_child_does_not_consume_a_depth_level(self):
+        graph = graph_for([f"n{index:03d}" for index in range(121)], one_file=True)
+
+        def scope_input(scope_id: str, graphs: Mapping[str, CallGraph]) -> ClusterScopeInput:
+            current = graphs["python"]
+            if scope_id == "root":
+                return ClusterScopeInput(
+                    leaf_clusters_by_language={"python": partition_for(current, {1: set(current.nodes)})}
+                )
+            partition = split_partition(current)
+            return ClusterScopeInput(
+                leaf_clusters_by_language={"python": partition},
+                previous_owner={cluster_id: "1.1" for cluster_id in partition.clusters},
+            )
+
+        result = ClusteringService().cluster_hierarchy({"python": graph}, max_depth=3, scope_input=scope_input)
+
+        self.assertIsNone(result.groups[0].children)
+
+    def test_expansion_gate_receives_the_child_graph_callable_count(self):
+        graph = graph_for([f"n{index:02d}" for index in range(31)], one_file=True)
+        graph.add_node(Node("Container", NodeType.CLASS, "/repo/scope.py", 100, 110))
+
+        def scope_input(scope_id: str, graphs: Mapping[str, CallGraph]) -> ClusterScopeInput:
+            current = graphs["python"]
+            partition = (
+                partition_for(current, {1: set(current.nodes)}) if scope_id == "root" else split_partition(current)
+            )
+            return ClusterScopeInput(leaf_clusters_by_language={"python": partition})
+
+        with patch("static_analyzer.clustering.service.scope_is_separable", return_value=False) as separable:
+            ClusteringService().cluster_hierarchy({"python": graph}, max_depth=2, scope_input=scope_input)
+
+        self.assertEqual(separable.call_args.args[3], 31)
 
     def test_rejects_a_depth_below_the_root_level(self):
         with self.assertRaisesRegex(ValueError, "max_depth must be at least 1"):

--- a/tests/static_analyzer/test_clustering_scope.py
+++ b/tests/static_analyzer/test_clustering_scope.py
@@ -102,7 +102,7 @@ class TestClusteringScope(unittest.TestCase):
     def test_previous_owners_become_stable_group_ids(self):
         graph = graph_for("python", ["a", "b", "c"])
         cluster_result = cluster_result_for(graph, {1: {"a"}, 2: {"b"}, 3: {"c"}})
-        _groups, expected_fresh_modularity = GroupingService().group(
+        _groups, expected_unanchored_modularity = GroupingService().group(
             {"python": cluster_result},
             {"python": graph.to_networkx(reference_kinds=())},
         )
@@ -114,7 +114,7 @@ class TestClusteringScope(unittest.TestCase):
         )
 
         self.assertEqual([group.group_id for group in result.groups], ["2", "4", "7"])
-        self.assertEqual(result.fresh_modularity, expected_fresh_modularity)
+        self.assertEqual(result.unanchored_modularity, expected_unanchored_modularity)
         self.assertFalse(result.regrouped)
 
     def test_new_group_ids_follow_the_highest_surviving_sibling(self):
@@ -155,6 +155,32 @@ class TestClusteringScope(unittest.TestCase):
         self.assertEqual(expanded.strategy, METHOD_LEVEL_STRATEGY)
         self.assertEqual(len(expanded.clusters), 5)
         self.assertTrue(all(len(members) == 1 for members in expanded.clusters.values()))
+
+    def test_method_level_fallback_preserves_owners_by_member(self):
+        graph = graph_for("python", ["a", "b", "c", "d", "e", "new"])
+        cluster_result = cluster_result_for(
+            graph,
+            {
+                0: {"d", "e"},
+                4: {"a", "b", "c"},
+            },
+        )
+
+        result = ClusteringService().cluster_scope(
+            {"python": graph},
+            scope_id="9",
+            leaf_clusters_by_language={"python": cluster_result},
+            previous_owner={0: "9.1", 4: "9.2"},
+            method_level_fallback=True,
+        )
+
+        owner_by_member = {
+            member: group.previous_component_id
+            for group in result.groups
+            for member in group.symbol_members_by_language.get("python", set())
+        }
+        self.assertTrue(all(owner_by_member[member] == "9.1" for member in {"d", "e"}))
+        self.assertTrue(all(owner_by_member[member] == "9.2" for member in {"a", "b", "c"}))
 
 
 if __name__ == "__main__":

--- a/tests/static_analyzer/test_clustering_scope.py
+++ b/tests/static_analyzer/test_clustering_scope.py
@@ -102,6 +102,10 @@ class TestClusteringScope(unittest.TestCase):
     def test_previous_owners_become_stable_group_ids(self):
         graph = graph_for("python", ["a", "b", "c"])
         cluster_result = cluster_result_for(graph, {1: {"a"}, 2: {"b"}, 3: {"c"}})
+        _groups, expected_fresh_modularity = GroupingService().group(
+            {"python": cluster_result},
+            {"python": graph.to_networkx(reference_kinds=())},
+        )
 
         result = ClusteringService().cluster_scope(
             {"python": graph},
@@ -110,6 +114,7 @@ class TestClusteringScope(unittest.TestCase):
         )
 
         self.assertEqual([group.group_id for group in result.groups], ["2", "4", "7"])
+        self.assertEqual(result.fresh_modularity, expected_fresh_modularity)
         self.assertFalse(result.regrouped)
 
     def test_new_group_ids_follow_the_highest_surviving_sibling(self):


### PR DESCRIPTION
## Goal

Build the entire deterministic clustering hierarchy before analysis agents run, rather than discovering and regrouping each component independently while traversing the analysis tree.

Each child scope is computed from the exact induced subgraph owned by its parent group, so hierarchy depth and boundaries come from one structural pipeline.

## Behavioral impact (upfront)

This PR adds recursive hierarchy construction on top of the one-scope result introduced in #495. It does **not** yet make the existing full or incremental analysis pipelines consume that hierarchy; those integrations remain in the follow-up PRs.

| Area | Impact |
|---|---|
| Existing full/incremental analysis | **No intended runtime change.** Existing agents still own hierarchy traversal until #498 and #499 migrate those paths. |
| Hierarchy API | **Intentional new API.** `ClusteringService.cluster_hierarchy(...)` recursively composes `ClusterScopeResult`s up to the requested depth. |
| Child scope boundary | **Intentional contract tightening.** Every child is clustered from the exact per-language induced subgraphs of its parent group, excluding sibling-only symbols and edges. |
| Coarse child partitions | **Preserves the existing fallback behavior.** Child scopes with fewer than `MIN_CLUSTERS_THRESHOLD` natural clusters expand to callable-level clusters, then classes when needed. |
| Incremental ownership during fallback | **Stable component/group IDs are preserved.** Synthetic leaf-cluster IDs may change because fallback creates a new partition, but previous ownership is remapped through the original members after fallback and cross-language reindexing. |
| Non-splitting child results | **No redundant hierarchy levels.** A result with fewer than two non-empty child groups is not attached and does not consume recursion depth. |
| Expansion sizing | **Correctness fix.** The minimum-size gate counts actual `CALLABLE_TYPES` in the exact child graphs instead of counting members retained by natural clustering or class symbols. |
| Expansion policy | **No threshold change.** The existing method/file ceilings and modularity threshold move to `ClusteringConfig` and are shared by hierarchy construction and the existing planner. |
| Modularity metadata | **Intentional naming clarification.** `modularity` scores the actual returned grouping, including ownership anchors; `unanchored_modularity` scores the best grouping without previous ownership and drives structural separability decisions. |

## Result contract and API mapping

| Before | After | Contract / reason |
|---|---|---|
| Callers repeatedly derive child subgraphs and invoke one-scope clustering while traversing analysis components | `ClusteringService.cluster_hierarchy(graphs, max_depth, scope_input)` | Builds the complete structural hierarchy once, before downstream analysis consumes it. |
| Component/file-level traversal can include sibling symbols from shared files | Each child uses `CallGraph.filter_by_nodes(...)` with its parent group's exact language-qualified symbol membership | Makes every recursive scope an exact induced graph boundary. |
| Child partition and prior ownership acquisition are coupled to individual analysis paths | `ClusterScopeInput(leaf_clusters_by_language, previous_owner)` callback | Lets fresh and incremental callers seed each scope without coupling clustering to persisted analysis models. |
| Planner-local size and separability rules | Shared `clustering/expansion.py` rules backed by `ClusteringConfig` | Keeps the hierarchy and remaining planner path on one deterministic policy. |
| Cluster-member counts stand in for scope method counts | Actual callable count from the exact child `CallGraph`s is passed into `scope_is_separable(...)` | Includes singleton callables omitted by natural clustering and excludes classes from the method floor. |
| Fallback replaces local cluster IDs while ownership remains keyed to the old partition | Ownership is projected from original cluster members onto the final fallback/reindexed partition | Prevents numeric ID collisions from assigning unrelated historical component IDs. |
| Anchored grouping exposes a vaguely named `fresh_modularity` | `unanchored_modularity` on `AnchoredGrouping` and `ClusterScopeResult` | Makes clear that this score is the ownership-independent structural baseline, not another group's state. |
| A one-group child can repeat its parent's membership and consume depth | Child scopes require at least two non-empty groups before attachment | Prevents redundant single-child chains and false expansion. |

`cluster_hierarchy()` clusters the root scope, builds exact induced graphs for each group, obtains optional scope-local partitions and ownership anchors through `ClusterScopeInput`, applies method-level fallback to coarse child partitions, and attaches only structurally justified multi-group children until `max_depth` is reached.

For anchored scopes, `modularity` remains the score of the groups that will actually be returned. `unanchored_modularity` is retained separately because expansion should reflect the graph's current structural separability rather than cohesion introduced by a persisted ownership layout.

## Compatibility boundary

`ClusteringService.cluster()` and `cluster_scope()` remain available. The existing planner retains its public behavior and now delegates its shared size/modularity decision to `clustering/expansion.py`.

This PR only **produces** the recursive hierarchy. It does not materialize analysis components from it and does not replace the current full or incremental orchestration. #498 migrates fresh/full analysis, #499 migrates ownership-anchored incremental analysis, and #500 removes the superseded paths.

## Validation

- `uv run pytest --cov=. --cov-report=term --cov-fail-under=80` — **2,156 passed, 28 skipped**, **83.14% coverage**.
- Focused hierarchy, scope, and planner suites — **41 passed**.
- `uv run mypy .` — passed across 336 source files.
- `uv run black ...` — passed for all changed Python files.
- Commit pre-commit hook — passed.
- `git diff --check` — passed.

## Stack roadmap

| Position | PR | Responsibility |
|---|---|---|
| Foundation | [#494](https://github.com/CodeBoarding/CodeBoarding/pull/494) | Move the existing grouping algorithms behind the stateless `GroupingService` API without intentionally changing grouping behavior. |
| Previous | [#495](https://github.com/CodeBoarding/CodeBoarding/pull/495) | Define and compute a complete structural result for one graph scope, including groups, members, and sibling communication. |
| **This PR** | **#497** | Recursively compose scope results into a deterministic hierarchy using exact induced subgraphs and centralized expansion rules. |
| Next | [#498](https://github.com/CodeBoarding/CodeBoarding/pull/498) | Make fresh/full analysis consume the precomputed hierarchy instead of regrouping inside agents. |
| Follow-up | [#499](https://github.com/CodeBoarding/CodeBoarding/pull/499) | Make incremental analysis build and consume an ownership-anchored hierarchy while preserving stable member ownership. |
| Final cleanup | [#500](https://github.com/CodeBoarding/CodeBoarding/pull/500) | Remove the legacy agent-side grouping and recursive incremental orchestration once both analysis paths use the hierarchy. |

Amp-Thread-ID: https://ampcode.com/threads/T-01a01478-33f2-70cf-8a11-9475c7d3a4cd
Co-authored-by: Amp <amp@ampcode.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
