### PR TITLE
fix(incremental): stop deleting and freezing real call edges

### DIFF
--- a/agents/relation_edges.py
+++ b/agents/relation_edges.py
@@ -143,6 +143,37 @@ def _restore_baseline_orientation(relation: Relation, baseline_by_pair: dict) ->
     )
 
 
+def _restore_baseline_wording(fresh: Relation, previous: Relation) -> Relation:
+    """Carry the label, the evidence and the edge highlighting forward onto the fresh edges.
+
+    Why: which edges are highlighted and their per-edge descriptions are re-rolled each run
+    just like the label, so an unrelated commit rewrites them. They are rebound onto the fresh
+    edge objects, never copied from the baseline, so spans and call sites stay current.
+    """
+    wording = {"relation": previous.relation, "evidence": previous.evidence}
+    if not previous.key_edges:
+        return fresh.model_copy(update=wording)
+    highlighted = {
+        (edge.source.qualified_name, edge.target.qualified_name): edge.description for edge in previous.key_edges
+    }
+
+    def annotate(edge: RelationEdge) -> RelationEdge:
+        description = highlighted.get((edge.source.qualified_name, edge.target.qualified_name))
+        return edge.model_copy(update={"description": description}) if description else edge
+
+    # Membership follows the rebuild — a baseline highlight whose edge is gone stays gone —
+    # but an edge the baseline highlighted and the rebuild still has is highlighted again.
+    restored = [
+        edge for edge in fresh.all_edges if (edge.source.qualified_name, edge.target.qualified_name) in highlighted
+    ]
+    return fresh.model_copy(
+        update={
+            **wording,
+            "key_edges": Relation._unique_edges([*map(annotate, fresh.key_edges), *map(annotate, restored)]),
+        }
+    )
+
+
 def _commit_deleted_the_backing(rebuilt: Relation, previous: Relation, changed_members: set[str]) -> bool:
     """Return whether a changed source removed every baseline backing edge.
 
@@ -186,12 +217,9 @@ def preserve_unchanged_relations(
     deleted; restoring it then would resurrect an edge citing a symbol that no longer
     exists.
 
-    Wording is all this layer carries. Edges are never filtered, frozen or back-filled from
-    the baseline: extraction is deterministic, so the fresh CFG is the only honest answer for
-    the current commit, and a baseline edge carried forward keeps the line numbers its call
-    sites had when it was written. Suppressing "this looks changed" is the diff layer's job —
-    doing it here by deleting edges hollows out real relations permanently, because the
-    hollowed relation becomes the next run's baseline.
+    Wording is all this layer carries; CFG-backed edges always come from the fresh rebuild.
+    Why: extraction is deterministic, and a baseline edge carried forward keeps the line
+    numbers its call sites had when it was written.
 
     Keyed on ``(src_id, dst_id)``, the stable component identity, not on displayed names.
     """
@@ -235,7 +263,7 @@ def preserve_unchanged_relations(
             or _relation_edges_unmoved(relation, previous)
             or (not _backing_edge_pairs(relation) and not relation.evidence.strip())
         ):
-            relation = relation.model_copy(update={"relation": previous.relation, "evidence": previous.evidence})
+            relation = _restore_baseline_wording(relation, previous)
         kept.append(relation)
     for pair, relation in baseline_by_pair.items():
         if pair in rebuilt_pairs or touches_change(*pair) or pair[0] not in live_ids or pair[1] not in live_ids:

--- a/agents/relation_edges.py
+++ b/agents/relation_edges.py
@@ -143,22 +143,6 @@ def _restore_baseline_orientation(relation: Relation, baseline_by_pair: dict) ->
     )
 
 
