### PR TITLE
feat: support third-party Anthropic providers

### DIFF
--- a/PYPI.md
+++ b/PYPI.md
@@ -116,9 +116,11 @@ LLM provider keys and model overrides are stored in `~/.codeboarding/config.toml
 # Uncomment exactly one provider key
 # openai_api_key    = "sk-..."
 # anthropic_api_key = "sk-ant-..."
-# anthropic_base_url = "https://resource.services.ai.azure.com/anthropic"
 # google_api_key    = "AIza..."
 # ollama_base_url   = "http://localhost:11434"
+
+# Optional Anthropic endpoint override; requires anthropic_api_key above
+# anthropic_base_url = "https://resource.services.ai.azure.com/anthropic"
 
 [llm]
 # Optional: override the default model for your active provider

--- a/PYPI.md
+++ b/PYPI.md
@@ -116,6 +116,7 @@ LLM provider keys and model overrides are stored in `~/.codeboarding/config.toml
 # Uncomment exactly one provider key
 # openai_api_key    = "sk-..."
 # anthropic_api_key = "sk-ant-..."
+# anthropic_base_url = "https://resource.services.ai.azure.com/anthropic"
 # google_api_key    = "AIza..."
 # ollama_base_url   = "http://localhost:11434"
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ On first run, CodeBoarding creates `~/.codeboarding/config.toml`. Set one provid
 # openai_api_key            = "sk-..."
 # openai_base_url           = "https://api.example.com/v1"  # any OpenAI-compatible gateway
 # anthropic_api_key         = "sk-ant-..."
+# anthropic_base_url        = "https://resource.services.ai.azure.com/anthropic"  # Azure Foundry
 # google_api_key            = "AIza..."
 # vercel_api_key            = "vck_..."
 # aws_bearer_token_bedrock  = "..."
