### PR TITLE
fix(engine): credit a call to the declaration a reader would name

### DIFF
--- a/static_analyzer/analysis_cache.py
+++ b/static_analyzer/analysis_cache.py
@@ -138,15 +138,6 @@ class StaticAnalysisCache:
         with FileLock(self.lock_path, timeout=30):
             return self._read_tag_sha_unlocked()
 
-    def _tag_version_is_stale(self) -> bool:
-        """Whether a tag file exists and names a version this build does not produce."""
-        try:
-            text = self.sha_path.read_text(encoding="utf-8").strip()
-        except (OSError, FileNotFoundError):
-            return False
-        lines = [line.strip() for line in text.splitlines() if line.strip()]
-        return bool(lines) and lines[0] != _TAG_VERSION
-
     def _read_tag_sha_unlocked(self) -> str | None:
         try:
             text = self.sha_path.read_text(encoding="utf-8").strip()
@@ -297,6 +288,15 @@ class StaticAnalysisCache:
                     self.sha_path.unlink()
                 except OSError:
                     pass
+
+    def _tag_version_is_stale(self) -> bool:
+        """Whether a tag file exists and names a version this build does not produce."""
+        try:
+            text = self.sha_path.read_text(encoding="utf-8").strip()
+        except (OSError, FileNotFoundError):
+            return False
+        lines = [line.strip() for line in text.splitlines() if line.strip()]
+        return bool(lines) and lines[0] != _TAG_VERSION
 
 
 def copy_cache_files(src_dir: Path, dest_dir: Path) -> bool:

--- a/static_analyzer/analysis_cache.py
+++ b/static_analyzer/analysis_cache.py
@@ -152,6 +152,15 @@ class StaticAnalysisCache:
             return None
         return sha
 
+    def _tag_version_is_stale(self) -> bool:
+        """Whether a tag file exists and names a version this build does not produce."""
+        try:
+            text = self.sha_path.read_text(encoding="utf-8").strip()
+        except (OSError, FileNotFoundError):
+            return False
+        lines = [line.strip() for line in text.splitlines() if line.strip()]
+        return bool(lines) and lines[0] != _TAG_VERSION
+
     def _legacy_pkl_path(self) -> Path:
         return self.artifact_dir / _LEGACY_CACHE_SUBDIR / _LEGACY_PKL_NAME
 
@@ -202,6 +211,11 @@ class StaticAnalysisCache:
                     expected_sha,
                 )
                 return None
+        elif self._tag_version_is_stale():
+            # A read-only consumer asks for no SHA gate, but a pickle an older engine wrote
+            # still describes a graph this build would not produce. Only a tag that exists and
+            # disagrees rejects; the untagged legacy artifact below is still read.
+            return None
 
         target = self.pkl_path
         if not target.exists():

--- a/static_analyzer/analysis_cache.py
+++ b/static_analyzer/analysis_cache.py
@@ -212,9 +212,8 @@ class StaticAnalysisCache:
                 )
                 return None
         elif self._tag_version_is_stale():
-            # A read-only consumer asks for no SHA gate, but a pickle an older engine wrote
-            # still describes a graph this build would not produce. Only a tag that exists and
-            # disagrees rejects; the untagged legacy artifact below is still read.
+            # No SHA gate still means no stale engine: a tag that exists and disagrees rejects,
+            # while the untagged legacy artifact below is still read.
             return None
 
         target = self.pkl_path

--- a/static_analyzer/analysis_cache.py
+++ b/static_analyzer/analysis_cache.py
@@ -138,6 +138,15 @@ class StaticAnalysisCache:
         with FileLock(self.lock_path, timeout=30):
             return self._read_tag_sha_unlocked()
 