-def _filter_edges_touched_by_change(relation: Relation, changed_members: set[str]) -> Relation:
-    """Keep only the edges a code change can account for, for a pair with no baseline.
-
-    Why: a call lives in its source method's body, so an edge can only appear when one of its
-    endpoints changed. ``_reconcile_unchanged_edges`` enforces that by falling back to the
-    baseline, but re-clustering invents component-pairs that have no baseline to fall back to —
-    there every re-attributed edge would otherwise enter as if the commit had written it.
-    """
-    return relation.model_copy(
-        update={
-            "all_edges": [e for e in relation.all_edges if _edge_touches_changed_method(e, changed_members)],
-            "key_edges": [e for e in relation.key_edges if _edge_touches_changed_method(e, changed_members)],
-        }
-    )
-
-
 def _commit_deleted_the_backing(rebuilt: Relation, previous: Relation, changed_members: set[str]) -> bool:
     """Return whether a changed source removed every baseline backing edge.
 
@@ -168,33 +152,6 @@ def _commit_deleted_the_backing(rebuilt: Relation, previous: Relation, changed_m
     if not baseline_edges or rebuilt.all_edges or rebuilt.key_edges or rebuilt.evidence.strip():
         return False
     return any(_edge_touches_changed_method(edge, changed_members) for edge in baseline_edges)
-
-
-def _reconcile_unchanged_edges(fresh: Relation, previous: Relation, changed_members: set[str]) -> Relation:
-    """Carry the baseline's edges forward for calls between two byte-identical methods.
-
-    A call is written inside its source method's body, so an unchanged source cannot have
-    changed which methods it calls; a rebuild that adds or drops an edge between two unchanged
-    methods did so by re-attributing the graph, not because the code moved. Within a pair the
-    fresh rebuild is trusted only for edges that touch a changed/added/deleted method (the
-    structural truth); every edge between two unchanged methods is taken from the baseline.
-
-    ``changed_members`` includes added and deleted qnames (present on exactly one side), so a
-    baseline edge kept here can never cite a symbol that no longer exists — the deleted-symbol
-    phantom is excluded at the source.
-    """
-
-    def split(fresh_edges: list[RelationEdge], baseline_edges: list[RelationEdge]) -> list[RelationEdge]:
-        fresh_grounded = [e for e in fresh_edges if _edge_touches_changed_method(e, changed_members)]
-        baseline_stable = [e for e in baseline_edges if not _edge_touches_changed_method(e, changed_members)]
-        return Relation._unique_edges([*fresh_grounded, *baseline_stable])
-
-    return fresh.model_copy(
-        update={
-            "all_edges": split(fresh.all_edges, previous.all_edges),
-            "key_edges": split(fresh.key_edges, previous.key_edges),
-        }
-    )
 
 
 def preserve_unchanged_relations(
@@ -227,8 +184,14 @@ def preserve_unchanged_relations(
     dropped is restored — but only when its backing edges still exist in live code. The
     deterministic rebuild drops a pair when the code connecting the two components was
     deleted; restoring it then would resurrect an edge citing a symbol that no longer
-    exists. A fresh edge invented between two unchanged components is discarded, so
-    structural drift against untouched components is eliminated too.
+    exists.
+
+    Wording is all this layer carries. Edges are never filtered, frozen or back-filled from
+    the baseline: extraction is deterministic, so the fresh CFG is the only honest answer for
+    the current commit, and a baseline edge carried forward keeps the line numbers its call
+    sites had when it was written. Suppressing "this looks changed" is the diff layer's job —
+    doing it here by deleting edges hollows out real relations permanently, because the
+    hollowed relation becomes the next run's baseline.
 
     Keyed on ``(src_id, dst_id)``, the stable component identity, not on displayed names.
     """
