### PR TITLE
ci(codeboarding): review every push to a pull request

### DIFF
--- a/.github/workflows/codeboarding.yml
+++ b/.github/workflows/codeboarding.yml
@@ -2,7 +2,7 @@ name: CodeBoarding review
 
 on:
   pull_request:
-    types: [opened, reopened, ready_for_review, closed]
+    types: [opened, reopened, ready_for_review, closed, synchronize]
   issue_comment:
     types: [created]
 
@@ -24,7 +24,9 @@ jobs:
       issues: write         # the /codeboarding issue_comment trigger + comment API
       id-token: write       # mint a GitHub OIDC token for the free hosted tier (write is the only level for id-token)
     if: >
-      (github.event_name == 'pull_request' && github.event.action != 'closed' && github.event.pull_request.draft == false) ||
+      (github.event_name == 'pull_request' && github.event.action != 'closed' &&
+       github.event.pull_request.draft == false &&
+       github.event.pull_request.head.repo.full_name == github.repository) ||
       (github.event_name == 'issue_comment' && github.event.issue.pull_request != null &&
        startsWith(github.event.comment.body, '/codeboarding') &&
        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association))


### PR DESCRIPTION
Opened by hand, because the product will not open it for you: `depth_level: 4` marks this workflow as customised, and the setup flow refuses to regenerate a file it did not fully write. That refusal is correct, and it is exactly why this repository has stayed on the pre-`synchronize` triggers while every stock repository moved on.

## What changes

**`synchronize` joins the `pull_request` triggers**, so a push to an open pull request is reviewed rather than only the first commit being reviewed.

That is affordable now because the action reuses a pull request's previous analysis: a run covers what changed since the last one instead of re-deriving everything. It was left out originally for the opposite reason.

It also only works from a push. GitHub hands a run triggered by `issue_comment` a **read-only cache token**, so `/codeboarding` can read the cached analysis but never write it. Until now this repository has been paying for a full analysis on every single review.

**The job's `if:` also requires the head repo to be this repo.** A fork PR's token cannot write the review comment, so the action refuses those runs anyway; without the check, every fork push starts a runner that reads its own guard and stops. `synchronize` turns that from once per fork PR into once per push. A maintainer can still review a fork PR by commenting `/codeboarding`, which is gated on author association rather than on the head repo.

## What deliberately does not change

**The concurrency block.** `cancel-in-progress` fires only on `closed`, so GitHub keeps at most one run in progress and one pending, and a push arriving mid-run replaces whatever was waiting rather than queueing behind it.

That is the behaviour we want. There is a single sticky comment per pull request, so a review of a superseded commit has nowhere to live that the next review will not take, and letting a slower run for an older head finish last would leave the pull request describing a commit that is no longer there. Nothing is lost by skipping it: the analysis is seeded from the newest cached snapshot by key prefix, not by sha, and diffed against the tree it checked out rather than against a commit range, so the run that survives covers the skipped push's commits too.

**`depth_level: 4`** and every other local setting, untouched. The diff is four lines.

## Related

Same change as CodeBoarding-webview#72 made to the generated template, and CodeBoarding-action#87 to the README example. CodeBoarding-webview#77 is what will notice this repository is behind in future rather than showing it a green check, though it still will not open the pull request for you, for the reason at the top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated workflow triggers for synchronized pull request changes.
  * Added safeguards to prevent workflow runs from untrusted forked repositories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->