### PR TITLE
feat(incremental): show the model the calls the commit touched

### DIFF
--- a/agents/incremental_agent.py
+++ b/agents/incremental_agent.py
@@ -300,7 +300,7 @@ class IncrementalAgent(StaticAnalysisEnricherMixin, CodeBoardingAgent):
         self,
         scope: AnalysisInsights,
         scope_name: str,
-        clustering: ClusterScopeResult,
+        static_call_evidence: str,
     ) -> ComponentApiSurfaces:
         """Analyze API surfaces for one updated scope."""
         logger.info("[IncrementalAgent] Analyzing API surfaces for scope: %s", scope_name)
@@ -308,10 +308,7 @@ class IncrementalAgent(StaticAnalysisEnricherMixin, CodeBoardingAgent):
             component_summaries=ComponentArchitecture(
                 description=scope.description, components=scope.components
             ).llm_str(),
-            static_call_evidence=render_scope_connections(
-                clustering,
-                {component.component_id: component.name for component in scope.components},
-            ),
+            static_call_evidence=static_call_evidence,
         )
         return self._parse_invoke(prompt, ComponentApiSurfaces)
 
@@ -322,6 +319,7 @@ class IncrementalAgent(StaticAnalysisEnricherMixin, CodeBoardingAgent):
         scope_name: str,
         api_surfaces: ComponentApiSurfaces,
         clustering: ClusterScopeResult,
+        static_call_evidence: str,
     ) -> list[Relation]:
         """Discover evidence-backed relations and attach deterministic CFG edges."""
         logger.info("[IncrementalAgent] Discovering component relations for scope: %s", scope_name)
@@ -338,10 +336,7 @@ class IncrementalAgent(StaticAnalysisEnricherMixin, CodeBoardingAgent):
                 description=scope.description, components=scope.components
             ).llm_str(),
             api_surfaces=api_surfaces.llm_str(),
-            static_call_evidence=render_scope_connections(
-                clustering,
-                {component.component_id: component.name for component in scope.components},
-            ),
+            static_call_evidence=static_call_evidence,
         )
         relation_result: ComponentRelations = self._invoke_validate(
             prompt,
@@ -409,12 +404,19 @@ class IncrementalAgent(StaticAnalysisEnricherMixin, CodeBoardingAgent):
         }
 
         if context.changed_ids:
-            api_surfaces = self.step_api_surfaces(scope, scope_name, context.clustering)
+            # Rendered once and shared: both prompts must agree on what the commit touched.
+            static_call_evidence = render_scope_connections(
+                context.clustering,
+                {component.component_id: component.name for component in scope.components},
+                changed_members,
+            )
+            api_surfaces = self.step_api_surfaces(scope, scope_name, static_call_evidence)
             rels = self.step_relation_analysis(
                 scope,
                 scope_name,
                 api_surfaces,
                 context.clustering,
+                static_call_evidence,
             )
         else:
             # Nothing in this scope changed, so preserve_unchanged_relations below would discard any

--- a/agents/incremental_agent.py
+++ b/agents/incremental_agent.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import threading
+from collections.abc import Collection
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
@@ -377,6 +378,7 @@ class IncrementalAgent(StaticAnalysisEnricherMixin, CodeBoardingAgent):
         scope_name: str,
         context: ScopeRelationContext,
         changed_members: set[str] | None = None,
+        unattributed_files: Collection[str] = (),
     ) -> list[Relation]:
         """Run the API-surface and relation stages for one updated scope, or skip both when nothing in it changed."""
         if len(scope.components) < 2:
@@ -403,12 +405,15 @@ class IncrementalAgent(StaticAnalysisEnricherMixin, CodeBoardingAgent):
             if relation.src_name and relation.dst_name
         }
 
+        gated_members: set[str] = set()
         if context.changed_ids:
             # Rendered once and shared: both prompts must agree on what the commit touched.
+            gated_members = set() if unattributed_files else changed_members or set()
             static_call_evidence = render_scope_connections(
                 context.clustering,
                 {component.component_id: component.name for component in scope.components},
-                changed_members,
+                gated_members,
+                baseline_by_pair,
             )
             api_surfaces = self.step_api_surfaces(scope, scope_name, static_call_evidence)
             rels = self.step_relation_analysis(
@@ -463,6 +468,7 @@ class IncrementalAgent(StaticAnalysisEnricherMixin, CodeBoardingAgent):
                 live_ids,
                 live_qnames,
                 changed_members,
+                gated_members,
             )
             # Preservation runs after the grounding filters and re-injects baseline edges, so
             # the assembled list is filtered once more — otherwise a baseline's invented or
@@ -482,6 +488,7 @@ class IncrementalAgent(StaticAnalysisEnricherMixin, CodeBoardingAgent):
         sub_analyses: dict[str, AnalysisInsights],
         relation_contexts: dict[str, ScopeRelationContext],
         changed_members: set[str] | None = None,