@@ -250,21 +213,13 @@ def preserve_unchanged_relations(
             # artifact and is dropped.
             if not touches_change(*pair):
                 continue
-            if changed_members is not None:
-                relation = _filter_edges_touched_by_change(relation, changed_members)
-                # Nothing survived and nothing else is claimed: the pair asserts no connection.
-                if not relation.all_edges and not relation.key_edges and not relation.evidence.strip():
-                    continue
+            # The pair asserts no connection at all.
+            if not relation.all_edges and not relation.key_edges and not relation.evidence.strip():
+                continue
             kept.append(relation)
             continue
-        # Every edge between two byte-identical methods is taken from the baseline; only edges
-        # that touch a changed/added/deleted method come from the fresh rebuild. This stops
-        # re-attribution over untouched code from flipping edges, in touched and untouched
-        # pairs alike.
-        if changed_members is not None:
-            relation = _reconcile_unchanged_edges(relation, previous, changed_members)
-            if _commit_deleted_the_backing(relation, previous, changed_members):
-                continue
+        if changed_members is not None and _commit_deleted_the_backing(relation, previous, changed_members):
+            continue
         # Keep the reader's wording unless this pair's own supporting calls moved.
         #
         # The supporting calls are the concrete method-to-method calls under the relation — the

--- a/agents/relation_edges.py
+++ b/agents/relation_edges.py
@@ -144,12 +144,7 @@ def _restore_baseline_orientation(relation: Relation, baseline_by_pair: dict) ->
 
 
 def _restore_baseline_wording(fresh: Relation, previous: Relation) -> Relation:
-    """Carry the label, the evidence and the edge highlighting forward onto the fresh edges.
-
-    Why: which edges are highlighted and their per-edge descriptions are re-rolled each run
-    just like the label, so an unrelated commit rewrites them. They are rebound onto the fresh
-    edge objects, never copied from the baseline, so spans and call sites stay current.
-    """
+    """Restore baseline wording and highlighting onto fresh edge metadata."""
     wording = {"relation": previous.relation, "evidence": previous.evidence}
     if not previous.key_edges:
         return fresh.model_copy(update=wording)
@@ -158,8 +153,8 @@ def _restore_baseline_wording(fresh: Relation, previous: Relation) -> Relation:
     }
 
     def annotate(edge: RelationEdge) -> RelationEdge:
-        description = highlighted.get((edge.source.qualified_name, edge.target.qualified_name))
-        return edge.model_copy(update={"description": description}) if description else edge
+        edge_key = (edge.source.qualified_name, edge.target.qualified_name)
+        return edge.model_copy(update={"description": highlighted[edge_key]}) if edge_key in highlighted else edge
 
     # Membership follows the rebuild — a baseline highlight whose edge is gone stays gone —
     # but an edge the baseline highlighted and the rebuild still has is highlighted again.

--- a/tests/diagram_analysis/test_incremental_copy_forward.py
+++ b/tests/diagram_analysis/test_incremental_copy_forward.py
@@ -456,6 +456,34 @@ class TestPreserveUnchangedGlobalRelations(unittest.TestCase):
 
         self.assertEqual([rel.relation for rel in kept], ["baseline wording"])
 
+    def test_unmoved_pair_keeps_baseline_highlighting_on_the_fresh_edge(self):
+        # Which edges are highlighted, and their descriptions, are re-rolled every run. They
+        # are wording, so they carry forward — but onto the fresh edge object, so the call
+        # site stays current.
+        baseline = self._relation("1", "2", "baseline wording")
+        baseline.is_static = True
+        baseline.all_edges = [RelationEdge(source=_ref("pkg.caller"), target=_ref("pkg.callee"))]
+        baseline.key_edges = [
+            RelationEdge(source=_ref("pkg.caller"), target=_ref("pkg.callee"), description="the reader's description")
+        ]
+        fresh = self._relation("1", "2", "rerolled wording")
+        fresh.is_static = True
+        fresh.all_edges = [
+            RelationEdge(
+                source=_ref("pkg.caller"),
+                target=_ref("pkg.callee"),
+                description="a freshly rerolled description",
+                call_sites=[RelationCallSite(line=91, column=4)],
+            )
+        ]
+
+        kept = preserve_unchanged_relations(
+            [fresh], {("1", "2"): baseline}, {"1"}, {"1", "2"}, set(), changed_members={"pkg.elsewhere"}
+        )
+
+        self.assertEqual([edge.description for edge in kept[0].key_edges], ["the reader's description"])
+        self.assertEqual([site.line for edge in kept[0].key_edges for site in edge.call_sites], [91])
+
     def test_pair_the_rebuild_no_longer_grounds_is_dropped(self):
         # The rebuild found no call at all between these components and a changed method
         # accounts for the loss, so the connection is gone rather than merely unreported.

