### PR TITLE
ci: let reviews reuse the analysis an earlier run published

### DIFF
--- a/.github/workflows/codeboarding.yml
+++ b/.github/workflows/codeboarding.yml
@@ -20,6 +20,7 @@ jobs:
     timeout-minutes: 60
     permissions:
       contents: read        # check out the repo + read the committed baseline (no writes in review mode)
+      actions: read         # download the analysis an earlier run published, instead of re-deriving this PR every push
       pull-requests: write  # post the architecture-diff PR comment
       issues: write         # the /codeboarding issue_comment trigger + comment API
       id-token: write       # mint a GitHub OIDC token for the free hosted tier (write is the only level for id-token)


### PR DESCRIPTION
One line: `actions: read` on the review job.

## Why it is needed

The action stores a pull request's analysis as a workflow artifact so the next run covers only the commits pushed since it, and finds it through the Actions API. **Listing artifacts requires `actions: read`. Uploading requires nothing.**

Without the scope, a run publishes a bundle every time and reads one never. So this repository currently:

- re-derives the **entire** pull request on every push, and this workflow runs on `synchronize`, so that is once per push;
- re-analyzes the merge base whenever no other repository published it;
- uploads two bundles per run that nothing will ever read.

## Why nobody noticed

A denied listing and an empty result print the same line:

```
##[notice]No stored codeboarding-warmstart-…-pr123 to reuse
```

which is exactly what a repository legitimately prints on its first run. It looks like a permanently cold cache with no explanation. (CodeBoarding-action#98 makes the denied case say so.)

## Measured

Same repository, same action version, permission added — from an end-to-end test on CodeBoarding-webview:

| | before | after |
|---|---|---|
| base lookup | miss, recomputed | hit, no analysis run |
| warm-start lookup | miss | hit |
| seed | `base` | `pr-chain` |
| engine passes | 2 | **1** |

Nothing else changed between those two runs.

## Scope

Review only. Sync mode publishes but never fetches, so `codeboarding-sync.yml` needs no change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the review workflow permissions to allow reading analysis results from earlier workflow runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->