+        unattributed_files: Collection[str] = (),
     ) -> None:
         """Regenerate relations for every touched scope with at least two components.
 
@@ -498,11 +505,25 @@ class IncrementalAgent(StaticAnalysisEnricherMixin, CodeBoardingAgent):
 
         if len(tasks) <= 1:
             results = [
-                (scope_id, self.generate_scope_relations(scope, scope_id, relation_contexts[scope_id], changed_members))
+                (
+                    scope_id,
+                    self.generate_scope_relations(
+                        scope,
+                        scope_id,
+                        relation_contexts[scope_id],
+                        changed_members,
+                        unattributed_files,
+                    ),
+                )
                 for scope_id, scope in tasks
             ]
         else:
-            results = self._generate_scope_relations_parallel(tasks, relation_contexts, changed_members)
+            results = self._generate_scope_relations_parallel(
+                tasks,
+                relation_contexts,
+                changed_members,
+                unattributed_files,
+            )
 
         all_llm_rels = [
             (scope_id, rels) for scope_id, rels in results if rels and relation_contexts[scope_id].changed_ids
@@ -516,6 +537,7 @@ class IncrementalAgent(StaticAnalysisEnricherMixin, CodeBoardingAgent):
         tasks: list[tuple[str, AnalysisInsights]],
         relation_contexts: dict[str, ScopeRelationContext],
         changed_members: set[str] | None,
+        unattributed_files: Collection[str],
     ) -> list[tuple[str, list[Relation]]]:
         """Regenerate each scope's relations concurrently, one agent clone per worker thread.
 
@@ -536,7 +558,11 @@ class IncrementalAgent(StaticAnalysisEnricherMixin, CodeBoardingAgent):
                 with workers_lock:
                     workers.append(worker)
             return scope_id, worker.generate_scope_relations(
-                scope, scope_id, relation_contexts[scope_id], changed_members
+                scope,
+                scope_id,
+                relation_contexts[scope_id],
+                changed_members,
+                unattributed_files,
             )
 
         try:

--- a/agents/llm_renderers/clustering.py
+++ b/agents/llm_renderers/clustering.py
@@ -1,7 +1,9 @@
 """Render deterministic cluster groups for agent prompts."""
 
+from collections.abc import Collection, Mapping
 from pathlib import Path
 
+from agents.agent_responses import Relation
 from agents.relation_edges import edge_touches_change
 from clustering_ids import ClusterId
 from static_analyzer.clustering import ClusterGroup, ClusterScopeResult