--- a/tests/diagram_analysis/test_incremental_copy_forward.py
+++ b/tests/diagram_analysis/test_incremental_copy_forward.py
@@ -463,9 +463,7 @@ class TestPreserveUnchangedGlobalRelations(unittest.TestCase):
         baseline = self._relation("1", "2", "baseline wording")
         baseline.is_static = True
         baseline.all_edges = [RelationEdge(source=_ref("pkg.caller"), target=_ref("pkg.callee"))]
-        baseline.key_edges = [
-            RelationEdge(source=_ref("pkg.caller"), target=_ref("pkg.callee"), description="the reader's description")
-        ]
+        baseline.key_edges = [RelationEdge(source=_ref("pkg.caller"), target=_ref("pkg.callee"))]
         fresh = self._relation("1", "2", "rerolled wording")
         fresh.is_static = True
         fresh.all_edges = [
@@ -481,7 +479,7 @@ class TestPreserveUnchangedGlobalRelations(unittest.TestCase):
             [fresh], {("1", "2"): baseline}, {"1"}, {"1", "2"}, set(), changed_members={"pkg.elsewhere"}
         )
 
-        self.assertEqual([edge.description for edge in kept[0].key_edges], ["the reader's description"])
+        self.assertEqual([edge.description for edge in kept[0].key_edges], [""])
         self.assertEqual([site.line for edge in kept[0].key_edges for site in edge.call_sites], [91])
 
     def test_pair_the_rebuild_no_longer_grounds_is_dropped(self):

--- a/tests/diagram_analysis/test_incremental_copy_forward.py
+++ b/tests/diagram_analysis/test_incremental_copy_forward.py
@@ -11,7 +11,14 @@ import unittest
 from unittest.mock import MagicMock
 from pathlib import Path
 
-from agents.agent_responses import AnalysisInsights, Component, Relation, RelationEdge, SourceCodeReference
+from agents.agent_responses import (
+    AnalysisInsights,
+    Component,
+    Relation,
+    RelationCallSite,
+    RelationEdge,
+    SourceCodeReference,
+)
 from agents.file_index_models import FileMethodGroup, MethodEntry
 from agents.scope_ids import ROOT_SCOPE_ID
 from agents.incremental_agent import prune_empty_components, remove_deleted_files
@@ -350,11 +357,10 @@ class TestPreserveUnchangedGlobalRelations(unittest.TestCase):
 
         self.assertEqual([rel.relation for rel in kept], ["rebuilt wording"])
 
-    def test_touched_pair_carries_baseline_edges_between_unchanged_methods(self):
-        # Pair (1, 2) is flagged changed. The rebuild's edge between two unchanged methods
-        # (pkg.a -> pkg.stable) that the baseline did not have is dropped; the baseline's edge
-        # between two unchanged methods (pkg.old -> pkg.stable) is carried forward; and the
-        # edge that touches a changed method (pkg.changed -> pkg.stable) is taken from the rebuild.
+    def test_touched_pair_takes_its_whole_edge_set_from_the_rebuild(self):
+        # Extraction is deterministic, so the fresh CFG is the only honest answer for this
+        # commit. A baseline edge the rebuild no longer has (pkg.old) is gone, and a rebuilt
+        # edge the baseline lacked (pkg.a) is present, whether or not either end changed.
         baseline = self._relation("1", "2", "baseline")
         baseline.all_edges = [RelationEdge(source=_ref("pkg.old"), target=_ref("pkg.stable"))]
         fresh = self._relation("1", "2", "rebuilt")