+    def _tag_version_is_stale(self) -> bool:
+        """Whether a tag file exists and names a version this build does not produce."""
+        try:
+            text = self.sha_path.read_text(encoding="utf-8").strip()
+        except (OSError, FileNotFoundError):
+            return False
+        lines = [line.strip() for line in text.splitlines() if line.strip()]
+        return bool(lines) and lines[0] != _TAG_VERSION
+
     def _read_tag_sha_unlocked(self) -> str | None:
         try:
             text = self.sha_path.read_text(encoding="utf-8").strip()
@@ -151,15 +160,6 @@ class StaticAnalysisCache:
             logger.info(f"Static analysis tag has unknown version {version!r}; treating as cache miss")
             return None
         return sha
-
-    def _tag_version_is_stale(self) -> bool:
-        """Whether a tag file exists and names a version this build does not produce."""
-        try:
-            text = self.sha_path.read_text(encoding="utf-8").strip()
-        except (OSError, FileNotFoundError):
-            return False
-        lines = [line.strip() for line in text.splitlines() if line.strip()]
-        return bool(lines) and lines[0] != _TAG_VERSION
 
     def _legacy_pkl_path(self) -> Path:
         return self.artifact_dir / _LEGACY_CACHE_SUBDIR / _LEGACY_PKL_NAME

--- a/static_analyzer/config.py
+++ b/static_analyzer/config.py
@@ -245,6 +245,11 @@ class NodeType(IntEnum):
 
 # Convenience sets – module-level so mypy can resolve them without monkey-patching.
 CALLABLE_TYPES: set[NodeType] = {NodeType.METHOD, NodeType.FUNCTION, NodeType.CONSTRUCTOR}