@@ -57,7 +59,8 @@ def render_cluster_groups(group_ids: dict[str, list[ClusterId]], group_descripti
 def render_scope_connections(
     scope: ClusterScopeResult,
     group_names: dict[str, str],
-    changed_members: set[str] | None = None,
+    changed_members: Collection[str] = (),
+    baseline_by_pair: Mapping[tuple[str, str], Relation] | None = None,
 ) -> str:
     """Render precomputed cross-group communication for an agent prompt."""
     if not scope.connections:
@@ -65,41 +68,62 @@ def render_scope_connections(
 
     lines: list[str] = []
     if changed_members:
-        lines.append("Pairs marked '*' carry a call this change touched; the rest are shown as counts only.")
+        lines.append("Calls marked '*' changed, calls marked '-' were removed; untouched pairs show counts only.")
     for connection in scope.connections:
         source = group_names.get(connection.source_group_id, connection.source_group_id)
         target = group_names.get(connection.target_group_id, connection.target_group_id)
         edges = connection.edges
         edge_count = len(edges)
         plural = "s" if edge_count != 1 else ""
-        hot = (
-            [
-                edge
-                for edge in edges
-                if edge_touches_change(
-                    edge.source_qualified_name,
-                    edge.target_qualified_name,
-                    changed_members,
-                )
-            ]
-            if changed_members
-            else []
+        hot = [
+            edge
+            for edge in edges
+            if edge_touches_change(
+                edge.source_qualified_name,
+                edge.target_qualified_name,
+                changed_members,
+            )
+        ]
+        current_pairs = {(edge.source_qualified_name, edge.target_qualified_name) for edge in edges}
+        previous = (
+            baseline_by_pair.get((connection.source_group_id, connection.target_group_id))
+            if baseline_by_pair is not None
+            else None
         )
-        if changed_members and not hot:
+        baseline_edges = (previous.all_edges or previous.key_edges) if previous is not None else []
+        removed = [
+            edge
+            for edge in baseline_edges
+            if (edge.source.qualified_name, edge.target.qualified_name) not in current_pairs
+            and edge_touches_change(
+                edge.source.qualified_name,
+                edge.target.qualified_name,
+                changed_members,
+            )
+        ]
+        if changed_members and not hot and not removed:
             lines.append(f"\n{source} -> {target} ({edge_count} edge{plural}, none touched by this change)")
             continue
-        if hot:
-            header = f"({edge_count} edge{plural}, {len(hot)} touched by this change):"
-            ordered = hot + [edge for edge in edges if edge not in hot]
+        if hot or removed:
+            header = f"({edge_count} edge{plural}, {len(hot) + len(removed)} touched by this change):"
+            hot_ids = {id(edge) for edge in hot}
+            ordered = [
+                *[("* ", edge.source_qualified_name, edge.target_qualified_name) for edge in hot],
+                *[("- ", edge.source.qualified_name, edge.target.qualified_name) for edge in removed],
+                *[
+                    ("", edge.source_qualified_name, edge.target_qualified_name)
+                    for edge in edges
+                    if id(edge) not in hot_ids
+                ],
+            ]
         else:
             header = f"({edge_count} edge{plural}):"
-            ordered = list(edges)
+            ordered = [("", edge.source_qualified_name, edge.target_qualified_name) for edge in edges]
         lines.append(f"\n{source} -> {target} {header}")
-        for edge in ordered[:MAX_CONNECTION_EDGES]:
-            short_source = edge.source_qualified_name.split(".")[-1]
-            short_target = edge.target_qualified_name.split(".")[-1]
-            marker = "* " if edge in hot else ""
+        for marker, source_qualified_name, target_qualified_name in ordered[:MAX_CONNECTION_EDGES]:
+            short_source = source_qualified_name.split(".")[-1]
+            short_target = target_qualified_name.split(".")[-1]
             lines.append(f"  {marker}{short_source} -> {short_target}")
-        if edge_count > MAX_CONNECTION_EDGES:
-            lines.append(f"  ... and {edge_count - MAX_CONNECTION_EDGES} more")
+        if len(ordered) > MAX_CONNECTION_EDGES:
+            lines.append(f"  ... and {len(ordered) - MAX_CONNECTION_EDGES} more")
     return "\n".join(lines)

--- a/agents/llm_renderers/clustering.py
+++ b/agents/llm_renderers/clustering.py
@@ -98,7 +98,7 @@ def render_scope_connections(
         for edge in ordered[:MAX_CONNECTION_EDGES]:
             short_source = edge.source_qualified_name.split(".")[-1]
             short_target = edge.target_qualified_name.split(".")[-1]
-            marker = "* " if edge in hot else "  "
+            marker = "* " if edge in hot else ""
             lines.append(f"  {marker}{short_source} -> {short_target}")
         if edge_count > MAX_CONNECTION_EDGES:
             lines.append(f"  ... and {edge_count - MAX_CONNECTION_EDGES} more")

--- a/agents/llm_renderers/clustering.py
+++ b/agents/llm_renderers/clustering.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 
+from agents.relation_edges import edge_touches_change
 from clustering_ids import ClusterId
 from static_analyzer.clustering import ClusterGroup, ClusterScopeResult
 
@@ -53,21 +54,52 @@ def render_cluster_groups(group_ids: dict[str, list[ClusterId]], group_descripti
     return f"# Grouped Cluster Components\n{body}"
 
 
-def render_scope_connections(scope: ClusterScopeResult, group_names: dict[str, str]) -> str:
+def render_scope_connections(
+    scope: ClusterScopeResult,
+    group_names: dict[str, str],
+    changed_members: set[str] | None = None,
+) -> str:
     """Render precomputed cross-group communication for an agent prompt."""
     if not scope.connections:
         return "No cross-component communication edges found."
 
     lines: list[str] = []
+    if changed_members:
+        lines.append("Pairs marked '*' carry a call this change touched; the rest are shown as counts only.")
     for connection in scope.connections:
         source = group_names.get(connection.source_group_id, connection.source_group_id)
         target = group_names.get(connection.target_group_id, connection.target_group_id)
-        edge_count = len(connection.edges)
-        lines.append(f"\n{source} -> {target} ({edge_count} edge{'s' if edge_count != 1 else ''}):")
-        for edge in connection.edges[:MAX_CONNECTION_EDGES]:
+        edges = connection.edges
+        edge_count = len(edges)
+        plural = "s" if edge_count != 1 else ""
+        hot = (
+            [
+                edge
+                for edge in edges
+                if edge_touches_change(
+                    edge.source_qualified_name,
+                    edge.target_qualified_name,
+                    changed_members,
+                )
+            ]
+            if changed_members
+            else []
+        )
+        if changed_members and not hot:
+            lines.append(f"\n{source} -> {target} ({edge_count} edge{plural}, none touched by this change)")
+            continue
+        if hot:
+            header = f"({edge_count} edge{plural}, {len(hot)} touched by this change):"
+            ordered = hot + [edge for edge in edges if edge not in hot]
+        else:
+            header = f"({edge_count} edge{plural}):"
+            ordered = list(edges)
+        lines.append(f"\n{source} -> {target} {header}")
+        for edge in ordered[:MAX_CONNECTION_EDGES]:
             short_source = edge.source_qualified_name.split(".")[-1]
             short_target = edge.target_qualified_name.split(".")[-1]
-            lines.append(f"  {short_source} -> {short_target}")
+            marker = "* " if edge in hot else "  "
+            lines.append(f"  {marker}{short_source} -> {short_target}")
         if edge_count > MAX_CONNECTION_EDGES:
             lines.append(f"  ... and {edge_count - MAX_CONNECTION_EDGES} more")
     return "\n".join(lines)

--- a/agents/relation_edges.py
+++ b/agents/relation_edges.py
@@ -54,6 +54,40 @@ def index_relation_endpoints(analysis: AnalysisInsights, repo_dir: Path) -> None
             entry.merge_method_spans(spans)
 
 
+def edge_touches_change(source: str, target: str, changed_members: set[str] | None) -> bool:
+    """Whether this edge is evidence the commit gives for re-describing its pair.
+
+    Symmetric, unlike ``_edge_touches_changed_method``: that one asks whether the commit
+    deleted a call, which only a changed *source* can do. Re-describing a connection is
+    warranted by either end moving.
+    """
+    if not changed_members:
+        return False
+    return source in changed_members or target in changed_members
+
+
+def pair_untouched_by_change(
+    relation: Relation, changed_members: set[str] | None, previous: Relation | None = None
+) -> bool:
+    """Whether the commit gives no reason to re-describe this pair.
+
+    The prompt renders such a pair as a bare count, so its wording comes from the baseline
+    rather than the model. ``previous`` is read too: a call the commit deleted is absent from
+    the rebuilt edges, so judging on those alone would call the pair untouched and pin a label
+    that still describes the deleted interaction.
+    """
+    if not changed_members:
+        return False
+    edges = list(relation.all_edges or relation.key_edges)
+    if not edges:
+        return False
+    if previous is not None:
+        edges += list(previous.all_edges or previous.key_edges)
+    return not any(
+        edge_touches_change(edge.source.qualified_name, edge.target.qualified_name, changed_members) for edge in edges
+    )
+
+
 def _is_internal_self_relation(relation: Relation) -> bool:
     """A component related to itself by concrete intra-component calls.
 
@@ -255,32 +289,6 @@ def _edge_touches_changed_method(edge: RelationEdge, changed_members: set[str]) 
     return edge.source.qualified_name in changed_members
 
 
-def edge_touches_change(source: str, target: str, changed_members: set[str] | None) -> bool:
-    """Whether this edge is evidence the commit gives for re-describing its pair.
-
-    Symmetric, unlike ``_edge_touches_changed_method``: that one asks whether the commit
-    deleted a call, which only a changed *source* can do. Re-describing a connection is
-    warranted by either end moving.
-    """
-    if not changed_members:
-        return False
-    return source in changed_members or target in changed_members
-
-
-def pair_untouched_by_change(relation: Relation, changed_members: set[str] | None) -> bool:
-    """Whether the commit gives no reason to re-describe this pair.
-
-    The prompt renders such a pair as a bare count, so its wording has to come from the
-    baseline — a pair the model was never shown in detail must never take a model label.
-    """
-    if not changed_members:
-        return False
-    edges = relation.all_edges or relation.key_edges
-    return bool(edges) and not any(
-        edge_touches_change(edge.source.qualified_name, edge.target.qualified_name, changed_members) for edge in edges
-    )
-
-
 def _restore_baseline_orientation(relation: Relation, baseline_by_pair: dict) -> Relation:
     """Put an ungrounded relation back the way round the reader last saw it.
 
@@ -431,7 +439,7 @@ def preserve_unchanged_relations(
             not touches_change(*pair)
             or _relation_edges_unmoved(relation, previous)
             or (not _backing_edge_pairs(relation) and not relation.evidence.strip())
-            or pair_untouched_by_change(relation, changed_members)
+            or pair_untouched_by_change(relation, changed_members, previous)
         ):
             relation = _restore_baseline_wording(relation, previous)
         kept.append(relation)

--- a/agents/relation_edges.py
+++ b/agents/relation_edges.py
@@ -57,9 +57,7 @@ def index_relation_endpoints(analysis: AnalysisInsights, repo_dir: Path) -> None
 def edge_touches_change(source: str, target: str, changed_members: set[str] | None) -> bool:
     """Whether this edge is evidence the commit gives for re-describing its pair.
 
-    Symmetric, unlike ``_edge_touches_changed_method``: that one asks whether the commit
-    deleted a call, which only a changed *source* can do. Re-describing a connection is
-    warranted by either end moving.
+    Symmetric, unlike ``_edge_touches_changed_method``: either end moving warrants a re-description.
     """
     if not changed_members:
         return False
@@ -71,10 +69,8 @@ def pair_untouched_by_change(
 ) -> bool:
     """Whether the commit gives no reason to re-describe this pair.
 
-    The prompt renders such a pair as a bare count, so its wording comes from the baseline
-    rather than the model. ``previous`` is read too: a call the commit deleted is absent from
-    the rebuilt edges, so judging on those alone would call the pair untouched and pin a label
-    that still describes the deleted interaction.
+    Why ``previous``: a deleted call is absent from the rebuilt edges, so judging on those alone
+    would pin a label that still describes it.
     """
     if not changed_members:
         return False

--- a/agents/relation_edges.py
+++ b/agents/relation_edges.py
@@ -64,8 +64,7 @@ def pair_untouched_by_change(
 ) -> bool:
     """Whether the commit gives no reason to re-describe this pair.
 
-    Why ``previous``: a deleted call is absent from the rebuilt edges, so judging on those alone
-    would pin a label that still describes it.
+    Why: baseline calls expose deletions absent from rebuilt edges.
     """
     if not changed_members:
         return False

--- a/agents/relation_edges.py
+++ b/agents/relation_edges.py
@@ -255,6 +255,32 @@ def _edge_touches_changed_method(edge: RelationEdge, changed_members: set[str]) 
     return edge.source.qualified_name in changed_members
 
 
+def edge_touches_change(source: str, target: str, changed_members: set[str] | None) -> bool:
+    """Whether this edge is evidence the commit gives for re-describing its pair.
+
+    Symmetric, unlike ``_edge_touches_changed_method``: that one asks whether the commit
+    deleted a call, which only a changed *source* can do. Re-describing a connection is
+    warranted by either end moving.
+    """
+    if not changed_members:
+        return False
+    return source in changed_members or target in changed_members
+
+
+def pair_untouched_by_change(relation: Relation, changed_members: set[str] | None) -> bool:
+    """Whether the commit gives no reason to re-describe this pair.
+
+    The prompt renders such a pair as a bare count, so its wording has to come from the
+    baseline — a pair the model was never shown in detail must never take a model label.
+    """
+    if not changed_members:
+        return False
+    edges = relation.all_edges or relation.key_edges
+    return bool(edges) and not any(
+        edge_touches_change(edge.source.qualified_name, edge.target.qualified_name, changed_members) for edge in edges
+    )
+
+
 def _restore_baseline_orientation(relation: Relation, baseline_by_pair: dict) -> Relation:
     """Put an ungrounded relation back the way round the reader last saw it.
 
@@ -396,10 +422,16 @@ def preserve_unchanged_relations(
         # 17 of the relations in `referenced-symbol-deleted` whose calls had not moved at all.
         # A pair with no supporting calls has nothing that could have moved, so its wording is
         # kept too — an edgeless runtime relation is prose, and re-rolling prose is the churn.
+        #
+        # The last disjunct pairs with the prompt: a pair carrying no edge the commit touched
+        # is rendered to the model as a bare count, so it cannot have been described afresh and
+        # must keep the baseline's wording. Without it, gating the prompt would trade edge
+        # churn for wording churn.
         if (
             not touches_change(*pair)
             or _relation_edges_unmoved(relation, previous)
             or (not _backing_edge_pairs(relation) and not relation.evidence.strip())
+            or pair_untouched_by_change(relation, changed_members)
         ):
             relation = _restore_baseline_wording(relation, previous)
         kept.append(relation)

--- a/agents/relation_edges.py
+++ b/agents/relation_edges.py
@@ -1,6 +1,6 @@
 """Merge component relations and index their source endpoints."""
 
-from collections.abc import Callable
+from collections.abc import Callable, Collection
 from pathlib import Path
 
 from agents.agent_responses import AnalysisInsights, Relation, RelationEdge, SourceCodeReference
@@ -54,18 +54,13 @@ def index_relation_endpoints(analysis: AnalysisInsights, repo_dir: Path) -> None
             entry.merge_method_spans(spans)
 
 
-def edge_touches_change(source: str, target: str, changed_members: set[str] | None) -> bool:
-    """Whether this edge is evidence the commit gives for re-describing its pair.
-
-    Symmetric, unlike ``_edge_touches_changed_method``: either end moving warrants a re-description.
-    """
-    if not changed_members:
-        return False
+def edge_touches_change(source: str, target: str, changed_members: Collection[str]) -> bool:
+    """Return whether either endpoint changed and warrants re-describing the pair."""
     return source in changed_members or target in changed_members
 
 
 def pair_untouched_by_change(
-    relation: Relation, changed_members: set[str] | None, previous: Relation | None = None
+    relation: Relation, changed_members: Collection[str], previous: Relation | None = None
 ) -> bool:
     """Whether the commit gives no reason to re-describe this pair.
 
@@ -75,10 +70,10 @@ def pair_untouched_by_change(
     if not changed_members:
         return False
     edges = list(relation.all_edges or relation.key_edges)
-    if not edges:
-        return False
     if previous is not None:
         edges += list(previous.all_edges or previous.key_edges)
+    if not edges:
+        return False
     return not any(
         edge_touches_change(edge.source.qualified_name, edge.target.qualified_name, changed_members) for edge in edges
     )
@@ -360,15 +355,16 @@ def preserve_unchanged_relations(
     live_ids: set[str],
     live_qnames: set[str],
     changed_members: set[str] | None = None,
+    gated_members: Collection[str] = (),
 ) -> list[Relation]:
     """Keep the wording a reader already read for any relation whose call edges did not move.
 
     Regeneration re-derives every relation in its scope and re-words even the edges between
     components whose connection is unchanged, so a one-line diff relabels the whole diagram.
     The label carries forward whenever the pair's backing call edges are identical to the
-    baseline; the call edges themselves always come from the fresh rebuild — they are the
-    structural truth and must never go stale. A pair is re-worded only when its connection
-    genuinely moved (an edge appeared, vanished, or repointed).
+    baseline and the incremental prompt summarized the pair. The call edges themselves always
+    come from the fresh rebuild — they are the structural truth and must never go stale. A pair
+    is re-worded when its connection moved or the commit changed one of its call endpoints.
 
     The endpoint-change set alone is too coarse to gate wording: a component is flagged
     changed for any module-level edit to a file it merely co-owns, and clustering disperses
@@ -416,31 +412,23 @@ def preserve_unchanged_relations(
             continue
         if changed_members is not None and _commit_deleted_the_backing(relation, previous, changed_members):
             continue
-        # Keep the reader's wording unless this pair's own supporting calls moved.
-        #
-        # The supporting calls are the concrete method-to-method calls under the relation — the
-        # ones that show WHERE one component reaches the other. They are the only evidence that
-        # the connection itself changed, so they are what decides whether it may be re-worded.
-        # Gating on the endpoint components' change flags instead re-words far more: a component
-        # is flagged for any edit to a file it merely co-owns, so deleting one function re-worded
-        # 17 of the relations in `referenced-symbol-deleted` whose calls had not moved at all.
-        # A pair with no supporting calls has nothing that could have moved, so its wording is
-        # kept too — an edgeless runtime relation is prose, and re-rolling prose is the churn.
-        #
-        # The last disjunct pairs with the prompt: a pair carrying no edge the commit touched
-        # is rendered to the model as a bare count, so it cannot have been described afresh and
-        # must keep the baseline's wording. Without it, gating the prompt would trade edge
-        # churn for wording churn.
-        if (
-            not touches_change(*pair)
-            or _relation_edges_unmoved(relation, previous)
-            or (not _backing_edge_pairs(relation) and not relation.evidence.strip())
-            or pair_untouched_by_change(relation, changed_members, previous)
+        pair_untouched = pair_untouched_by_change(relation, gated_members, previous)
+        pair_has_edges = bool(relation.all_edges or relation.key_edges or previous.all_edges or previous.key_edges)
+        pair_touched = bool(gated_members) and pair_has_edges and not pair_untouched
+        if pair_untouched or (
+            not pair_touched
+            and (
+                not touches_change(*pair)
+                or _relation_edges_unmoved(relation, previous)
+                or (not _backing_edge_pairs(relation) and not relation.evidence.strip())
+            )
         ):
             relation = _restore_baseline_wording(relation, previous)
         kept.append(relation)
     for pair, relation in baseline_by_pair.items():
-        if pair in rebuilt_pairs or touches_change(*pair) or pair[0] not in live_ids or pair[1] not in live_ids:
+        if pair in rebuilt_pairs or pair[0] not in live_ids or pair[1] not in live_ids:
+            continue
+        if touches_change(*pair) and not pair_untouched_by_change(relation, gated_members):
             continue
         if not _relation_backing_survives(relation, live_qnames):
             continue

--- a/diagram_analysis/diagram_generator.py
+++ b/diagram_analysis/diagram_generator.py
@@ -1564,6 +1564,7 @@ class DiagramGenerator:
                         for scope_id, context in apply_result.relation_contexts.items()
                     },
                     self._changed_members,
+                    self._changed_unattributed_files,
                 )
 
             self._refresh_files_index(root_analysis, sub_analyses)

--- a/tests/agents/test_cfg_evidence_gating.py
+++ b/tests/agents/test_cfg_evidence_gating.py
@@ -59,3 +59,17 @@ class TestPairUntouchedByChange(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestDeletedCallEvidence(unittest.TestCase):
+    def test_a_call_the_commit_deleted_still_counts(self):
+        # The deleted edge is absent from the rebuild, so judging on the rebuild alone would
+        # pin a label that still describes the interaction the commit removed.
+        rebuilt = relation(edge("pkg.stable", "pkg.callee"))
+        previous = relation(edge("pkg.stable", "pkg.callee"), edge("pkg.gone", "pkg.callee"))
+        self.assertFalse(pair_untouched_by_change(rebuilt, {"pkg.gone"}, previous))
+
+    def test_an_untouched_pair_stays_untouched_with_a_baseline(self):
+        rebuilt = relation(edge("pkg.stable", "pkg.callee"))
+        previous = relation(edge("pkg.stable", "pkg.callee"))
+        self.assertTrue(pair_untouched_by_change(rebuilt, {"pkg.elsewhere"}, previous))

--- a/tests/agents/test_cfg_evidence_gating.py
+++ b/tests/agents/test_cfg_evidence_gating.py
@@ -1,0 +1,61 @@
+"""An incremental prompt details the pairs the commit touched and counts the rest.
+
+The gate and the wording-restore path share one predicate on purpose: a pair the model was
+shown as a bare count must never end up carrying a model-authored label.
+"""
+
+import unittest
+
+from agents.agent_responses import Relation, RelationEdge, SourceCodeReference
+from agents.relation_edges import edge_touches_change, pair_untouched_by_change
+
+
+def edge(src: str, dst: str) -> RelationEdge:
+    return RelationEdge(
+        source=SourceCodeReference(qualified_name=src, reference_file="pkg/mod.py"),
+        target=SourceCodeReference(qualified_name=dst, reference_file="pkg/mod.py"),
+    )
+
+
+def relation(*edges: RelationEdge) -> Relation:
+    return Relation(relation="calls", src_name="1", dst_name="2", src_id="1", dst_id="2", all_edges=list(edges))
+
+
+class TestEdgeTouchesChange(unittest.TestCase):
+    def test_a_changed_source_makes_the_edge_evidence(self):
+        self.assertTrue(edge_touches_change("pkg.caller", "pkg.callee", {"pkg.caller"}))
+
+    def test_a_changed_target_also_makes_the_edge_evidence(self):
+        # Asymmetric with the deletion predicate on purpose: either end moving is a reason
+        # to re-describe the connection.
+        self.assertTrue(edge_touches_change("pkg.caller", "pkg.callee", {"pkg.callee"}))
+
+    def test_an_untouched_edge_is_not_evidence(self):
+        self.assertFalse(edge_touches_change("pkg.caller", "pkg.callee", {"pkg.elsewhere"}))
+
+    def test_a_full_run_has_no_changed_members(self):
+        self.assertFalse(edge_touches_change("pkg.caller", "pkg.callee", None))
+        self.assertFalse(edge_touches_change("pkg.caller", "pkg.callee", set()))
+
+
+class TestPairUntouchedByChange(unittest.TestCase):
+    def test_a_pair_with_no_touched_edge_is_untouched(self):
+        rel = relation(edge("pkg.a", "pkg.b"), edge("pkg.c", "pkg.d"))
+        self.assertTrue(pair_untouched_by_change(rel, {"pkg.elsewhere"}))
+
+    def test_one_touched_edge_makes_the_whole_pair_touched(self):
+        rel = relation(edge("pkg.a", "pkg.b"), edge("pkg.c", "pkg.d"))
+        self.assertFalse(pair_untouched_by_change(rel, {"pkg.c"}))
+
+    def test_an_edgeless_pair_is_not_claimed_either_way(self):
+        # It has no supporting calls, so the existing edgeless branch decides its wording.
+        self.assertFalse(pair_untouched_by_change(relation(), {"pkg.a"}))
+
+    def test_a_full_run_never_reports_a_pair_untouched(self):
+        rel = relation(edge("pkg.a", "pkg.b"))
+        self.assertFalse(pair_untouched_by_change(rel, None))
+        self.assertFalse(pair_untouched_by_change(rel, set()))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/agents/test_cfg_evidence_gating.py
+++ b/tests/agents/test_cfg_evidence_gating.py
@@ -1,13 +1,11 @@
-"""An incremental prompt details the pairs the commit touched and counts the rest.
-
-The gate and the wording-restore path share one predicate on purpose: a pair the model was
-shown as a bare count must never end up carrying a model-authored label.
-"""
+"""Keep incremental CFG evidence gating and relation preservation aligned."""
 
 import unittest
 
 from agents.agent_responses import Relation, RelationEdge, SourceCodeReference
-from agents.relation_edges import edge_touches_change, pair_untouched_by_change
+from agents.llm_renderers import render_scope_connections
+from agents.relation_edges import edge_touches_change, pair_untouched_by_change, preserve_unchanged_relations
+from static_analyzer.clustering import ClusterConnectionEdge, ClusterScopeResult, GroupConnection
 
 
 def edge(src: str, dst: str) -> RelationEdge:
@@ -19,6 +17,26 @@ def edge(src: str, dst: str) -> RelationEdge:
 
 def relation(*edges: RelationEdge) -> Relation:
     return Relation(relation="calls", src_name="1", dst_name="2", src_id="1", dst_id="2", all_edges=list(edges))
+
+
+def clustering(*edges: tuple[str, str]) -> ClusterScopeResult:
+    return ClusterScopeResult(
+        scope_id="root",
+        connections=[
+            GroupConnection(
+                source_group_id="1",
+                target_group_id="2",
+                edges=[
+                    ClusterConnectionEdge(
+                        language="python",
+                        source_qualified_name=source,
+                        target_qualified_name=target,
+                    )
+                    for source, target in edges
+                ],
+            )
+        ],
+    )
 
 
 class TestEdgeTouchesChange(unittest.TestCase):
@@ -34,7 +52,6 @@ class TestEdgeTouchesChange(unittest.TestCase):
         self.assertFalse(edge_touches_change("pkg.caller", "pkg.callee", {"pkg.elsewhere"}))
 
     def test_a_full_run_has_no_changed_members(self):
-        self.assertFalse(edge_touches_change("pkg.caller", "pkg.callee", None))
         self.assertFalse(edge_touches_change("pkg.caller", "pkg.callee", set()))
 
 
@@ -53,12 +70,7 @@ class TestPairUntouchedByChange(unittest.TestCase):
 
     def test_a_full_run_never_reports_a_pair_untouched(self):
         rel = relation(edge("pkg.a", "pkg.b"))
-        self.assertFalse(pair_untouched_by_change(rel, None))
         self.assertFalse(pair_untouched_by_change(rel, set()))
-
-
-if __name__ == "__main__":
-    unittest.main()
 
 
 class TestDeletedCallEvidence(unittest.TestCase):
@@ -73,3 +85,97 @@ class TestDeletedCallEvidence(unittest.TestCase):
         rebuilt = relation(edge("pkg.stable", "pkg.callee"))
         previous = relation(edge("pkg.stable", "pkg.callee"))
         self.assertTrue(pair_untouched_by_change(rebuilt, {"pkg.elsewhere"}, previous))
+
+    def test_an_untouched_baseline_counts_when_the_rebuild_has_no_edges(self):
+        rebuilt = relation()
+        previous = relation(edge("pkg.stable", "pkg.callee"))
+        self.assertTrue(pair_untouched_by_change(rebuilt, {"pkg.elsewhere"}, previous))
+
+
+class TestScopeConnectionRendering(unittest.TestCase):
+    def test_full_run_output_is_unchanged(self):
+        rendered = render_scope_connections(
+            clustering(("pkg.caller", "pkg.callee")),
+            {"1": "A", "2": "B"},
+        )
+
+        self.assertEqual(rendered, "\nA -> B (1 edge):\n  caller -> callee")
+
+    def test_untouched_pair_collapses_to_its_count(self):
+        rendered = render_scope_connections(
+            clustering(("pkg.caller", "pkg.callee")),
+            {"1": "A", "2": "B"},
+            {"pkg.elsewhere"},
+        )
+
+        self.assertIn("A -> B (1 edge, none touched by this change)", rendered)
+        self.assertNotIn("caller -> callee", rendered)
+
+    def test_touched_calls_render_first(self):
+        rendered = render_scope_connections(
+            clustering(
+                ("pkg.stable", "pkg.callee"),
+                ("pkg.changed", "pkg.callee"),
+            ),
+            {"1": "A", "2": "B"},
+            {"pkg.changed"},
+        )
+
+        self.assertLess(rendered.index("* changed -> callee"), rendered.index("stable -> callee"))
+
+    def test_deleted_call_is_shown_as_changed_evidence(self):
+        previous = relation(
+            edge("pkg.stable", "pkg.callee"),
+            edge("pkg.removed", "pkg.callee"),
+        )
+
+        rendered = render_scope_connections(
+            clustering(("pkg.stable", "pkg.callee")),
+            {"1": "A", "2": "B"},
+            {"pkg.removed"},
+            {("1", "2"): previous},
+        )
+
+        self.assertIn("1 touched by this change", rendered)
+        self.assertIn("- removed -> callee", rendered)
+        self.assertNotIn("none touched by this change", rendered)
+
+
+class TestGatedRelationPreservation(unittest.TestCase):
+    def test_touched_pair_with_identical_edges_keeps_new_wording(self):
+        rebuilt = relation(edge("pkg.caller", "pkg.callee"))
+        rebuilt.relation = "new wording"
+        previous = relation(edge("pkg.caller", "pkg.callee"))
+        previous.relation = "old wording"
+
+        kept = preserve_unchanged_relations(
+            [rebuilt],
+            {("1", "2"): previous},
+            {"2"},
+            {"1", "2"},
+            {"pkg.caller", "pkg.callee"},
+            {"pkg.callee"},
+            {"pkg.callee"},
+        )
+
+        self.assertEqual(kept[0].relation, "new wording")
+
+    def test_omitted_cold_pair_is_restored(self):
+        previous = relation(edge("pkg.caller", "pkg.callee"))
+        previous.relation = "old wording"
+
+        kept = preserve_unchanged_relations(
+            [],
+            {("1", "2"): previous},
+            {"1"},
+            {"1", "2"},
+            {"pkg.caller", "pkg.callee"},
+            {"pkg.elsewhere"},
+            {"pkg.elsewhere"},
+        )
+
+        self.assertEqual(kept[0].relation, "old wording")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/agents/test_incremental_agent.py
+++ b/tests/agents/test_incremental_agent.py
@@ -581,14 +581,18 @@ class TestIncrementalRelations(unittest.TestCase):
                 clustering=clustering,
                 changed_ids=frozenset({"1", "2"}),
             ),
+            {source.fully_qualified_name},
+            {"settings.py"},
         )
 
         self.assertEqual(generated, relation_result.components_relations)
         self.assertEqual(agent._parse_invoke.call_args.args[1], ComponentApiSurfaces)
         self.assertNotIn("legacy relation", agent._parse_invoke.call_args.args[0])
+        self.assertNotIn("untouched pairs show counts only", agent._parse_invoke.call_args.args[0])
         relation_call = agent._invoke_validate.call_args
         self.assertEqual(relation_call.args[1], ComponentRelations)
         self.assertNotIn("legacy relation", relation_call.args[0])
+        self.assertNotIn("untouched pairs show counts only", relation_call.args[0])
         self.assertEqual(relation_call.kwargs["validators"][0].__name__, "validate_relations")
         self.assertEqual(len(scope.components_relations), 1)
         relation = scope.components_relations[0]
@@ -613,9 +617,21 @@ class TestIncrementalRelations(unittest.TestCase):
         root = AnalysisInsights(description="root", components=[], components_relations=[])
         context = ScopeRelationContext(clustering=_clustering())
 
-        agent.generate_all_scope_relations(root, {}, {"root": context}, {"pkg.changed"})
+        agent.generate_all_scope_relations(
+            root,
+            {},
+            {"root": context},
+            {"pkg.changed"},
+            {"settings.py"},
+        )
 
-        agent.generate_scope_relations.assert_called_once_with(root, "root", context, {"pkg.changed"})
+        agent.generate_scope_relations.assert_called_once_with(
+            root,
+            "root",
+            context,
+            {"pkg.changed"},
+            {"settings.py"},
+        )
 
     def test_single_component_scope_clears_stale_relations_and_resolves_references(self) -> None:
         agent = object.__new__(IncrementalAgent)


### PR DESCRIPTION
Stacked on #508.

`build_scope_cfg_string` has no notion of `changed_members`, so an incremental run hands the model **every** cross-component edge in a scope — the same helper the full-run agents use — across **two** prompts per changed scope (`step_api_surfaces` and `step_relation_analysis`). On a real webview step, 30 of 366 root-scope edges touch a changed method, so 92% of the evidence is unrelated to the change.

## The gate

A pair carrying no touched edge renders as one line stating its weight:

```
Code Review & Stream Interface -> Shared UI Utilities (61 edges, none touched by this change)
```

instead of up to ten call lines. It **stays visible** — dropping it entirely would hide that A talks to B at all, degrading the api-surface answer and inviting the model to invent the relation back.

**Component-pair gating was measured and rejected first.** Changed-ness propagates to ancestors, so 47 of 47 root pairs stay hot and a pair gate cuts 5% of lines. Only edge-level hotness has leverage.

## The trap, and why the restore path widens in the same commit

The model's output **replaces** the scope's relations wholesale. So evidence hidden from it is a relation it cannot describe — and today's restore path is far too narrow to catch that: `touches_change` is true for every root pair, and `_relation_edges_unmoved` fails whenever an edge count drifted. **Gating alone would trade edge churn for wording churn.**

So the prompt gate and the restore path share one predicate. `pair_untouched_by_change` becomes a third disjunct in the wording-restore condition, which makes the invariant hold:

> a pair the prompt rendered as a bare count never takes a model-authored label.

No plumbing is needed to keep the two sides in sync — both are pure functions of `(the relation's fresh edges, changed_members)`, and both sides already hold both.

`edge_touches_change` is deliberately **symmetric**, unlike the existing `_edge_touches_changed_method`. That one asks whether the commit deleted a call, which only a changed *source* can do. This one asks whether the edge is evidence for re-describing the pair, which either end moving supplies.

## Measured

One real webview step, **357 changed methods** — a large change, so this is a conservative figure. A small PR gates far harder.

| scope | now | gated | cut |
|---|---|---|---|
| root | 324 | 178 | **45%** |
| scope 1 | 170 | 154 | 9% |
| scope 3 | 64 | 26 | 59% |
| **all scopes** | **657** | **439** | **33%** |

Rendered twice per changed scope, so the token saving doubles.

A **full run is untouched**: `changed_members` is empty and the output is byte-identical to today's.

## Ordering

⚠️ This touches `preserve_unchanged_relations`, which **#505 also rewrites**. #505 is open against `main`; this sits on the engine stack. They conflict in one place — the wording-restore condition. Resolution is additive: keep #505's `_restore_baseline_wording(relation, previous)` call and add `or pair_untouched_by_change(relation, changed_members)` to the same condition. **Merge #505 first.**

## Tests

`tests/agents/test_cfg_evidence_gating.py`, 8 cases covering both predicates, including the symmetry that distinguishes them from the deletion predicate and the full-run degradation.

Full suite: 2158 passed. The 3 `test_cli_parser` failures are pre-existing on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved incremental relation updates by focusing analysis on changed or affected code.
  * Preserved existing descriptions for unchanged relationships while identifying removed or modified connections.
  * Accounted for changes in files without attributed members, including module-level and configuration updates.
  * Highlighted affected connections and prioritized them in generated relationship views.

* **Tests**
  * Added coverage for evidence filtering, changed and deleted connections, relationship preservation, and connection ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->