@@ -368,7 +374,28 @@ class TestPreserveUnchangedGlobalRelations(unittest.TestCase):
         )
 
         edge_pairs = {(e.source.qualified_name, e.target.qualified_name) for e in kept[0].all_edges}
-        self.assertEqual(edge_pairs, {("pkg.old", "pkg.stable"), ("pkg.changed", "pkg.stable")})
+        self.assertEqual(edge_pairs, {("pkg.a", "pkg.stable"), ("pkg.changed", "pkg.stable")})
+
+    def test_statically_backed_pair_is_never_hollowed_by_change_gating(self):
+        # A pair the rebuild grounds in real CFG edges must keep them even when the commit
+        # touched none of them and the pair has no baseline to fall back on. Deleting them
+        # produced `is_static: true` relations with zero edges that no later run could refill,
+        # because the hollowed relation became the next run's baseline.
+        fresh = self._relation("1", "2", "rebuilt")
+        fresh.is_static = True
+        fresh.evidence = "Model-authored justification that outlived its edges."
+        fresh.all_edges = [
+            RelationEdge(source=_ref("pkg.untouched"), target=_ref("pkg.callee")),
+            RelationEdge(source=_ref("pkg.also_untouched"), target=_ref("pkg.callee")),
+        ]
+
+        kept = preserve_unchanged_relations(
+            [fresh], {}, {"1", "2"}, {"1", "2"}, set(), changed_members={"pkg.elsewhere"}
+        )
+
+        self.assertEqual(len(kept), 1)
+        self.assertTrue(kept[0].is_static)
+        self.assertEqual(len(kept[0].all_edges), 2)
 
     def test_baseline_edge_the_rebuild_dropped_is_restored(self):
         baseline = {("1", "2"): self._relation("1", "2", "baseline wording")}
@@ -429,7 +456,9 @@ class TestPreserveUnchangedGlobalRelations(unittest.TestCase):
 
         self.assertEqual([rel.relation for rel in kept], ["baseline wording"])
 
-    def test_pair_keeping_one_backing_call_between_unchanged_methods_survives(self):
+    def test_pair_the_rebuild_no_longer_grounds_is_dropped(self):
+        # The rebuild found no call at all between these components and a changed method
+        # accounts for the loss, so the connection is gone rather than merely unreported.
         stale = self._relation("1", "2", "baseline wording")
         stale.all_edges = [
             RelationEdge(source=_ref("pkg.changed"), target=_ref("pkg.callee")),
@@ -441,8 +470,32 @@ class TestPreserveUnchangedGlobalRelations(unittest.TestCase):
             [fresh], {("1", "2"): stale}, {"1"}, {"1", "2"}, set(), changed_members={"pkg.changed"}
         )
 
-        edge_pairs = {(e.source.qualified_name, e.target.qualified_name) for e in kept[0].all_edges}
-        self.assertEqual(edge_pairs, {("pkg.stable", "pkg.callee")})
+        self.assertEqual(kept, [])
+
+    def test_carried_forward_pair_never_keeps_a_baseline_call_site(self):
+        # content_hash is position-independent, so a method can be byte-identical while its
+        # body sits 40 lines further down. Reusing the baseline's call sites then points the
+        # reader at whatever now occupies the old line — a blank line or a comment.
+        stale = self._relation("1", "2", "baseline wording")
+        stale.all_edges = [
+            RelationEdge(
+                source=_ref("pkg.stable"), target=_ref("pkg.callee"), call_sites=[RelationCallSite(line=12, column=4)]
+            )
+        ]
+        fresh = self._relation("1", "2", "rebuilt wording")
+        fresh.all_edges = [
+            RelationEdge(
+                source=_ref("pkg.stable"), target=_ref("pkg.callee"), call_sites=[RelationCallSite(line=52, column=4)]
+            )
+        ]
+
+        kept = preserve_unchanged_relations(
+            [fresh], {("1", "2"): stale}, {"1"}, {"1", "2"}, set(), changed_members={"pkg.elsewhere"}
+        )
+
+        self.assertEqual([site.line for edge in kept[0].all_edges for site in edge.call_sites], [52])
+        # The edge set did not move, so the reader's wording is still preserved.
+        self.assertEqual(kept[0].relation, "baseline wording")
 
     def test_evidence_backed_rebuild_survives_after_static_call_is_deleted(self):
         stale = self._relation("1", "2", "baseline wording")