@@ -142,6 +143,8 @@ On first run, CodeBoarding creates `~/.codeboarding/config.toml`. Set one provid
 ```
 
 `openai_base_url` points CodeBoarding at any OpenAI-compatible gateway. Set the gateway API key as `openai_api_key`, then choose its model IDs with `agent_model` and `parsing_model`. The equivalent shell variables are `OPENAI_BASE_URL`, `OPENAI_API_KEY`, `AGENT_MODEL`, and `PARSING_MODEL`.
+
+`anthropic_base_url` points the Anthropic client at a compatible Messages API, including Azure Foundry Claude deployments. Set the deployment key as `anthropic_api_key` and use deployment names for `agent_model` and `parsing_model`.
 
 Shell environment variables such as `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`, and `OLLAMA_BASE_URL` take precedence over the config file. For private repositories, set `GITHUB_TOKEN` in your environment.
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ On first run, CodeBoarding creates `~/.codeboarding/config.toml`. Set one provid
 
 `openai_base_url` points CodeBoarding at any OpenAI-compatible gateway. Set the gateway API key as `openai_api_key`, then choose its model IDs with `agent_model` and `parsing_model`. The equivalent shell variables are `OPENAI_BASE_URL`, `OPENAI_API_KEY`, `AGENT_MODEL`, and `PARSING_MODEL`.
 
-`anthropic_base_url` points the Anthropic client at a compatible Messages API, including Azure Foundry Claude deployments. Set the deployment key as `anthropic_api_key` and use deployment names for `agent_model` and `parsing_model`.
+`anthropic_base_url` points the Anthropic client at a compatible Messages API, including Azure Foundry Claude deployments. Set the deployment key as `anthropic_api_key` and use canonical Anthropic model IDs such as `claude-sonnet-5` for `agent_model` and `parsing_model` so CodeBoarding selects the correct model capabilities and prompts.
 
 Shell environment variables such as `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`, and `OLLAMA_BASE_URL` take precedence over the config file. For private repositories, set `GITHUB_TOKEN` in your environment.
 

--- a/agents/llm_config.py
+++ b/agents/llm_config.py
@@ -31,6 +31,7 @@ _OPENROUTER_FALLBACK_CONTEXT_WINDOW = ContextWindow(1_048_576, 65_536, is_fallba
 _SAMPLING_PARAM_FREE_MODEL_SUBSTRINGS = (
     "claude-opus-4-7",
     "claude-opus-4-8",
+    "claude-opus-5",
     "claude-sonnet-5",
     "claude-fable-5",
     "claude-mythos-5",
@@ -174,13 +175,14 @@ LLM_PROVIDERS = {
     ),
     "anthropic": LLMConfig(
         chat_class=ChatAnthropic,
-        selection_envs=["ANTHROPIC_API_KEY", "ANTHROPIC_BASE_URL"],
+        selection_envs=["ANTHROPIC_API_KEY"],
         api_key_env="ANTHROPIC_API_KEY",
         agent_model="claude-sonnet-5",
         parsing_model="claude-haiku-4-5",
         llm_type=LLMType.CLAUDE,
         extra_args={
             "base_url": lambda: os.getenv("ANTHROPIC_BASE_URL"),
+            "thinking": {"type": "disabled"},
             "max_tokens": 8192,
             "timeout": None,
             "max_retries": 0,
@@ -412,14 +414,20 @@ def validate_api_key_provided() -> None:
     capable providers (self-hosted / OpenAI-compatible endpoints, e.g. an
     ``OPENAI_BASE_URL`` with no key) are therefore valid: they are selected by
     their base URL, and the client falls back to a placeholder key downstream.
-    In that case we log a warning rather than fail. Ambiguity detection (more
-    than one selected provider) is preserved so a stray second key is still
-    surfaced, and a key set for an unselected provider (e.g. LITELLM_API_KEY
-    without LITELLM_BASE_URL) is reported rather than silently ignored.
+    In that case we log a warning rather than fail.
+    An ``ANTHROPIC_BASE_URL`` alone reports its missing key without selecting
+    Anthropic when another provider is configured.
+    Ambiguity detection (more than one selected provider) is preserved so a
+    stray second key is still surfaced, and a key set for an unselected provider
+    (e.g. LITELLM_API_KEY without LITELLM_BASE_URL) is reported rather than
+    silently ignored.
     """
     hints = _unselected_key_hints()
     selected = selected_providers()
     if not selected:
+        anthropic = LLM_PROVIDERS["anthropic"]
+        if os.getenv("ANTHROPIC_BASE_URL") and not anthropic.has_real_api_key():
+            raise LLMConfigError("Provider 'anthropic' requires ANTHROPIC_API_KEY.")
         message = f"No LLM provider selected. Set one of: {', '.join(_all_selection_envs())}."
         raise LLMConfigError(" ".join([message, *hints]))
     if len(selected) > 1:
@@ -436,8 +444,6 @@ def validate_api_key_provided() -> None:
             name,
             config.api_key_env,
         )
-    elif config.api_key_env and not config.has_real_api_key():
-        raise LLMConfigError(f"Provider '{name}' requires {config.api_key_env}.")
 
 
 def initialize_agent_llm(model_override: str | None = None) -> BaseChatModel:

--- a/agents/llm_config.py
+++ b/agents/llm_config.py
@@ -26,11 +26,12 @@ logger = logging.getLogger(__name__)
 _OPENROUTER_FALLBACK_CONTEXT_WINDOW = ContextWindow(1_048_576, 65_536, is_fallback=True)
 
 # Model families that reject sampling params (temperature/top_p/top_k) with HTTP 400.
-# Why: Anthropic removed them starting with Opus 4.7; sending temperature (even 0) 400s.
+# Why: newer Anthropic models deprecate them; sending temperature (even 0) 400s.
 # Substrings match bare IDs and Bedrock-prefixed forms (e.g. us.anthropic.claude-opus-4-8-v1:0).
 _SAMPLING_PARAM_FREE_MODEL_SUBSTRINGS = (
     "claude-opus-4-7",
     "claude-opus-4-8",
+    "claude-sonnet-5",
     "claude-fable-5",
     "claude-mythos-5",
 )
@@ -173,12 +174,13 @@ LLM_PROVIDERS = {
     ),
     "anthropic": LLMConfig(
         chat_class=ChatAnthropic,
-        selection_envs=["ANTHROPIC_API_KEY"],
+        selection_envs=["ANTHROPIC_API_KEY", "ANTHROPIC_BASE_URL"],
         api_key_env="ANTHROPIC_API_KEY",
-        agent_model="claude-sonnet-4-6",
+        agent_model="claude-sonnet-5",
         parsing_model="claude-haiku-4-5",
         llm_type=LLMType.CLAUDE,
         extra_args={
+            "base_url": lambda: os.getenv("ANTHROPIC_BASE_URL"),
             "max_tokens": 8192,
             "timeout": None,
             "max_retries": 0,
@@ -434,6 +436,8 @@ def validate_api_key_provided() -> None:
             name,
             config.api_key_env,
         )
+    elif config.api_key_env and not config.has_real_api_key():
+        raise LLMConfigError(f"Provider '{name}' requires {config.api_key_env}.")
 
 
 def initialize_agent_llm(model_override: str | None = None) -> BaseChatModel:

--- a/tests/agents/test_llm_config.py
+++ b/tests/agents/test_llm_config.py
@@ -82,6 +82,12 @@ class TestValidateApiKeyProvided:
 
 
 class TestProviderSelection:
+    def test_anthropic_defaults_to_sonnet_5_and_haiku_4_5(self):
+        anthropic = LLM_PROVIDERS["anthropic"]
+
+        assert anthropic.agent_model == "claude-sonnet-5"
+        assert anthropic.parsing_model == "claude-haiku-4-5"
+
     def test_kimi_defaults_to_k2_6(self):
         kimi = LLM_PROVIDERS["kimi"]
 
@@ -116,6 +122,24 @@ class TestProviderSelection:
             assert aws.is_selected_by_env() is True
             assert aws.get_api_key() is None
             assert aws.has_real_api_key() is False
+
+    def test_anthropic_base_url_is_passed_to_client(self):
+        env = {
+            "ANTHROPIC_API_KEY": "sk-ant-test",
+            "ANTHROPIC_BASE_URL": "https://resource.services.ai.azure.com/anthropic",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            anthropic = LLM_PROVIDERS["anthropic"]
+            assert anthropic.get_resolved_extra_args()["base_url"] == env["ANTHROPIC_BASE_URL"]
+
+    def test_anthropic_base_url_without_key_is_rejected(self):
+        with patch.dict(
+            os.environ,
+            {"ANTHROPIC_BASE_URL": "https://resource.services.ai.azure.com/anthropic"},
+            clear=True,
+        ):
+            with pytest.raises(LLMConfigError, match="requires ANTHROPIC_API_KEY"):
+                validate_api_key_provided()
 
 
 class TestLLMConfigKeyless:
@@ -560,13 +584,14 @@ class TestEnvironmentVariables:
 
 
 class TestTemperatureGating:
-    """temperature must be omitted for Anthropic models that reject sampling params (Opus 4.7+)."""
+    """temperature must be omitted for Anthropic models that reject sampling params."""
 
     @pytest.mark.parametrize(
         "model_name",
         [
             "claude-opus-4-7",
             "claude-opus-4-8",
+            "claude-sonnet-5",
             "claude-fable-5",
             "claude-mythos-5",
             "anthropic.claude-opus-4-8",  # Bedrock prefix

--- a/tests/agents/test_llm_config.py
+++ b/tests/agents/test_llm_config.py
@@ -123,23 +123,35 @@ class TestProviderSelection:
             assert aws.get_api_key() is None
             assert aws.has_real_api_key() is False
 
-    def test_anthropic_base_url_is_passed_to_client(self):
+    def test_anthropic_client_options_are_resolved(self):
         env = {
             "ANTHROPIC_API_KEY": "sk-ant-test",
             "ANTHROPIC_BASE_URL": "https://resource.services.ai.azure.com/anthropic",
         }
         with patch.dict(os.environ, env, clear=True):
             anthropic = LLM_PROVIDERS["anthropic"]
-            assert anthropic.get_resolved_extra_args()["base_url"] == env["ANTHROPIC_BASE_URL"]
+            extra_args = anthropic.get_resolved_extra_args()
+            assert extra_args["base_url"] == env["ANTHROPIC_BASE_URL"]
+            assert extra_args["thinking"] == {"type": "disabled"}
 
-    def test_anthropic_base_url_without_key_is_rejected(self):
-        with patch.dict(
-            os.environ,
-            {"ANTHROPIC_BASE_URL": "https://resource.services.ai.azure.com/anthropic"},
-            clear=True,
-        ):
+    def test_anthropic_base_url_requires_key_without_selecting_provider(self):
+        env = {"ANTHROPIC_BASE_URL": "https://resource.services.ai.azure.com/anthropic"}
+        with patch.dict(os.environ, env, clear=True):
+            assert LLM_PROVIDERS["anthropic"].is_selected_by_env() is False
             with pytest.raises(LLMConfigError, match="requires ANTHROPIC_API_KEY"):
                 validate_api_key_provided()
+
+    def test_anthropic_base_url_does_not_conflict_with_selected_provider(self):
+        env = {
+            "OPENAI_API_KEY": "sk-test",
+            "ANTHROPIC_BASE_URL": "https://resource.services.ai.azure.com/anthropic",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            validate_api_key_provided()
+
+    def test_native_provider_base_url_without_key_remains_valid(self):
+        with patch.dict(os.environ, {"DEEPSEEK_BASE_URL": "http://localhost:8000/v1"}, clear=True):
+            validate_api_key_provided()
 
 
 class TestLLMConfigKeyless:
@@ -591,6 +603,7 @@ class TestTemperatureGating:
         [
             "claude-opus-4-7",
             "claude-opus-4-8",
+            "claude-opus-5",
             "claude-sonnet-5",
             "claude-fable-5",
             "claude-mythos-5",

--- a/tests/test_user_config.py
+++ b/tests/test_user_config.py
@@ -2,6 +2,7 @@ import os
 
 from agents.llm_config import LLM_PROVIDERS
 from user_config import (
+    _PROVIDER_ENDPOINT_OVERRIDES,
     _PROVIDER_ENDPOINTS,
     _PROVIDER_SECRETS,
     CONFIG_TEMPLATE,
@@ -237,7 +238,7 @@ class TestProviderEnvContract:
                     f"'{config.api_key_env.lower()}' to _PROVIDER_SECRETS in user_config.py."
                 )
 
-    def test_secrets_are_secrets_and_endpoints_are_endpoints(self):
+    def test_provider_setting_buckets_are_consistent(self):
         # The bucket names are the documentation - keep them honest.
         key_envs = {c.api_key_env for c in LLM_PROVIDERS.values() if c.api_key_env}
         # Credentials consumed by the SDK itself rather than passed as a kwarg
@@ -252,9 +253,14 @@ class TestProviderEnvContract:
         assert (
             not stray_endpoints
         ), f"_PROVIDER_ENDPOINTS entries that are not non-secret selection vars: {sorted(stray_endpoints)}"
+        selecting_overrides = set(_PROVIDER_ENDPOINT_OVERRIDES.values()) & selection_envs
+        assert not selecting_overrides, (
+            "_PROVIDER_ENDPOINT_OVERRIDES entries must not select providers: " f"{sorted(selecting_overrides)}"
+        )
 
     def test_entries_are_discoverable_and_loadable(self):
-        for key, env in (_PROVIDER_SECRETS | _PROVIDER_ENDPOINTS).items():
+        provider_settings = _PROVIDER_SECRETS | _PROVIDER_ENDPOINTS | _PROVIDER_ENDPOINT_OVERRIDES
+        for key, env in provider_settings.items():
             assert key == env.lower(), f"config key '{key}' must be the lowercase of '{env}'"
             assert (
                 key in ProviderUserConfig.__dataclass_fields__

--- a/tests/test_user_config.py
+++ b/tests/test_user_config.py
@@ -101,6 +101,22 @@ class TestUserConfigApplyToEnv:
             os.environ.clear()
             os.environ.update(original)
 
+    def test_injects_anthropic_base_url(self):
+        cfg = UserConfig(
+            provider=ProviderUserConfig(anthropic_base_url="https://resource.services.ai.azure.com/anthropic")
+        )
+
+        original = os.environ.copy()
+        try:
+            os.environ.pop("ANTHROPIC_BASE_URL", None)
+
+            cfg.apply_to_env()
+
+            assert os.environ["ANTHROPIC_BASE_URL"] == "https://resource.services.ai.azure.com/anthropic"
+        finally:
+            os.environ.clear()
+            os.environ.update(original)
+
     def test_injects_litellm_proxy_key_and_base_url(self):
         cfg = UserConfig(
             provider=ProviderUserConfig(
@@ -153,6 +169,18 @@ class TestLoadUserConfig:
         cfg = load_user_config(path)
 
         assert cfg.provider.openai_base_url is None
+
+    def test_loads_anthropic_base_url(self, tmp_path):
+        path = tmp_path / "config.toml"
+        path.write_text(
+            "[provider]\n"
+            'anthropic_api_key = "local"\n'
+            'anthropic_base_url = "https://resource.services.ai.azure.com/anthropic"\n'
+        )
+
+        cfg = load_user_config(path)
+
+        assert cfg.provider.anthropic_base_url == "https://resource.services.ai.azure.com/anthropic"
 
 
 class TestEnsureConfigTemplate:

--- a/user_config.py
+++ b/user_config.py
@@ -44,6 +44,7 @@ _PROVIDER_SECRETS: dict[str, str] = {
 # Defaulted base URLs (vercel, deepseek, glm, kimi) are shell-override-only on purpose.
 _PROVIDER_ENDPOINTS: dict[str, str] = {
     "openai_base_url": "OPENAI_BASE_URL",
+    "anthropic_base_url": "ANTHROPIC_BASE_URL",
     "ollama_base_url": "OLLAMA_BASE_URL",
     "litellm_base_url": "LITELLM_BASE_URL",
 }
@@ -63,6 +64,7 @@ CONFIG_TEMPLATE = """\
 # openai_api_key            = "sk-..."
 # openai_base_url           = "http://localhost:8000/v1"   # self-hosted / OpenAI-compatible proxy
 # anthropic_api_key         = "sk-ant-..."
+# anthropic_base_url        = "https://resource.services.ai.azure.com/anthropic"
 # google_api_key            = "AIza..."
 # vercel_api_key            = "vck_..."
 # aws_bearer_token_bedrock  = "..."
@@ -93,6 +95,7 @@ class ProviderUserConfig:
     openai_api_key: str | None = None
     openai_base_url: str | None = None
     anthropic_api_key: str | None = None
+    anthropic_base_url: str | None = None
     google_api_key: str | None = None
     vercel_api_key: str | None = None
     aws_bearer_token_bedrock: str | None = None
@@ -144,6 +147,7 @@ def load_user_config(path: Path = CONFIG_PATH) -> UserConfig:
             openai_api_key=provider_data.get("openai_api_key") or None,
             openai_base_url=provider_data.get("openai_base_url") or None,
             anthropic_api_key=provider_data.get("anthropic_api_key") or None,
+            anthropic_base_url=provider_data.get("anthropic_base_url") or None,
             google_api_key=provider_data.get("google_api_key") or None,
             vercel_api_key=provider_data.get("vercel_api_key") or None,
             aws_bearer_token_bedrock=provider_data.get("aws_bearer_token_bedrock") or None,

--- a/user_config.py
+++ b/user_config.py
@@ -18,7 +18,7 @@ from utils import CODEBOARDING_DIR_NAME
 
 CONFIG_PATH = Path.home() / CODEBOARDING_DIR_NAME / "config.toml"
 
-# Both dicts feed config.toml's [provider] table; values are injected into
+# These mappings feed config.toml's [provider] table; values are injected into
 # os.environ at startup. Provider selection itself is decided solely by
 # LLMConfig.selection_envs in agents/llm_config.py — membership here only
 # controls what can live in config.toml (contract-tested in tests/test_user_config.py).
@@ -44,12 +44,16 @@ _PROVIDER_SECRETS: dict[str, str] = {
 # Defaulted base URLs (vercel, deepseek, glm, kimi) are shell-override-only on purpose.
 _PROVIDER_ENDPOINTS: dict[str, str] = {
     "openai_base_url": "OPENAI_BASE_URL",
-    "anthropic_base_url": "ANTHROPIC_BASE_URL",
     "ollama_base_url": "OLLAMA_BASE_URL",
     "litellm_base_url": "LITELLM_BASE_URL",
 }
 
-_PROVIDER_KEY_TO_ENV: dict[str, str] = _PROVIDER_SECRETS | _PROVIDER_ENDPOINTS
+# Optional endpoints forwarded after another setting selects the provider.
+_PROVIDER_ENDPOINT_OVERRIDES: dict[str, str] = {
+    "anthropic_base_url": "ANTHROPIC_BASE_URL",
+}
+
+_PROVIDER_KEY_TO_ENV: dict[str, str] = _PROVIDER_SECRETS | _PROVIDER_ENDPOINTS | _PROVIDER_ENDPOINT_OVERRIDES
 
 # Template written to ~/.codeboarding/config.toml on first install.
 CONFIG_TEMPLATE = """\


### PR DESCRIPTION
## Summary
- support custom Anthropic-compatible Messages API endpoints through `ANTHROPIC_BASE_URL` / `anthropic_base_url`
- require an Anthropic API key when selecting Anthropic through a custom base URL
- update the default Anthropic agent model to Claude Sonnet 5 and omit unsupported sampling parameters
- document Azure Foundry configuration and add provider/config regression coverage

## Testing
- `uv run pytest tests/agents/test_llm_config.py tests/test_user_config.py` (148 passed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring custom Anthropic-compatible endpoints, including Azure AI/Foundry deployments.
  * Added `anthropic_base_url` to configuration files, environment settings, and TOML examples.
  * Updated Anthropic configuration guidance to use canonical model IDs, such as `claude-sonnet-5`.

* **Bug Fixes**
  * Improved endpoint validation and API key handling.
  * Improved compatibility for Anthropic models that do not support sampling parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->