### PR TITLE
refactor(analysis): consume precomputed clustering hierarchy

### DIFF
--- a/agents/abstraction_agent.py
+++ b/agents/abstraction_agent.py
@@ -37,7 +37,7 @@ from static_analyzer.cfg import DEFAULT_REFERENCE_KINDS
 from static_analyzer.analysis_result import StaticAnalysisResults
 from static_analyzer.cluster_helpers import build_all_cluster_results
 from static_analyzer.config import Language
-from static_analyzer.clustering import ClusterResult
+from static_analyzer.clustering import ClusterResult, ClusterScopeResult
 
 logger = logging.getLogger(__name__)
 
@@ -192,12 +192,23 @@ class AbstractionAgent(ClusterMethodsMixin, CodeBoardingAgent):
         assign_relation_ids(analysis)
         self.build_static_relations(analysis)
 
-    def run(self):
-        # Build full cluster results dict for all languages ONCE
-        cluster_results = build_all_cluster_results(self.static_analysis)
+    def run_scope(self, scope: ClusterScopeResult) -> tuple[AnalysisInsights, dict[str, ClusterResult]]:
+        """Name and analyze a precomputed root clustering scope."""
+        return self._run_clustered(
+            self.cluster_analysis_from_scope(scope),
+            scope.leaf_clusters_by_language,
+        )
 
-        # Step 1: Deterministically partition leaf clusters into the top-level groups (Leiden, modularity-peak N)
-        cluster_analysis = self.step_clusters_grouping(cluster_results)
+    def run(self) -> tuple[AnalysisInsights, dict[str, ClusterResult]]:
+        """Cluster and analyze the root scope directly."""
+        cluster_results = build_all_cluster_results(self.static_analysis)
+        return self._run_clustered(self.step_clusters_grouping(cluster_results), cluster_results)
+
+    def _run_clustered(
+        self,
+        cluster_analysis: ClusterAnalysis,
+        cluster_results: dict[str, ClusterResult],
+    ) -> tuple[AnalysisInsights, dict[str, ClusterResult]]:
         if not cluster_analysis.cluster_components:
             # No leaf clusters means the repo has no callable structure to abstract
             # (unsupported/empty/no-code). Fail loudly instead of emptying the
@@ -207,26 +218,20 @@ class AbstractionAgent(ClusterMethodsMixin, CodeBoardingAgent):
                 "no callable structure to build an architecture from."
             )
 
-        # Step 2: Name and describe each fixed group into a component (LLM, one component per group)
+        # Name and describe each fixed group into a component (LLM, one component per group)
         analysis = self.step_final_analysis(cluster_analysis, cluster_results)
-        # Step 3: Assign hierarchical component IDs ("1", "2", "3", ...)
+        # Assign hierarchical component IDs ("1", "2", "3", ...)
         assign_component_ids(analysis)
-        # Step 4: Resolve cluster IDs deterministically from group names
+        # Resolve cluster IDs deterministically from group names
         self._resolve_cluster_ids_from_groups(analysis, cluster_analysis)
-        # Step 5: Populate file_methods deterministically from cluster results + orphan assignment
+        # Populate file_methods deterministically from cluster results + orphan assignment
         self.populate_file_methods(analysis, cluster_results)
 
-        # Step 6: Analyze component API surfaces
         api_surfaces = self.step_api_surfaces(analysis)
-
-        # Step 7: Discover relations from API surfaces and attach deterministic all_edges
         self.step_relation_analysis(analysis, api_surfaces, cluster_analysis, cluster_results)
 
-        # Step 8: Fix source code reference lines (resolves reference_file paths for key_entities and key_edges)
         analysis = self.reference_resolver.fix_source_code_reference_lines(analysis)
-        # Step 9: Index relation endpoints after reference resolution
         index_relation_endpoints(analysis, self.repo_dir)
-        # Step 10: Ensure unique key entities across components
         self._ensure_unique_key_entities(analysis)
 
         return analysis, cluster_results

--- a/agents/abstraction_agent.py
+++ b/agents/abstraction_agent.py
@@ -33,10 +33,7 @@ from agents.validation import (
 )
 from monitoring import trace
 from static_analyzer import StaticAnalysisFatalError
-from static_analyzer.cfg import DEFAULT_REFERENCE_KINDS
 from static_analyzer.analysis_result import StaticAnalysisResults
-from static_analyzer.cluster_helpers import build_all_cluster_results
-from static_analyzer.config import Language
 from static_analyzer.clustering import ClusterResult, ClusterScopeResult
 
 logger = logging.getLogger(__name__)
@@ -79,22 +76,6 @@ class AbstractionAgent(ClusterMethodsMixin, CodeBoardingAgent):
                 ],
             ),
         }
-
-    @trace
-    def step_clusters_grouping(self, cluster_results: dict[str, ClusterResult]) -> ClusterAnalysis:
-        """Deterministically partition leaf clusters into the top-level component groups.
-
-        Resolution-tuned Leiden picks both the count (modularity peak over
-        ``[5, 8]``) and the membership, so the top-level structure is stable across
-        re-runs — the LLM no longer decides it; it only names them in the
-        final-analysis step.
-        """
-        logger.info(f"[AbstractionAgent] Super-clustering leaf clusters for: {self.project_name}")
-        cfg_graphs = {
-            lang: self.static_analysis.get_cfg(Language(lang)).to_networkx(DEFAULT_REFERENCE_KINDS)
-            for lang in cluster_results
-        }
-        return self.deterministic_cluster_grouping(cluster_results, cfg_graphs)
 
     @trace
     def step_final_analysis(
@@ -192,23 +173,10 @@ class AbstractionAgent(ClusterMethodsMixin, CodeBoardingAgent):
         assign_relation_ids(analysis)
         self.build_static_relations(analysis)
 
-    def run_scope(self, scope: ClusterScopeResult) -> tuple[AnalysisInsights, dict[str, ClusterResult]]:
+    def run(self, scope: ClusterScopeResult) -> tuple[AnalysisInsights, dict[str, ClusterResult]]:
         """Name and analyze a precomputed root clustering scope."""
-        return self._run_clustered(
-            self.cluster_analysis_from_scope(scope),
-            scope.leaf_clusters_by_language,
-        )
-
-    def run(self) -> tuple[AnalysisInsights, dict[str, ClusterResult]]:
-        """Cluster and analyze the root scope directly."""
-        cluster_results = build_all_cluster_results(self.static_analysis)
-        return self._run_clustered(self.step_clusters_grouping(cluster_results), cluster_results)
-
-    def _run_clustered(
-        self,
-        cluster_analysis: ClusterAnalysis,
-        cluster_results: dict[str, ClusterResult],
-    ) -> tuple[AnalysisInsights, dict[str, ClusterResult]]:
+        cluster_analysis = self.cluster_analysis_from_scope(scope)
+        cluster_results = scope.leaf_clusters_by_language
         if not cluster_analysis.cluster_components:
             # No leaf clusters means the repo has no callable structure to abstract
             # (unsupported/empty/no-code). Fail loudly instead of emptying the

--- a/agents/abstraction_agent.py
+++ b/agents/abstraction_agent.py
@@ -10,9 +10,7 @@ from agents.agent_responses import (
     ComponentApiSurfaces,
     ComponentArchitecture,
     ComponentRelations,
-    ClusterAnalysis,
     MetaAnalysisInsights,
-    assign_component_ids,
     assign_relation_ids,
 )
 from agents.cluster_methods_mixin import ClusterMethodsMixin
@@ -78,17 +76,13 @@ class AbstractionAgent(ClusterMethodsMixin, CodeBoardingAgent):
         }
 
     @trace
-    def step_final_analysis(
-        self, llm_cluster_analysis: ClusterAnalysis, cluster_results: dict[str, ClusterResult]
-    ) -> AnalysisInsights:
+    def step_llm_analysis(self, scope: ClusterScopeResult) -> AnalysisInsights:
         logger.info(f"[AbstractionAgent] Generating final component analysis for: {self.project_name}")
-
-        cluster_str = llm_cluster_analysis.llm_str() if llm_cluster_analysis else "No cluster analysis available."
-
-        group_names = [cc.name for cc in llm_cluster_analysis.cluster_components] if llm_cluster_analysis else []
+        cluster_results = scope.leaf_clusters_by_language
+        group_names = scope.group_names()
 
         prompt = self.prompts["final_analysis"].format(
-            cluster_analysis=cluster_str,
+            cluster_analysis=scope.llm_str(),
         )
 
         if group_names:
@@ -100,7 +94,7 @@ class AbstractionAgent(ClusterMethodsMixin, CodeBoardingAgent):
         context = ValidationContext(
             cluster_results=cluster_results,
             static_analysis=self.static_analysis,
-            llm_cluster_analysis=llm_cluster_analysis,
+            clustering=scope,
         )
 
         architecture = self._invoke_repair_validate(
@@ -114,12 +108,12 @@ class AbstractionAgent(ClusterMethodsMixin, CodeBoardingAgent):
             repair_context=ComponentRepairContext(
                 reference_resolver=self.reference_resolver,
                 cluster_results=cluster_results,
-                llm_cluster_analysis=llm_cluster_analysis,
+                clustering=scope,
             ),
             validation_context=context,
             max_validation_attempts=3,
         )
-        self.assemble_one_component_per_group(architecture, llm_cluster_analysis, cluster_results)
+        self.assemble_one_component_per_group(architecture, scope)
         return AnalysisInsights(
             description=architecture.description,
             components=architecture.components,
@@ -141,13 +135,13 @@ class AbstractionAgent(ClusterMethodsMixin, CodeBoardingAgent):
         self,
         analysis: AnalysisInsights,
         api_surfaces: ComponentApiSurfaces,
-        cluster_analysis: ClusterAnalysis,
-        cluster_results: dict[str, ClusterResult],
+        scope: ClusterScopeResult,
     ) -> None:
         logger.info(f"[AbstractionAgent] Discovering component relations for: {self.project_name}")
+        cluster_results = scope.leaf_clusters_by_language
         static_call_evidence = self.build_scope_cfg_string(analysis)
-        cfg_graphs = self.static_analysis.available_cfgs()
-        self.toolkit.context.cluster_analysis = cluster_analysis
+        cfg_graphs = scope.graphs_by_language
+        self.toolkit.context.clustering = scope
         self.toolkit.context.cluster_results = cluster_results
         self.toolkit.context.cfg_graphs = cfg_graphs
         prompt = self.prompts["relation_analysis"].format(
@@ -164,7 +158,7 @@ class AbstractionAgent(ClusterMethodsMixin, CodeBoardingAgent):
                 cfg_graphs=cfg_graphs,
                 repo_dir=str(self.repo_dir),
                 static_analysis=self.static_analysis,
-                llm_cluster_analysis=cluster_analysis,
+                clustering=scope,
                 components=analysis.components,
             ),
             max_validation_attempts=3,
@@ -175,9 +169,8 @@ class AbstractionAgent(ClusterMethodsMixin, CodeBoardingAgent):
 
     def run(self, scope: ClusterScopeResult) -> tuple[AnalysisInsights, dict[str, ClusterResult]]:
         """Name and analyze a precomputed root clustering scope."""
-        cluster_analysis = self.cluster_analysis_from_scope(scope)
         cluster_results = scope.leaf_clusters_by_language
-        if not cluster_analysis.cluster_components:
+        if not scope.groups:
             # No leaf clusters means the repo has no callable structure to abstract
             # (unsupported/empty/no-code). Fail loudly instead of emptying the
             # architecture and crashing downstream in populate_file_methods.
@@ -187,16 +180,14 @@ class AbstractionAgent(ClusterMethodsMixin, CodeBoardingAgent):
             )
 
         # Name and describe each fixed group into a component (LLM, one component per group)
-        analysis = self.step_final_analysis(cluster_analysis, cluster_results)
-        # Assign hierarchical component IDs ("1", "2", "3", ...)
-        assign_component_ids(analysis)
+        analysis = self.step_llm_analysis(scope)
         # Resolve cluster IDs deterministically from group names
-        self._resolve_cluster_ids_from_groups(analysis, cluster_analysis)
+        self._resolve_cluster_ids_from_groups(analysis, scope)
         # Populate file_methods deterministically from cluster results + orphan assignment
         self.populate_file_methods(analysis, cluster_results)
 
         api_surfaces = self.step_api_surfaces(analysis)
-        self.step_relation_analysis(analysis, api_surfaces, cluster_analysis, cluster_results)
+        self.step_relation_analysis(analysis, api_surfaces, scope)
 
         analysis = self.reference_resolver.fix_source_code_reference_lines(analysis)
         index_relation_endpoints(analysis, self.repo_dir)

--- a/agents/agent_responses.py
+++ b/agents/agent_responses.py
@@ -435,6 +435,9 @@ class ClusterAnalysis(LLMBaseModel):
         description="Grouped clusters into logical components. Multiple cluster IDs can be grouped together if they work as a cohesive unit."
     )
 
+    def group_ids(self) -> dict[str, list[ClusterId]]:
+        return {group.name: group.cluster_ids for group in self.cluster_components}
+
     def llm_str(self):
         if not self.cluster_components:
             return "No clusters analyzed."

--- a/agents/cluster_methods_mixin.py
+++ b/agents/cluster_methods_mixin.py
@@ -40,6 +40,7 @@ from static_analyzer.cfg import CallGraph, DEFAULT_REFERENCE_KINDS
 from static_analyzer.clustering import (
     METHOD_LEVEL_STRATEGY,
     ClusterResult,
+    ClusterScopeResult,
     ClusteringService,
     MethodClusterPaths,
 )
@@ -116,6 +117,25 @@ class ClusterMethodsMixin:
     # These attributes must be provided by the class using this mixin
     repo_dir: Path
     static_analysis: StaticAnalysisResults
+
+    @staticmethod
+    def cluster_analysis_from_scope(scope: ClusterScopeResult) -> ClusterAnalysis:
+        """Adapt a precomputed structural scope to the agents' naming prompt."""
+        combined = combine_cluster_results(scope.leaf_clusters_by_language)
+        return ClusterAnalysis(
+            cluster_components=[
+                ClustersComponent(
+                    name=f"Group {index}",
+                    cluster_ids=group.cluster_ids,
+                    description=_summarize_group(
+                        set(group.cluster_ids),
+                        combined.clusters,
+                        combined.cluster_to_files,
+                    ),
+                )
+                for index, group in enumerate(scope.groups, start=1)
+            ]
+        )
 
     def deterministic_cluster_grouping(
         self,

--- a/agents/cluster_methods_mixin.py
+++ b/agents/cluster_methods_mixin.py
@@ -44,7 +44,6 @@ from static_analyzer.clustering import (
     ClusteringService,
     MethodClusterPaths,
 )
-from static_analyzer.clustering.grouping import GroupingService
 from static_analyzer.node import Node
 
 logger = logging.getLogger(__name__)
@@ -136,45 +135,6 @@ class ClusterMethodsMixin:
                 for index, group in enumerate(scope.groups, start=1)
             ]
         )