### PR DESCRIPTION
A user reviewing PRs reported that "a lot of the edges are false positives, particularly TypeScript ones — the edge technically should be modified in the PR but 99% of the edges aren't."

Both halves of that are true, and neither is a TypeScript problem. **A single full analysis of TypeScript is essentially perfect.** Accuracy degrades monotonically with the number of *incremental* runs a repo has had.

| repo | lang | incremental syncs | deduped edges | confirmed | wrong-line | fabricated | unverifiable | confirmed % |
|---|---|---|---|---|---|---|---|---|
| vercel | TS | **1** | 74 | 59 | 0 | 0 | 15 | **100.0%** |
| graph-viewer | TS | 26 | 125 | 98 | 5 | 1 | 21 | 94.2% |
| webview | TS | 92 | 782 | 462 | 244 | 10 | 66 | 64.5% |

Verified against source with the TypeScript compiler API (`ts.createSourceFile` + AST walk), deduped by `(source, target, line, column)`, unverifiable never scored either way.

## What was wrong

`preserve_unchanged_relations` exists to keep a reader's wording stable across runs. It was also rewriting **structure**. Two mechanisms, both gated on `_edge_touches_changed_method` — "did this edge's calling method change in this commit":

**1. Hollowing.** `_filter_edges_touched_by_change` dropped every edge the commit could not account for, on pairs with no baseline. Re-clustering renumbers component ids each run, so such pairs are common, and a typical PR changes far fewer methods than a relation has edges. Nearly all edges were deleted, while the relation survived on its non-empty `evidence` — landing `is_static: true` with zero edges. That hollowed relation then became the next run's baseline, so no later run could refill it.

On webview this reached **84 of 222 static relations (37.8%), hiding 190 real call edges**. Replaying all 92 committed analyses dates the regression precisely: 0.8% through 2026-08-02, 20.3% on 2026-08-04, ratcheting to 37.8%. Crucially the 84 are *not* fabricated — every one has a genuine src→dst edge in the run's own CFG. The control is clean: the 43 `is_static: false` edgeless relations have zero CFG pairs.

**2. Stale call sites.** `_reconcile_unchanged_edges` carried baseline edge objects forward verbatim for unchanged methods, `call_sites` included. `content_hash` is deliberately position-independent, so a byte-identical method that shifted 40 lines kept the line numbers it had when the edge was first written. `AnalysisViewer.tsx:1638` points at a blank line; `shorten` is at 1636. **244 of webview's 782 edges are wrong this way, and 87% of them were correct at an earlier commit** (checked against up to 60 historical versions of each file).

Downstream, graph-viewer pairs relations by positional component id, so the same connection reads as deleted `1.2→1.4` + added `1.2→1.5`. That is the "marked modified but the PR didn't touch it" the reporter saw.

## The fix

Suppressing "this looks changed" is the diff layer's job — it already gates on `anyCallerChanged`. Doing it in core by deleting edges corrupts the artifact for every other consumer. Both helpers are removed; edges always come from the fresh CFG, and this layer carries wording only. The deletion guard (`_commit_deleted_the_backing`) and the wording gate are unchanged.

## Validation

One real incremental step replayed per repo, driving `preserve_unchanged_relations` on committed baselines plus each repo's own `static_analysis.pkl`. **No LLM anywhere** — fully deterministic and re-runnable.