+
+# Name fragments an LSP server uses for a symbol that is a real lexical scope but not a
+# declaration a reader would name: inline callbacks (``map() callback``) and anonymous
+# functions (``<function>``). A call written inside one belongs to whatever encloses it.
+ANONYMOUS_SYMBOL_MARKERS: tuple[str, ...] = (") callback", "<function>", "<arrow", "<unknown>")
 CLASS_TYPES: set[NodeType] = {NodeType.CLASS, NodeType.INTERFACE, NodeType.STRUCT, NodeType.ENUM}
 DATA_TYPES: set[NodeType] = {
     NodeType.PROPERTY,

--- a/static_analyzer/engine/edge_builder.py
+++ b/static_analyzer/engine/edge_builder.py
@@ -521,14 +521,18 @@ def _resolve_definitions(
                         if adapter.is_class_like(parent_kind):
                             parent_qname = parent_qualified_name(target.qualified_name)
                             parent_sym = st.symbols.get(parent_qname)
-                            if parent_sym is not None and _is_valid_edge(caller, parent_sym):
-                                _add_edge_call_site(edge_set, caller.qualified_name, parent_qname, call_site)
+                            if (
+                                parent_sym is not None
+                                and _is_valid_edge(caller, parent_sym)
+                                and _is_valid_edge(attributed, parent_sym)
+                            ):
+                                _add_edge_call_site(edge_set, attributed.qualified_name, parent_qname, call_site)
 
                     # Queue implementation query for polymorphic dispatch
                     if adapter.is_callable(target.kind):
                         impl_queries_pending.append(
                             ImplementationQuery(
-                                caller_qname=caller.qualified_name,
+                                caller_qname=attributed.qualified_name,
                                 target_file=target.file_path,
                                 target_line=target.start_line,
                                 target_char=target.start_char,

--- a/static_analyzer/engine/edge_builder.py
+++ b/static_analyzer/engine/edge_builder.py
@@ -290,7 +290,12 @@ def _process_references_for_position(
                     continue
             if sym.qualified_name.startswith(container.qualified_name + "."):
                 continue
-            _add_edge_site(edge_set, container.qualified_name, sym.qualified_name, ref_file, ref_line, ref_char)
+            # Every guard above sees the innermost container, which is what decides whether
+            # this reference is an edge at all. Only the credit line is rolled up.
+            attributed = st.attribution_symbol(container).qualified_name
+            if attributed == sym.qualified_name or sym.qualified_name.startswith(attributed + "."):
+                continue
+            _add_edge_site(edge_set, attributed, sym.qualified_name, ref_file, ref_line, ref_char)
 
     return refs_total, refs_call_sites
 
@@ -380,12 +385,15 @@ def _resolve_iterated_types(
                     if target is None or not _is_valid_edge(caller, target):
                         continue
                     resolved += 1
-                    _add_edge_call_site(edge_set, caller.qualified_name, target.qualified_name, site)
+                    attributed = st.attribution_symbol(caller)
+                    if not _is_valid_edge(attributed, target):
+                        continue
+                    _add_edge_call_site(edge_set, attributed.qualified_name, target.qualified_name, site)
                     # The loop calls the enumerator, so name it too when the
                     # type declares one rather than inheriting it.
                     for enumerator in _members_named(target, st, "GetEnumerator"):
-                        if _is_valid_edge(caller, enumerator):
-                            _add_edge_call_site(edge_set, caller.qualified_name, enumerator.qualified_name, site)
+                        if _is_valid_edge(caller, enumerator) and _is_valid_edge(attributed, enumerator):
+                            _add_edge_call_site(edge_set, attributed.qualified_name, enumerator.qualified_name, site)
     return resolved
 
 
@@ -489,16 +497,23 @@ def _resolve_definitions(
                     if not _is_valid_edge(caller, target):
                         continue
 
-                    _add_edge_call_site(edge_set, caller.qualified_name, target.qualified_name, call_site)
+                    # Guards keep the innermost caller; only the credit line rolls up.
+                    attributed = st.attribution_symbol(caller)
+                    if not _is_valid_edge(attributed, target):
+                        continue
+
+                    _add_edge_call_site(edge_set, attributed.qualified_name, target.qualified_name, call_site)
 
                     for override in _override_targets(target, st, dispatch):
-                        if _is_valid_edge(caller, override):
-                            _add_edge_call_site(edge_set, caller.qualified_name, override.qualified_name, call_site)
+                        if _is_valid_edge(caller, override) and _is_valid_edge(attributed, override):
+                            _add_edge_call_site(edge_set, attributed.qualified_name, override.qualified_name, call_site)
 
                     if (call_site.lsp_line, call_site.lsp_column) in collection_positions:
                         for adder in _members_named(target, st, "Add"):
-                            if _is_valid_edge(caller, adder):
-                                _add_edge_call_site(edge_set, caller.qualified_name, adder.qualified_name, call_site)
+                            if _is_valid_edge(caller, adder) and _is_valid_edge(attributed, adder):
+                                _add_edge_call_site(
+                                    edge_set, attributed.qualified_name, adder.qualified_name, call_site
+                                )
 
                     # If target is a callable with a class-like parent, also add edge to the parent class
                     if adapter.is_callable(target.kind) and target.parent_chain:

--- a/static_analyzer/engine/models.py
+++ b/static_analyzer/engine/models.py
@@ -23,6 +23,9 @@ class SymbolInfo:
     end_line: int
     end_char: int
     parent_chain: list[tuple[str, int]] = field(default_factory=list)
+    # Arrived as VARIABLE/CONSTANT and was promoted to CLASS for having callable children.
+    # A `const raw = await fn(() => ...)` wrapper is a scope, not a name a reader would use.
+    promoted_from_variable: bool = False
 
     @property
     def definition_location(self) -> tuple[str, int, int]:

--- a/static_analyzer/engine/models.py
+++ b/static_analyzer/engine/models.py
@@ -23,8 +23,8 @@ class SymbolInfo:
     end_line: int
     end_char: int
     parent_chain: list[tuple[str, int]] = field(default_factory=list)
-    # Arrived as VARIABLE/CONSTANT and was promoted to CLASS for having callable children.
-    # A `const raw = await fn(() => ...)` wrapper is a scope, not a name a reader would use.
+    # Promoted to CLASS for having callable children: a namespace object, or a
+    # `const raw = await fn(() => ...)` wrapper that is a scope rather than a name.
     promoted_from_variable: bool = False
 
     @property

--- a/static_analyzer/engine/symbol_table.py
+++ b/static_analyzer/engine/symbol_table.py
@@ -280,18 +280,27 @@ class SymbolTable:
 
         best: SymbolInfo | None = None
         best_size = float("inf")
+        # A promoted `const x = ...` wrapper is a name a reader recognises, unlike an anonymous
+        # callback, so it is a usable credit — but only when nothing named encloses it. Module
+        # level is exactly that case: there is no function above it to prefer.
+        fallback: SymbolInfo | None = None
+        fallback_size = float("inf")
         for other in self._file_symbols.get(str(sym.file_path), []):
-            if other.qualified_name == sym.qualified_name or self._is_unnameable(other):
+            if other.qualified_name == sym.qualified_name or self._is_anonymous(other):
                 continue
             if not (self._naming.is_callable(other.kind) or self._naming.is_class_like(other.kind)):
                 continue
             if not self._encloses(other, sym):
                 continue
             size = (other.end_line - other.start_line) * 10000 + (other.end_char - other.start_char)
-            if size < best_size:
+            if other.promoted_from_variable:
+                if size < fallback_size:
+                    fallback = other
+                    fallback_size = size
+            elif size < best_size:
                 best = other
                 best_size = size
-        return best or sym
+        return best or fallback or sym
 
     def get_equivalent_names(self, qualified_name: str) -> list[str]:
         """Get equivalent symbol names for edge expansion using pre-built index."""
@@ -357,7 +366,12 @@ class SymbolTable:
         return False
 
     def _is_unnameable(self, sym: SymbolInfo) -> bool:
-        return sym.promoted_from_variable or any(marker in sym.name for marker in ANONYMOUS_SYMBOL_MARKERS)
+        """Whether this symbol's own name is not one a reader would use as a caller."""
+        return sym.promoted_from_variable or self._is_anonymous(sym)
+
+    @staticmethod
+    def _is_anonymous(sym: SymbolInfo) -> bool:
+        return any(marker in sym.name for marker in ANONYMOUS_SYMBOL_MARKERS)
 
     @staticmethod
     def _encloses(outer: SymbolInfo, inner: SymbolInfo) -> bool:

--- a/static_analyzer/engine/symbol_table.py
+++ b/static_analyzer/engine/symbol_table.py
@@ -272,8 +272,7 @@ class SymbolTable:
     def attribution_symbol(self, sym: SymbolInfo) -> SymbolInfo:
         """The innermost enclosing declaration a reader would name, or ``sym`` itself.
 
-        Why not reused as the container: the reference guards need the innermost symbol, and
-        widening it there drops grounded call sites.
+        Why credit only: the guards need the innermost symbol, widening it there drops call sites.
         """
         if not self._is_unnameable(sym):
             return sym

--- a/static_analyzer/engine/symbol_table.py
+++ b/static_analyzer/engine/symbol_table.py
@@ -6,7 +6,7 @@ import logging
 from pathlib import Path
 
 from static_analyzer.engine.protocols import SymbolNaming
-from static_analyzer.config import NodeType
+from static_analyzer.config import ANONYMOUS_SYMBOL_MARKERS, NodeType
 from static_analyzer.engine.lsp_constants import CALLABLE_KINDS
 from static_analyzer.engine.models import SymbolInfo
 
@@ -76,10 +76,12 @@ class SymbolTable:
 
             # Promote variables/constants with method children to class
             children = sym.get("children", [])
+            promoted = False
             if kind in (NodeType.VARIABLE, NodeType.CONSTANT) and children:
                 child_kinds = {c.get("kind", 0) for c in children}
                 if child_kinds & CALLABLE_KINDS:
                     kind = NodeType.CLASS
+                    promoted = True
 
             range_info = sym.get("range", sym.get("location", {}).get("range", {}))
             sel_range = sym.get("selectionRange", range_info)
@@ -108,6 +110,7 @@ class SymbolTable:
                 start_char=start_char,
                 end_line=end_line,
                 end_char=end_char,
+                promoted_from_variable=promoted,
             )
             info.parent_chain = list(parent_chain)
 
@@ -131,6 +134,7 @@ class SymbolTable:
                         start_char=start_char,
                         end_line=end_line,
                         end_char=end_char,
+                        promoted_from_variable=promoted,
                     )
                     unq_info.parent_chain = []
                     self._symbols[unqualified_name] = unq_info
@@ -154,6 +158,7 @@ class SymbolTable:
                                 start_char=start_char,
                                 end_line=end_line,
                                 end_char=end_char,
+                                promoted_from_variable=promoted,
                             )
                             p_info.parent_chain = list(partial_chain)
                             self._symbols[partial_name] = p_info
@@ -263,6 +268,38 @@ class SymbolTable:
                     best_size = size
 
         return best or sym
+
+    def attribution_symbol(self, sym: SymbolInfo) -> SymbolInfo:
+        """The innermost enclosing declaration a reader would name.
+
+        An LSP server reports inline callbacks and anonymous functions as symbols, and a
+        ``const raw = await fn(...)`` wrapper is promoted to class-like during registration.
+        None of those are names anyone uses, so a call written inside one is credited to the
+        declaration enclosing it. Falls back to ``sym`` when nothing encloses it, which keeps
+        a module-level arrow const crediting itself.
+
+        Only the credit line moves: this is deliberately not used to decide which references
+        become edges, because the reference guards need the innermost container.
+        """
+        if not self._is_unnameable(sym):
+            return sym
+
+        best: SymbolInfo | None = None
+        best_size = float("inf")
+        for other in self._file_symbols.get(str(sym.file_path), []):
+            if other.qualified_name == sym.qualified_name or self._is_unnameable(other):
+                continue
+            if not (self._naming.is_callable(other.kind) or self._naming.is_class_like(other.kind)):
+                continue
+            if other.start_line <= sym.start_line and other.end_line >= sym.end_line:
+                size = (other.end_line - other.start_line) * 10000 + (other.end_char - other.start_char)
+                if size < best_size:
+                    best = other
+                    best_size = size
+        return best or sym
+
+    def _is_unnameable(self, sym: SymbolInfo) -> bool:
+        return sym.promoted_from_variable or any(marker in sym.name for marker in ANONYMOUS_SYMBOL_MARKERS)
 
     def get_equivalent_names(self, qualified_name: str) -> list[str]:
         """Get equivalent symbol names for edge expansion using pre-built index."""

--- a/static_analyzer/engine/symbol_table.py
+++ b/static_analyzer/engine/symbol_table.py
@@ -270,16 +270,10 @@ class SymbolTable:
         return best or sym
 
     def attribution_symbol(self, sym: SymbolInfo) -> SymbolInfo:
-        """The innermost enclosing declaration a reader would name.
+        """The innermost enclosing declaration a reader would name, or ``sym`` itself.
 
-        An LSP server reports inline callbacks and anonymous functions as symbols, and a
-        ``const raw = await fn(...)`` wrapper is promoted to class-like during registration.
-        None of those are names anyone uses, so a call written inside one is credited to the
-        declaration enclosing it. Falls back to ``sym`` when nothing encloses it, which keeps
-        a module-level arrow const crediting itself.
-
-        Only the credit line moves: this is deliberately not used to decide which references
-        become edges, because the reference guards need the innermost container.
+        Why not reused as the container: the reference guards need the innermost symbol, and
+        widening it there drops grounded call sites.
         """
         if not self._is_unnameable(sym):
             return sym
@@ -291,15 +285,13 @@ class SymbolTable:
                 continue
             if not (self._naming.is_callable(other.kind) or self._naming.is_class_like(other.kind)):
                 continue
-            if other.start_line <= sym.start_line and other.end_line >= sym.end_line:
-                size = (other.end_line - other.start_line) * 10000 + (other.end_char - other.start_char)
-                if size < best_size:
-                    best = other
-                    best_size = size
+            if not self._encloses(other, sym):
+                continue
+            size = (other.end_line - other.start_line) * 10000 + (other.end_char - other.start_char)
+            if size < best_size:
+                best = other
+                best_size = size
         return best or sym
-
-    def _is_unnameable(self, sym: SymbolInfo) -> bool:
-        return sym.promoted_from_variable or any(marker in sym.name for marker in ANONYMOUS_SYMBOL_MARKERS)
 
     def get_equivalent_names(self, qualified_name: str) -> list[str]:
         """Get equivalent symbol names for edge expansion using pre-built index."""
@@ -363,3 +355,21 @@ class SymbolTable:
                 return True
 
         return False
+
+    def _is_unnameable(self, sym: SymbolInfo) -> bool:
+        return sym.promoted_from_variable or any(marker in sym.name for marker in ANONYMOUS_SYMBOL_MARKERS)
+
+    @staticmethod
+    def _encloses(outer: SymbolInfo, inner: SymbolInfo) -> bool:
+        """Whether *outer*'s range fully contains *inner*'s, character bounds included.
+
+        Why characters: several declarations can share a line, and comparing lines alone lets
+        an unrelated neighbour win.
+        """
+        if outer.start_line > inner.start_line or outer.end_line < inner.end_line:
+            return False
+        if outer.start_line == inner.start_line and outer.start_char > inner.start_char:
+            return False
+        if outer.end_line == inner.end_line and outer.end_char < inner.end_char:
+            return False
+        return True

--- a/static_analyzer/node.py
+++ b/static_analyzer/node.py
@@ -3,7 +3,14 @@
 Node behavior is separate from the static analyzer configuration definitions.
 """
 
-from static_analyzer.config import CALLABLE_TYPES, CLASS_TYPES, DATA_TYPES, ENTITY_LABELS, NodeType
+from static_analyzer.config import (
+    ANONYMOUS_SYMBOL_MARKERS,
+    CALLABLE_TYPES,
+    CLASS_TYPES,
+    DATA_TYPES,
+    ENTITY_LABELS,
+    NodeType,
+)
 
 
 class Node:
@@ -42,8 +49,7 @@ class Node:
         """Return True if this node represents a data entity (property, field, variable, constant)."""
         return self.type in DATA_TYPES
 
-    # Patterns indicating callback or anonymous function nodes from LSP
-    _CALLBACK_PATTERNS = (") callback", "<function>", "<arrow")
+    _CALLBACK_PATTERNS = ANONYMOUS_SYMBOL_MARKERS
 
     def is_callback_or_anonymous(self) -> bool:
         """Return True if this node represents a callback or anonymous function.

--- a/tests/static_analyzer/test_attribution_symbol.py
+++ b/tests/static_analyzer/test_attribution_symbol.py
@@ -1,0 +1,73 @@
+"""A call is credited to the innermost declaration a reader would name."""
+
+import unittest
+from pathlib import Path
+
+from static_analyzer.config import NodeType
+from static_analyzer.engine.adapters.typescript_adapter import TypeScriptAdapter
+from static_analyzer.engine.models import SymbolInfo
+from static_analyzer.engine.symbol_table import SymbolTable
+
+
+def sym(qname, start, end, kind=NodeType.FUNCTION, name=None, promoted=False):
+    return SymbolInfo(
+        name=name if name is not None else qname.split(".")[-1],
+        qualified_name=qname,
+        kind=kind,
+        file_path=Path("src/github.ts"),
+        start_line=start,
+        start_char=0,
+        end_line=end,
+        end_char=0,
+        promoted_from_variable=promoted,
+    )
+
+
+class TestAttributionSymbol(unittest.TestCase):
+    def setUp(self):
+        self.st = SymbolTable(TypeScriptAdapter())
+
+    def _load(self, symbols):
+        self.st.file_symbols["src/github.ts"] = symbols
+
+    def test_a_named_symbol_credits_itself(self):
+        named = sym("src.github.listReviewComments", 10, 30)
+        self._load([named])
+        self.assertIs(self.st.attribution_symbol(named), named)
+
+    def test_a_callback_credits_its_enclosing_function(self):
+        outer = sym("src.github.listReviewComments", 10, 30)
+        callback = sym("src.github.listReviewComments.raw.ghPaginate() callback", 12, 14, name="ghPaginate() callback")
+        self._load([outer, callback])
+        self.assertEqual(self.st.attribution_symbol(callback).qualified_name, outer.qualified_name)
+
+    def test_a_promoted_variable_wrapper_is_stepped_past(self):
+        # `const raw = await ghPaginate(...)` is promoted to class-like at registration.
+        outer = sym("src.github.listReviewComments", 10, 30)
+        wrapper = sym("src.github.listReviewComments.raw", 12, 16, kind=NodeType.CLASS, promoted=True)
+        self._load([outer, wrapper])
+        self.assertEqual(self.st.attribution_symbol(wrapper).qualified_name, outer.qualified_name)
+
+    def test_the_innermost_named_enclosure_wins(self):
+        file_level = sym("src.github.module", 1, 100, kind=NodeType.CLASS)
+        outer = sym("src.github.listReviewComments", 10, 30)
+        callback = sym("src.github.listReviewComments.map() callback", 12, 14, name="map() callback")
+        self._load([file_level, outer, callback])
+        self.assertEqual(self.st.attribution_symbol(callback).qualified_name, outer.qualified_name)
+
+    def test_a_callback_inside_a_callback_reaches_the_named_function(self):
+        outer = sym("src.github.listRepos", 10, 40)
+        mid = sym("src.github.listRepos.then() callback", 12, 30, name="then() callback")
+        inner = sym("src.github.listRepos.then() callback.map() callback", 14, 20, name="map() callback")
+        self._load([outer, mid, inner])
+        self.assertEqual(self.st.attribution_symbol(inner).qualified_name, outer.qualified_name)
+
+    def test_a_module_level_anonymous_function_credits_itself(self):
+        # Nothing encloses it, so there is no better name to use.
+        lone = sym("src.github.<function>", 5, 9, name="<function>")
+        self._load([lone])
+        self.assertIs(self.st.attribution_symbol(lone), lone)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/static_analyzer/test_attribution_symbol.py
+++ b/tests/static_analyzer/test_attribution_symbol.py
@@ -65,6 +65,22 @@ class TestAttributionSymbol(unittest.TestCase):
         self._load([lone])
         self.assertIs(self.st.attribution_symbol(lone), lone)
 
+    def test_a_module_level_wrapper_is_used_when_nothing_else_encloses(self):
+        # `export const raw = await ghPaginate(() => ...)` at module level: no function above
+        # it, so the promoted wrapper is the best name available and beats crediting the
+        # callback to itself.
+        wrapper = sym("src.github.raw", 4, 9, kind=NodeType.CLASS, promoted=True)
+        callback = sym("src.github.raw.ghPaginate() callback", 5, 8, name="ghPaginate() callback")
+        self._load([wrapper, callback])
+        self.assertEqual(self.st.attribution_symbol(callback).qualified_name, wrapper.qualified_name)
+
+    def test_a_named_function_still_beats_a_promoted_wrapper(self):
+        outer = sym("src.github.listRepos", 2, 20)
+        wrapper = sym("src.github.listRepos.raw", 4, 9, kind=NodeType.CLASS, promoted=True)
+        callback = sym("src.github.listRepos.raw.map() callback", 5, 8, name="map() callback")
+        self._load([outer, wrapper, callback])
+        self.assertEqual(self.st.attribution_symbol(callback).qualified_name, outer.qualified_name)
+
     def _load(self, symbols):
         self.st.file_symbols["src/github.ts"] = symbols
 

--- a/tests/static_analyzer/test_attribution_symbol.py
+++ b/tests/static_analyzer/test_attribution_symbol.py
@@ -27,9 +27,6 @@ class TestAttributionSymbol(unittest.TestCase):
     def setUp(self):
         self.st = SymbolTable(TypeScriptAdapter())
 
-    def _load(self, symbols):
-        self.st.file_symbols["src/github.ts"] = symbols
-
     def test_a_named_symbol_credits_itself(self):
         named = sym("src.github.listReviewComments", 10, 30)
         self._load([named])
@@ -67,6 +64,9 @@ class TestAttributionSymbol(unittest.TestCase):
         lone = sym("src.github.<function>", 5, 9, name="<function>")
         self._load([lone])
         self.assertIs(self.st.attribution_symbol(lone), lone)
+
+    def _load(self, symbols):
+        self.st.file_symbols["src/github.ts"] = symbols
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Stacked on #507.

An LSP server reports inline callbacks and anonymous functions as symbols, and `find_containing_symbol` returns the innermost one. So a call written inside an arrow callback is credited to `listReviewComments.raw.ghPaginate() callback` rather than to `listReviewComments`.

On CodeBoarding-webview that is **499 of 1923 TypeScript edges — 25.9%** — whose source is a name nobody uses. It shows up in the graph, in the diagram labels, and in the CFG evidence handed to the model (`forEach() callback -> highlightCode`).

Worth noting: this did **not** shrink after the JSX language-id fix, contrary to what I expected when planning. #506 removed synthetic *targets* (46 → 6); synthetic *sources* stayed at 25.9%. I re-measured before writing this rather than assuming.

## The obvious fix is wrong, and I measured it first

Teaching `lift_to_callable` to walk past synthetic callables looks fine on aggregate counts but **silently destroys grounding**. `container` isn't only the credit line — it's also the input to the declaration-line guard. Once it becomes `listReviewComments.raw`, whose `start_line` equals the reference line (`const raw = await ghPaginate(...)`), the reference is dropped. That version loses 30 grounded call sites and takes `ghPaginate` from 12 callers down to 3.

So: **every guard keeps seeing the innermost container, and only the recorded source name rolls up**, via a new `SymbolTable.attribution_symbol`.

## Measured — it is a pure relabel

| | before | after |
|---|---|---|
| synthetic edge sources | 499 (25.9%) | **17 (1.0%)** |
| call sites | 2324 | **2324** (unchanged) |
| grounding `(target, line, col)` | 2298 | **2298** (3 lost, 3 gained) |
| nodes | 3243 | 3242 |
| edges | 1923 | 1758 |
| `ghPaginate` callers | 12, of which 2 named | **10, all 10 named** |

Edges drop because callbacks merge into their parent — two callbacks in one function calling the same target become one edge carrying both call sites, which is why the call-site count is unchanged.

## Why nodes are untouched

Nodes are clustering input. Deleting 1198 of 3243 would move the partition for reasons that have nothing to do with the partition being wrong, and the CONTAINS reference edges tying a callback to its parent would all need rewriting. The symbol table, `methods_index` and those reference edges all keep the callback; only the credit line on a call edge moves.

Applied to **both** edge strategies, so Java and C# get it too.

## Tidying

`_CALLBACK_PATTERNS` in `node.py` had no production caller and duplicated the marker list. Both now read one tuple in `constants.py`.

## Tests

`tests/static_analyzer/test_attribution_symbol.py`, 6 cases: a named symbol credits itself, a callback credits its enclosing function, a promoted `const` wrapper is stepped past, the innermost *named* enclosure wins, a callback nested in a callback still reaches the function, and a module-level anonymous function credits itself.

Full suite: 2158 passed. The 3 `test_cli_parser` failures are pre-existing on `main`. Tag bumped to v6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