-
-    def deterministic_cluster_grouping(
-        self,
-        cluster_results: dict[str, ClusterResult],
-        cfg_graphs: dict[str, nx.DiGraph],
-        *,
-        subcomponents: bool = False,
-    ) -> ClusterAnalysis:
-        """Partition leaf clusters into fixed component groups via resolution-tuned Leiden.
-
-        The count (modularity peak over the configured range) and membership are chosen
-        deterministically, so the structure is stable across re-runs — the LLM no
-        longer decides it. Each group gets a stable ``Group i`` label and a summary
-        of its members; the final-analysis step only names and describes them.
-
-        ``cfg_graphs`` must span exactly the same scope as ``cluster_results`` — the
-        component's own subgraph when splitting a component, the whole repo at the
-        top level. Handing it the repo graph for a component scope makes the split
-        disagree with the separability gate, which reads the subgraph.
-        """
-        groups, _modularity = GroupingService().group(
-            cluster_results,
-            cfg_graphs,
-            subcomponents=subcomponents,
-        )
-        combined = combine_cluster_results(cluster_results)
-        cluster_components = [
-            ClustersComponent(
-                name=f"Group {i}",
-                cluster_ids=sorted(group),
-                description=_summarize_group(group, combined.clusters, combined.cluster_to_files),
-            )
-            for i, group in enumerate(groups, start=1)
-        ]
-        logger.info(
-            f"[{type(self).__name__}] Partitioned {sum(len(g) for g in groups)} leaf clusters "
-            f"into {len(cluster_components)} deterministic groups"
-        )
-        return ClusterAnalysis(cluster_components=cluster_components)
 
     @staticmethod
     def assemble_one_component_per_group(

--- a/agents/cluster_methods_mixin.py
+++ b/agents/cluster_methods_mixin.py
@@ -6,8 +6,6 @@ import networkx as nx
 
 from agents.agent_responses import (
     AnalysisInsights,
-    ClusterAnalysis,
-    ClustersComponent,
     Component,
     ComponentArchitecture,
 )
@@ -49,33 +47,16 @@ from static_analyzer.node import Node
 logger = logging.getLogger(__name__)
 
 
-def _summarize_group(
-    group: set[int],
+def _fallback_component(
+    group_name: str,
+    cluster_ids: list[int],
+    description: str,
     node_lookup: dict[int, set[str]],
-    file_lookup: dict[int, set[str]],
-    max_symbols: int = 12,
-    max_files: int = 8,
-) -> str:
-    """A deterministic, name-rich blurb so the LLM can name a group without re-clustering."""
-    symbols = group_symbols(sorted(group), node_lookup)
-    files = sorted({path for cid in group for path in file_lookup.get(cid, set())})
-    file_names = [Path(path).name for path in files]
-
-    parts = [f"{len(group)} leaf clusters, {len(symbols)} symbols across {len(files)} files."]
-    if file_names:
-        shown = ", ".join(file_names[:max_files])
-        parts.append(f"Files: {shown}{', ...' if len(file_names) > max_files else ''}")
-    if symbols:
-        shown = ", ".join(symbols[:max_symbols])
-        parts.append(f"Key symbols: {shown}{', ...' if len(symbols) > max_symbols else ''}")
-    return " ".join(parts)
-
-
-def _fallback_component(group: ClustersComponent, node_lookup: dict[int, set[str]]) -> Component:
+) -> Component:
     """Deterministic component for a group the LLM failed to name (merged/dropped it)."""
-    symbols = group_symbols(group.cluster_ids, node_lookup)
-    name = symbols[0].split(".")[-1] if symbols else group.name
-    return Component(name=name, description=group.description, key_entities=[])
+    symbols = group_symbols(cluster_ids, node_lookup)
+    name = symbols[0].split(".")[-1] if symbols else group_name
+    return Component(name=name, description=description, key_entities=[])
 
 
 def scoped_snapshot_from_lineage(
@@ -118,29 +99,9 @@ class ClusterMethodsMixin:
     static_analysis: StaticAnalysisResults
 
     @staticmethod
-    def cluster_analysis_from_scope(scope: ClusterScopeResult) -> ClusterAnalysis:
-        """Adapt a precomputed structural scope to the agents' naming prompt."""
-        combined = combine_cluster_results(scope.leaf_clusters_by_language)
-        return ClusterAnalysis(
-            cluster_components=[
-                ClustersComponent(
-                    name=f"Group {index}",
-                    cluster_ids=group.cluster_ids,
-                    description=_summarize_group(
-                        set(group.cluster_ids),
-                        combined.clusters,
-                        combined.cluster_to_files,
-                    ),
-                )
-                for index, group in enumerate(scope.groups, start=1)
-            ]
-        )
-
-    @staticmethod
     def assemble_one_component_per_group(
         architecture: ComponentArchitecture,
-        cluster_analysis: ClusterAnalysis,
-        cluster_results: dict[str, ClusterResult],
+        scope: ClusterScopeResult,
     ) -> None:
         """Force exactly one component per fixed group — the count is Leiden's, not the LLM's.
 
@@ -150,7 +111,9 @@ class ClusterMethodsMixin:
         keeps its name/description/key_entities; any group the LLM merged away or
         dropped gets a deterministic fallback so the count never drifts.
         """
-        node_lookup = combine_cluster_results(cluster_results).clusters
+        node_lookup = combine_cluster_results(scope.leaf_clusters_by_language).clusters
+        group_ids = scope.group_ids()
+        descriptions = scope.group_descriptions()
         claimant: dict[str, Component] = {}
         for comp in architecture.components:
             for group_name in comp.source_group_names:
@@ -158,14 +121,21 @@ class ClusterMethodsMixin:
 
         used: set[int] = set()
         final: list[Component] = []
-        for group in cluster_analysis.cluster_components:
-            comp = claimant.get(group.name.lower())
+        for group_name, group in zip(group_ids, scope.groups, strict=True):
+            cluster_ids = group_ids[group_name]
+            comp = claimant.get(group_name.lower())
             if comp is None or id(comp) in used:
-                comp = _fallback_component(group, node_lookup)
+                comp = _fallback_component(
+                    group_name,
+                    cluster_ids,
+                    descriptions[group_name],
+                    node_lookup,
+                )
             else:
                 used.add(id(comp))
                 comp = comp.model_copy(deep=True)
-            comp.source_group_names = [group.name]
+            comp.source_group_names = [group_name]
+            comp.component_id = group.group_id
             final.append(comp)
 
         if len(final) != len(architecture.components):
@@ -224,10 +194,10 @@ class ClusterMethodsMixin:
 
             component.key_entities = [e for e in component.key_entities if e not in entities_to_remove]
 
-    def _resolve_cluster_ids_from_groups(self, analysis: AnalysisInsights, cluster_analysis: ClusterAnalysis) -> None:
+    def _resolve_cluster_ids_from_groups(self, analysis: AnalysisInsights, scope: ClusterScopeResult) -> None:
         """Resolve source_cluster_ids deterministically from source_group_names via case-insensitive lookup."""
         group_name_to_ids: dict[str, list[ClusterId]] = {
-            cc.name.lower(): cc.cluster_ids for cc in cluster_analysis.cluster_components
+            name.lower(): cluster_ids for name, cluster_ids in scope.group_ids().items()
         }
 
         for component in analysis.components:
@@ -351,8 +321,8 @@ class ClusterMethodsMixin:
         self,
         cluster_results: dict[str, ClusterResult],
         cfg_graphs: dict[str, CallGraph] | None = None,
-    ) -> dict[str, Node]:
-        """Build a lookup of qualified_name -> Node for all languages present in cluster_results.
+    ) -> dict[tuple[str, str], Node]:
+        """Build a language-qualified node lookup for all clustered languages.
 
         Args:
             cluster_results: Language -> ClusterResult mapping (used to determine languages).
@@ -360,12 +330,12 @@ class ClusterMethodsMixin:
                         When provided (e.g. subgraph from DetailsAgent), only nodes
                         from these graphs are included, preventing scope leakage.
         """
-        all_nodes: dict[str, Node] = {}
+        all_nodes: dict[tuple[str, str], Node] = {}
         for lang in cluster_results:
             cfg = (
                 cfg_graphs[lang] if cfg_graphs and lang in cfg_graphs else self.static_analysis.get_cfg(Language(lang))
             )
-            all_nodes.update(cfg.nodes)
+            all_nodes.update({(lang, qualified_name): node for qualified_name, node in cfg.nodes.items()})
         return all_nodes
 
     def _build_undirected_graphs(
@@ -392,6 +362,7 @@ class ClusterMethodsMixin:
 
     def _find_nearest_cluster(
         self,
+        language: str,
         node_name: str,
         cluster_results: dict[str, ClusterResult],
         undirected_graphs: dict[str, nx.Graph],
@@ -410,22 +381,22 @@ class ClusterMethodsMixin:
         best_cluster: int | None = None
         best_dist = float("inf")
 
-        for lang, cr in cluster_results.items():
-            nx_graph = undirected_graphs.get(lang)
-            if nx_graph is None or node_name not in nx_graph:
-                continue
+        cluster_result = cluster_results.get(language)
+        nx_graph = undirected_graphs.get(language)
+        if cluster_result is None or nx_graph is None or node_name not in nx_graph:
+            return None
 
-            try:
-                distances = nx.single_source_shortest_path_length(nx_graph, node_name)
-            except nx.NetworkXError:
-                continue
+        try:
+            distances = nx.single_source_shortest_path_length(nx_graph, node_name)
+        except nx.NetworkXError:
+            return None
 
-            for cluster_id, members in cr.clusters.items():
-                for member in members:
-                    d = distances.get(member)
-                    if d is not None and d < best_dist:
-                        best_dist = d
-                        best_cluster = cluster_id
+        for cluster_id, members in cluster_result.clusters.items():
+            for member in members:
+                distance = distances.get(member)
+                if distance is not None and distance < best_dist:
+                    best_dist = distance
+                    best_cluster = cluster_id
 
         return best_cluster
 
@@ -495,18 +466,18 @@ class ClusterMethodsMixin:
 
     def _build_node_to_cluster_map(
         self, cluster_results: dict[str, ClusterResult], source_cluster_id_prefix: str = ""
-    ) -> tuple[dict[str, ComponentId], set[ComponentId]]:
-        """Build node_name (qualified name) -> cluster_id mapping and collect all cluster IDs."""
+    ) -> tuple[dict[tuple[str, str], ComponentId], set[ComponentId]]:
+        """Build language-qualified node-to-cluster membership and collect all cluster IDs."""
         all_cluster_ids: set[ComponentId] = set()
-        node_to_cluster: dict[str, ComponentId] = {}
-        for cr in cluster_results.values():
+        node_to_cluster: dict[tuple[str, str], ComponentId] = {}
+        for language, cr in cluster_results.items():
             for cid, members in cr.clusters.items():
                 cluster_id = CodeBoardingClusterIds.qualify_local_id(
                     CodeBoardingClusterIds.from_graph_id(cid), source_cluster_id_prefix
                 )
                 all_cluster_ids.add(cluster_id)
                 for name in members:
-                    node_to_cluster[name] = cluster_id
+                    node_to_cluster[(language, name)] = cluster_id
         return node_to_cluster, all_cluster_ids
 
     def _validate_cluster_coverage(
@@ -523,6 +494,7 @@ class ClusterMethodsMixin:
 
     def _find_component_by_file(
         self,
+        language: str,
         node: Node,
         cluster_results: dict[str, ClusterResult],
         cluster_to_component: dict[str, Component],
@@ -532,21 +504,21 @@ class ClusterMethodsMixin:
         file_path = node.file_path
         if not file_path:
             return None
-        for cr in cluster_results.values():
-            cluster_ids = cr.get_clusters_for_file(file_path)
-            for cid in cluster_ids:
-                cluster_id = CodeBoardingClusterIds.qualify_local_id(
-                    CodeBoardingClusterIds.from_graph_id(cid), source_cluster_id_prefix
-                )
-                comp = cluster_to_component.get(cluster_id)
-                if comp is not None:
-                    return comp
+        cluster_result = cluster_results[language]
+        cluster_ids = cluster_result.get_clusters_for_file(file_path)
+        for cid in cluster_ids:
+            cluster_id = CodeBoardingClusterIds.qualify_local_id(
+                CodeBoardingClusterIds.from_graph_id(cid), source_cluster_id_prefix
+            )
+            comp = cluster_to_component.get(cluster_id)
+            if comp is not None:
+                return comp
         return None
 
     def _assign_nodes_to_components(
         self,
-        all_nodes: dict[str, Node],
-        node_to_cluster: dict[str, str],
+        all_nodes: dict[tuple[str, str], Node],
+        node_to_cluster: dict[tuple[str, str], str],
         cluster_to_component: dict[str, Component],
         cluster_results: dict[str, ClusterResult],
         fallback_component: Component,
@@ -555,14 +527,14 @@ class ClusterMethodsMixin:
     ) -> dict[str, list[Node]]:
         """Assign every node to a component via its cluster, file co-location, graph distance, or fallback."""
         component_nodes: dict[str, list[Node]] = defaultdict(list)
-        unassigned: list[str] = []
+        unassigned: list[tuple[str, str]] = []
 
-        for qname, node in all_nodes.items():
-            cid = node_to_cluster.get(qname)
+        for node_key, node in all_nodes.items():
+            cid = node_to_cluster.get(node_key)
             if cid is not None and cid in cluster_to_component:
                 component_nodes[cluster_to_component[cid].component_id].append(node)
             else:
-                unassigned.append(qname)
+                unassigned.append(node_key)
 
         if unassigned:
             logger.info(f"Assigning {len(unassigned)} orphan node(s)")
@@ -575,18 +547,24 @@ class ClusterMethodsMixin:
         # Pre-build undirected graphs once for all orphan lookups
         undirected_graphs = self._build_undirected_graphs(cluster_results, cfg_graphs) if unassigned else {}
 
-        for qname in unassigned:
-            node = all_nodes[qname]
+        for language, qname in unassigned:
+            node = all_nodes[(language, qname)]
 
             # 1. Try file co-location: if the node's file already belongs to a cluster/component
-            comp = self._find_component_by_file(node, cluster_results, cluster_to_component, source_cluster_id_prefix)
+            comp = self._find_component_by_file(
+                language,
+                node,
+                cluster_results,
+                cluster_to_component,
+                source_cluster_id_prefix,
+            )
             if comp is not None:
                 assigned_by_file += 1
                 component_nodes[comp.component_id].append(node)
                 continue
 
             # 2. Try graph distance: find the nearest cluster in the call graph
-            nearest_cid = self._find_nearest_cluster(qname, cluster_results, undirected_graphs)
+            nearest_cid = self._find_nearest_cluster(language, qname, cluster_results, undirected_graphs)
             nearest_cluster_id = (
                 CodeBoardingClusterIds.qualify_local_id(
                     CodeBoardingClusterIds.from_graph_id(nearest_cid), source_cluster_id_prefix

--- a/agents/details_agent.py
+++ b/agents/details_agent.py
@@ -34,7 +34,8 @@ from agents.validation import (
 )
 from monitoring import trace
 from static_analyzer.analysis_result import StaticAnalysisResults
-from static_analyzer.cfg import CallGraph, DEFAULT_REFERENCE_KINDS
+from static_analyzer.cfg import CallGraph
+from static_analyzer.config import Language
 from static_analyzer.clustering import ClusterResult, ClusterScopeResult
 
 logger = logging.getLogger(__name__)
@@ -78,26 +79,6 @@ class DetailsAgent(ClusterMethodsMixin, CodeBoardingAgent):
         }
 
     @trace
-    def step_clusters_grouping(
-        self,
-        component: Component,
-        subgraph_cluster_results: dict[str, ClusterResult],
-        subgraph_cfgs: dict[str, CallGraph],
-    ) -> ClusterAnalysis:
-        """Deterministically partition the component's subgraph into sub-component groups.
-
-        Same resolution-tuned Leiden as the top level, but with the sub-component
-        range ``[3, 8]``: the count (modularity peak) and membership are chosen
-        deterministically from the subgraph structure, not by the LLM.
-        """
-        logger.info(f"[DetailsAgent] Super-clustering subgraph for component: {component.name}")
-        return self.deterministic_cluster_grouping(
-            subgraph_cluster_results,
-            {lang: cfg.to_networkx(DEFAULT_REFERENCE_KINDS) for lang, cfg in subgraph_cfgs.items()},
-            subcomponents=True,
-        )
-
-    @trace
     def step_final_analysis(
         self,
         component: Component,
@@ -110,7 +91,7 @@ class DetailsAgent(ClusterMethodsMixin, CodeBoardingAgent):
 
         Args:
             component: The component being analyzed
-            cluster_analysis: The clustered structure from step_clusters_grouping
+            cluster_analysis: The precomputed clustered structure
             subgraph_cluster_results: Cluster results for the subgraph (for validation)
 
         Returns:
@@ -214,37 +195,26 @@ class DetailsAgent(ClusterMethodsMixin, CodeBoardingAgent):
         assign_relation_ids(analysis)
         self.build_static_relations(analysis, cfg_graphs, source_cluster_id_prefix=source_cluster_id_prefix)
 
-    def run_scope(
+    def run(
         self,
-        component: Component,
         scope: ClusterScopeResult,
-        subgraph_cfgs: dict[str, CallGraph],
+        component: Component,
     ) -> tuple[AnalysisInsights, dict[str, ClusterResult]]:
         """Name and analyze one precomputed component scope."""
         logger.info(f"[DetailsAgent] Processing precomputed component: {component.name}")
-        return self._run_clustered(
-            component,
-            self.cluster_analysis_from_scope(scope),
-            scope.leaf_clusters_by_language,
-            subgraph_cfgs,
-        )
+        subgraph_cfgs: dict[str, CallGraph] = {}
+        for language, partition in scope.leaf_clusters_by_language.items():
+            assigned_qnames = {
+                qualified_name
+                for group in scope.groups
+                for qualified_name in group.symbol_members_by_language.get(language, set())
+            } or {qualified_name for cluster in partition.clusters.values() for qualified_name in cluster}
+            subgraph = self.static_analysis.get_cfg(Language(language)).filter_by_nodes(assigned_qnames)
+            if subgraph.nodes:
+                subgraph_cfgs[language] = subgraph
 
-    def run(self, component: Component) -> tuple[AnalysisInsights, dict[str, ClusterResult]]:
-        """Cluster and analyze one component scope directly."""
-        logger.info(f"[DetailsAgent] Processing component: {component.name}")
-        subgraph_cluster_results, subgraph_cfgs = self._create_strict_component_subgraph(
-            component, source_cluster_id_prefix=component.component_id
-        )
-        cluster_analysis = self.step_clusters_grouping(component, subgraph_cluster_results, subgraph_cfgs)
-        return self._run_clustered(component, cluster_analysis, subgraph_cluster_results, subgraph_cfgs)
-
-    def _run_clustered(
-        self,
-        component: Component,
-        cluster_analysis: ClusterAnalysis,
-        subgraph_cluster_results: dict[str, ClusterResult],
-        subgraph_cfgs: dict[str, CallGraph],
-    ) -> tuple[AnalysisInsights, dict[str, ClusterResult]]:
+        cluster_analysis = self.cluster_analysis_from_scope(scope)
+        subgraph_cluster_results = scope.leaf_clusters_by_language
         analysis = self.step_final_analysis(component, cluster_analysis, subgraph_cluster_results, subgraph_cfgs)
 
         assign_component_ids(analysis, parent_id=component.component_id)

--- a/agents/details_agent.py
+++ b/agents/details_agent.py
@@ -7,13 +7,11 @@ from langchain_core.language_models import BaseChatModel
 from agents.agent import CodeBoardingAgent
 from agents.agent_responses import (
     AnalysisInsights,
-    ClusterAnalysis,
     ComponentApiSurfaces,
     ComponentArchitecture,
     ComponentRelations,
     Component,
     MetaAnalysisInsights,
-    assign_component_ids,
     assign_relation_ids,
 )
 from agents.prompts import (
@@ -34,8 +32,6 @@ from agents.validation import (
 )
 from monitoring import trace
 from static_analyzer.analysis_result import StaticAnalysisResults
-from static_analyzer.cfg import CallGraph
-from static_analyzer.config import Language
 from static_analyzer.clustering import ClusterResult, ClusterScopeResult
 
 logger = logging.getLogger(__name__)
@@ -79,31 +75,27 @@ class DetailsAgent(ClusterMethodsMixin, CodeBoardingAgent):
         }
 
     @trace
-    def step_final_analysis(
+    def step_llm_analysis(
         self,
         component: Component,
-        cluster_analysis: ClusterAnalysis,
-        subgraph_cluster_results: dict[str, ClusterResult],
-        subgraph_cfgs: dict[str, CallGraph],
+        scope: ClusterScopeResult,
     ) -> AnalysisInsights:
         """
         Generate detailed final analysis from grouped clusters.
 
         Args:
             component: The component being analyzed
-            cluster_analysis: The precomputed clustered structure
-            subgraph_cluster_results: Cluster results for the subgraph (for validation)
+            scope: The precomputed clustered structure
 
         Returns:
             AnalysisInsights with detailed component information
         """
         logger.info(f"[DetailsAgent] Generating final detailed analysis for: {component.name}")
-        cluster_str = cluster_analysis.llm_str() if cluster_analysis else "No cluster analysis available."
-
-        group_names = [cc.name for cc in cluster_analysis.cluster_components] if cluster_analysis else []
+        subgraph_cluster_results = scope.leaf_clusters_by_language
+        group_names = scope.group_names()
 
         prompt = self.prompts["final_analysis"].format(
-            cluster_analysis=cluster_str,
+            cluster_analysis=scope.llm_str(),
             component=component.llm_str(),
         )
 
@@ -113,14 +105,14 @@ class DetailsAgent(ClusterMethodsMixin, CodeBoardingAgent):
                 f"Every one of these names: {group_names} must appear in exactly one component's source_group_names\n"
             )
 
-        self.toolkit.context.cluster_analysis = cluster_analysis
+        self.toolkit.context.clustering = scope
         self.toolkit.context.cluster_results = subgraph_cluster_results
-        self.toolkit.context.cfg_graphs = subgraph_cfgs
+        self.toolkit.context.cfg_graphs = scope.graphs_by_language
 
         context = ValidationContext(
             cluster_results=subgraph_cluster_results,
             static_analysis=self.static_analysis,
-            llm_cluster_analysis=cluster_analysis,
+            clustering=scope,
         )
 
         architecture = self._invoke_repair_validate(
@@ -134,12 +126,12 @@ class DetailsAgent(ClusterMethodsMixin, CodeBoardingAgent):
             repair_context=ComponentRepairContext(
                 reference_resolver=self.reference_resolver,
                 cluster_results=subgraph_cluster_results,
-                llm_cluster_analysis=cluster_analysis,
+                clustering=scope,
             ),
             validation_context=context,
             max_validation_attempts=3,
         )
-        self.assemble_one_component_per_group(architecture, cluster_analysis, subgraph_cluster_results)
+        self.assemble_one_component_per_group(architecture, scope)
         result = AnalysisInsights(
             description=architecture.description,
             components=architecture.components,
@@ -162,14 +154,14 @@ class DetailsAgent(ClusterMethodsMixin, CodeBoardingAgent):
         self,
         analysis: AnalysisInsights,
         api_surfaces: ComponentApiSurfaces,
-        cluster_analysis: ClusterAnalysis,
-        cluster_results: dict[str, ClusterResult],
-        cfg_graphs: dict[str, CallGraph],
+        scope: ClusterScopeResult,
         source_cluster_id_prefix: str,
     ) -> None:
         logger.info(f"[DetailsAgent] Discovering component relations for: {self.project_name}")
+        cluster_results = scope.leaf_clusters_by_language
+        cfg_graphs = scope.graphs_by_language
         static_call_evidence = self.build_scope_cfg_string(analysis)
-        self.toolkit.context.cluster_analysis = cluster_analysis
+        self.toolkit.context.clustering = scope
         self.toolkit.context.cluster_results = cluster_results
         self.toolkit.context.cfg_graphs = cfg_graphs
         prompt = self.prompts["relation_analysis"].format(
@@ -186,7 +178,7 @@ class DetailsAgent(ClusterMethodsMixin, CodeBoardingAgent):
                 cfg_graphs=cfg_graphs,
                 repo_dir=str(self.repo_dir),
                 static_analysis=self.static_analysis,
-                llm_cluster_analysis=cluster_analysis,
+                clustering=scope,
                 components=analysis.components,
             ),
             max_validation_attempts=3,
@@ -202,32 +194,17 @@ class DetailsAgent(ClusterMethodsMixin, CodeBoardingAgent):
     ) -> tuple[AnalysisInsights, dict[str, ClusterResult]]:
         """Name and analyze one precomputed component scope."""
         logger.info(f"[DetailsAgent] Processing precomputed component: {component.name}")
-        subgraph_cfgs: dict[str, CallGraph] = {}
-        for language, partition in scope.leaf_clusters_by_language.items():
-            assigned_qnames = {
-                qualified_name
-                for group in scope.groups
-                for qualified_name in group.symbol_members_by_language.get(language, set())
-            } or {qualified_name for cluster in partition.clusters.values() for qualified_name in cluster}
-            subgraph = self.static_analysis.get_cfg(Language(language)).filter_by_nodes(assigned_qnames)
-            if subgraph.nodes:
-                subgraph_cfgs[language] = subgraph
-
-        cluster_analysis = self.cluster_analysis_from_scope(scope)
         subgraph_cluster_results = scope.leaf_clusters_by_language
-        analysis = self.step_final_analysis(component, cluster_analysis, subgraph_cluster_results, subgraph_cfgs)
+        analysis = self.step_llm_analysis(component, scope)
 
-        assign_component_ids(analysis, parent_id=component.component_id)
-        self._resolve_cluster_ids_from_groups(analysis, cluster_analysis)
-        self.populate_file_methods(analysis, subgraph_cluster_results, subgraph_cfgs)
+        self._resolve_cluster_ids_from_groups(analysis, scope)
+        self.populate_file_methods(analysis, subgraph_cluster_results, scope.graphs_by_language)
 
         api_surfaces = self.step_api_surfaces(analysis)
         self.step_relation_analysis(
             analysis,
             api_surfaces,
-            cluster_analysis,
-            subgraph_cluster_results,
-            subgraph_cfgs,
+            scope,
             component.component_id,
         )
 

--- a/agents/details_agent.py
+++ b/agents/details_agent.py
@@ -35,7 +35,7 @@ from agents.validation import (
 from monitoring import trace
 from static_analyzer.analysis_result import StaticAnalysisResults
 from static_analyzer.cfg import CallGraph, DEFAULT_REFERENCE_KINDS
-from static_analyzer.clustering import ClusterResult
+from static_analyzer.clustering import ClusterResult, ClusterScopeResult
 
 logger = logging.getLogger(__name__)
 
@@ -214,55 +214,44 @@ class DetailsAgent(ClusterMethodsMixin, CodeBoardingAgent):
         assign_relation_ids(analysis)
         self.build_static_relations(analysis, cfg_graphs, source_cluster_id_prefix=source_cluster_id_prefix)
 
-    def run(self, component: Component):
-        """
-        Analyze a component in detail by creating a subgraph and analyzing its structure.
+    def run_scope(
+        self,
+        component: Component,
+        scope: ClusterScopeResult,
+        subgraph_cfgs: dict[str, CallGraph],
+    ) -> tuple[AnalysisInsights, dict[str, ClusterResult]]:
+        """Name and analyze one precomputed component scope."""
+        logger.info(f"[DetailsAgent] Processing precomputed component: {component.name}")
+        return self._run_clustered(
+            component,
+            self.cluster_analysis_from_scope(scope),
+            scope.leaf_clusters_by_language,
+            subgraph_cfgs,
+        )
 
-        This follows the same pattern as AbstractionAgent but operates on a component-level
-        subgraph instead of the full codebase.
-
-        Pipeline:
-        1. Create subgraph from component's assigned files (with method-level expansion if < 5 clusters)
-        2. LLM groups clusters into logical sub-components
-        3. LLM creates components from groups (validated: key_entities must be in cluster scope)
-        4. Deterministically assign methods via cluster -> component mapping
-
-        Args:
-            component: Component to analyze in detail
-
-        Returns:
-            Tuple of (AnalysisInsights, cluster_results dict) with detailed component information
-        """
+    def run(self, component: Component) -> tuple[AnalysisInsights, dict[str, ClusterResult]]:
+        """Cluster and analyze one component scope directly."""
         logger.info(f"[DetailsAgent] Processing component: {component.name}")
-
-        # Step 1: Create subgraph from component's assigned files using strict filtering
-        # If subgraph has < MIN_CLUSTERS_THRESHOLD clusters, auto-expands to method-level
         subgraph_cluster_results, subgraph_cfgs = self._create_strict_component_subgraph(
             component, source_cluster_id_prefix=component.component_id
         )
-
-        # Step 2: Group clusters within the subgraph
         cluster_analysis = self.step_clusters_grouping(component, subgraph_cluster_results, subgraph_cfgs)
+        return self._run_clustered(component, cluster_analysis, subgraph_cluster_results, subgraph_cfgs)
 
-        # Step 3: Generate detailed analysis from grouped clusters
-        # Validation ensures key_entities are within cluster scope (no rescue needed)
+    def _run_clustered(
+        self,
+        component: Component,
+        cluster_analysis: ClusterAnalysis,
+        subgraph_cluster_results: dict[str, ClusterResult],
+        subgraph_cfgs: dict[str, CallGraph],
+    ) -> tuple[AnalysisInsights, dict[str, ClusterResult]]:
         analysis = self.step_final_analysis(component, cluster_analysis, subgraph_cluster_results, subgraph_cfgs)
 
-        # Step 4: Assign hierarchical component IDs (e.g., "1.1", "1.2" under parent "1")
         assign_component_ids(analysis, parent_id=component.component_id)
-
-        # Step 5: Resolve cluster IDs deterministically from group names
         self._resolve_cluster_ids_from_groups(analysis, cluster_analysis)
-
-        # Step 6: Populate file_methods deterministically from cluster results + orphan assignment
-        # Pass subgraph_cfgs to scope node collection to the component's filtered graph
-        # With method-level expansion, each method has its own cluster -> deterministic assignment
         self.populate_file_methods(analysis, subgraph_cluster_results, subgraph_cfgs)
 
-        # Step 7: Analyze component API surfaces
         api_surfaces = self.step_api_surfaces(analysis)
-
-        # Step 8: Discover relations from API surfaces and attach deterministic all_edges
         self.step_relation_analysis(
             analysis,
             api_surfaces,
@@ -272,13 +261,8 @@ class DetailsAgent(ClusterMethodsMixin, CodeBoardingAgent):
             component.component_id,
         )
 
-        # Step 9: Fix source code reference lines (resolves reference_file paths)
         analysis = self.reference_resolver.fix_source_code_reference_lines(analysis)
-
-        # Step 10: Index relation endpoints after reference resolution
         index_relation_endpoints(analysis, self.repo_dir)
-
-        # Step 11: Ensure unique key entities across components
         self._ensure_unique_key_entities(analysis)
 
         return analysis, subgraph_cluster_results

--- a/agents/incremental_agent.py
+++ b/agents/incremental_agent.py
@@ -340,7 +340,7 @@ class IncrementalAgent(ClusterMethodsMixin, CodeBoardingAgent):
     ) -> list[Relation]:
         """Discover evidence-backed relations and attach deterministic CFG edges."""
         logger.info("[IncrementalAgent] Discovering component relations for scope: %s", scope_name)
-        self.toolkit.context.cluster_analysis = cluster_analysis
+        self.toolkit.context.clustering = cluster_analysis
         self.toolkit.context.cluster_results = cluster_results
         self.toolkit.context.cfg_graphs = cfg_graphs
         prompt = self.prompts["relation_analysis"].format(
@@ -359,7 +359,7 @@ class IncrementalAgent(ClusterMethodsMixin, CodeBoardingAgent):
                 cfg_graphs=cfg_graphs,
                 repo_dir=str(self.repo_dir),
                 static_analysis=self.static_analysis,
-                llm_cluster_analysis=cluster_analysis,
+                clustering=cluster_analysis,
                 components=scope.components,
             ),
             max_validation_attempts=3,

--- a/agents/repair.py
+++ b/agents/repair.py
@@ -7,7 +7,7 @@ from difflib import SequenceMatcher
 from typing import Protocol
 
 from agents.agent_responses import ClusterAnalysis, Component
-from static_analyzer.clustering import ClusterResult
+from static_analyzer.clustering import ClusterResult, ClusterScopeResult
 from static_analyzer.reference_resolver import StaticReferenceResolver
 
 logger = logging.getLogger(__name__)
@@ -20,13 +20,13 @@ class ComponentRepairTarget(Protocol):
 @dataclass
 class ComponentRepairContext:
     reference_resolver: StaticReferenceResolver
-    llm_cluster_analysis: ClusterAnalysis
+    clustering: ClusterScopeResult | ClusterAnalysis
     cluster_results: dict[str, ClusterResult] = field(default_factory=dict)
 
 
 def repair_component_group_names(result: ComponentRepairTarget, context: ComponentRepairContext) -> None:
     """Canonicalize unambiguous component source-group names."""
-    expected_group_names = {group.name for group in context.llm_cluster_analysis.cluster_components}
+    expected_group_names = set(context.clustering.group_ids())
     canonical_names = {_normalize_group_name(name): name for name in expected_group_names}
     corrected_count = 0
 

--- a/agents/tools/base.py
+++ b/agents/tools/base.py
@@ -8,7 +8,7 @@ from repo_utils.ignore import RepoIgnoreManager
 from repo_utils.change_detector import ChangeSet
 from static_analyzer.analysis_result import StaticAnalysisResults
 from static_analyzer.cfg import CallGraph
-from static_analyzer.clustering import ClusterResult
+from static_analyzer.clustering import ClusterResult, ClusterScopeResult
 
 
 class RepoContext(BaseModel):
@@ -20,7 +20,7 @@ class RepoContext(BaseModel):
     ignore_manager: RepoIgnoreManager
     static_analysis: Optional[StaticAnalysisResults] = None
     changes: ChangeSet | None = None
-    cluster_analysis: ClusterAnalysis = Field(default_factory=lambda: ClusterAnalysis(cluster_components=[]))
+    clustering: ClusterScopeResult | ClusterAnalysis = Field(default_factory=lambda: ClusterScopeResult(scope_id=""))
     cluster_results: dict[str, ClusterResult] = Field(default_factory=dict)
     cfg_graphs: dict[str, CallGraph] = Field(default_factory=dict)
     # Shared caches to prevent redundant filesystem walks

--- a/agents/tools/component_bridge_edges.py
+++ b/agents/tools/component_bridge_edges.py
@@ -27,7 +27,7 @@ class ComponentBridgeEdgesTool(BaseRepoTool):
     args_schema: ArgsSchema = ComponentBridgeEdgesInput
 
     def _run(self, source_group_names: list[str], destination_group_names: list[str]) -> str:
-        if not self.context.cluster_analysis.cluster_components:
+        if not self.context.clustering.group_ids():
             return "No grouped cluster context available."
 
         source_clusters = self._cluster_ids_for_groups(source_group_names)
@@ -70,11 +70,12 @@ class ComponentBridgeEdgesTool(BaseRepoTool):
 
     def _cluster_ids_for_groups(self, group_names: list[str]) -> set[int]:
         requested = set(group_names)
-        cluster_ids: set[int] = set()
-        for group in self.context.cluster_analysis.cluster_components:
-            if group.name in requested:
-                cluster_ids.update(group.cluster_ids)
-        return cluster_ids
+        return {
+            cluster_id
+            for name, cluster_ids in self.context.clustering.group_ids().items()
+            if name in requested
+            for cluster_id in cluster_ids
+        }
 
     def _nodes_for_clusters(self, cluster_ids: set[int]) -> set[str]:
         nodes: set[str] = set()

--- a/agents/validation.py
+++ b/agents/validation.py
@@ -16,7 +16,7 @@ from agents.agent_responses import (
 from repo_utils import normalize_path
 from static_analyzer.analysis_result import StaticAnalysisResults
 from static_analyzer.cfg import CallGraph
-from static_analyzer.clustering import ClusterResult
+from static_analyzer.clustering import ClusterResult, ClusterScopeResult
 from static_analyzer.reference_resolver import StaticReferenceResolver
 
 logger = logging.getLogger(__name__)
@@ -49,7 +49,7 @@ class ValidationContext:
     valid_component_names: set[str] = field(default_factory=set)  # For file classification validation
     repo_dir: str | None = None  # For path normalization
     static_analysis: StaticAnalysisResults | None = None  # For qualified name validation
-    llm_cluster_analysis: ClusterAnalysis | None = None  # For group name coverage validation
+    clustering: ClusterScopeResult | ClusterAnalysis = field(default_factory=lambda: ClusterScopeResult(scope_id=""))
     components: list[Component] = field(default_factory=list)  # For relation-only validation steps
 
 
@@ -113,11 +113,10 @@ def validate_group_name_coverage(result: ComponentValidationTarget, context: Val
     Returns:
         ValidationResult with targeted feedback depending on the issue
     """
-    if not context.llm_cluster_analysis:
-        logger.warning("[Validation] No cluster_analysis provided for group name coverage validation")
+    expected_group_names = set(context.clustering.group_ids())
+    if not expected_group_names:
+        logger.warning("[Validation] No clustering provided for group name coverage validation")
         return ValidationResult(is_valid=True)
-
-    expected_group_names = {cc.name for cc in context.llm_cluster_analysis.cluster_components}
 
     referenced_group_names: set[str] = set()
     for component in result.components:
@@ -325,14 +324,14 @@ def validate_relation_component_names(
 
 def validate_relation_evidence(result: RelationValidationTarget, context: ValidationContext) -> ValidationResult:
     """Validate LLM relations against directed CFG edges or explicit runtime evidence."""
-    if not context.llm_cluster_analysis or not context.cluster_results or not context.cfg_graphs:
+    if not context.clustering.group_ids() or not context.cluster_results or not context.cfg_graphs:
         logger.warning("[Validation] Missing static context for relation evidence validation")
         return ValidationResult(is_valid=True)
 
     components = context.components
     if not components and isinstance(result, AnalysisInsights):
         components = result.components
-    component_to_clusters = _component_cluster_ids(components, context.llm_cluster_analysis)
+    component_to_clusters = _component_cluster_ids(components, context.clustering)
     cluster_edge_lookup = _build_cluster_edge_lookup(context.cluster_results, context.cfg_graphs)
     unsupported: list[str] = []
     invalid_key_edges: list[str] = []
@@ -485,8 +484,10 @@ def _build_cluster_edge_lookup(
     return cluster_edge_lookup
 
 
-def _component_cluster_ids(components: list[Component], cluster_analysis: ClusterAnalysis) -> dict[str, list[int]]:
-    group_to_cluster_ids = {group.name: group.cluster_ids for group in cluster_analysis.cluster_components}
+def _component_cluster_ids(
+    components: list[Component], clustering: ClusterScopeResult | ClusterAnalysis
+) -> dict[str, list[int]]:
+    group_to_cluster_ids = clustering.group_ids()
     component_to_clusters: dict[str, list[int]] = {}
     for component in components:
         cluster_ids: list[int] = []

--- a/codeboarding_workflows/analysis.py
+++ b/codeboarding_workflows/analysis.py
@@ -99,7 +99,7 @@ def run_partial(
 
     depth_level = int(metadata.get("depth_cap", metadata.get("depth_level", DEFAULT_DEPTH_LEVEL)))
     generator = build_generator(run_paths, run_context, depth_level=depth_level)
-    generator.pre_analysis()
+    generator.prepare_analysis(hierarchy_depth=depth_level + 1)
 
     full_analysis = load_full_analysis(run_paths.output_dir)
     if full_analysis is None:

--- a/codeboarding_workflows/analysis.py
+++ b/codeboarding_workflows/analysis.py
@@ -98,9 +98,6 @@ def run_partial(
         )
 
     depth_level = int(metadata.get("depth_cap", metadata.get("depth_level", DEFAULT_DEPTH_LEVEL)))
-    generator = build_generator(run_paths, run_context, depth_level=depth_level)
-    generator.prepare_analysis(hierarchy_depth=depth_level + 1)
-
     full_analysis = load_full_analysis(run_paths.output_dir)
     if full_analysis is None:
         # Metadata was present but the unified read failed — treat as a
@@ -130,6 +127,9 @@ def run_partial(
     if component_to_analyze is None:
         logger.error(f"Component with ID '{component_id}' not found in analysis")
         return
+
+    generator = build_generator(run_paths, run_context, depth_level=depth_level)
+    generator.prepare_analysis(hierarchy_depth=depth_level + 1, target_component=component_to_analyze)
 
     _, sub_analysis, _ = generator.process_component(component_to_analyze)
     if sub_analysis is None:

--- a/diagram_analysis/diagram_generator.py
+++ b/diagram_analysis/diagram_generator.py
@@ -84,7 +84,7 @@ from static_analyzer.cluster_relations import (
     prune_ungrounded_edges,
 )
 from static_analyzer.config import Language
-from static_analyzer.clustering import ClusterGroup, ClusterResult, ClusterScopeResult, ClusteringService
+from static_analyzer.clustering import ClusterGroup, ClusterResult, ClusterScopeResult
 from static_analyzer.clustering.orchestration import build_clustering_hierarchy
 from static_analyzer.scanner import ProjectScanner
 from telemetry.events import track_analysis
@@ -601,7 +601,7 @@ class DiagramGenerator:
         # save-time global rebuild must treat it as changed.
         self._baseline_member_keys: dict[str, frozenset[tuple[str, str]]] = {}
         # Whole-tree content hash, stamped into the pkl's sibling .sha file as the
-        # diff base for the next warm-start (NOT a cache gate). ``pre_analysis``
+        # diff base for the next warm-start (NOT a cache gate). ``prepare_analysis``
         # fills it from the live tree when unset; ``None`` is a tag-less save.
         self.source_sha: str | None = None
         # Whole-tree ``{posix_path: sha16}`` fingerprint, computed once per run and
@@ -612,6 +612,7 @@ class DiagramGenerator:
 
         self.details_agent: DetailsAgent | None = None
         self.static_analysis: StaticAnalysisResults | None = None  # Cache static analysis for reuse
+        self.clustering_hierarchy: ClusterScopeResult | None = None
         self.abstraction_agent: AbstractionAgent | None = None
         self.meta_agent: MetaAgent | None = None
         self.incremental_agent: IncrementalAgent | None = None
@@ -626,7 +627,8 @@ class DiagramGenerator:
         # deterministic pipeline. Keyed by membership, so a changed component re-runs.
         self._separable_cache: dict[frozenset[tuple[str, str]], bool] = {}
         self._clustering_groups: dict[str, ClusterGroup] = {}
-        self._preclustered_scopes: dict[str, tuple[ClusterScopeResult, dict[str, CallGraph]]] = {}
+        self._preclustered_scopes: dict[str, ClusterScopeResult] = {}
+        self._analysis_start_time = time.time()
 
     @track_analysis
     def process_component(
@@ -637,22 +639,20 @@ class DiagramGenerator:
     def _index_clustering_hierarchy(
         self,
         hierarchy: ClusterScopeResult,
-        root_graphs: dict[str, CallGraph],
     ) -> None:
         """Index precomputed child scopes by the component IDs agents will assign."""
         self._clustering_groups.clear()
         self._preclustered_scopes.clear()
 
-        def visit(scope: ClusterScopeResult, graphs: dict[str, CallGraph]) -> None:
+        def visit(scope: ClusterScopeResult) -> None:
             for group in scope.groups:
                 self._clustering_groups[group.group_id] = group
                 if group.children is None:
                     continue
-                child_graphs = ClusteringService.induced_graphs(group, graphs)
-                self._preclustered_scopes[group.group_id] = (group.children, child_graphs)
-                visit(group.children, child_graphs)
+                self._preclustered_scopes[group.group_id] = group.children
+                visit(group.children)
 
-        visit(hierarchy, root_graphs)
+        visit(hierarchy)
 
     def _reroot_clustering_groups(self, absorbed_ids: list[str]) -> None:
         """Keep precomputed expansion flags aligned with absorbed component IDs."""
@@ -780,19 +780,11 @@ class DiagramGenerator:
         try:
             assert self.details_agent is not None
 
-            preclustered = self._preclustered_scopes.get(component.component_id)
-            if preclustered is not None:
-                scope, cfgs = preclustered
-                analysis, _ = self.details_agent.run_scope(component, scope, cfgs)
-                new_components = [
-                    child for child in analysis.components if child.component_id in self._preclustered_scopes
-                ]
-            else:
-                analysis, _ = self.details_agent.run(component)
-                parent_had_clusters = bool(component.source_cluster_ids)
-                new_components = get_expandable_components(
-                    analysis, parent_had_clusters=parent_had_clusters, separable=self._component_separable
-                )
+            scope = self._preclustered_scopes.get(component.component_id)
+            if scope is None:
+                raise ValueError(f"No precomputed clustering scope for component {component.component_id}")
+            analysis, _ = self.details_agent.run(scope, component)
+            new_components = [child for child in analysis.components if child.component_id in self._preclustered_scopes]
 
             return component.component_id, analysis, new_components
         except LLMAuthError:
@@ -948,7 +940,7 @@ class DiagramGenerator:
         StaticAnalysisCache(self.output_dir, self.repo_location).save(self.static_analysis, source_sha=self.source_sha)
 
     def _source_tree_fingerprint_map(self) -> dict[str, str]:
-        """The whole-tree fingerprint, fingerprinting on first use if pre_analysis didn't."""
+        """The whole-tree fingerprint, fingerprinting on first use if preparation didn't."""
         if self._source_tree_fingerprint is None:
             self._source_tree_fingerprint = hash_repo_source_files(self.repo_location)
         return self._source_tree_fingerprint
@@ -1009,9 +1001,14 @@ class DiagramGenerator:
             }
         )
 
-    def pre_analysis(self):
-        analysis_start_time = time.time()
-
+    def deterministic_analysis(
+        self,
+        *,
+        include_clustering: bool = True,
+        hierarchy_depth: int | None = None,
+    ) -> None:
+        """Run source fingerprinting, static analysis, and deterministic clustering."""
+        self._analysis_start_time = time.time()
         # Fingerprint the whole tree once; source_sha, the sidecar, and every
         # save's source_tree_hash reuse it instead of re-walking per call.
         self._source_tree_fingerprint = hash_repo_source_files(self.repo_location)
@@ -1021,29 +1018,21 @@ class DiagramGenerator:
         if self.source_sha is None:
             self.source_sha = self._source_tree_hash() or None
 
-        # Initialize LLMs before spawning threads so both share the same instances
-        agent_llm, parsing_llm = initialize_llms()
-
-        self._initialize_meta_agent(agent_llm, parsing_llm)
-
-        # Decide how to obtain static analysis results, then run it in parallel
-        # with the meta-context computation so neither blocks the other.
         if self._static_analyzer is not None:
             logger.info("Using injected StaticAnalyzer (clients already running)")
-            static_callable = self._get_static_with_injected_analyzer
+            static_analysis = self._get_static_with_injected_analyzer()
         else:
-            static_callable = self._get_static_with_new_analyzer
-
-        with ThreadPoolExecutor(max_workers=2) as executor:
-            meta_agent = self.meta_agent
-            assert meta_agent is not None
-            static_future = executor.submit(static_callable)
-            meta_future = executor.submit(meta_agent.analyze_project_metadata, skip_cache=self.force_full_analysis)
-            static_analysis = static_future.result()
-            meta_context = meta_future.result()
+            static_analysis = self._get_static_with_new_analyzer()
 
         self.static_analysis = static_analysis
-        self.meta_context = meta_context
+        self.clustering_hierarchy = None
+        self._clustering_groups.clear()
+        self._preclustered_scopes.clear()
+        if include_clustering:
+            depth = hierarchy_depth if hierarchy_depth is not None else self.depth_level
+            hierarchy = build_clustering_hierarchy(static_analysis, depth)
+            self.clustering_hierarchy = hierarchy
+            self._index_clustering_hierarchy(hierarchy)
 
         # --- Capture Static Analysis Stats ---
         static_stats: dict[str, Any] = {"repo_name": self.repo_name, "languages": {}}
@@ -1061,8 +1050,6 @@ class DiagramGenerator:
 
         self._run_health_report(static_analysis)
 
-        self._initialize_agents(static_analysis, meta_context, agent_llm, parsing_llm)
-
         if self.monitoring_enabled:
             monitoring_dir = get_monitoring_run_dir(self.log_path, create=True)
             logger.debug(f"Monitoring enabled. Writing stats to {monitoring_dir}")
@@ -1073,14 +1060,38 @@ class DiagramGenerator:
                 json.dump(static_stats, f, indent=2)
             logger.debug(f"Written code_stats.json to {code_stats_file}")
 
-            # Initialize streaming writer (handles timing and run_metadata.json)
+    def agent_init(self) -> None:
+        """Initialize the LLM-backed agents after deterministic analysis."""
+        assert self.static_analysis is not None
+        agent_llm, parsing_llm = initialize_llms()
+        self._initialize_meta_agent(agent_llm, parsing_llm)
+        assert self.meta_agent is not None
+        meta_context = self.meta_agent.analyze_project_metadata(skip_cache=self.force_full_analysis)
+        self.meta_context = meta_context
+        self._initialize_agents(self.static_analysis, meta_context, agent_llm, parsing_llm)
+
+        if self.monitoring_enabled:
+            monitoring_dir = get_monitoring_run_dir(self.log_path, create=True)
             self.stats_writer = StreamingStatsWriter(
                 monitoring_dir=monitoring_dir,
                 agents_dict=self._monitoring_agents,
                 repo_name=self.project_name or self.repo_name,
                 output_dir=str(self.output_dir),
-                start_time=analysis_start_time,
+                start_time=self._analysis_start_time,
             )
+
+    def prepare_analysis(
+        self,
+        *,
+        include_clustering: bool = True,
+        hierarchy_depth: int | None = None,
+    ) -> None:
+        """Prepare deterministic inputs, then initialize the analysis agents."""
+        self.deterministic_analysis(
+            include_clustering=include_clustering,
+            hierarchy_depth=hierarchy_depth,
+        )
+        self.agent_init()
 
     def _generate_subcomponents(
         self,
@@ -1183,8 +1194,13 @@ class DiagramGenerator:
         The output is stored in a single analysis.json file in output_dir.
         Components are analyzed in parallel as soon as their parents complete.
         """
-        if self.details_agent is None or self.abstraction_agent is None:
-            self.pre_analysis()
+        if (
+            self.details_agent is None
+            or self.abstraction_agent is None
+            or self.static_analysis is None
+            or self.clustering_hierarchy is None
+        ):
+            self.prepare_analysis()
 
         # Start monitoring (tracks start time)
         monitor = self.stats_writer if self.stats_writer else nullcontext()
@@ -1193,19 +1209,11 @@ class DiagramGenerator:
             logger.info("Generating initial analysis")
 
             assert self.abstraction_agent is not None
-
-            if self.static_analysis is not None:
-                hierarchy = build_clustering_hierarchy(self.static_analysis, self.depth_level)
-                self._index_clustering_hierarchy(hierarchy, self.static_analysis.available_cfgs())
-                analysis, _cluster_results = self.abstraction_agent.run_scope(hierarchy)
-                root_components = [
-                    component
-                    for component in analysis.components
-                    if component.component_id in self._preclustered_scopes
-                ]
-            else:
-                analysis, _cluster_results = self.abstraction_agent.run()
-                root_components = get_expandable_components(analysis, separable=self._component_separable)
+            assert self.clustering_hierarchy is not None
+            analysis, _cluster_results = self.abstraction_agent.run(self.clustering_hierarchy)
+            root_components = [
+                component for component in analysis.components if component.component_id in self._preclustered_scopes
+            ]
             logger.info(f"Found {len(root_components)} components to analyze at level 1")
 
             # Process components using a frontier queue: submit children as soon as parent finishes.
@@ -1459,7 +1467,7 @@ class DiagramGenerator:
         Raises when no trustworthy baseline or scoped update plan is available.
         """
         if self.details_agent is None or self.incremental_agent is None:
-            self.pre_analysis()
+            self.prepare_analysis(include_clustering=False)
         assert self.static_analysis is not None
         assert self.details_agent is not None
         assert self.incremental_agent is not None

--- a/diagram_analysis/diagram_generator.py
+++ b/diagram_analysis/diagram_generator.py
@@ -639,6 +639,7 @@ class DiagramGenerator:
         *,
         hierarchy_depth: int | None = None,
         target_component: Component | None = None,
+        require_incremental_baseline: bool = False,
     ) -> None:
         """Run source fingerprinting, static analysis, and deterministic clustering."""
         self._analysis_start_time = time.time()
@@ -658,6 +659,13 @@ class DiagramGenerator:
             static_analysis = self._get_static_with_new_analyzer()
 
         self.static_analysis = static_analysis
+        if require_incremental_baseline:
+            baseline = static_analysis.incremental_base_results
+            if baseline is None or not snapshot_from_static_analysis(baseline).all_cluster_ids():
+                error = IncrementalCacheMissingError(self.output_dir)
+                logger.error("%s", error)
+                raise error
+
         depth = hierarchy_depth if hierarchy_depth is not None else self.depth_level
         self.clustering_hierarchy = build_clustering_hierarchy(static_analysis, depth)
         if target_component is not None:
@@ -714,11 +722,13 @@ class DiagramGenerator:
         *,
         hierarchy_depth: int | None = None,
         target_component: Component | None = None,
+        require_incremental_baseline: bool = False,
     ) -> None:
         """Prepare deterministic inputs, then initialize the analysis agents."""
         self.deterministic_analysis(
             hierarchy_depth=hierarchy_depth,
             target_component=target_component,
+            require_incremental_baseline=require_incremental_baseline,
         )
         self.agent_init()
 
@@ -794,8 +804,10 @@ class DiagramGenerator:
                     component.component_id
                     for component in scope.components
                     if component.component_id
-                    and (group := clustering_groups.get(component.component_id)) is not None
-                    and group.expandable
+                    and (
+                        component.component_id in sub_analyses
+                        or ((group := clustering_groups.get(component.component_id)) is not None and group.expandable)
+                    )
                 ]
 
             return precomputed_ids(root_analysis), {
@@ -1466,7 +1478,7 @@ class DiagramGenerator:
         Raises when no trustworthy baseline or scoped update plan is available.
         """
         if self.details_agent is None or self.incremental_agent is None:
-            self.prepare_analysis()
+            self.prepare_analysis(require_incremental_baseline=True)
         assert self.static_analysis is not None
         assert self.details_agent is not None
         assert self.incremental_agent is not None
@@ -1529,7 +1541,11 @@ class DiagramGenerator:
                 changed_members.unattributed_files if changed_members is not None else set()
             )
 
-            snapshot_source = self.static_analysis.incremental_base_results or self.static_analysis
+            snapshot_source = self.static_analysis.incremental_base_results
+            if snapshot_source is None:
+                error = IncrementalCacheMissingError(self.output_dir)
+                logger.error("%s", error)
+                raise error
             old_snapshot = snapshot_from_static_analysis(snapshot_source)
             if not old_snapshot.all_cluster_ids():
                 # No cluster_cache on the live CFG — no prior pkl, legacy pkl,

--- a/diagram_analysis/diagram_generator.py
+++ b/diagram_analysis/diagram_generator.py
@@ -84,7 +84,7 @@ from static_analyzer.cluster_relations import (
     prune_ungrounded_edges,
 )
 from static_analyzer.config import Language
-from static_analyzer.clustering import ClusterGroup, ClusterResult, ClusterScopeResult
+from static_analyzer.clustering import ClusterResult, ClusterScopeResult, ClusteringService
 from static_analyzer.clustering.orchestration import build_clustering_hierarchy
 from static_analyzer.scanner import ProjectScanner
 from telemetry.events import track_analysis
@@ -626,8 +626,6 @@ class DiagramGenerator:
         # plus Leiden sweep behind each answer is the expensive part of the
         # deterministic pipeline. Keyed by membership, so a changed component re-runs.
         self._separable_cache: dict[frozenset[tuple[str, str]], bool] = {}
-        self._clustering_groups: dict[str, ClusterGroup] = {}
-        self._preclustered_scopes: dict[str, ClusterScopeResult] = {}
         self._analysis_start_time = time.time()
 
     @track_analysis
@@ -636,38 +634,93 @@ class DiagramGenerator:
     ) -> tuple[str, AnalysisInsights, list[Component]] | tuple[None, None, list]:
         return self._process_component(component)
 
-    def _index_clustering_hierarchy(
+    def deterministic_analysis(
         self,
-        hierarchy: ClusterScopeResult,
+        *,
+        hierarchy_depth: int | None = None,
+        target_component: Component | None = None,
     ) -> None:
-        """Index precomputed child scopes by the component IDs agents will assign."""
-        self._clustering_groups.clear()
-        self._preclustered_scopes.clear()
+        """Run source fingerprinting, static analysis, and deterministic clustering."""
+        self._analysis_start_time = time.time()
+        # Fingerprint the whole tree once; source_sha, the sidecar, and every
+        # save's source_tree_hash reuse it instead of re-walking per call.
+        self._source_tree_fingerprint = hash_repo_source_files(self.repo_location)
+        # Compute the source-state tag from live source when a caller didn't
+        # supply one, so the pkl always gets a .sha sibling for the next
+        # warm-start — no caller has to thread source_sha in.
+        if self.source_sha is None:
+            self.source_sha = self._source_tree_hash() or None
 
-        def visit(scope: ClusterScopeResult) -> None:
-            for group in scope.groups:
-                self._clustering_groups[group.group_id] = group
-                if group.children is None:
-                    continue
-                self._preclustered_scopes[group.group_id] = group.children
-                visit(group.children)
+        if self._static_analyzer is not None:
+            logger.info("Using injected StaticAnalyzer (clients already running)")
+            static_analysis = self._get_static_with_injected_analyzer()
+        else:
+            static_analysis = self._get_static_with_new_analyzer()
 
-        visit(hierarchy)
+        self.static_analysis = static_analysis
+        depth = hierarchy_depth if hierarchy_depth is not None else self.depth_level
+        self.clustering_hierarchy = build_clustering_hierarchy(static_analysis, depth)
+        if target_component is not None:
+            self._register_component_scope(target_component, depth)
 
-    def _reroot_clustering_groups(self, absorbed_ids: list[str]) -> None:
-        """Keep precomputed expansion flags aligned with absorbed component IDs."""
-        for child_id in absorbed_ids:
-            parent_id = child_id.rpartition(".")[0]
-            prefix = f"{child_id}."
-            rerooted: dict[str, ClusterGroup] = {}
-            for group_id, group in self._clustering_groups.items():
-                if group_id == child_id:
-                    continue
-                if group_id.startswith(prefix):
-                    tail = group_id.removeprefix(prefix)
-                    group_id = f"{parent_id}.{tail}" if parent_id else tail
-                rerooted[group_id] = group
-            self._clustering_groups = rerooted
+        # --- Capture Static Analysis Stats ---
+        static_stats: dict[str, Any] = {"repo_name": self.repo_name, "languages": {}}
+        scanner = ProjectScanner(self.repo_location)
+        loc_by_language = {pl.language: pl.size for pl in scanner.scan()}
+        for language in static_analysis.get_languages():
+            files = static_analysis.get_source_files(language)
+            static_stats["languages"][language] = {
+                "file_count": len(files),
+                "lines_of_code": loc_by_language.get(language, 0),
+            }
+
+        # Build file coverage data from scanner's all_text_files and analyzed files
+        self.file_coverage_data = self._build_file_coverage(scanner, static_analysis)
+
+        self._run_health_report(static_analysis)
+
+        if self.monitoring_enabled:
+            monitoring_dir = get_monitoring_run_dir(self.log_path, create=True)
+            logger.debug(f"Monitoring enabled. Writing stats to {monitoring_dir}")
+
+            # Save code_stats.json
+            code_stats_file = monitoring_dir / "code_stats.json"
+            with open(code_stats_file, "w", encoding="utf-8") as f:
+                json.dump(static_stats, f, indent=2)
+            logger.debug(f"Written code_stats.json to {code_stats_file}")
+
+    def agent_init(self) -> None:
+        """Initialize the LLM-backed agents after deterministic analysis."""
+        assert self.static_analysis is not None
+        agent_llm, parsing_llm = initialize_llms()
+        self._initialize_meta_agent(agent_llm, parsing_llm)
+        assert self.meta_agent is not None
+        meta_context = self.meta_agent.analyze_project_metadata(skip_cache=self.force_full_analysis)
+        self.meta_context = meta_context
+        self._initialize_agents(self.static_analysis, meta_context, agent_llm, parsing_llm)
+
+        if self.monitoring_enabled:
+            monitoring_dir = get_monitoring_run_dir(self.log_path, create=True)
+            self.stats_writer = StreamingStatsWriter(
+                monitoring_dir=monitoring_dir,
+                agents_dict=self._monitoring_agents,
+                repo_name=self.project_name or self.repo_name,
+                output_dir=str(self.output_dir),
+                start_time=self._analysis_start_time,
+            )
+
+    def prepare_analysis(
+        self,
+        *,
+        hierarchy_depth: int | None = None,
+        target_component: Component | None = None,
+    ) -> None:
+        """Prepare deterministic inputs, then initialize the analysis agents."""
+        self.deterministic_analysis(
+            hierarchy_depth=hierarchy_depth,
+            target_component=target_component,
+        )
+        self.agent_init()
 
     def _component_separable(self, component: Component) -> bool:
         """Deterministic gate: should this component be split into sub-components?
@@ -733,14 +786,15 @@ class DiagramGenerator:
         if self.details_agent is None:
             return None, None
 
-        if self._clustering_groups:
+        clustering_groups = self.clustering_hierarchy.clustering_groups if self.clustering_hierarchy else {}
+        if clustering_groups:
 
             def precomputed_ids(scope: AnalysisInsights) -> list[str]:
                 return [
                     component.component_id
                     for component in scope.components
                     if component.component_id
-                    and (group := self._clustering_groups.get(component.component_id)) is not None
+                    and (group := clustering_groups.get(component.component_id)) is not None
                     and group.expandable
                 ]
 
@@ -780,11 +834,12 @@ class DiagramGenerator:
         try:
             assert self.details_agent is not None
 
-            scope = self._preclustered_scopes.get(component.component_id)
+            preclustered_scopes = self.clustering_hierarchy.preclustered_scopes if self.clustering_hierarchy else {}
+            scope = preclustered_scopes.get(component.component_id)
             if scope is None:
                 raise ValueError(f"No precomputed clustering scope for component {component.component_id}")
             analysis, _ = self.details_agent.run(scope, component)
-            new_components = [child for child in analysis.components if child.component_id in self._preclustered_scopes]
+            new_components = [child for child in analysis.components if child.component_id in preclustered_scopes]
 
             return component.component_id, analysis, new_components
         except LLMAuthError:
@@ -1001,97 +1056,38 @@ class DiagramGenerator:
             }
         )
 
-    def deterministic_analysis(
-        self,
-        *,
-        include_clustering: bool = True,
-        hierarchy_depth: int | None = None,
-    ) -> None:
-        """Run source fingerprinting, static analysis, and deterministic clustering."""
-        self._analysis_start_time = time.time()
-        # Fingerprint the whole tree once; source_sha, the sidecar, and every
-        # save's source_tree_hash reuse it instead of re-walking per call.
-        self._source_tree_fingerprint = hash_repo_source_files(self.repo_location)
-        # Compute the source-state tag from live source when a caller didn't
-        # supply one, so the pkl always gets a .sha sibling for the next
-        # warm-start — no caller has to thread source_sha in.
-        if self.source_sha is None:
-            self.source_sha = self._source_tree_hash() or None
-
-        if self._static_analyzer is not None:
-            logger.info("Using injected StaticAnalyzer (clients already running)")
-            static_analysis = self._get_static_with_injected_analyzer()
-        else:
-            static_analysis = self._get_static_with_new_analyzer()
-
-        self.static_analysis = static_analysis
-        self.clustering_hierarchy = None
-        self._clustering_groups.clear()
-        self._preclustered_scopes.clear()
-        if include_clustering:
-            depth = hierarchy_depth if hierarchy_depth is not None else self.depth_level
-            hierarchy = build_clustering_hierarchy(static_analysis, depth)
-            self.clustering_hierarchy = hierarchy
-            self._index_clustering_hierarchy(hierarchy)
-
-        # --- Capture Static Analysis Stats ---
-        static_stats: dict[str, Any] = {"repo_name": self.repo_name, "languages": {}}
-        scanner = ProjectScanner(self.repo_location)
-        loc_by_language = {pl.language: pl.size for pl in scanner.scan()}
-        for language in static_analysis.get_languages():
-            files = static_analysis.get_source_files(language)
-            static_stats["languages"][language] = {
-                "file_count": len(files),
-                "lines_of_code": loc_by_language.get(language, 0),
-            }
-
-        # Build file coverage data from scanner's all_text_files and analyzed files
-        self.file_coverage_data = self._build_file_coverage(scanner, static_analysis)
-
-        self._run_health_report(static_analysis)
-
-        if self.monitoring_enabled:
-            monitoring_dir = get_monitoring_run_dir(self.log_path, create=True)
-            logger.debug(f"Monitoring enabled. Writing stats to {monitoring_dir}")
-
-            # Save code_stats.json
-            code_stats_file = monitoring_dir / "code_stats.json"
-            with open(code_stats_file, "w", encoding="utf-8") as f:
-                json.dump(static_stats, f, indent=2)
-            logger.debug(f"Written code_stats.json to {code_stats_file}")
-
-    def agent_init(self) -> None:
-        """Initialize the LLM-backed agents after deterministic analysis."""
+    def _register_component_scope(self, component: Component, hierarchy_depth: int) -> None:
+        """Precompute an exact hierarchy rooted at one persisted component ID."""
         assert self.static_analysis is not None
-        agent_llm, parsing_llm = initialize_llms()
-        self._initialize_meta_agent(agent_llm, parsing_llm)
-        assert self.meta_agent is not None
-        meta_context = self.meta_agent.analyze_project_metadata(skip_cache=self.force_full_analysis)
-        self.meta_context = meta_context
-        self._initialize_agents(self.static_analysis, meta_context, agent_llm, parsing_llm)
-
-        if self.monitoring_enabled:
-            monitoring_dir = get_monitoring_run_dir(self.log_path, create=True)
-            self.stats_writer = StreamingStatsWriter(
-                monitoring_dir=monitoring_dir,
-                agents_dict=self._monitoring_agents,
-                repo_name=self.project_name or self.repo_name,
-                output_dir=str(self.output_dir),
-                start_time=self._analysis_start_time,
+        assert self.clustering_hierarchy is not None
+        member_keys = {
+            (normalize_repo_path(file_path, self.repo_location), qualified_name)
+            for file_path, qualified_name in _member_keys(component)
+        }
+        graphs: dict[str, CallGraph] = {}
+        for language, graph in self.static_analysis.available_cfgs().items():
+            owned_names = {
+                qualified_name
+                for qualified_name, node in graph.nodes.items()
+                if (normalize_repo_path(node.file_path, self.repo_location), qualified_name) in member_keys
+            }
+            if not owned_names:
+                continue
+            scoped_graph = graph.filter_by_nodes(owned_names)
+            if scoped_graph.nodes:
+                graphs[language] = scoped_graph
+        if not graphs:
+            raise ValueError(
+                f"Cannot build clustering scope for component {component.component_id}: no owned CFG nodes"
             )
 
-    def prepare_analysis(
-        self,
-        *,
-        include_clustering: bool = True,
-        hierarchy_depth: int | None = None,
-    ) -> None:
-        """Prepare deterministic inputs, then initialize the analysis agents."""
-        self.deterministic_analysis(
-            include_clustering=include_clustering,
-            hierarchy_depth=hierarchy_depth,
+        remaining_depth = max(1, hierarchy_depth - _component_depth(component.component_id))
+        scope = ClusteringService().cluster_hierarchy(
+            graphs,
+            remaining_depth,
+            root_scope_id=component.component_id,
         )
-        self.agent_init()
+        self.clustering_hierarchy.register_scope(component.component_id, scope)
 
     def _generate_subcomponents(
         self,
@@ -1212,7 +1208,9 @@ class DiagramGenerator:
             assert self.clustering_hierarchy is not None
             analysis, _cluster_results = self.abstraction_agent.run(self.clustering_hierarchy)
             root_components = [
-                component for component in analysis.components if component.component_id in self._preclustered_scopes
+                component
+                for component in analysis.components
+                if component.component_id in self.clustering_hierarchy.preclustered_scopes
             ]
             logger.info(f"Found {len(root_components)} components to analyze at level 1")
 
@@ -1295,7 +1293,8 @@ class DiagramGenerator:
             else []
         )
         absorbed_ids = absorb_single_child_components(root_analysis, sub_analyses, cluster_caches)
-        self._reroot_clustering_groups(absorbed_ids)
+        if hierarchy := getattr(self, "clustering_hierarchy", None):
+            hierarchy.reroot_indexes(absorbed_ids)
         assert_scope_containment(root_analysis, sub_analyses)
 
     def finalize_and_save(
@@ -1467,7 +1466,7 @@ class DiagramGenerator:
         Raises when no trustworthy baseline or scoped update plan is available.
         """
         if self.details_agent is None or self.incremental_agent is None:
-            self.prepare_analysis(include_clustering=False)
+            self.prepare_analysis()
         assert self.static_analysis is not None
         assert self.details_agent is not None
         assert self.incremental_agent is not None
@@ -1632,6 +1631,8 @@ class DiagramGenerator:
                 if _component_depth(component.component_id) < self.depth_level
             ]
             if new_components:
+                for component in new_components:
+                    self._register_component_scope(component, self.depth_level)
                 _, redetailed_subs = self._generate_subcomponents(root_analysis, new_components, sub_analyses)
                 _merge_sub_analyses(sub_analyses, redetailed_subs)
 

--- a/diagram_analysis/diagram_generator.py
+++ b/diagram_analysis/diagram_generator.py
@@ -72,7 +72,7 @@ from monitoring.paths import get_monitoring_run_dir
 from repo_utils.change_detector import ChangeSet
 from repo_utils.ignore import RepoIgnoreManager
 from static_analyzer import StaticAnalyzer, get_static_analysis
-from static_analyzer.cfg import DEFAULT_REFERENCE_KINDS
+from static_analyzer.cfg import CallGraph, DEFAULT_REFERENCE_KINDS
 from static_analyzer.analysis_cache import StaticAnalysisCache
 from static_analyzer.analysis_result import StaticAnalysisResults
 from static_analyzer.reference_resolver import StaticReferenceResolver
@@ -84,7 +84,8 @@ from static_analyzer.cluster_relations import (
     prune_ungrounded_edges,
 )
 from static_analyzer.config import Language
-from static_analyzer.clustering import ClusterResult
+from static_analyzer.clustering import ClusterGroup, ClusterResult, ClusterScopeResult, ClusteringService
+from static_analyzer.clustering.orchestration import build_clustering_hierarchy
 from static_analyzer.scanner import ProjectScanner
 from telemetry.events import track_analysis
 
@@ -624,12 +625,49 @@ class DiagramGenerator:
         # plus Leiden sweep behind each answer is the expensive part of the
         # deterministic pipeline. Keyed by membership, so a changed component re-runs.
         self._separable_cache: dict[frozenset[tuple[str, str]], bool] = {}
+        self._clustering_groups: dict[str, ClusterGroup] = {}
+        self._preclustered_scopes: dict[str, tuple[ClusterScopeResult, dict[str, CallGraph]]] = {}
 
     @track_analysis
     def process_component(
         self, component: Component
     ) -> tuple[str, AnalysisInsights, list[Component]] | tuple[None, None, list]:
         return self._process_component(component)
+
+    def _index_clustering_hierarchy(
+        self,
+        hierarchy: ClusterScopeResult,
+        root_graphs: dict[str, CallGraph],
+    ) -> None:
+        """Index precomputed child scopes by the component IDs agents will assign."""
+        self._clustering_groups.clear()
+        self._preclustered_scopes.clear()
+
+        def visit(scope: ClusterScopeResult, graphs: dict[str, CallGraph]) -> None:
+            for group in scope.groups:
+                self._clustering_groups[group.group_id] = group
+                if group.children is None:
+                    continue
+                child_graphs = ClusteringService.induced_graphs(group, graphs)
+                self._preclustered_scopes[group.group_id] = (group.children, child_graphs)
+                visit(group.children, child_graphs)
+
+        visit(hierarchy, root_graphs)
+
+    def _reroot_clustering_groups(self, absorbed_ids: list[str]) -> None:
+        """Keep precomputed expansion flags aligned with absorbed component IDs."""
+        for child_id in absorbed_ids:
+            parent_id = child_id.rpartition(".")[0]
+            prefix = f"{child_id}."
+            rerooted: dict[str, ClusterGroup] = {}
+            for group_id, group in self._clustering_groups.items():
+                if group_id == child_id:
+                    continue
+                if group_id.startswith(prefix):
+                    tail = group_id.removeprefix(prefix)
+                    group_id = f"{parent_id}.{tail}" if parent_id else tail
+                rerooted[group_id] = group
+            self._clustering_groups = rerooted
 
     def _component_separable(self, component: Component) -> bool:
         """Deterministic gate: should this component be split into sub-components?
@@ -695,6 +733,21 @@ class DiagramGenerator:
         if self.details_agent is None:
             return None, None
 
+        if self._clustering_groups:
+
+            def precomputed_ids(scope: AnalysisInsights) -> list[str]:
+                return [
+                    component.component_id
+                    for component in scope.components
+                    if component.component_id
+                    and (group := self._clustering_groups.get(component.component_id)) is not None
+                    and group.expandable
+                ]
+
+            return precomputed_ids(root_analysis), {
+                scope_id: precomputed_ids(scope) for scope_id, scope in sub_analyses.items()
+            }
+
         def expandable_ids(scope: AnalysisInsights, parent_had_clusters: bool = True) -> list[str]:
             ids = [
                 component.component_id
@@ -727,16 +780,19 @@ class DiagramGenerator:
         try:
             assert self.details_agent is not None
 
-            analysis, _ = self.details_agent.run(component)
-
-            # Track whether parent had clusters for expansion decision
-            parent_had_clusters = bool(component.source_cluster_ids)
-
-            # Get new components to analyze (deterministic, no LLM). The separability
-            # gate keeps cohesive sub-components as leaves rather than splitting them.
-            new_components = get_expandable_components(
-                analysis, parent_had_clusters=parent_had_clusters, separable=self._component_separable
-            )
+            preclustered = self._preclustered_scopes.get(component.component_id)
+            if preclustered is not None:
+                scope, cfgs = preclustered
+                analysis, _ = self.details_agent.run_scope(component, scope, cfgs)
+                new_components = [
+                    child for child in analysis.components if child.component_id in self._preclustered_scopes
+                ]
+            else:
+                analysis, _ = self.details_agent.run(component)
+                parent_had_clusters = bool(component.source_cluster_ids)
+                new_components = get_expandable_components(
+                    analysis, parent_had_clusters=parent_had_clusters, separable=self._component_separable
+                )
 
             return component.component_id, analysis, new_components
         except LLMAuthError:
@@ -1138,14 +1194,22 @@ class DiagramGenerator:
 
             assert self.abstraction_agent is not None
 
-            analysis, cluster_results = self.abstraction_agent.run()
-            # Get the initial components to analyze (deterministic, no LLM). The
-            # separability gate keeps cohesive top-level components as leaves.
-            root_components = get_expandable_components(analysis, separable=self._component_separable)
+            if self.static_analysis is not None:
+                hierarchy = build_clustering_hierarchy(self.static_analysis, self.depth_level)
+                self._index_clustering_hierarchy(hierarchy, self.static_analysis.available_cfgs())
+                analysis, _cluster_results = self.abstraction_agent.run_scope(hierarchy)
+                root_components = [
+                    component
+                    for component in analysis.components
+                    if component.component_id in self._preclustered_scopes
+                ]
+            else:
+                analysis, _cluster_results = self.abstraction_agent.run()
+                root_components = get_expandable_components(analysis, separable=self._component_separable)
             logger.info(f"Found {len(root_components)} components to analyze at level 1")
 
             # Process components using a frontier queue: submit children as soon as parent finishes.
-            expanded_components, sub_analyses = self._generate_subcomponents(analysis, root_components)
+            _expanded_components, sub_analyses = self._generate_subcomponents(analysis, root_components)
 
             analysis_path = self.finalize_and_save(analysis, sub_analyses)
             logger.info(f"Analysis complete. Written unified analysis to {analysis_path}")
@@ -1222,7 +1286,8 @@ class DiagramGenerator:
             if self.static_analysis
             else []
         )
-        absorb_single_child_components(root_analysis, sub_analyses, cluster_caches)
+        absorbed_ids = absorb_single_child_components(root_analysis, sub_analyses, cluster_caches)
+        self._reroot_clustering_groups(absorbed_ids)
         assert_scope_containment(root_analysis, sub_analyses)
 
     def finalize_and_save(

--- a/static_analyzer/clustering/models.py
+++ b/static_analyzer/clustering/models.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 from collections import defaultdict
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
+from pathlib import Path
 
 from clustering_ids import ClusterId, ComponentId, GroupId, ScopeId
-from static_analyzer.cfg.edge import CallSiteLocation
+from static_analyzer.cfg import CallGraph, CallSiteLocation
 from static_analyzer.node import Node
 
 # Marker on a ClusterResult whose clusters are synthetic one-method-per-cluster
@@ -130,9 +131,117 @@ class ClusterScopeResult:
     """The leaf clusters, architectural groups, and communication for one graph scope."""
 
     scope_id: ScopeId
+    graphs_by_language: dict[str, CallGraph] = field(default_factory=dict)
     leaf_clusters_by_language: dict[str, ClusterResult] = field(default_factory=dict)
     groups: list[ClusterGroup] = field(default_factory=list)
     connections: list[GroupConnection] = field(default_factory=list)
     modularity: float = 0.0  # Score of the actual groups, including ownership anchors.
     unanchored_modularity: float = 0.0  # Best score without previous ownership anchors.
     regrouped: bool = False
+    clustering_groups: dict[GroupId, ClusterGroup] = field(default_factory=dict, init=False, repr=False)
+    preclustered_scopes: dict[GroupId, ClusterScopeResult] = field(default_factory=dict, init=False, repr=False)
+
+    def group_names(self) -> list[str]:
+        return [f"Group {index}" for index, _group in enumerate(self.groups, start=1)]
+
+    def group_ids(self) -> dict[str, list[ClusterId]]:
+        return {name: group.cluster_ids for name, group in zip(self.group_names(), self.groups, strict=True)}
+
+    def group_descriptions(self) -> dict[str, str]:
+        clusters: dict[ClusterId, set[str]] = {}
+        cluster_to_files: dict[ClusterId, set[str]] = {}
+        for result in self.leaf_clusters_by_language.values():
+            clusters.update(result.clusters)
+            cluster_to_files.update(result.cluster_to_files)
+        return {
+            name: self._group_summary(set(group.cluster_ids), clusters, cluster_to_files)
+            for name, group in zip(self.group_names(), self.groups, strict=True)
+        }
+
+    def llm_str(self) -> str:
+        descriptions = self.group_descriptions()
+        if not descriptions:
+            return "No clusters analyzed."
+        body = "\n".join(
+            f"**{name}** (cluster_ids: [{', '.join(str(cluster_id) for cluster_id in cluster_ids)}])\n"
+            f"   {descriptions[name]}"
+            for name, cluster_ids in self.group_ids().items()
+        )
+        return f"# Grouped Cluster Components\n{body}"
+
+    def index_hierarchy(self) -> None:
+        """Index all groups and retained child scopes in this hierarchy."""
+        self.clustering_groups.clear()
+        self.preclustered_scopes.clear()
+
+        def visit(scope: ClusterScopeResult) -> None:
+            for group in scope.groups:
+                self.clustering_groups[group.group_id] = group
+                if group.children is None:
+                    continue
+                self.preclustered_scopes[group.group_id] = group.children
+                visit(group.children)
+
+        visit(self)
+
+    def register_scope(self, owner_id: GroupId, scope: ClusterScopeResult) -> None:
+        """Register an exact component scope and its retained descendants."""
+        scope.index_hierarchy()
+        self.preclustered_scopes[owner_id] = scope
+        self.clustering_groups.update(scope.clustering_groups)
+        self.preclustered_scopes.update(scope.preclustered_scopes)
+
+    def reroot_indexes(self, absorbed_ids: list[GroupId]) -> None:
+        """Keep hierarchy lookups aligned with save-time single-child absorption."""
+        for child_id in absorbed_ids:
+            parent_id = child_id.rpartition(".")[0]
+            prefix = f"{child_id}."
+            rerooted_groups: dict[GroupId, ClusterGroup] = {}
+            for group_id, group in self.clustering_groups.items():
+                if group_id == child_id:
+                    continue
+                if group_id.startswith(prefix):
+                    tail = group_id.removeprefix(prefix)
+                    group_id = f"{parent_id}.{tail}" if parent_id else tail
+                    group.group_id = group_id
+                rerooted_groups[group_id] = group
+            self.clustering_groups = rerooted_groups
+
+            rerooted_scopes: dict[GroupId, ClusterScopeResult] = {}
+            for group_id, scope in self.preclustered_scopes.items():
+                if group_id == child_id:
+                    continue
+                if group_id.startswith(prefix):
+                    tail = group_id.removeprefix(prefix)
+                    group_id = f"{parent_id}.{tail}" if parent_id else tail
+                    scope.scope_id = group_id
+                rerooted_scopes[group_id] = scope
+            self.preclustered_scopes = rerooted_scopes
+
+    def __post_init__(self) -> None:
+        self.index_hierarchy()
+
+    @staticmethod
+    def _group_summary(
+        group: set[ClusterId],
+        node_lookup: dict[ClusterId, set[str]],
+        file_lookup: dict[ClusterId, set[str]],
+        max_symbols: int = 12,
+        max_files: int = 8,
+    ) -> str:
+        """Build a deterministic, name-rich group summary."""
+        symbols = sorted(
+            {qualified_name for cluster_id in group for qualified_name in node_lookup.get(cluster_id, set())},
+            key=lambda qualified_name: (qualified_name.count("."), qualified_name),
+        )
+        files = sorted({path for cluster_id in group for path in file_lookup.get(cluster_id, set())})
+        file_names = [Path(path).name for path in files]
+
+        parts = [f"{len(group)} leaf clusters, {len(symbols)} symbols across {len(files)} files."]
+        if file_names:
+            shown = ", ".join(file_names[:max_files])
+            parts.append(f"Files: {shown}{', ...' if len(file_names) > max_files else ''}")
+        if symbols:
+            shown = ", ".join(symbols[:max_symbols])
+            parts.append(f"Key symbols: {shown}{', ...' if len(symbols) > max_symbols else ''}")
+        return " ".join(parts)

--- a/static_analyzer/clustering/models.py
+++ b/static_analyzer/clustering/models.py
@@ -113,6 +113,7 @@ class ClusterGroup:
     cluster_ids: list[ClusterId]
     symbol_members_by_language: dict[str, set[str]] = field(default_factory=dict)
     previous_component_id: ComponentId = ""
+    expandable: bool = False
     children: ClusterScopeResult | None = None
 
     @property

--- a/static_analyzer/clustering/orchestration.py
+++ b/static_analyzer/clustering/orchestration.py
@@ -1,14 +1,34 @@
 """Root-scope clustering orchestration and cache synchronization."""
 
 import logging
+from collections.abc import Mapping
 
 from static_analyzer.analysis_result import StaticAnalysisResults
-from static_analyzer.config import Language
+from static_analyzer.cfg import CallGraph
 from static_analyzer.clustering.grouping import reindex_cluster_result
-from static_analyzer.clustering.models import ClusterResult
+from static_analyzer.clustering.models import ClusterResult, ClusterScopeInput, ClusterScopeResult
 from static_analyzer.clustering.service import ClusteringService
+from static_analyzer.config import Language
 
 logger = logging.getLogger(__name__)
+
+
+def build_clustering_hierarchy(static_analysis: StaticAnalysisResults, max_depth: int) -> ClusterScopeResult:
+    """Build and cache the complete deterministic hierarchy for a full analysis."""
+    root_partitions = build_all_cluster_results(static_analysis)
+
+    def scope_input(scope_id: str, _graphs: Mapping[str, CallGraph]) -> ClusterScopeInput:
+        return (
+            ClusterScopeInput(leaf_clusters_by_language=root_partitions) if scope_id == "root" else ClusterScopeInput()
+        )
+
+    hierarchy = ClusteringService().cluster_hierarchy(
+        static_analysis.available_cfgs(),
+        max_depth,
+        scope_input,
+    )
+    _record_child_scopes(static_analysis, hierarchy)
+    return hierarchy
 
 
 def build_all_cluster_results(static_analysis: StaticAnalysisResults) -> dict[str, ClusterResult]:
@@ -40,3 +60,13 @@ def _sync_cluster_cache(static_analysis: StaticAnalysisResults, cluster_results:
             static_analysis.get_clusters(Language(language)).adopt(result)
         except ValueError:
             logger.warning("Could not sync cluster cache for unknown language %s", language)
+
+
+def _record_child_scopes(static_analysis: StaticAnalysisResults, scope: ClusterScopeResult) -> None:
+    """Store retained child partitions under their parent component IDs."""
+    for group in scope.groups:
+        if group.children is None:
+            continue
+        for language, partition in group.children.leaf_clusters_by_language.items():
+            static_analysis.get_clusters(Language(language)).record_scope(partition, group.group_id)
+        _record_child_scopes(static_analysis, group.children)

--- a/static_analyzer/clustering/orchestration.py
+++ b/static_analyzer/clustering/orchestration.py
@@ -18,9 +18,9 @@ def build_clustering_hierarchy(static_analysis: StaticAnalysisResults, max_depth
     root_partitions = build_all_cluster_results(static_analysis)
 
     def scope_input(scope_id: str, _graphs: Mapping[str, CallGraph]) -> ClusterScopeInput:
-        return (
-            ClusterScopeInput(leaf_clusters_by_language=root_partitions) if scope_id == "root" else ClusterScopeInput()
-        )
+        if scope_id == "root":
+            return ClusterScopeInput(leaf_clusters_by_language=root_partitions)
+        return ClusterScopeInput()
 
     hierarchy = ClusteringService().cluster_hierarchy(
         static_analysis.available_cfgs(),

--- a/static_analyzer/clustering/service.py
+++ b/static_analyzer/clustering/service.py
@@ -172,6 +172,19 @@ class ClusteringService:
         self._cluster_children(root, graphs, 1, max_depth, scope_input)
         return root
 
+    @staticmethod
+    def induced_graphs(group: ClusterGroup, graphs: Mapping[str, CallGraph]) -> dict[str, CallGraph]:
+        """Return the exact per-language subgraphs owned by ``group``."""
+        child_graphs: dict[str, CallGraph] = {}
+        for language, graph in graphs.items():
+            members = group.symbol_members_by_language.get(language, set())
+            if not members:
+                continue
+            child = graph.filter_by_nodes(members)
+            if child.nodes:
+                child_graphs[language] = child
+        return child_graphs
+
     def _cluster_children(
         self,
         scope: ClusterScopeResult,
@@ -180,10 +193,8 @@ class ClusteringService:
         max_depth: int,
         scope_input: Callable[[ScopeId, Mapping[str, CallGraph]], ClusterScopeInput],
     ) -> None:
-        if depth >= max_depth:
-            return
         for group in scope.groups:
-            child_graphs = self._induced_graphs(group, graphs)
+            child_graphs = self.induced_graphs(group, graphs)
             method_count, file_count = self._scope_size(child_graphs)
             if not child_graphs or not file_count:
                 continue
@@ -205,20 +216,11 @@ class ClusteringService:
                 method_count,
             ):
                 continue
+            group.expandable = True
+            if depth >= max_depth:
+                continue
             group.children = child
             self._cluster_children(child, child_graphs, depth + 1, max_depth, scope_input)
-
-    @staticmethod
-    def _induced_graphs(group: ClusterGroup, graphs: Mapping[str, CallGraph]) -> dict[str, CallGraph]:
-        child_graphs: dict[str, CallGraph] = {}
-        for language, graph in graphs.items():
-            members = group.symbol_members_by_language.get(language, set())
-            if not members:
-                continue
-            child = graph.filter_by_nodes(members)
-            if child.nodes:
-                child_graphs[language] = child
-        return child_graphs
 
     @staticmethod
     def _scope_size(graphs: Mapping[str, CallGraph]) -> tuple[int, int]:

--- a/static_analyzer/clustering/service.py
+++ b/static_analyzer/clustering/service.py
@@ -146,6 +146,7 @@ class ClusteringService:
         connections = self._build_connections(graphs, groups)
         return ClusterScopeResult(
             scope_id=scope_id,
+            graphs_by_language=dict(graphs),
             leaf_clusters_by_language=scope_leaf_clusters,
             groups=groups,
             connections=connections,
@@ -159,21 +160,25 @@ class ClusteringService:
         graphs: Mapping[str, CallGraph],
         max_depth: int,
         scope_input: Callable[[ScopeId, Mapping[str, CallGraph]], ClusterScopeInput] = _unseeded_scope,
+        root_scope_id: ScopeId = _ROOT_SCOPE_ID,
     ) -> ClusterScopeResult:
         """Recursively cluster every expandable exact subgraph up to ``max_depth``."""
         if max_depth < 1:
             raise ValueError("max_depth must be at least 1")
-        root_input = scope_input(_ROOT_SCOPE_ID, graphs)
+        root_input = scope_input(root_scope_id, graphs)
         root = self.cluster_scope(
             graphs,
+            scope_id=root_scope_id,
             leaf_clusters_by_language=root_input.leaf_clusters_by_language,
             previous_owner=root_input.previous_owner,
+            method_level_fallback=root_scope_id != _ROOT_SCOPE_ID,
         )
         self._cluster_children(root, graphs, 1, max_depth, scope_input)
+        root.index_hierarchy()
         return root
 
     @staticmethod
-    def induced_graphs(group: ClusterGroup, graphs: Mapping[str, CallGraph]) -> dict[str, CallGraph]:
+    def _induced_graphs(group: ClusterGroup, graphs: Mapping[str, CallGraph]) -> dict[str, CallGraph]:
         """Return the exact per-language subgraphs owned by ``group``."""
         child_graphs: dict[str, CallGraph] = {}
         for language, graph in graphs.items():
@@ -194,7 +199,7 @@ class ClusteringService:
         scope_input: Callable[[ScopeId, Mapping[str, CallGraph]], ClusterScopeInput],
     ) -> None:
         for group in scope.groups:
-            child_graphs = self.induced_graphs(group, graphs)
+            child_graphs = self._induced_graphs(group, graphs)
             method_count, file_count = self._scope_size(child_graphs)
             if not child_graphs or not file_count:
                 continue

--- a/tests/agents/test_abstraction_agent.py
+++ b/tests/agents/test_abstraction_agent.py
@@ -3,8 +3,6 @@ import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import networkx as nx
-
 from agents.abstraction_agent import AbstractionAgent
 from agents.agent_responses import (
     AnalysisInsights,
@@ -81,83 +79,7 @@ class TestAbstractionAgent(unittest.TestCase):
             parsing_llm=MagicMock(),
         )
 
-    @staticmethod
-    def _clustered_graph(cluster_ids):
-        """A ClusterResult + matching nx graph: one chained pair of nodes per cluster id."""
-        clusters, cluster_to_files, file_to_clusters = {}, {}, {}
-        graph = nx.DiGraph()
-        for cid in cluster_ids:
-            nodes = [f"pkg.mod{cid}.a", f"pkg.mod{cid}.b"]
-            clusters[cid] = set(nodes)
-            path = f"/repo/mod{cid}.py"
-            cluster_to_files[cid] = {path}
-            file_to_clusters[path] = {cid}
-            for node in nodes:
-                graph.add_node(node, file_path=path)
-            graph.add_edge(nodes[0], nodes[1])
-        # Chain consecutive clusters so the meta-graph is connected.
-        ids = list(cluster_ids)
-        for prev, cur in zip(ids, ids[1:]):
-            graph.add_edge(f"pkg.mod{prev}.b", f"pkg.mod{cur}.a")
-        cr = ClusterResult(
-            clusters=clusters, cluster_to_files=cluster_to_files, file_to_clusters=file_to_clusters, strategy="test"
-        )
-        return cr, graph
-
-    def _assert_partition(self, result, expected_ids):
-        self.assertIsInstance(result, ClusterAnalysis)
-        self.assertGreaterEqual(len(result.cluster_components), 1)
-        # Names are the deterministic Group-1..N labels.
-        self.assertEqual(
-            [cc.name for cc in result.cluster_components],
-            [f"Group {i}" for i in range(1, len(result.cluster_components) + 1)],
-        )
-        # Every leaf cluster is owned by exactly one group (a true partition).
-        assigned = [cid for cc in result.cluster_components for cid in cc.cluster_ids]
-        self.assertEqual(sorted(assigned), sorted(expected_ids))
-        self.assertEqual(len(assigned), len(set(assigned)))
-
-    def test_step_clusters_grouping_single_language(self):
-        agent = self._make_agent()
-        cr, graph = self._clustered_graph(range(1, 13))
-        self.mock_static_analysis.get_cfg.return_value.to_networkx.return_value = graph
-        cluster_results = {"python": cr}
-
-        result = agent.step_clusters_grouping(cluster_results)
-        result_again = agent.step_clusters_grouping(cluster_results)
-
-        self._assert_partition(result, list(range(1, 13)))
-        # Deterministic: same membership on a re-run.
-        self.assertEqual(
-            [sorted(cc.cluster_ids) for cc in result.cluster_components],
-            [sorted(cc.cluster_ids) for cc in result_again.cluster_components],
-        )
-
-    def test_step_clusters_grouping_multiple_languages(self):
-        self.mock_static_analysis.get_languages.return_value = ["python", "javascript"]
-        agent = self._make_agent()
-        # Globally-unique cluster ids across languages, sharing one combined graph.
-        _, graph = self._clustered_graph(range(1, 13))
-        py_cr, _ = self._clustered_graph(range(1, 7))
-        js_cr, _ = self._clustered_graph(range(7, 13))
-        self.mock_static_analysis.get_cfg.return_value.to_networkx.return_value = graph
-        cluster_results = {"python": py_cr, "javascript": js_cr}
-
-        result = agent.step_clusters_grouping(cluster_results)
-
-        self._assert_partition(result, list(range(1, 13)))
-        self.mock_static_analysis.get_cfg.assert_called()
-
-    def test_step_clusters_grouping_no_languages(self):
-        self.mock_static_analysis.get_languages.return_value = []
-        agent = self._make_agent()
-
-        result = agent.step_clusters_grouping({})
-
-        self.assertIsInstance(result, ClusterAnalysis)
-        self.assertEqual(result.cluster_components, [])
-
-    def test_run_scope_uses_the_precomputed_groups(self):
+    def test_run_uses_the_precomputed_groups(self):
         agent = self._make_agent()
         partition = ClusterResult(clusters={1: {"a"}, 2: {"b"}}, strategy="test")
         scope = ClusterScopeResult(
@@ -170,10 +92,18 @@ class TestAbstractionAgent(unittest.TestCase):
             scope.leaf_clusters_by_language,
         )
 
-        with patch.object(agent, "_run_clustered", return_value=expected) as run_clustered:
-            result = agent.run_scope(scope)
+        with (
+            patch.object(agent, "step_final_analysis", return_value=expected[0]) as final_analysis,
+            patch.object(agent, "populate_file_methods"),
+            patch.object(agent, "step_api_surfaces", return_value=MagicMock()),
+            patch.object(agent, "step_relation_analysis"),
+            patch.object(agent.reference_resolver, "fix_source_code_reference_lines", return_value=expected[0]),
+            patch("agents.abstraction_agent.index_relation_endpoints"),
+            patch.object(agent, "_ensure_unique_key_entities"),
+        ):
+            result = agent.run(scope)
 
-        cluster_analysis, partitions = run_clustered.call_args.args
+        cluster_analysis, partitions = final_analysis.call_args.args
         self.assertEqual(result, expected)
         self.assertIs(partitions, scope.leaf_clusters_by_language)
         self.assertEqual(len(cluster_analysis.cluster_components), 1)

--- a/tests/agents/test_abstraction_agent.py
+++ b/tests/agents/test_abstraction_agent.py
@@ -6,8 +6,6 @@ from unittest.mock import MagicMock, patch
 from agents.abstraction_agent import AbstractionAgent
 from agents.agent_responses import (
     AnalysisInsights,
-    ClusterAnalysis,
-    ClustersComponent,
     Component,
     ComponentArchitecture,
     MetaAnalysisInsights,
@@ -93,7 +91,7 @@ class TestAbstractionAgent(unittest.TestCase):
         )
 
         with (
-            patch.object(agent, "step_final_analysis", return_value=expected[0]) as final_analysis,
+            patch.object(agent, "step_llm_analysis", return_value=expected[0]) as llm_analysis,
             patch.object(agent, "populate_file_methods"),
             patch.object(agent, "step_api_surfaces", return_value=MagicMock()),
             patch.object(agent, "step_relation_analysis"),
@@ -103,15 +101,11 @@ class TestAbstractionAgent(unittest.TestCase):
         ):
             result = agent.run(scope)
 
-        cluster_analysis, partitions = final_analysis.call_args.args
         self.assertEqual(result, expected)
-        self.assertIs(partitions, scope.leaf_clusters_by_language)
-        self.assertEqual(len(cluster_analysis.cluster_components), 1)
-        self.assertEqual(cluster_analysis.cluster_components[0].cluster_ids, [1, 2])
+        llm_analysis.assert_called_once_with(scope)
 
     @patch("agents.abstraction_agent.AbstractionAgent._invoke_repair_validate")
-    def test_step_final_analysis(self, mock_invoke_repair_validate):
-        # Test step_final_analysis
+    def test_step_llm_analysis(self, mock_invoke_repair_validate):
         mock_llm = MagicMock()
         mock_parsing_llm = MagicMock()
         agent = AbstractionAgent(
@@ -123,8 +117,9 @@ class TestAbstractionAgent(unittest.TestCase):
             parsing_llm=mock_parsing_llm,
         )
 
-        cluster_analysis = ClusterAnalysis(
-            cluster_components=[],
+        scope = ClusterScopeResult(
+            scope_id="root",
+            leaf_clusters_by_language={"python": ClusterResult(clusters={1: {"node1"}})},
         )
 
         mock_response = AnalysisInsights(
@@ -134,24 +129,28 @@ class TestAbstractionAgent(unittest.TestCase):
         )
         mock_invoke_repair_validate.return_value = mock_response
 
-        mock_cluster_result = ClusterResult(clusters={1: {"node1"}})
-        cluster_results = {"python": mock_cluster_result}
-
-        result = agent.step_final_analysis(cluster_analysis, cluster_results)
+        result = agent.step_llm_analysis(scope)
 
         self.assertEqual(result, mock_response)
 
     @patch("agents.abstraction_agent.AbstractionAgent._invoke_repair_validate")
-    def test_step_final_analysis_pins_one_component_per_group(self, mock_invoke_repair_validate):
+    def test_step_llm_analysis_pins_one_component_per_group(self, mock_invoke_repair_validate):
         """Even when the LLM merges/drops groups, the result has exactly one component per group."""
         agent = self._make_agent()
 
-        cluster_analysis = ClusterAnalysis(
-            cluster_components=[
-                ClustersComponent(name="Group 1", cluster_ids=[1, 2], description="g1"),
-                ClustersComponent(name="Group 2", cluster_ids=[3], description="g2"),
-                ClustersComponent(name="Group 3", cluster_ids=[4, 5], description="g3"),
-            ]
+        cluster_results = {
+            "python": ClusterResult(
+                clusters={1: {"a"}, 2: {"b"}, 3: {"c"}, 4: {"pkg.Widget"}, 5: {"e"}},
+            )
+        }
+        scope = ClusterScopeResult(
+            scope_id="root",
+            leaf_clusters_by_language=cluster_results,
+            groups=[
+                ClusterGroup(group_id="2", cluster_ids=[1, 2]),
+                ClusterGroup(group_id="4", cluster_ids=[3]),
+                ClusterGroup(group_id="7", cluster_ids=[4, 5]),
+            ],
         )
         # LLM output: keeps Group 1, merges Group 2 + 3 into one component (drops a slot).
         mock_invoke_repair_validate.return_value = ComponentArchitecture(
@@ -162,17 +161,12 @@ class TestAbstractionAgent(unittest.TestCase):
             ],
         )
 
-        cluster_results = {
-            "python": ClusterResult(
-                clusters={1: {"a"}, 2: {"b"}, 3: {"c"}, 4: {"pkg.Widget"}, 5: {"e"}},
-            )
-        }
-
-        result = agent.step_final_analysis(cluster_analysis, cluster_results)
+        result = agent.step_llm_analysis(scope)
 
         # Exactly one component per group, each backed by exactly one group.
         self.assertEqual(len(result.components), 3)
         self.assertEqual([c.source_group_names for c in result.components], [["Group 1"], ["Group 2"], ["Group 3"]])
+        self.assertEqual([c.component_id for c in result.components], ["2", "4", "7"])
         # The claimed groups keep the LLM's names; the dropped one gets a deterministic fallback.
         self.assertEqual(result.components[0].name, "Auth")
         self.assertEqual(result.components[1].name, "Data")

--- a/tests/agents/test_abstraction_agent.py
+++ b/tests/agents/test_abstraction_agent.py
@@ -15,7 +15,7 @@ from agents.agent_responses import (
     MetaAnalysisInsights,
 )
 from static_analyzer.analysis_result import StaticAnalysisResults
-from static_analyzer.clustering import ClusterResult
+from static_analyzer.clustering import ClusterGroup, ClusterResult, ClusterScopeResult
 
 
 class TestAbstractionAgent(unittest.TestCase):
@@ -156,6 +156,28 @@ class TestAbstractionAgent(unittest.TestCase):
 
         self.assertIsInstance(result, ClusterAnalysis)
         self.assertEqual(result.cluster_components, [])
+
+    def test_run_scope_uses_the_precomputed_groups(self):
+        agent = self._make_agent()
+        partition = ClusterResult(clusters={1: {"a"}, 2: {"b"}}, strategy="test")
+        scope = ClusterScopeResult(
+            scope_id="root",
+            leaf_clusters_by_language={"python": partition},
+            groups=[ClusterGroup(group_id="1", cluster_ids=[1, 2])],
+        )
+        expected = (
+            AnalysisInsights(description="done", components=[], components_relations=[]),
+            scope.leaf_clusters_by_language,
+        )
+
+        with patch.object(agent, "_run_clustered", return_value=expected) as run_clustered:
+            result = agent.run_scope(scope)
+
+        cluster_analysis, partitions = run_clustered.call_args.args
+        self.assertEqual(result, expected)
+        self.assertIs(partitions, scope.leaf_clusters_by_language)
+        self.assertEqual(len(cluster_analysis.cluster_components), 1)
+        self.assertEqual(cluster_analysis.cluster_components[0].cluster_ids, [1, 2])
 
     @patch("agents.abstraction_agent.AbstractionAgent._invoke_repair_validate")
     def test_step_final_analysis(self, mock_invoke_repair_validate):

--- a/tests/agents/test_cluster_methods_mixin.py
+++ b/tests/agents/test_cluster_methods_mixin.py
@@ -194,7 +194,7 @@ class TestFindNearestCluster(unittest.TestCase):
         # C is distance-1 from D (cluster 2) and distance-1 from B (cluster 1).
         # Both clusters have a member at distance 1, so the first one found wins
         # (deterministic dict order).
-        result = mixin._find_nearest_cluster("C", cluster_results, undirected_graphs)
+        result = mixin._find_nearest_cluster("python", "C", cluster_results, undirected_graphs)
         self.assertIn(result, {1, 2})
 
     def test_returns_none_for_disconnected_node(self):
@@ -207,7 +207,7 @@ class TestFindNearestCluster(unittest.TestCase):
         mixin = self._make_mixin(cfg)
 
         undirected_graphs = mixin._build_undirected_graphs(cluster_results)
-        result = mixin._find_nearest_cluster("Z", cluster_results, undirected_graphs)
+        result = mixin._find_nearest_cluster("python", "Z", cluster_results, undirected_graphs)
         self.assertIsNone(result)
 
     def test_returns_none_when_node_not_in_graph(self):
@@ -218,7 +218,7 @@ class TestFindNearestCluster(unittest.TestCase):
         mixin = self._make_mixin(cfg)
 
         undirected_graphs = mixin._build_undirected_graphs(cluster_results)
-        result = mixin._find_nearest_cluster("NONEXISTENT", cluster_results, undirected_graphs)
+        result = mixin._find_nearest_cluster("python", "NONEXISTENT", cluster_results, undirected_graphs)
         self.assertIsNone(result)
 
     def test_node_inside_cluster_returns_own_cluster(self):
@@ -229,7 +229,7 @@ class TestFindNearestCluster(unittest.TestCase):
         mixin = self._make_mixin(cfg)
 
         undirected_graphs = mixin._build_undirected_graphs(cluster_results)
-        result = mixin._find_nearest_cluster("A", cluster_results, undirected_graphs)
+        result = mixin._find_nearest_cluster("python", "A", cluster_results, undirected_graphs)
         self.assertEqual(result, 1)
 
     def test_prefers_closer_cluster(self):
@@ -256,7 +256,7 @@ class TestFindNearestCluster(unittest.TestCase):
         mixin = self._make_mixin(cfg)
 
         undirected_graphs = mixin._build_undirected_graphs(cluster_results)
-        result = mixin._find_nearest_cluster("W", cluster_results, undirected_graphs)
+        result = mixin._find_nearest_cluster("python", "W", cluster_results, undirected_graphs)
         self.assertEqual(result, 10)
 
 

--- a/tests/agents/test_details_agent.py
+++ b/tests/agents/test_details_agent.py
@@ -22,7 +22,13 @@ from diagram_analysis.file_index import build_files_index
 from static_analyzer.analysis_result import StaticAnalysisResults
 from static_analyzer.config import NodeType
 from static_analyzer.cfg import CallGraph
-from static_analyzer.clustering import ClusterCache, ClusterResult, ClusteringService
+from static_analyzer.clustering import (
+    ClusterCache,
+    ClusterGroup,
+    ClusterResult,
+    ClusterScopeResult,
+    ClusteringService,
+)
 from static_analyzer.node import Node
 
 
@@ -212,6 +218,31 @@ class TestDetailsAgent(unittest.TestCase):
             [sorted(cc.cluster_ids) for cc in result.cluster_components],
             [sorted(cc.cluster_ids) for cc in result_again.cluster_components],
         )
+
+    def test_run_scope_skips_local_reclustering(self):
+        agent = self._make_agent()
+        partition = ClusterResult(clusters={1: {"test.func"}}, strategy="test")
+        scope = ClusterScopeResult(
+            scope_id="1",
+            leaf_clusters_by_language={"python": partition},
+            groups=[ClusterGroup(group_id="1.1", cluster_ids=[1])],
+        )
+        cfgs = {"python": CallGraph(language="python")}
+        expected = (
+            AnalysisInsights(description="done", components=[], components_relations=[]),
+            scope.leaf_clusters_by_language,
+        )
+
+        with (
+            patch.object(agent, "_run_clustered", return_value=expected) as run_clustered,
+            patch.object(agent, "step_clusters_grouping") as regroup,
+        ):
+            result = agent.run_scope(self.test_component, scope, cfgs)
+
+        self.assertEqual(result, expected)
+        regroup.assert_not_called()
+        self.assertIs(run_clustered.call_args.args[2], scope.leaf_clusters_by_language)
+        self.assertIs(run_clustered.call_args.args[3], cfgs)
 
     @patch("agents.details_agent.DetailsAgent._invoke_repair_validate")
     def test_step_final_analysis(self, mock_invoke_repair_validate):

--- a/tests/agents/test_details_agent.py
+++ b/tests/agents/test_details_agent.py
@@ -8,8 +8,6 @@ import networkx as nx
 from agents.details_agent import DetailsAgent
 from agents.agent_responses import (
     AnalysisInsights,
-    ClusterAnalysis,
-    ClustersComponent,
     Component,
     ComponentApiSurfaces,
     ComponentRelations,
@@ -189,22 +187,21 @@ class TestDetailsAgent(unittest.TestCase):
     def test_run_uses_precomputed_scope(self):
         agent = self._make_agent()
         partition = ClusterResult(clusters={1: {"test.func"}}, strategy="test")
+        cfg = CallGraph(language="python")
+        cfg.add_node(Node("test.func", NodeType.FUNCTION, "test.py", 1, 10))
         scope = ClusterScopeResult(
             scope_id="1",
+            graphs_by_language={"python": cfg},
             leaf_clusters_by_language={"python": partition},
             groups=[ClusterGroup(group_id="1.1", cluster_ids=[1])],
         )
-        cfg = CallGraph(language="python")
-        cfg.add_node(Node("test.func", NodeType.FUNCTION, "test.py", 1, 10))
-        cfg.add_node(Node("test_utils.helper", NodeType.FUNCTION, "test_utils.py", 1, 5))
-        self.mock_static_analysis.get_cfg.return_value = cfg
         expected = (
             AnalysisInsights(description="done", components=[], components_relations=[]),
             scope.leaf_clusters_by_language,
         )
 
         with (
-            patch.object(agent, "step_final_analysis", return_value=expected[0]) as final_analysis,
+            patch.object(agent, "step_llm_analysis", return_value=expected[0]) as llm_analysis,
             patch.object(agent, "populate_file_methods"),
             patch.object(agent, "step_api_surfaces", return_value=MagicMock()),
             patch.object(agent, "step_relation_analysis"),
@@ -215,14 +212,12 @@ class TestDetailsAgent(unittest.TestCase):
             result = agent.run(scope, self.test_component)
 
         self.assertEqual(result, expected)
-        _component, cluster_analysis, partitions, cfgs = final_analysis.call_args.args
-        self.assertEqual(cluster_analysis.cluster_components[0].cluster_ids, [1])
-        self.assertIs(partitions, scope.leaf_clusters_by_language)
-        self.assertEqual(set(cfgs["python"].nodes), {"test.func"})
+        _component, received_scope = llm_analysis.call_args.args
+        self.assertIs(received_scope, scope)
+        self.mock_static_analysis.get_cfg.assert_not_called()
 
     @patch("agents.details_agent.DetailsAgent._invoke_repair_validate")
-    def test_step_final_analysis(self, mock_invoke_repair_validate):
-        # Test step_final_analysis
+    def test_step_llm_analysis(self, mock_invoke_repair_validate):
         mock_llm = MagicMock()
         mock_parsing_llm = MagicMock()
         agent = DetailsAgent(
@@ -240,8 +235,8 @@ class TestDetailsAgent(unittest.TestCase):
         )
         mock_invoke_repair_validate.return_value = mock_response
 
-        cluster_analysis = ClusterAnalysis(cluster_components=[])
-        result = agent.step_final_analysis(self.test_component, cluster_analysis, {}, {})
+        scope = ClusterScopeResult(scope_id="1")
+        result = agent.step_llm_analysis(self.test_component, scope)
 
         self.assertEqual(result, mock_response)
         mock_invoke_repair_validate.assert_called_once()
@@ -259,11 +254,12 @@ class TestDetailsAgent(unittest.TestCase):
             parsing_llm=mock_parsing_llm,
         )
 
-        cluster_analysis = ClusterAnalysis(
-            cluster_components=[
-                ClustersComponent(name="GroupA", cluster_ids=[1, 2], description="Group A"),
-                ClustersComponent(name="GroupB", cluster_ids=[3, 4], description="Group B"),
-            ]
+        scope = ClusterScopeResult(
+            scope_id="1",
+            groups=[
+                ClusterGroup(group_id="1.1", cluster_ids=[1, 2]),
+                ClusterGroup(group_id="1.2", cluster_ids=[3, 4]),
+            ],
         )
 
         analysis = AnalysisInsights(
@@ -273,19 +269,19 @@ class TestDetailsAgent(unittest.TestCase):
                     name="Comp1",
                     description="Comp1",
                     key_entities=[],
-                    source_group_names=["GroupA", "GroupB"],
+                    source_group_names=["Group 1", "Group 2"],
                 ),
                 Component(
                     name="Comp2",
                     description="Comp2",
                     key_entities=[],
-                    source_group_names=["GroupA"],
+                    source_group_names=["Group 1"],
                 ),
             ],
             components_relations=[],
         )
 
-        agent._resolve_cluster_ids_from_groups(analysis, cluster_analysis)
+        agent._resolve_cluster_ids_from_groups(analysis, scope)
 
         self.assertEqual(analysis.components[0].source_cluster_ids, ["1", "2", "3", "4"])
         self.assertEqual(analysis.components[1].source_cluster_ids, ["1", "2"])
@@ -303,10 +299,9 @@ class TestDetailsAgent(unittest.TestCase):
             parsing_llm=mock_parsing_llm,
         )
 
-        cluster_analysis = ClusterAnalysis(
-            cluster_components=[
-                ClustersComponent(name="GroupA", cluster_ids=[1, 2], description="Group A"),
-            ]
+        scope = ClusterScopeResult(
+            scope_id="1",
+            groups=[ClusterGroup(group_id="1.1", cluster_ids=[1, 2])],
         )
 
         analysis = AnalysisInsights(
@@ -316,13 +311,13 @@ class TestDetailsAgent(unittest.TestCase):
                     name="Comp1",
                     description="Comp1",
                     key_entities=[],
-                    source_group_names=["groupa"],
+                    source_group_names=["group 1"],
                 ),
             ],
             components_relations=[],
         )
 
-        agent._resolve_cluster_ids_from_groups(analysis, cluster_analysis)
+        agent._resolve_cluster_ids_from_groups(analysis, scope)
 
         self.assertEqual(analysis.components[0].source_cluster_ids, ["1", "2"])
 

--- a/tests/agents/test_details_agent.py
+++ b/tests/agents/test_details_agent.py
@@ -120,19 +120,6 @@ class TestDetailsAgent(unittest.TestCase):
         )
         return cr, graph
 
-    def _assert_partition(self, result, expected_ids):
-        self.assertIsInstance(result, ClusterAnalysis)
-        self.assertGreaterEqual(len(result.cluster_components), 1)
-        # Names are the deterministic Group-1..N labels.
-        self.assertEqual(
-            [cc.name for cc in result.cluster_components],
-            [f"Group {i}" for i in range(1, len(result.cluster_components) + 1)],
-        )
-        # Every leaf cluster is owned by exactly one group (a true, disjoint partition).
-        assigned = [cid for cc in result.cluster_components for cid in cc.cluster_ids]
-        self.assertEqual(sorted(assigned), sorted(expected_ids))
-        self.assertEqual(len(assigned), len(set(assigned)))
-
     def test_init(self):
         # Test initialization
         mock_llm = MagicMock()
@@ -199,27 +186,7 @@ class TestDetailsAgent(unittest.TestCase):
         mock_cfg.filter_by_nodes.assert_called_with(expected_qnames)
         mock_cluster.assert_called_once_with(mock_subgraph)
 
-    def test_step_clusters_grouping(self):
-        # Grouping is deterministic (resolution-tuned Leiden on the subgraph), no LLM call.
-        agent = self._make_agent()
-        cr, graph = self._clustered_graph(range(1, 11))
-        subgraph_cfg = MagicMock()
-        subgraph_cfg.to_networkx.return_value = graph
-        subgraph_cluster_results = {"python": cr}
-        subgraph_cfgs = {"python": subgraph_cfg}
-
-        result = agent.step_clusters_grouping(self.test_component, subgraph_cluster_results, subgraph_cfgs)
-        result_again = agent.step_clusters_grouping(self.test_component, subgraph_cluster_results, subgraph_cfgs)
-
-        # A complete, disjoint partition of the leaf clusters into "Group i" components.
-        self._assert_partition(result, list(range(1, 11)))
-        # Deterministic: same membership on a re-run.
-        self.assertEqual(
-            [sorted(cc.cluster_ids) for cc in result.cluster_components],
-            [sorted(cc.cluster_ids) for cc in result_again.cluster_components],
-        )
-
-    def test_run_scope_skips_local_reclustering(self):
+    def test_run_uses_precomputed_scope(self):
         agent = self._make_agent()
         partition = ClusterResult(clusters={1: {"test.func"}}, strategy="test")
         scope = ClusterScopeResult(
@@ -227,22 +194,31 @@ class TestDetailsAgent(unittest.TestCase):
             leaf_clusters_by_language={"python": partition},
             groups=[ClusterGroup(group_id="1.1", cluster_ids=[1])],
         )
-        cfgs = {"python": CallGraph(language="python")}
+        cfg = CallGraph(language="python")
+        cfg.add_node(Node("test.func", NodeType.FUNCTION, "test.py", 1, 10))
+        cfg.add_node(Node("test_utils.helper", NodeType.FUNCTION, "test_utils.py", 1, 5))
+        self.mock_static_analysis.get_cfg.return_value = cfg
         expected = (
             AnalysisInsights(description="done", components=[], components_relations=[]),
             scope.leaf_clusters_by_language,
         )
 
         with (
-            patch.object(agent, "_run_clustered", return_value=expected) as run_clustered,
-            patch.object(agent, "step_clusters_grouping") as regroup,
+            patch.object(agent, "step_final_analysis", return_value=expected[0]) as final_analysis,
+            patch.object(agent, "populate_file_methods"),
+            patch.object(agent, "step_api_surfaces", return_value=MagicMock()),
+            patch.object(agent, "step_relation_analysis"),
+            patch.object(agent.reference_resolver, "fix_source_code_reference_lines", return_value=expected[0]),
+            patch("agents.details_agent.index_relation_endpoints"),
+            patch.object(agent, "_ensure_unique_key_entities"),
         ):
-            result = agent.run_scope(self.test_component, scope, cfgs)
+            result = agent.run(scope, self.test_component)
 
         self.assertEqual(result, expected)
-        regroup.assert_not_called()
-        self.assertIs(run_clustered.call_args.args[2], scope.leaf_clusters_by_language)
-        self.assertIs(run_clustered.call_args.args[3], cfgs)
+        _component, cluster_analysis, partitions, cfgs = final_analysis.call_args.args
+        self.assertEqual(cluster_analysis.cluster_components[0].cluster_ids, [1])
+        self.assertIs(partitions, scope.leaf_clusters_by_language)
+        self.assertEqual(set(cfgs["python"].nodes), {"test.func"})
 
     @patch("agents.details_agent.DetailsAgent._invoke_repair_validate")
     def test_step_final_analysis(self, mock_invoke_repair_validate):
@@ -400,14 +376,13 @@ class TestDetailsAgent(unittest.TestCase):
             agent_llm=mock_llm,
             parsing_llm=mock_parsing_llm,
         )
-        # Mock StaticAnalysis and CFG behavior for run
-        abs_assigned = {str(self.repo_dir / fg.file_path) for fg in self.test_component.file_methods}
-        mock_cluster_result = MagicMock()
-        mock_cluster_result.get_cluster_ids.return_value = {1}
-        mock_cluster_result.get_files_for_cluster.return_value = abs_assigned
-
-        # Real subgraph cluster result + graph so deterministic grouping has structure.
+        self.test_component.component_id = "1"
         sub_cluster_result, subgraph_graph = self._clustered_graph(range(1, 7))
+        scope = ClusterScopeResult(
+            scope_id="1",
+            leaf_clusters_by_language={"python": sub_cluster_result},
+            groups=[ClusterGroup(group_id="1.1", cluster_ids=list(range(1, 7)))],
+        )
 
         mock_node = MagicMock()
         mock_node.file_path = str(self.repo_dir / "src" / "main.py")
@@ -418,16 +393,14 @@ class TestDetailsAgent(unittest.TestCase):
 
         mock_subgraph = MagicMock()
         mock_subgraph.nodes = {"n1": mock_node}
-        mock_subgraph.cluster.return_value = sub_cluster_result
         mock_subgraph.to_cluster_string.return_value = "Component CFG String"
         mock_subgraph.to_networkx.return_value = subgraph_graph
 
         mock_cfg = MagicMock()
-        mock_cfg.cluster.return_value = mock_cluster_result
         mock_cfg.filter_by_nodes.return_value = mock_subgraph
         # _build_cluster_string calls cfg.to_cluster_string on the original cfg
         mock_cfg.to_cluster_string.return_value = "Cluster 1: method_a, method_b"
-        # deterministic_cluster_grouping reads the (super-)graph via get_cfg(...).to_networkx()
+        # Clustering reads the (super-)graph via get_cfg(...).to_networkx().
         mock_cfg.to_networkx.return_value = subgraph_graph
 
         self.mock_static_analysis.get_languages.return_value = ["python"]
@@ -454,7 +427,7 @@ class TestDetailsAgent(unittest.TestCase):
         mock_parse_invoke.return_value = api_response
         mock_fix_ref.return_value = final_response
 
-        analysis, _subgraph_results = agent.run(self.test_component)
+        analysis, _subgraph_results = agent.run(scope, self.test_component)
 
         self.assertEqual(analysis, final_response)
         mock_invoke_validate.assert_called_once_with(

--- a/tests/agents/test_method_uniqueness.py
+++ b/tests/agents/test_method_uniqueness.py
@@ -92,6 +92,48 @@ def _assert_no_duplicate_methods_by_location(test_case: unittest.TestCase, analy
         test_case.fail(f"{len(duplicates)} physical method(s) appear in multiple sibling components:\n{detail}{more}")
 
 
+class TestPolyglotQualifiedNameIdentity(unittest.TestCase):
+    def test_same_qualified_name_in_two_languages_keeps_both_nodes(self):
+        python_graph = CallGraph(language="python")
+        python_graph.add_node(Node("main.main", NodeType.FUNCTION, "/repo/main.py", 1, 3))
+        go_graph = CallGraph(language="go")
+        go_graph.add_node(Node("main.main", NodeType.FUNCTION, "/repo/main.go", 5, 8))
+        cluster_results = {
+            "python": ClusterResult(clusters={1: {"main.main"}}),
+            "go": ClusterResult(clusters={2: {"main.main"}}),
+        }
+        analysis = AnalysisInsights(
+            description="polyglot",
+            components=[
+                Component(
+                    name="Python entrypoint",
+                    description="python",
+                    key_entities=[],
+                    source_cluster_ids=["1"],
+                    component_id="1",
+                ),
+                Component(
+                    name="Go entrypoint",
+                    description="go",
+                    key_entities=[],
+                    source_cluster_ids=["2"],
+                    component_id="2",
+                ),
+            ],
+            components_relations=[],
+        )
+        mixin = MockMixin(repo_dir=Path("/repo"), static_analysis=MagicMock())
+
+        mixin.populate_file_methods(
+            analysis,
+            cluster_results,
+            {"python": python_graph, "go": go_graph},
+        )
+
+        self.assertEqual([group.file_path for group in analysis.components[0].file_methods], ["main.py"])
+        self.assertEqual([group.file_path for group in analysis.components[1].file_methods], ["main.go"])
+
+
 class TestMethodUniquenessWithAliases(unittest.TestCase):
     """Reproduce the nanoclaw bug: the same physical method has two qualified-name
     aliases that end up in different clusters and hence different components.

--- a/tests/agents/test_repair.py
+++ b/tests/agents/test_repair.py
@@ -1,17 +1,11 @@
 from pathlib import Path
 
-from agents.agent_responses import (
-    ClusterAnalysis,
-    ClustersComponent,
-    Component,
-    ComponentArchitecture,
-    SourceCodeReference,
-)
+from agents.agent_responses import Component, ComponentArchitecture, SourceCodeReference
 from agents.repair import ComponentRepairContext, repair_component_group_names, repair_key_entities
 from agents.validation import ValidationContext, validate_group_name_coverage, validate_key_entities
 from static_analyzer.analysis_result import StaticAnalysisResults
 from static_analyzer.config import Language, NodeType
-from static_analyzer.clustering import ClusterResult
+from static_analyzer.clustering import ClusterGroup, ClusterResult, ClusterScopeResult
 from static_analyzer.node import Node
 from static_analyzer.reference_resolver import StaticReferenceResolver
 
@@ -45,13 +39,15 @@ def _component_repair_context() -> ComponentRepairContext:
             strategy="test",
         )
     }
-    cluster_analysis = ClusterAnalysis(
-        cluster_components=[ClustersComponent(name="API Handler", cluster_ids=[1], description="Handles requests.")]
+    scope = ClusterScopeResult(
+        scope_id="root",
+        leaf_clusters_by_language=cluster_results,
+        groups=[ClusterGroup(group_id="1", cluster_ids=[1])],
     )
     return ComponentRepairContext(
         reference_resolver=StaticReferenceResolver(Path("/tmp/fake-repo"), static_analysis),
         cluster_results=cluster_results,
-        llm_cluster_analysis=cluster_analysis,
+        clustering=scope,
     )
 
 
@@ -62,7 +58,7 @@ def test_component_repairs_canonicalize_names_and_keep_only_resolved_in_scope_en
             Component(
                 name="API",
                 description="Handles requests.",
-                source_group_names=["API Handlr"],
+                source_group_names=["Grop 1"],
                 key_entities=[
                     SourceCodeReference(qualified_name="pkg/service.run"),
                     SourceCodeReference(qualified_name="other.service.run"),
@@ -76,7 +72,7 @@ def test_component_repairs_canonicalize_names_and_keep_only_resolved_in_scope_en
     repair_component_group_names(architecture, context)
     repair_key_entities(architecture, context)
 
-    assert architecture.components[0].source_group_names == ["API Handler"]
+    assert architecture.components[0].source_group_names == ["Group 1"]
     assert [entity.qualified_name for entity in architecture.components[0].key_entities] == ["pkg.service.run"]
 
 
@@ -87,7 +83,7 @@ def test_component_validators_do_not_mutate_repairable_metadata() -> None:
             Component(
                 name="API",
                 description="Handles requests.",
-                source_group_names=["API Handlr"],
+                source_group_names=["Grop 1"],
                 key_entities=[SourceCodeReference(qualified_name="pkg/service.run")],
             )
         ],
@@ -96,7 +92,7 @@ def test_component_validators_do_not_mutate_repairable_metadata() -> None:
     validation_context = ValidationContext(
         cluster_results=repair_context.cluster_results,
         static_analysis=repair_context.reference_resolver.static_analysis,
-        llm_cluster_analysis=repair_context.llm_cluster_analysis,
+        clustering=repair_context.clustering,
     )
     before = architecture.model_dump()
 

--- a/tests/agents/test_validation.py
+++ b/tests/agents/test_validation.py
@@ -14,8 +14,6 @@ from agents.validation import (
     validate_relations,
 )
 from agents.agent_responses import (
-    ClusterAnalysis,
-    ClustersComponent,
     AnalysisInsights,
     Component,
     Relation,
@@ -25,7 +23,7 @@ from agents.agent_responses import (
     FileClassification,
 )
 from static_analyzer.cfg import CallGraph
-from static_analyzer.clustering import ClusterResult
+from static_analyzer.clustering import ClusterGroup, ClusterResult, ClusterScopeResult
 from static_analyzer.node import Node
 from static_analyzer.config import NodeType
 
@@ -341,24 +339,26 @@ class TestValidateRelationEvidence(unittest.TestCase):
             cluster_to_files={},
             strategy="test",
         )
-        cluster_analysis = ClusterAnalysis(
-            cluster_components=[
-                ClustersComponent(name="GroupA", cluster_ids=[1], description="A"),
-                ClustersComponent(name="GroupB", cluster_ids=[2], description="B"),
-            ]
+        scope = ClusterScopeResult(
+            scope_id="root",
+            leaf_clusters_by_language={"python": cluster_result},
+            groups=[
+                ClusterGroup(group_id="1", cluster_ids=[1]),
+                ClusterGroup(group_id="2", cluster_ids=[2]),
+            ],
         )
         return ValidationContext(
             cluster_results={"python": cluster_result},
             cfg_graphs={"python": cfg},
-            llm_cluster_analysis=cluster_analysis,
+            clustering=scope,
         )
 
     def _make_analysis(self, relation: Relation) -> AnalysisInsights:
         return AnalysisInsights(
             description="test",
             components=[
-                Component(name="A", description="A", key_entities=[], source_group_names=["GroupA"]),
-                Component(name="B", description="B", key_entities=[], source_group_names=["GroupB"]),
+                Component(name="A", description="A", key_entities=[], source_group_names=["Group 1"]),
+                Component(name="B", description="B", key_entities=[], source_group_names=["Group 2"]),
             ],
             components_relations=[relation],
         )
@@ -505,8 +505,8 @@ class TestValidateRelationEvidence(unittest.TestCase):
         analysis = AnalysisInsights(
             description="test",
             components=[
-                Component(name="A", description="A", key_entities=[], source_group_names=["GroupA"]),
-                Component(name="B", description="B", key_entities=[], source_group_names=["GroupB"]),
+                Component(name="A", description="A", key_entities=[], source_group_names=["Group 1"]),
+                Component(name="B", description="B", key_entities=[], source_group_names=["Group 2"]),
             ],
             components_relations=[
                 Relation(relation="calls", src_name="A", dst_name="B"),

--- a/tests/agents/tools/test_cfg_tools.py
+++ b/tests/agents/tools/test_cfg_tools.py
@@ -2,11 +2,7 @@ import unittest
 from pathlib import Path
 from unittest.mock import MagicMock
 
-from agents.agent_responses import (
-    ClusterAnalysis,
-    ClustersComponent,
-    Component,
-)
+from agents.agent_responses import Component
 from agents.file_index_models import FileMethodGroup
 from agents.tools import ComponentBridgeEdgesTool, GetCFGTool, MethodInvocationsTool
 from agents.tools.base import RepoContext
@@ -14,7 +10,7 @@ from repo_utils.ignore import RepoIgnoreManager
 from static_analyzer import StaticAnalyzer
 from static_analyzer.analysis_result import StaticAnalysisResults
 from static_analyzer.cfg import CallGraph, Edge
-from static_analyzer.clustering import ClusterResult
+from static_analyzer.clustering import ClusterGroup, ClusterResult, ClusterScopeResult
 from static_analyzer.config import Language, NodeType
 from static_analyzer.node import Node
 from utils import get_artifact_dir
@@ -165,17 +161,19 @@ class TestComponentBridgeEdgesTool(unittest.TestCase):
                 clusters={1: {src.fully_qualified_name}, 2: {dst.fully_qualified_name}, 3: {other.fully_qualified_name}}
             )
         }
-        cluster_analysis = ClusterAnalysis(
-            cluster_components=[
-                ClustersComponent(name="Source Group", cluster_ids=[1], description="source"),
-                ClustersComponent(name="Destination Group", cluster_ids=[2], description="destination"),
-                ClustersComponent(name="Other Group", cluster_ids=[3], description="other"),
-            ]
+        scope = ClusterScopeResult(
+            scope_id="root",
+            leaf_clusters_by_language=cluster_results,
+            groups=[
+                ClusterGroup(group_id="1", cluster_ids=[1]),
+                ClusterGroup(group_id="2", cluster_ids=[2]),
+                ClusterGroup(group_id="3", cluster_ids=[3]),
+            ],
         )
         context = RepoContext(
             repo_dir=Path("."),
             ignore_manager=RepoIgnoreManager(Path(".")),
-            cluster_analysis=cluster_analysis,
+            clustering=scope,
             cluster_results=cluster_results,
             cfg_graphs={"python": cfg},
         )
@@ -183,7 +181,7 @@ class TestComponentBridgeEdgesTool(unittest.TestCase):
 
     def test_returns_directed_edges_between_component_groups(self):
         tool = self._make_tool()
-        result = tool._run(["Source Group"], ["Destination Group"])
+        result = tool._run(["Group 1"], ["Group 2"])
 
         self.assertIn("Directed static bridge edges (1)", result)
         self.assertIn("pkg.source.call", result)
@@ -192,7 +190,7 @@ class TestComponentBridgeEdgesTool(unittest.TestCase):
 
     def test_reverse_direction_is_not_reported(self):
         tool = self._make_tool()
-        result = tool._run(["Destination Group"], ["Source Group"])
+        result = tool._run(["Group 2"], ["Group 1"])
 
         self.assertEqual(result, "No directed static bridge edges found between these component groups.")
 

--- a/tests/codeboarding_workflows/test_analysis.py
+++ b/tests/codeboarding_workflows/test_analysis.py
@@ -14,7 +14,7 @@ def patched(tmp_path: Path):
     """Patch the collaborators of ``run_incremental`` and yield their mocks.
 
     Detection is git-free via ``detect_changes_from_fingerprint``. The warm-start
-    source_sha is computed inside the generator (pre_analysis), not here.
+    source_sha is computed inside the generator (prepare_analysis), not here.
     """
     with ExitStack() as stack:
         gen_cls = stack.enter_context(patch("codeboarding_workflows.analysis.DiagramGenerator"))

--- a/tests/diagram_analysis/test_diagram_analysis.py
+++ b/tests/diagram_analysis/test_diagram_analysis.py
@@ -980,8 +980,30 @@ class TestDiagramGenerator(unittest.TestCase):
         gen.prepare_analysis(hierarchy_depth=3)
 
         self.assertEqual(calls, ["deterministic", "agents"])
-        gen.deterministic_analysis.assert_called_once_with(hierarchy_depth=3, target_component=None)
+        gen.deterministic_analysis.assert_called_once_with(
+            hierarchy_depth=3,
+            target_component=None,
+            require_incremental_baseline=False,
+        )
         gen.agent_init.assert_called_once_with()
+
+    def test_deterministic_analysis_rejects_missing_incremental_baseline_before_clustering(self):
+        gen = DiagramGenerator(
+            repo_location=self.repo_location,
+            temp_folder=self.temp_folder,
+            repo_name="test_repo",
+            output_dir=self.output_dir,
+            depth_level=2,
+            run_id="test-run-id",
+            log_path="test_repo/test-run-log",
+        )
+        gen._get_static_with_new_analyzer = Mock(return_value=StaticAnalysisResults())
+
+        with patch("diagram_analysis.diagram_generator.build_clustering_hierarchy") as mock_build_hierarchy:
+            with self.assertRaises(IncrementalCacheMissingError):
+                gen.deterministic_analysis(require_incremental_baseline=True)
+
+        mock_build_hierarchy.assert_not_called()
 
     def test_process_component_with_exception(self):
         # Test processing a component that raises an exception
@@ -1121,6 +1143,37 @@ class TestDiagramGenerator(unittest.TestCase):
 
         self.assertEqual(root_ids, ["1"])
         self.assertEqual(sub_ids, {})
+        mock_get_expandable_components.assert_not_called()
+
+    @patch("diagram_analysis.diagram_generator.get_expandable_components")
+    def test_preclustered_save_preserves_generated_subtree_owner(self, mock_get_expandable_components):
+        gen = DiagramGenerator(
+            repo_location=self.repo_location,
+            temp_folder=self.temp_folder,
+            repo_name="test_repo",
+            output_dir=self.output_dir,
+            depth_level=2,
+            run_id="test-run-id",
+            log_path="test_repo/test-run-log",
+        )
+        owner = Component(name="A", description="", key_entities=[], component_id="1")
+        child = Component(name="A child", description="", key_entities=[], component_id="1.1")
+        root_analysis = AnalysisInsights(description="root", components=[owner], components_relations=[])
+        sub_analyses = {"1": AnalysisInsights(description="child scope", components=[child], components_relations=[])}
+        gen.details_agent = Mock()
+        gen.clustering_hierarchy = ClusterScopeResult(scope_id="root")
+        gen.clustering_hierarchy.register_scope(
+            "1",
+            ClusterScopeResult(
+                scope_id="1",
+                groups=[ClusterGroup(group_id="1.1", cluster_ids=[1], expandable=False)],
+            ),
+        )
+
+        root_ids, sub_ids = gen._expandable_ids_for_tree(root_analysis, sub_analyses)
+
+        self.assertEqual(root_ids, ["1"])
+        self.assertEqual(sub_ids, {"1": []})
         mock_get_expandable_components.assert_not_called()
 
     def test_absorbed_ids_reroot_preclustered_expansion_flags(self):

--- a/tests/diagram_analysis/test_diagram_analysis.py
+++ b/tests/diagram_analysis/test_diagram_analysis.py
@@ -47,7 +47,7 @@ from static_analyzer.analysis_cache import StaticAnalysisCache
 from static_analyzer.analysis_result import StaticAnalysisResults
 from static_analyzer.config import Language, NodeType
 from static_analyzer.cfg import CallGraph
-from static_analyzer.clustering import ClusterResult
+from static_analyzer.clustering import ClusterGroup, ClusterResult, ClusterScopeResult
 from static_analyzer.node import Node
 
 
@@ -983,6 +983,127 @@ class TestDiagramGenerator(unittest.TestCase):
         self.assertIsNone(result_name)
         self.assertIsNone(result_analysis)
         self.assertEqual(new_components, [])
+
+    @patch("diagram_analysis.diagram_generator.get_expandable_components")
+    def test_process_component_traverses_the_preclustered_scope(self, mock_get_expandable_components):
+        gen = DiagramGenerator(
+            repo_location=self.repo_location,
+            temp_folder=self.temp_folder,
+            repo_name="test_repo",
+            output_dir=self.output_dir,
+            depth_level=3,
+            run_id="test-run-id",
+            log_path="test_repo/test-run-log",
+        )
+        component = Component(name="Root", description="", key_entities=[], component_id="1")
+        child = Component(name="Child", description="", key_entities=[], component_id="1.1")
+        child_analysis = AnalysisInsights(description="child", components=[child], components_relations=[])
+        scope = ClusterScopeResult(scope_id="1")
+        grandchild_scope = ClusterScopeResult(scope_id="1.1")
+        gen.details_agent = Mock()
+        gen.details_agent.run_scope.return_value = (child_analysis, scope.leaf_clusters_by_language)
+        gen._preclustered_scopes = {
+            "1": (scope, {}),
+            "1.1": (grandchild_scope, {}),
+        }
+
+        component_id, result, new_components = gen.process_component(component)
+
+        self.assertEqual(component_id, "1")
+        self.assertIs(result, child_analysis)
+        self.assertEqual(new_components, [child])
+        gen.details_agent.run_scope.assert_called_once_with(component, scope, {})
+        gen.details_agent.run.assert_not_called()
+        mock_get_expandable_components.assert_not_called()
+
+    @patch("diagram_analysis.diagram_generator.get_expandable_components")
+    def test_preclustered_expansion_flags_are_reused_when_saving(self, mock_get_expandable_components):
+        gen = DiagramGenerator(
+            repo_location=self.repo_location,
+            temp_folder=self.temp_folder,
+            repo_name="test_repo",
+            output_dir=self.output_dir,
+            depth_level=2,
+            run_id="test-run-id",
+            log_path="test_repo/test-run-log",
+        )
+        expandable = Component(name="A", description="", key_entities=[], component_id="1")
+        leaf = Component(name="B", description="", key_entities=[], component_id="2")
+        analysis = AnalysisInsights(description="root", components=[expandable, leaf], components_relations=[])
+        gen.details_agent = Mock()
+        gen._clustering_groups = {
+            "1": ClusterGroup(group_id="1", cluster_ids=[1], expandable=True),
+            "2": ClusterGroup(group_id="2", cluster_ids=[2], expandable=False),
+        }
+
+        root_ids, sub_ids = gen._expandable_ids_for_tree(analysis, {})
+
+        self.assertEqual(root_ids, ["1"])
+        self.assertEqual(sub_ids, {})
+        mock_get_expandable_components.assert_not_called()
+
+    def test_absorbed_ids_reroot_preclustered_expansion_flags(self):
+        gen = DiagramGenerator(
+            repo_location=self.repo_location,
+            temp_folder=self.temp_folder,
+            repo_name="test_repo",
+            output_dir=self.output_dir,
+            depth_level=3,
+            run_id="test-run-id",
+            log_path="test_repo/test-run-log",
+        )
+        gen._clustering_groups = {
+            "1": ClusterGroup(group_id="1", cluster_ids=[1]),
+            "1.1": ClusterGroup(group_id="1.1", cluster_ids=[2]),
+            "1.1.2": ClusterGroup(group_id="1.1.2", cluster_ids=[3], expandable=True),
+        }
+
+        gen._reroot_clustering_groups(["1.1"])
+
+        self.assertEqual(set(gen._clustering_groups), {"1", "1.2"})
+        self.assertTrue(gen._clustering_groups["1.2"].expandable)
+
+    @patch("diagram_analysis.diagram_generator.get_expandable_components")
+    @patch("diagram_analysis.diagram_generator.build_clustering_hierarchy")
+    def test_full_analysis_builds_the_hierarchy_before_running_agents(
+        self,
+        mock_build_hierarchy,
+        mock_get_expandable_components,
+    ):
+        gen = DiagramGenerator(
+            repo_location=self.repo_location,
+            temp_folder=self.temp_folder,
+            repo_name="test_repo",
+            output_dir=self.output_dir,
+            depth_level=2,
+            run_id="test-run-id",
+            log_path="test_repo/test-run-log",
+        )
+        child_scope = ClusterScopeResult(scope_id="1")
+        hierarchy = ClusterScopeResult(
+            scope_id="root",
+            groups=[ClusterGroup(group_id="1", cluster_ids=[1], expandable=True, children=child_scope)],
+        )
+        component = Component(name="Root", description="", key_entities=[], component_id="1")
+        analysis = AnalysisInsights(description="root", components=[component], components_relations=[])
+        gen.static_analysis = MagicMock(spec=StaticAnalysisResults)
+        gen.static_analysis.available_cfgs.return_value = {}
+        gen.details_agent = Mock()
+        gen.abstraction_agent = Mock()
+        gen.abstraction_agent.run_scope.return_value = (analysis, {})
+        gen._generate_subcomponents = Mock(return_value=([], {}))
+        expected_path = self.output_dir / "analysis.json"
+        gen.finalize_and_save = Mock(return_value=expected_path)
+        mock_build_hierarchy.return_value = hierarchy
+
+        result = gen.generate_analysis()
+
+        self.assertEqual(result, expected_path)
+        mock_build_hierarchy.assert_called_once_with(gen.static_analysis, 2)
+        gen.abstraction_agent.run_scope.assert_called_once_with(hierarchy)
+        gen.abstraction_agent.run.assert_not_called()
+        gen._generate_subcomponents.assert_called_once_with(analysis, [component])
+        mock_get_expandable_components.assert_not_called()
 
     @patch("diagram_analysis.diagram_generator.save_analysis")
     @patch("diagram_analysis.diagram_generator.get_expandable_components")

--- a/tests/diagram_analysis/test_diagram_analysis.py
+++ b/tests/diagram_analysis/test_diagram_analysis.py
@@ -896,7 +896,7 @@ class TestDiagramGenerator(unittest.TestCase):
     @patch("diagram_analysis.diagram_generator.MetaAgent")
     @patch("diagram_analysis.diagram_generator.DetailsAgent")
     @patch("diagram_analysis.diagram_generator.AbstractionAgent")
-    def test_pre_analysis(
+    def test_prepare_analysis(
         self,
         mock_abstraction,
         mock_details,
@@ -905,7 +905,7 @@ class TestDiagramGenerator(unittest.TestCase):
         mock_get_static_analysis,
         mock_scanner,
     ):
-        # Test pre_analysis method
+        # Test prepare_analysis method
         # Return a proper StaticAnalysisResults object
         mock_analysis_results = StaticAnalysisResults()
         mock_analysis_results.diagnostics = {}
@@ -945,15 +945,43 @@ class TestDiagramGenerator(unittest.TestCase):
             log_path="test_repo/test-run-log",
         )
 
-        with (patch("diagram_analysis.diagram_generator.IncrementalAgent") as mock_incremental,):
-            gen.pre_analysis()
+        hierarchy = ClusterScopeResult(scope_id="root")
+        with (
+            patch("diagram_analysis.diagram_generator.IncrementalAgent") as mock_incremental,
+            patch(
+                "diagram_analysis.diagram_generator.build_clustering_hierarchy", return_value=hierarchy
+            ) as mock_build_hierarchy,
+        ):
+            gen.prepare_analysis()
 
         # Verify agents were created
+        mock_build_hierarchy.assert_called_once_with(mock_analysis_results, 2)
+        self.assertIs(gen.clustering_hierarchy, hierarchy)
         self.assertIsNotNone(gen.meta_agent)
         self.assertIsNotNone(gen.details_agent)
         self.assertIsNotNone(gen.abstraction_agent)
         self.assertIs(gen.incremental_agent, mock_incremental.return_value)
         mock_meta_instance.analyze_project_metadata.assert_called_once_with(skip_cache=False)
+
+    def test_prepare_analysis_runs_deterministic_analysis_before_agent_init(self):
+        gen = DiagramGenerator(
+            repo_location=self.repo_location,
+            temp_folder=self.temp_folder,
+            repo_name="test_repo",
+            output_dir=self.output_dir,
+            depth_level=2,
+            run_id="test-run-id",
+            log_path="test_repo/test-run-log",
+        )
+        calls = []
+        gen.deterministic_analysis = Mock(side_effect=lambda **_kwargs: calls.append("deterministic"))
+        gen.agent_init = Mock(side_effect=lambda: calls.append("agents"))
+
+        gen.prepare_analysis(hierarchy_depth=3)
+
+        self.assertEqual(calls, ["deterministic", "agents"])
+        gen.deterministic_analysis.assert_called_once_with(include_clustering=True, hierarchy_depth=3)
+        gen.agent_init.assert_called_once_with()
 
     def test_process_component_with_exception(self):
         # Test processing a component that raises an exception
@@ -975,7 +1003,8 @@ class TestDiagramGenerator(unittest.TestCase):
         gen.details_agent.run.side_effect = Exception("Test error")
 
         # Create test component
-        component = Component(name="TestComponent", description="Test", key_entities=[])
+        component = Component(name="TestComponent", description="Test", key_entities=[], component_id="1")
+        gen._preclustered_scopes = {"1": ClusterScopeResult(scope_id="1")}
 
         result_name, result_analysis, new_components = gen.process_component(component)
 
@@ -1001,10 +1030,10 @@ class TestDiagramGenerator(unittest.TestCase):
         scope = ClusterScopeResult(scope_id="1")
         grandchild_scope = ClusterScopeResult(scope_id="1.1")
         gen.details_agent = Mock()
-        gen.details_agent.run_scope.return_value = (child_analysis, scope.leaf_clusters_by_language)
+        gen.details_agent.run.return_value = (child_analysis, scope.leaf_clusters_by_language)
         gen._preclustered_scopes = {
-            "1": (scope, {}),
-            "1.1": (grandchild_scope, {}),
+            "1": scope,
+            "1.1": grandchild_scope,
         }
 
         component_id, result, new_components = gen.process_component(component)
@@ -1012,8 +1041,7 @@ class TestDiagramGenerator(unittest.TestCase):
         self.assertEqual(component_id, "1")
         self.assertIs(result, child_analysis)
         self.assertEqual(new_components, [child])
-        gen.details_agent.run_scope.assert_called_once_with(component, scope, {})
-        gen.details_agent.run.assert_not_called()
+        gen.details_agent.run.assert_called_once_with(scope, component)
         mock_get_expandable_components.assert_not_called()
 
     @patch("diagram_analysis.diagram_generator.get_expandable_components")
@@ -1064,12 +1092,7 @@ class TestDiagramGenerator(unittest.TestCase):
         self.assertTrue(gen._clustering_groups["1.2"].expandable)
 
     @patch("diagram_analysis.diagram_generator.get_expandable_components")
-    @patch("diagram_analysis.diagram_generator.build_clustering_hierarchy")
-    def test_full_analysis_builds_the_hierarchy_before_running_agents(
-        self,
-        mock_build_hierarchy,
-        mock_get_expandable_components,
-    ):
+    def test_full_analysis_consumes_the_precomputed_hierarchy(self, mock_get_expandable_components):
         gen = DiagramGenerator(
             repo_location=self.repo_location,
             temp_folder=self.temp_folder,
@@ -1088,28 +1111,24 @@ class TestDiagramGenerator(unittest.TestCase):
         analysis = AnalysisInsights(description="root", components=[component], components_relations=[])
         gen.static_analysis = MagicMock(spec=StaticAnalysisResults)
         gen.static_analysis.available_cfgs.return_value = {}
+        gen.clustering_hierarchy = hierarchy
+        gen._preclustered_scopes = {"1": child_scope}
         gen.details_agent = Mock()
         gen.abstraction_agent = Mock()
-        gen.abstraction_agent.run_scope.return_value = (analysis, {})
+        gen.abstraction_agent.run.return_value = (analysis, {})
         gen._generate_subcomponents = Mock(return_value=([], {}))
         expected_path = self.output_dir / "analysis.json"
         gen.finalize_and_save = Mock(return_value=expected_path)
-        mock_build_hierarchy.return_value = hierarchy
 
         result = gen.generate_analysis()
 
         self.assertEqual(result, expected_path)
-        mock_build_hierarchy.assert_called_once_with(gen.static_analysis, 2)
-        gen.abstraction_agent.run_scope.assert_called_once_with(hierarchy)
-        gen.abstraction_agent.run.assert_not_called()
+        gen.abstraction_agent.run.assert_called_once_with(hierarchy)
         gen._generate_subcomponents.assert_called_once_with(analysis, [component])
         mock_get_expandable_components.assert_not_called()
 
     @patch("diagram_analysis.diagram_generator.save_analysis")
-    @patch("diagram_analysis.diagram_generator.get_expandable_components")
-    def test_generate_analysis_frontier_submits_child_before_slow_sibling_finishes(
-        self, mock_get_expandable_components, mock_save_analysis
-    ):
+    def test_generate_analysis_frontier_submits_child_before_slow_sibling_finishes(self, mock_save_analysis):
         gen = DiagramGenerator(
             repo_location=self.repo_location,
             temp_folder=self.temp_folder,
@@ -1147,10 +1166,7 @@ class TestDiagramGenerator(unittest.TestCase):
         sub_analysis_b = AnalysisInsights(description="B sub", components=[], components_relations=[])
         sub_analysis_child = AnalysisInsights(description="Child sub", components=[], components_relations=[])
 
-        gen.abstraction_agent = Mock()
-        gen.abstraction_agent.run.return_value = (root_analysis, {})
-        gen.details_agent = Mock()  # pre_analysis is skipped when details/abstraction are already initialized
-        mock_get_expandable_components.return_value = [root_a, root_b]
+        gen.details_agent = Mock()
         mock_save_analysis.return_value = self.output_dir / "analysis.json"
 
         timestamps: dict[str, float] = {}
@@ -1173,9 +1189,10 @@ class TestDiagramGenerator(unittest.TestCase):
 
         gen._process_component = Mock(side_effect=process_component_side_effect)
 
-        result = gen.generate_analysis()
+        expanded_components, sub_analyses = gen._generate_subcomponents(root_analysis, [root_a, root_b])
 
-        self.assertEqual(result, (self.output_dir / "analysis.json").resolve())
+        self.assertEqual(set(sub_analyses), {"A", "B", "A-child"})
+        self.assertEqual({component.name for component in expanded_components}, {"A", "B", "A-child"})
         self.assertIn("child_start", timestamps)
         self.assertIn("b_end", timestamps)
         self.assertLess(timestamps["child_start"], timestamps["b_end"])
@@ -1183,7 +1200,7 @@ class TestDiagramGenerator(unittest.TestCase):
         processed_names = [call.args[0].name for call in gen._process_component.call_args_list]
         self.assertIn("A-child", processed_names)
 
-    def test_generate_analysis_uses_root_expandables_for_can_expand(self):
+    def test_generate_analysis_uses_hierarchy_expandables_for_can_expand(self):
         gen = DiagramGenerator(
             repo_location=self.repo_location,
             temp_folder=self.temp_folder,
@@ -1194,9 +1211,10 @@ class TestDiagramGenerator(unittest.TestCase):
             log_path="test_repo/test-run-log",
         )
 
-        # Prevent pre_analysis from running.
+        # Prevent prepare_analysis from running.
         gen.abstraction_agent = Mock()
         gen.details_agent = Mock()
+        gen.static_analysis = StaticAnalysisResults()
 
         comp1 = Component(
             name="Component1",
@@ -1237,9 +1255,16 @@ class TestDiagramGenerator(unittest.TestCase):
         )
         assign_component_ids(analysis)
 
+        hierarchy = ClusterScopeResult(
+            scope_id="root",
+            groups=[
+                ClusterGroup(group_id="1", cluster_ids=[1], expandable=True),
+                ClusterGroup(group_id="2", cluster_ids=[2], expandable=False),
+            ],
+        )
+        gen.clustering_hierarchy = hierarchy
+        gen._index_clustering_hierarchy(hierarchy)
         gen.abstraction_agent.run.return_value = (analysis, {})
-
-        planned = [analysis.components[0]]
         captured: dict[str, list[Component]] = {}
 
         def _capture_build(
@@ -1256,23 +1281,19 @@ class TestDiagramGenerator(unittest.TestCase):
             captured["expandable_components"] = expandable_components
             return "{}"
 
-        with patch("diagram_analysis.diagram_generator.get_expandable_components", return_value=planned):
-            with patch(
-                "diagram_analysis.io_utils.build_unified_analysis_json",
-                side_effect=_capture_build,
-            ):
-                gen.generate_analysis()
+        with patch(
+            "diagram_analysis.io_utils.build_unified_analysis_json",
+            side_effect=_capture_build,
+        ):
+            gen.generate_analysis()
 
-        # The run's separability-respecting expandable set is authoritative: only the planned
-        # component ("1") is advertised as expandable. Component "2" was kept as a leaf and must
-        # NOT be re-added by the save-time structural recompute.
+        # The deterministic hierarchy is authoritative: component "2" was kept as a leaf.
         self.assertEqual(
             sorted([c.component_id for c in captured["expandable_components"]]),
             [comp1.component_id],
         )
 
-    @patch("diagram_analysis.diagram_generator.get_expandable_components")
-    def test_generate_analysis_depth_one_preserves_root_expandable_flags(self, mock_get_expandable_components):
+    def test_generate_analysis_depth_one_preserves_root_expandable_flags(self):
         comp1 = Component(
             name="Comp1",
             description="Component one",
@@ -1308,8 +1329,6 @@ class TestDiagramGenerator(unittest.TestCase):
         )
         assign_component_ids(analysis)
 
-        mock_get_expandable_components.return_value = analysis.components
-
         gen = DiagramGenerator(
             repo_location=self.repo_location,
             temp_folder=self.temp_folder,
@@ -1322,6 +1341,16 @@ class TestDiagramGenerator(unittest.TestCase):
         gen.details_agent = Mock()
         gen.abstraction_agent = Mock()
         gen.incremental_agent = Mock()
+        gen.static_analysis = StaticAnalysisResults()
+        hierarchy = ClusterScopeResult(
+            scope_id="root",
+            groups=[
+                ClusterGroup(group_id="1", cluster_ids=[1], expandable=True),
+                ClusterGroup(group_id="2", cluster_ids=[2], expandable=True),
+            ],
+        )
+        gen.clustering_hierarchy = hierarchy
+        gen._index_clustering_hierarchy(hierarchy)
         gen.abstraction_agent.run.return_value = (analysis, {})
 
         gen.generate_analysis()
@@ -1372,10 +1401,8 @@ class TestDiagramGenerator(unittest.TestCase):
         self.assertEqual(_component_expansion_seeds([root, child, leaf], max_depth=1), [])
 
     @patch("diagram_analysis.diagram_generator.save_analysis")
-    @patch("diagram_analysis.diagram_generator.get_expandable_components")
     def test_generate_subcomponents_respects_absolute_depth(
         self,
-        mock_get_expandable_components,
         mock_save_analysis,
     ):
         gen = DiagramGenerator(
@@ -1399,12 +1426,13 @@ class TestDiagramGenerator(unittest.TestCase):
             components_relations=[],
         )
 
+        scope = ClusterScopeResult(scope_id="1.1")
+        gen._preclustered_scopes = {"1.1": scope}
         gen.details_agent.run.return_value = (child_analysis, {})
-        mock_get_expandable_components.return_value = [generated_child]
 
         expanded_components, sub_analyses = gen._generate_subcomponents(root_analysis, [depth_two, max_depth_leaf])
 
-        gen.details_agent.run.assert_called_once_with(depth_two)
+        gen.details_agent.run.assert_called_once_with(scope, depth_two)
         self.assertEqual([component.component_id for component in expanded_components], ["1.1"])
         self.assertEqual(set(sub_analyses), {"1.1"})
         self.assertEqual(mock_save_analysis.call_count, 1)

--- a/tests/diagram_analysis/test_diagram_analysis.py
+++ b/tests/diagram_analysis/test_diagram_analysis.py
@@ -21,7 +21,7 @@ from agents.agent_responses import (
     assign_component_ids,
 )
 from agents.file_index_models import FileEntry, FileMethodGroup, MethodEntry
-from agents.incremental_results import ScopeRelationContext, ScopeUpdateResult
+from agents.incremental_results import RecursiveScopeUpdateResult, ScopeRelationContext, ScopeUpdateResult
 from agents.relation_edges import index_relation_endpoints
 from diagram_analysis.analysis_json import (
     ComponentFileMethodGroupJson,
@@ -980,7 +980,7 @@ class TestDiagramGenerator(unittest.TestCase):
         gen.prepare_analysis(hierarchy_depth=3)
 
         self.assertEqual(calls, ["deterministic", "agents"])
-        gen.deterministic_analysis.assert_called_once_with(include_clustering=True, hierarchy_depth=3)
+        gen.deterministic_analysis.assert_called_once_with(hierarchy_depth=3, target_component=None)
         gen.agent_init.assert_called_once_with()
 
     def test_process_component_with_exception(self):
@@ -1004,7 +1004,11 @@ class TestDiagramGenerator(unittest.TestCase):
 
         # Create test component
         component = Component(name="TestComponent", description="Test", key_entities=[], component_id="1")
-        gen._preclustered_scopes = {"1": ClusterScopeResult(scope_id="1")}
+        scope = ClusterScopeResult(scope_id="1")
+        gen.clustering_hierarchy = ClusterScopeResult(
+            scope_id="root",
+            groups=[ClusterGroup(group_id="1", cluster_ids=[1], children=scope)],
+        )
 
         result_name, result_analysis, new_components = gen.process_component(component)
 
@@ -1027,14 +1031,17 @@ class TestDiagramGenerator(unittest.TestCase):
         component = Component(name="Root", description="", key_entities=[], component_id="1")
         child = Component(name="Child", description="", key_entities=[], component_id="1.1")
         child_analysis = AnalysisInsights(description="child", components=[child], components_relations=[])
-        scope = ClusterScopeResult(scope_id="1")
         grandchild_scope = ClusterScopeResult(scope_id="1.1")
+        scope = ClusterScopeResult(
+            scope_id="1",
+            groups=[ClusterGroup(group_id="1.1", cluster_ids=[1], children=grandchild_scope)],
+        )
+        gen.clustering_hierarchy = ClusterScopeResult(
+            scope_id="root",
+            groups=[ClusterGroup(group_id="1", cluster_ids=[1], children=scope)],
+        )
         gen.details_agent = Mock()
         gen.details_agent.run.return_value = (child_analysis, scope.leaf_clusters_by_language)
-        gen._preclustered_scopes = {
-            "1": scope,
-            "1.1": grandchild_scope,
-        }
 
         component_id, result, new_components = gen.process_component(component)
 
@@ -1043,6 +1050,49 @@ class TestDiagramGenerator(unittest.TestCase):
         self.assertEqual(new_components, [child])
         gen.details_agent.run.assert_called_once_with(scope, component)
         mock_get_expandable_components.assert_not_called()
+
+    def test_register_component_scope_uses_persisted_absorbed_id(self):
+        gen = DiagramGenerator(
+            repo_location=self.repo_location,
+            temp_folder=self.temp_folder,
+            repo_name="test_repo",
+            output_dir=self.output_dir,
+            depth_level=3,
+            run_id="test-run-id",
+            log_path="test_repo/test-run-log",
+        )
+        graph = CallGraph(language="python")
+        graph.add_node(Node("pkg.persisted.run", NodeType.FUNCTION, str(self.repo_location / "persisted.py"), 1, 4))
+        graph.add_node(Node("pkg.other.run", NodeType.FUNCTION, str(self.repo_location / "other.py"), 1, 4))
+        gen.static_analysis = StaticAnalysisResults()
+        gen.static_analysis.add_cfg(Language.PYTHON, graph)
+        gen.clustering_hierarchy = ClusterScopeResult(scope_id="root")
+        component = Component(
+            name="Persisted child",
+            description="",
+            key_entities=[],
+            component_id="2",
+            file_methods=[
+                FileMethodGroup(
+                    file_path="persisted.py",
+                    methods=[
+                        MethodEntry(
+                            qualified_name="pkg.persisted.run",
+                            start_line=1,
+                            end_line=4,
+                            node_type="FUNCTION",
+                        )
+                    ],
+                )
+            ],
+        )
+
+        gen._register_component_scope(component, hierarchy_depth=4)
+
+        scope = gen.clustering_hierarchy.preclustered_scopes["2"]
+        self.assertEqual(scope.scope_id, "2")
+        self.assertEqual(set(scope.graphs_by_language["python"].nodes), {"pkg.persisted.run"})
+        self.assertTrue(all(group.group_id.startswith("2.") for group in scope.groups))
 
     @patch("diagram_analysis.diagram_generator.get_expandable_components")
     def test_preclustered_expansion_flags_are_reused_when_saving(self, mock_get_expandable_components):
@@ -1059,10 +1109,13 @@ class TestDiagramGenerator(unittest.TestCase):
         leaf = Component(name="B", description="", key_entities=[], component_id="2")
         analysis = AnalysisInsights(description="root", components=[expandable, leaf], components_relations=[])
         gen.details_agent = Mock()
-        gen._clustering_groups = {
-            "1": ClusterGroup(group_id="1", cluster_ids=[1], expandable=True),
-            "2": ClusterGroup(group_id="2", cluster_ids=[2], expandable=False),
-        }
+        gen.clustering_hierarchy = ClusterScopeResult(
+            scope_id="root",
+            groups=[
+                ClusterGroup(group_id="1", cluster_ids=[1], expandable=True),
+                ClusterGroup(group_id="2", cluster_ids=[2], expandable=False),
+            ],
+        )
 
         root_ids, sub_ids = gen._expandable_ids_for_tree(analysis, {})
 
@@ -1071,25 +1124,34 @@ class TestDiagramGenerator(unittest.TestCase):
         mock_get_expandable_components.assert_not_called()
 
     def test_absorbed_ids_reroot_preclustered_expansion_flags(self):
-        gen = DiagramGenerator(
-            repo_location=self.repo_location,
-            temp_folder=self.temp_folder,
-            repo_name="test_repo",
-            output_dir=self.output_dir,
-            depth_level=3,
-            run_id="test-run-id",
-            log_path="test_repo/test-run-log",
+        hierarchy = ClusterScopeResult(
+            scope_id="root",
+            groups=[
+                ClusterGroup(
+                    group_id="1",
+                    cluster_ids=[1],
+                    children=ClusterScopeResult(
+                        scope_id="1",
+                        groups=[
+                            ClusterGroup(
+                                group_id="1.1",
+                                cluster_ids=[2],
+                                children=ClusterScopeResult(
+                                    scope_id="1.1",
+                                    groups=[ClusterGroup(group_id="1.1.2", cluster_ids=[3], expandable=True)],
+                                ),
+                            )
+                        ],
+                    ),
+                )
+            ],
         )
-        gen._clustering_groups = {
-            "1": ClusterGroup(group_id="1", cluster_ids=[1]),
-            "1.1": ClusterGroup(group_id="1.1", cluster_ids=[2]),
-            "1.1.2": ClusterGroup(group_id="1.1.2", cluster_ids=[3], expandable=True),
-        }
 
-        gen._reroot_clustering_groups(["1.1"])
+        hierarchy.reroot_indexes(["1.1"])
 
-        self.assertEqual(set(gen._clustering_groups), {"1", "1.2"})
-        self.assertTrue(gen._clustering_groups["1.2"].expandable)
+        self.assertEqual(set(hierarchy.clustering_groups), {"1", "1.2"})
+        self.assertTrue(hierarchy.clustering_groups["1.2"].expandable)
+        self.assertEqual(hierarchy.clustering_groups["1.2"].group_id, "1.2")
 
     @patch("diagram_analysis.diagram_generator.get_expandable_components")
     def test_full_analysis_consumes_the_precomputed_hierarchy(self, mock_get_expandable_components):
@@ -1112,7 +1174,6 @@ class TestDiagramGenerator(unittest.TestCase):
         gen.static_analysis = MagicMock(spec=StaticAnalysisResults)
         gen.static_analysis.available_cfgs.return_value = {}
         gen.clustering_hierarchy = hierarchy
-        gen._preclustered_scopes = {"1": child_scope}
         gen.details_agent = Mock()
         gen.abstraction_agent = Mock()
         gen.abstraction_agent.run.return_value = (analysis, {})
@@ -1263,7 +1324,6 @@ class TestDiagramGenerator(unittest.TestCase):
             ],
         )
         gen.clustering_hierarchy = hierarchy
-        gen._index_clustering_hierarchy(hierarchy)
         gen.abstraction_agent.run.return_value = (analysis, {})
         captured: dict[str, list[Component]] = {}
 
@@ -1350,7 +1410,6 @@ class TestDiagramGenerator(unittest.TestCase):
             ],
         )
         gen.clustering_hierarchy = hierarchy
-        gen._index_clustering_hierarchy(hierarchy)
         gen.abstraction_agent.run.return_value = (analysis, {})
 
         gen.generate_analysis()
@@ -1427,7 +1486,10 @@ class TestDiagramGenerator(unittest.TestCase):
         )
 
         scope = ClusterScopeResult(scope_id="1.1")
-        gen._preclustered_scopes = {"1.1": scope}
+        gen.clustering_hierarchy = ClusterScopeResult(
+            scope_id="root",
+            groups=[ClusterGroup(group_id="1.1", cluster_ids=[1], children=scope)],
+        )
         gen.details_agent.run.return_value = (child_analysis, {})
 
         expanded_components, sub_analyses = gen._generate_subcomponents(root_analysis, [depth_two, max_depth_leaf])
@@ -1799,6 +1861,65 @@ class TestDiagramGenerator(unittest.TestCase):
 
         self.assertEqual(_mock_incremental_agent.return_value.update_scope.call_count, 1)
         gen._generate_subcomponents.assert_not_called()
+
+    @patch("diagram_analysis.diagram_generator.prune_empty_components", return_value=set())
+    @patch("diagram_analysis.diagram_generator.compute_cluster_delta")
+    @patch("diagram_analysis.diagram_generator.snapshot_from_static_analysis")
+    def test_incremental_new_component_registers_scope_before_subcomponent_generation(
+        self,
+        mock_snapshot,
+        mock_delta,
+        _mock_prune,
+    ):
+        gen = DiagramGenerator(
+            repo_location=self.repo_location,
+            temp_folder=self.temp_folder,
+            repo_name="test_repo",
+            output_dir=self.output_dir,
+            depth_level=2,
+            run_id="test-run-id",
+            log_path="test_repo/test-run-log",
+        )
+        gen.details_agent = Mock()
+        gen.incremental_agent = Mock()
+        gen.static_analysis = Mock()
+        gen.static_analysis.get_languages.return_value = []
+        gen.static_analysis.incremental_base_results = Mock()
+
+        existing = Component(name="Existing", description="", key_entities=[], component_id="1")
+        created = Component(name="Created", description="", key_entities=[], component_id="2")
+        root_analysis = AnalysisInsights(description="root", components=[existing], components_relations=[])
+        sub_analyses: dict[str, AnalysisInsights] = {}
+
+        mock_snapshot.return_value.all_cluster_ids.return_value = {1}
+        mock_delta.return_value.has_changes = True
+        mock_delta.return_value.cluster_results.return_value = {}
+
+        def apply_incremental(*_args):
+            root_analysis.components.append(created)
+            return RecursiveScopeUpdateResult(refresh_ids={"2"}, new_component_ids={"2"})
+
+        call_order: list[str] = []
+
+        def generate_subcomponents(*_args):
+            call_order.append("generate")
+            return [], sub_analyses
+
+        def register_scope(*_args):
+            call_order.append("register")
+
+        gen._apply_incremental_scope_recursively = Mock(side_effect=apply_incremental)
+        gen._register_component_scope = Mock(side_effect=register_scope)
+        gen._generate_subcomponents = Mock(side_effect=generate_subcomponents)
+        gen._refresh_files_index = Mock()
+        gen.finalize_and_save = Mock(return_value=self.output_dir / "analysis.json")
+
+        gen.generate_analysis_incremental(root_analysis, sub_analyses)
+
+        self.assertEqual(call_order, ["register", "generate"])
+        gen._register_component_scope.assert_called_once_with(created, gen.depth_level)
+        gen._generate_subcomponents.assert_called_once_with(root_analysis, [created], sub_analyses)
+        gen.incremental_agent.detail_new_components.assert_called_once_with([created])
 
     @patch("diagram_analysis.diagram_generator.save_analysis")
     @patch("diagram_analysis.diagram_generator.prune_empty_components")

--- a/tests/diagram_analysis/test_tree_shape.py
+++ b/tests/diagram_analysis/test_tree_shape.py
@@ -300,7 +300,6 @@ class TestFinalizeForSaveEnforcesTheInvariant(unittest.TestCase):
         generator.static_analysis = None
         generator.repo_location = Path(".")
         generator._baseline_global_relations = None
-        generator._clustering_groups = {}
         root = analysis(
             component("1", "Kept", {"a.py": ["a.one"]}),
             component("2", "Degenerate", {"b.py": ["b.one"]}),
@@ -318,7 +317,6 @@ class TestFinalizeForSaveEnforcesTheInvariant(unittest.TestCase):
         generator = DiagramGenerator.__new__(DiagramGenerator)
         generator.static_analysis = None
         generator.repo_location = Path(".")
-        generator._clustering_groups = {}
         root = analysis(component("1", "Kept", {"a.py": ["a.one"]}), component("2", "Parent", {}))
         subs = {"2": analysis(component("2.1", "Child", {}))}
 

--- a/tests/diagram_analysis/test_tree_shape.py
+++ b/tests/diagram_analysis/test_tree_shape.py
@@ -300,6 +300,7 @@ class TestFinalizeForSaveEnforcesTheInvariant(unittest.TestCase):
         generator.static_analysis = None
         generator.repo_location = Path(".")
         generator._baseline_global_relations = None
+        generator._clustering_groups = {}
         root = analysis(
             component("1", "Kept", {"a.py": ["a.one"]}),
             component("2", "Degenerate", {"b.py": ["b.one"]}),
@@ -317,6 +318,7 @@ class TestFinalizeForSaveEnforcesTheInvariant(unittest.TestCase):
         generator = DiagramGenerator.__new__(DiagramGenerator)
         generator.static_analysis = None
         generator.repo_location = Path(".")
+        generator._clustering_groups = {}
         root = analysis(component("1", "Kept", {"a.py": ["a.one"]}), component("2", "Parent", {}))
         subs = {"2": analysis(component("2.1", "Child", {}))}
 

--- a/tests/static_analyzer/test_clustering_hierarchy.py
+++ b/tests/static_analyzer/test_clustering_hierarchy.py
@@ -1,10 +1,17 @@
 import unittest
 from collections.abc import Mapping
-from unittest.mock import patch
+from unittest.mock import MagicMock, call, patch
 
 from static_analyzer.cfg import CallGraph
-from static_analyzer.clustering import ClusterResult, ClusterScopeInput, ClusteringService
-from static_analyzer.config import NodeType
+from static_analyzer.clustering import (
+    ClusterGroup,
+    ClusterResult,
+    ClusterScopeInput,
+    ClusterScopeResult,
+    ClusteringService,
+)
+from static_analyzer.clustering.orchestration import build_clustering_hierarchy
+from static_analyzer.config import Language, NodeType
 from static_analyzer.node import Node
 
 
@@ -66,6 +73,8 @@ class TestClusteringHierarchy(unittest.TestCase):
         self.assertEqual(seen_nodes[group_b.group_id], members_b)
         self.assertEqual(seen_edges[group_a.group_id], set())
         self.assertEqual(seen_edges[group_b.group_id], set())
+        self.assertTrue(group_a.expandable)
+        self.assertFalse(group_b.expandable)
         self.assertIsNotNone(group_a.children)
         self.assertIsNone(group_b.children)
 
@@ -105,6 +114,7 @@ class TestClusteringHierarchy(unittest.TestCase):
 
         result = ClusteringService().cluster_hierarchy({"python": graph}, max_depth=3, scope_input=scope_input)
 
+        self.assertFalse(result.groups[0].expandable)
         self.assertIsNone(result.groups[0].children)
 
     def test_one_group_child_does_not_consume_a_depth_level(self):
@@ -145,6 +155,54 @@ class TestClusteringHierarchy(unittest.TestCase):
     def test_rejects_a_depth_below_the_root_level(self):
         with self.assertRaisesRegex(ValueError, "max_depth must be at least 1"):
             ClusteringService().cluster_hierarchy({}, max_depth=0)
+
+    @patch("static_analyzer.clustering.orchestration.build_all_cluster_results")
+    @patch.object(ClusteringService, "cluster_hierarchy")
+    def test_full_orchestration_reuses_root_partitions_and_records_child_lineage(
+        self,
+        cluster_hierarchy,
+        build_root,
+    ):
+        root_partition = ClusterResult(clusters={1: {"root"}})
+        child_partition = ClusterResult(clusters={2: {"child"}})
+        grandchild_partition = ClusterResult(clusters={3: {"grandchild"}})
+        grandchild_scope = ClusterScopeResult(
+            scope_id="1.1",
+            leaf_clusters_by_language={"python": grandchild_partition},
+        )
+        child_scope = ClusterScopeResult(
+            scope_id="1",
+            leaf_clusters_by_language={"python": child_partition},
+            groups=[ClusterGroup(group_id="1.1", cluster_ids=[2], children=grandchild_scope)],
+        )
+        hierarchy = ClusterScopeResult(
+            scope_id="root",
+            leaf_clusters_by_language={"python": root_partition},
+            groups=[ClusterGroup(group_id="1", cluster_ids=[1], children=child_scope)],
+        )
+        static_analysis = MagicMock()
+        static_analysis.available_cfgs.return_value = {"python": CallGraph(language="python")}
+        cache = MagicMock()
+        static_analysis.get_clusters.return_value = cache
+        build_root.return_value = {"python": root_partition}
+        cluster_hierarchy.return_value = hierarchy
+
+        result = build_clustering_hierarchy(static_analysis, max_depth=3)
+
+        self.assertIs(result, hierarchy)
+        graphs, depth, scope_input = cluster_hierarchy.call_args.args
+        self.assertEqual(graphs, static_analysis.available_cfgs.return_value)
+        self.assertEqual(depth, 3)
+        self.assertIs(scope_input("root", graphs).leaf_clusters_by_language["python"], root_partition)
+        self.assertEqual(scope_input("1", graphs).leaf_clusters_by_language, {})
+        self.assertEqual(
+            cache.record_scope.call_args_list,
+            [
+                call(child_partition, "1"),
+                call(grandchild_partition, "1.1"),
+            ],
+        )
+        static_analysis.get_clusters.assert_called_with(Language.PYTHON)
 
 
 if __name__ == "__main__":

--- a/tests/static_analyzer/test_clustering_hierarchy.py
+++ b/tests/static_analyzer/test_clustering_hierarchy.py
@@ -76,6 +76,8 @@ class TestClusteringHierarchy(unittest.TestCase):
         self.assertTrue(group_a.expandable)
         self.assertFalse(group_b.expandable)
         self.assertIsNotNone(group_a.children)
+        assert group_a.children is not None
+        self.assertEqual(set(group_a.children.graphs_by_language["python"].nodes), members_a)
         self.assertIsNone(group_b.children)
 
     def test_recurses_with_new_local_partitions_until_the_depth_cap(self):

--- a/tests/static_analyzer/test_clustering_scope.py
+++ b/tests/static_analyzer/test_clustering_scope.py
@@ -4,7 +4,9 @@ from static_analyzer.cfg import CallGraph
 from static_analyzer.config import NodeType
 from static_analyzer.clustering import (
     METHOD_LEVEL_STRATEGY,
+    ClusterGroup,
     ClusterResult,
+    ClusterScopeResult,
     ClusteringService,
     LeafClustersUnavailableError,
 )
@@ -38,6 +40,33 @@ def cluster_result_for(graph: CallGraph, clusters: dict[int, set[str]]) -> Clust
 
 
 class TestClusteringScope(unittest.TestCase):
+    def test_scope_formats_group_metadata_for_agent_prompts(self):
+        cluster_result = ClusterResult(
+            clusters={1: {"pkg.Service.run", "entrypoint"}, 2: {"pkg.Repository.load"}},
+            cluster_to_files={1: {"/repo/service.py"}, 2: {"/repo/repository.py"}},
+        )
+        scope = ClusterScopeResult(
+            scope_id="root",
+            leaf_clusters_by_language={"python": cluster_result},
+            groups=[
+                ClusterGroup(group_id="1", cluster_ids=[1]),
+                ClusterGroup(group_id="2", cluster_ids=[2]),
+            ],
+        )
+
+        self.assertEqual(scope.group_names(), ["Group 1", "Group 2"])
+        self.assertEqual(scope.group_ids(), {"Group 1": [1], "Group 2": [2]})
+        self.assertEqual(
+            scope.llm_str(),
+            "# Grouped Cluster Components\n"
+            "**Group 1** (cluster_ids: [1])\n"
+            "   1 leaf clusters, 2 symbols across 1 files. Files: service.py "
+            "Key symbols: entrypoint, pkg.Service.run\n"
+            "**Group 2** (cluster_ids: [2])\n"
+            "   1 leaf clusters, 1 symbols across 1 files. Files: repository.py "
+            "Key symbols: pkg.Repository.load",
+        )
+
     def test_grouping_matches_the_existing_supercluster_result(self):
         graph = graph_for("python", ["a", "b", "c"], [("a", "b"), ("b", "c")])
         cluster_result = cluster_result_for(graph, {1: {"a"}, 2: {"b"}, 3: {"c"}})
@@ -49,6 +78,7 @@ class TestClusteringScope(unittest.TestCase):
             {"python": graph}, leaf_clusters_by_language={"python": cluster_result}
         )
 
+        self.assertIs(result.graphs_by_language["python"], graph)
         self.assertEqual(
             sorted(sorted(group.cluster_ids) for group in result.groups),
             sorted(sorted(group) for group in expected),

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -134,7 +134,10 @@ class TestPartialUpdate(unittest.TestCase):
                 component_id="test_comp_id",
             )
 
-            mock_generator.prepare_analysis.assert_called_once_with(hierarchy_depth=2)
+            mock_generator.prepare_analysis.assert_called_once_with(
+                hierarchy_depth=2,
+                target_component=root_component,
+            )
             mock_generator.process_component.assert_called_once_with(root_component)
             mock_generator.finalize_and_save.assert_called_once_with(
                 root_analysis, {"test_comp_id": mock_sub_analysis}, persist_side_artifacts=False
@@ -193,7 +196,10 @@ class TestPartialUpdate(unittest.TestCase):
                 component_id="nested_comp_id",
             )
 
-            mock_generator.prepare_analysis.assert_called_once_with(hierarchy_depth=3)
+            mock_generator.prepare_analysis.assert_called_once_with(
+                hierarchy_depth=3,
+                target_component=nested_component,
+            )
             mock_generator.process_component.assert_called_once_with(nested_component)
             self.assertEqual(mock_generator_class.call_args.kwargs["depth_level"], 2)
             mock_generator.finalize_and_save.assert_called_once()
@@ -358,7 +364,7 @@ class TestLocalSource(unittest.TestCase):
                     component_id="does-not-matter",
                 )
 
-            mock_generator_class.return_value.prepare_analysis.assert_called_once_with(hierarchy_depth=2)
+            mock_generator_class.return_value.prepare_analysis.assert_not_called()
 
 
 class TestFullCliLocal(unittest.TestCase):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -134,7 +134,7 @@ class TestPartialUpdate(unittest.TestCase):
                 component_id="test_comp_id",
             )
 
-            mock_generator.pre_analysis.assert_called_once()
+            mock_generator.prepare_analysis.assert_called_once_with(hierarchy_depth=2)
             mock_generator.process_component.assert_called_once_with(root_component)
             mock_generator.finalize_and_save.assert_called_once_with(
                 root_analysis, {"test_comp_id": mock_sub_analysis}, persist_side_artifacts=False
@@ -193,7 +193,7 @@ class TestPartialUpdate(unittest.TestCase):
                 component_id="nested_comp_id",
             )
 
-            mock_generator.pre_analysis.assert_called_once()
+            mock_generator.prepare_analysis.assert_called_once_with(hierarchy_depth=3)
             mock_generator.process_component.assert_called_once_with(nested_component)
             self.assertEqual(mock_generator_class.call_args.kwargs["depth_level"], 2)
             mock_generator.finalize_and_save.assert_called_once()
@@ -218,9 +218,9 @@ class TestPartialUpdate(unittest.TestCase):
                     component_id="TestComponent",
                 )
 
-            # No metadata: raise before building the generator or touching pre_analysis.
+            # No metadata: raise before building the generator or touching prepare_analysis.
             mock_generator_class.assert_not_called()
-            mock_generator.pre_analysis.assert_not_called()
+            mock_generator.prepare_analysis.assert_not_called()
             mock_generator.process_component.assert_not_called()
 
 
@@ -339,7 +339,7 @@ class TestLocalSource(unittest.TestCase):
 
         mock_load_metadata.return_value = {"depth_level": 1}
         # Minimal non-None baseline so run_partial gets past both early-return guards
-        # and reaches pre_analysis (which is what this test asserts on).
+        # and reaches prepare_analysis (which is what this test asserts on).
         mock_load_full.return_value = (
             AnalysisInsights(description="root", components=[], components_relations=[]),
             {},
@@ -358,7 +358,7 @@ class TestLocalSource(unittest.TestCase):
                     component_id="does-not-matter",
                 )
 
-            mock_generator_class.return_value.pre_analysis.assert_called_once()
+            mock_generator_class.return_value.prepare_analysis.assert_called_once_with(hierarchy_depth=2)
 
 
 class TestFullCliLocal(unittest.TestCase):


### PR DESCRIPTION
## Goal

Make the deterministic clustering hierarchy the structural source of truth for full and partial analysis, while leaving the LLM agents responsible for names, descriptions, API surfaces, and relations.

## What this PR addresses

- Splits preparation into two explicit stages:
  - `deterministic_analysis(...)` runs source fingerprinting, static analysis, and clustering;
  - `agent_init()` initializes the LLM-backed agents;
  - `prepare_analysis(...)` composes both stages.
- Builds and indexes the complete `ClusterScopeResult` hierarchy before agent execution.
- Makes `ClusterScopeResult` authoritative for groups, exact per-language graphs, child scopes, and hierarchy indexes.
- Leaves each analysis agent with one public execution method:
  - `AbstractionAgent.run(scope)` for the root;
  - `DetailsAgent.run(scope, component)` for a component.
- Passes precomputed scopes directly to agent analysis; the temporary `ClusterAnalysis` model and `run_scope(...)` API are gone.
- Keeps partial analysis on the same preparation lifecycle: static analysis and clustering still run, and the persisted target component is registered as an exact scope before `DetailsAgent.run(...)`.
- Keeps hierarchy IDs aligned when single-child components are absorbed during final tree normalization.

## Behavior changes

- Full/details analysis no longer regroups when an agent reaches a scope. Group membership and expansion are fixed by deterministic analysis before any LLM call.
- No unrelated output behavior is intentionally changed. Existing naming, detail, API-surface, relation, and serialization stages remain in place.
- Details-agent result caching is removed separately in predecessor #510; static-analysis and metadata caching remain.

## Boundary of this PR

This PR owns full and partial hierarchy consumption. Incremental hierarchy migration and fail-fast baseline handling are isolated in #499. #500 then removes the superseded orchestration paths.

## Stack roadmap

| Position | PR | Responsibility |
|---|---|---|
| Foundation | [#494](https://github.com/CodeBoarding/CodeBoarding/pull/494) | Move grouping algorithms behind `GroupingService`. |
| Previous | [#495](https://github.com/CodeBoarding/CodeBoarding/pull/495) | Define the complete result for one clustered scope. |
| Previous | [#497](https://github.com/CodeBoarding/CodeBoarding/pull/497) | Build recursive scope results into a deterministic hierarchy. |
| Previous | [#510](https://github.com/CodeBoarding/CodeBoarding/pull/510) | Remove the low-value details-agent cache before changing hierarchy ownership. |
| **This PR** | **#498** | Make full and partial analysis consume the precomputed hierarchy. |
| Next | [#499](https://github.com/CodeBoarding/CodeBoarding/pull/499) | Migrate incremental analysis to an ownership-anchored hierarchy. |
| Final cleanup | [#500](https://github.com/CodeBoarding/CodeBoarding/pull/500) | Remove obsolete fallback and recursive orchestration paths. |

Amp-Thread-ID: https://ampcode.com/threads/T-01a01478-33f2-70cf-8a11-9475c7d3a4cd
Co-authored-by: Amp <amp@ampcode.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