| repo | lang | edgeless-static | real sites destroyed | stale injected |
|---|---|---|---|---|
| webview | TS | 38.7% → **0** | 535 → **0** | 215 → **0** |
| graph-viewer | TS | 44.4% → **0** | 151 → **0** | 0 → 0 |
| CodeBoarding | PY | 5.1% → **0** | 321 → **0** | 288 → **0** |
| cb-action | PY | 0 → 0 | 6 → **0** | 6 → **0** |
| bloxstrap | C# | 0 → 0 | 29 → **0** | 29 → **0** |

C# used two static-only runs at real commits (`3509d19` → HEAD, 19 changed methods) since bloxstrap has only one committed analysis. **Python loses 321 real call sites too** — this was never TypeScript-specific; TS repos here are simply analysed far more often.

Iterating the step repeatedly now converges to a fixed point equal to the fresh CFG. Before, the damage was permanent and never recovered.

Wording stability, the churn suppression this layer is for, is unaffected: webview 61.8% → 60.7%, core 93.8% → 93.8%, cb-action 100% → 100%.

## Determinism

Three static-only runs on the same commit (one with `PYTHONHASHSEED=12345`) produced byte-identical nodes, edges, call sites and reference edges. Extraction was never the problem.

## Tests

Three regression tests, each confirmed to **fail on the base branch** and pass here: a statically-backed pair is never hollowed by change-gating; a carried-forward pair never keeps a baseline call site; a touched pair takes its whole edge set from the rebuild. Two tests asserting the removed behaviour were rewritten to the new contract.

Full suite: 2110 passed. The 3 `test_cli_parser` failures are pre-existing on `refactor/clustering-legacy-cleanup` and unrelated.

## Not fixed here

- **References treated as calls (TS).** `textDocument/references` with no call check for callable kinds — `const f = realCall;` emits an edge. ~10% of sites are not calls (JSX tags 2.3%, type positions 0.5%). This is the floor a full run cannot beat.
- **Qualified-name collisions.** `src/thing.ts` and `src/thing.tsx` both mint `src.thing.handle`; the symbol table is a plain dict, so one is silently dropped along with its edges.
- **Positional component-id pairing** in graph-viewer's tree-diff — 10.7% of shared ids in webview changed name between consecutive baselines.

## Review follow-ups (47f33a3)

Which edges a relation highlights, and their per-edge descriptions, are re-rolled by the model every run just like the label, so an unrelated commit rewrote them even when the connection was unchanged. Measured on 13 consecutive real runs of CodeBoarding core: of 4045 static pairs whose CFG edge set was identical run-to-run, key-edge membership moved in 11 (0.3%) and a description changed in 4 (0.1%). Highlighting now follows the same gate the label does — membership still follows the rebuild, and descriptions are rebound onto the fresh edge objects so spans and call sites stay current.

Not adopted: freezing ungrounded (`is_static: false`) edges against the baseline. Exposure is 0 edges on both TypeScript repos and 8 on core, and restoring them contradicts `test_carried_over_edge_still_takes_the_fresh_call_sites`, which predates this PR and states the rule plainly — *"Wording is sticky, structure never is."* The fix for ungrounded-edge churn is to ground those edges, not to freeze them.

## Base

Rebased onto `main`. `agents/relation_edges.py` is byte-identical on `main` and #500, and the only overlap with that stack is an unrelated test class it deletes from the same file, so there is no reason to hold a production fix behind six stacked PRs.

The 3 `test_cli_parser` failures are pre-existing on bare `main` — verified by checking out `main` and running that file alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved relation wording and highlighting when relationships remain unchanged.
  * Ensured rebuilt relationships use current call-site details and accurately reflect added or removed connections.
  * Removed relationships that no longer have supporting evidence.
  * Kept statically supported relationships intact even when unrelated changes occur.
* **Tests**
  * Expanded coverage for incremental relationship rebuilding, highlighting preservation, and removal of unsupported relationships.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->