### PR TITLE
Wait for JDTLS symbol indexing before Java analysis

### DIFF
--- a/static_analyzer/__init__.py
+++ b/static_analyzer/__init__.py
@@ -14,7 +14,7 @@ from static_analyzer.cfg import CallGraph
 from static_analyzer.config import AdapterName, Language
 from static_analyzer.csharp_config_scanner import CSharpConfigScanner
 from static_analyzer.engine.adapters import get_adapter
-from static_analyzer.engine.call_graph_builder import CallGraphBuilder
+from static_analyzer.engine.call_graph_builder import CallGraphBuilder, SymbolIndexTimeoutError
 from static_analyzer.engine.language_adapter import LanguageAdapter
 from static_analyzer.engine.lsp_client import LSPClient
 from static_analyzer.engine.lsp_recycler import default_memory_budget, per_engine_memory_budget
@@ -1048,7 +1048,10 @@ class StaticAnalyzer:
             project_path,
             memory_budget_bytes=per_engine_memory_budget(max(max_concurrent_engines(), 1)),
         )
-        engine_result = builder.build(source_files)
+        try:
+            engine_result = builder.build(source_files)
+        except SymbolIndexTimeoutError as exc:
+            raise StaticAnalysisFatalError(str(exc)) from exc
         logger.info(f"CallGraphBuilder.build() for {adapter.language}: {time.monotonic() - t_build_start:.1f}s")
         if adapter.fail_on_empty_symbols is True and not builder.symbol_table.symbols:
             raise StaticAnalysisFatalError(

--- a/static_analyzer/engine/adapters/java_adapter.py
+++ b/static_analyzer/engine/adapters/java_adapter.py
@@ -33,6 +33,21 @@ class JavaAdapter(LanguageAdapter):
         return True
 
     @property
+    def sync_probe_requires_symbols(self) -> bool:
+        """JDTLS can emit ServiceReady before its symbol index is usable."""
+        return True
+
+    def select_sync_probe_files(self, source_files: list[Path]) -> list[Path]:
+        """Probe Java type sources rather than package or module descriptors."""
+        metadata_names = {"module-info.java", "package-info.java"}
+        candidates = [path for path in source_files if path.name not in metadata_names]
+        return candidates or source_files[:1]
+
+    @property
+    def fail_on_empty_symbols(self) -> bool:
+        return True
+
+    @property
     def language(self) -> str:
         return "Java"
 

--- a/static_analyzer/engine/call_graph_builder.py
+++ b/static_analyzer/engine/call_graph_builder.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import math
 import time
 from pathlib import Path
 
@@ -19,6 +20,10 @@ from static_analyzer.engine.source_inspector import SourceInspector
 from static_analyzer.engine.symbol_table import SymbolTable
 
 logger = logging.getLogger(__name__)
+
+
+class SymbolIndexTimeoutError(TimeoutError):
+    """Raised when an LSP never exposes a usable symbol index."""
 
 
 class CallGraphBuilder:
@@ -167,23 +172,23 @@ class CallGraphBuilder:
         # request backpressure while creating overlays, so they interleave
         # each didOpen notification with the matching documentSymbol request.
         if self._adapter.probe_before_open or interleave_open:
-            probe_result = self._send_sync_probe(source_files, probe_timeout)
+            probe_file, probe_result = self._send_sync_probe(source_files, probe_timeout)
             if not interleave_open:
                 self._bulk_did_open(source_files)
         else:
             self._bulk_did_open(source_files)
-            probe_result = self._send_sync_probe(source_files, probe_timeout)
+            probe_file, probe_result = self._send_sync_probe(source_files, probe_timeout)
 
         # Phase 1: extract symbols from each file
         pbar = ProgressLogger("Phase 1 (symbols)", total, unit="file")
-        for idx, file_path in enumerate(source_files, 1):
+        for file_path in source_files:
             if interleave_open:
                 self._lsp.did_open(file_path)
-            # Reuse the sync probe result for the first file to avoid a
+            # Reuse the sync probe result for its source file to avoid a
             # redundant document_symbol query (the probe can take minutes).
             # Interleaved adapters deliberately query again after didOpen so
             # that each overlay notification has a response barrier.
-            should_reuse_probe = idx == 1 and not interleave_open
+            should_reuse_probe = file_path == probe_file and not interleave_open
             if should_reuse_probe:
                 symbols = probe_result
             elif interleave_open:
@@ -213,19 +218,46 @@ class CallGraphBuilder:
         pbar.finish()
         logger.info("did_open %d files: %.1fs", total, time.monotonic() - t_open_start)
 
-    def _send_sync_probe(self, source_files: list[Path], probe_timeout: int) -> list[dict]:
+    def _send_sync_probe(self, source_files: list[Path], probe_timeout: int) -> tuple[Path | None, list[dict]]:
         """Send a documentSymbol probe to wait for the LSP server to finish indexing."""
         probe_result: list[dict] = []
         logger.info("Waiting for LSP server indexing (timeout=%ds)...", probe_timeout)
         t_probe = time.monotonic()
-        if source_files:
-            probe_result = self._lsp.document_symbol(source_files[0], timeout=probe_timeout)
+        probe_files = self._adapter.select_sync_probe_files(source_files) if source_files else []
+        probe_file: Path | None = None
+        deadline = t_probe + probe_timeout
+        attempts = 0
+        while probe_files:
+            probe_file = probe_files[attempts % len(probe_files)]
+            remaining = max(1, math.ceil(deadline - time.monotonic()))
+            try:
+                probe_result = self._lsp.document_symbol(probe_file, timeout=remaining)
+            except TimeoutError as exc:
+                if not self._adapter.sync_probe_requires_symbols:
+                    raise
+                raise SymbolIndexTimeoutError(
+                    f"{self._adapter.language} symbol index did not become usable within {probe_timeout}s while "
+                    f"probing {probe_file}; not caching empty analysis."
+                ) from exc
+            attempts += 1
+            if probe_result or not self._adapter.sync_probe_requires_symbols:
+                break
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise SymbolIndexTimeoutError(
+                    f"{self._adapter.language} symbol index did not become usable within {probe_timeout}s while "
+                    f"probing {probe_file}; not caching empty analysis."
+                )
+            if attempts == 1:
+                logger.info("Sync probe returned no symbols; waiting for the LSP index to become usable...")
+            time.sleep(min(1.0, remaining))
         logger.info(
-            "Sync probe: %.1fs (%d symbols)",
+            "Sync probe: %.1fs (%d symbols, %d attempt(s))",
             time.monotonic() - t_probe,
             len(probe_result) if probe_result else 0,
+            attempts,
         )
-        return probe_result
+        return probe_file, probe_result
 
     def _warmup_references(self, source_files: list[Path]) -> None:
         """Trigger the LSP server's cross-reference index build.

--- a/static_analyzer/engine/language_adapter.py
+++ b/static_analyzer/engine/language_adapter.py
@@ -201,6 +201,15 @@ class LanguageAdapter(ABC):
         return False
 
     @property
+    def sync_probe_requires_symbols(self) -> bool:
+        """If True, an empty document-symbol probe does not prove indexing is complete."""
+        return False
+
+    def select_sync_probe_files(self, source_files: list[Path]) -> list[Path]:
+        """Select source documents that can verify the LSP index is usable."""
+        return source_files[:1]
+
+    @property
     def workspace_owns_documents(self) -> bool:
         """If True, the server reads documents from the project, not from our didOpen.
 

--- a/tests/static_analyzer/test_call_graph_builder.py
+++ b/tests/static_analyzer/test_call_graph_builder.py
@@ -3,8 +3,11 @@
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from static_analyzer.config import Language, NodeType
-from static_analyzer.engine.call_graph_builder import CallGraphBuilder
+from static_analyzer.engine.adapters.java_adapter import JavaAdapter
+from static_analyzer.engine.call_graph_builder import CallGraphBuilder, SymbolIndexTimeoutError
 from static_analyzer.engine.edge_builder import EdgeMap, build_edges_via_references
 from static_analyzer.engine.language_adapter import LanguageAdapter
 from static_analyzer.engine.lsp_constants import DID_OPEN_BATCH_SIZE
@@ -54,6 +57,8 @@ def _make_adapter() -> MagicMock:
     adapter.get_probe_timeout_minimum.return_value = 0
     adapter.probe_before_open = False
     adapter.interleave_did_open_with_symbols = False
+    adapter.sync_probe_requires_symbols = False
+    adapter.select_sync_probe_files.side_effect = lambda files: files[:1]
     return adapter
 
 
@@ -117,6 +122,50 @@ class TestDiscoverSymbols:
         # document_symbol is called once for the probe, and the probe result is reused
         # for the first file, so no second call
         assert lsp.document_symbol.call_count == 1
+
+    @patch("static_analyzer.engine.call_graph_builder.time.sleep")
+    def test_retries_when_service_ready_precedes_symbols(self, mock_sleep):
+        lsp = _make_lsp()
+        adapter = _make_adapter()
+        adapter.sync_probe_requires_symbols = True
+        builder = CallGraphBuilder(lsp, adapter, Path("/project"))
+        symbols = [
+            {
+                "name": "Main",
+                "kind": NodeType.CLASS,
+                "range": {"start": {"line": 0, "character": 0}, "end": {"line": 2, "character": 1}},
+                "selectionRange": {"start": {"line": 0, "character": 6}, "end": {"line": 0, "character": 10}},
+            }
+        ]
+        lsp.document_symbol.side_effect = [[], symbols]
+
+        builder._discover_symbols([Path("/project/Main.java")])
+
+        assert lsp.document_symbol.call_count == 2
+        mock_sleep.assert_any_call(1.0)
+        assert builder.symbol_table.symbols
+
+    def test_permanently_empty_required_probe_times_out(self):
+        lsp = _make_lsp()
+        adapter = _make_adapter()
+        adapter.language = "Java"
+        adapter.sync_probe_requires_symbols = True
+        builder = CallGraphBuilder(lsp, adapter, Path("/project"))
+
+        with patch("static_analyzer.engine.call_graph_builder.time.monotonic", side_effect=[0.0, 0.0, 1.0]):
+            with pytest.raises(SymbolIndexTimeoutError, match="Java symbol index did not become usable"):
+                builder._send_sync_probe([Path("/project/Main.java")], probe_timeout=1)
+
+        lsp.document_symbol.assert_called_once()
+
+    def test_java_probe_uses_type_source_and_rejects_empty_analysis(self):
+        adapter = JavaAdapter()
+        package_info = Path("/project/src/package-info.java")
+        main = Path("/project/src/Main.java")
+
+        assert adapter.select_sync_probe_files([package_info, main]) == [main]
+        assert adapter.sync_probe_requires_symbols is True
+        assert adapter.fail_on_empty_symbols is True
 
     def test_empty_source_files(self):
         lsp = _make_lsp()

--- a/tests/static_analyzer/test_static_analyzer_start_clients.py
+++ b/tests/static_analyzer/test_static_analyzer_start_clients.py
@@ -15,6 +15,7 @@ import pytest
 from static_analyzer import EngineConfig, StaticAnalysisFatalError, StaticAnalyzer
 from static_analyzer.analysis_result import StaticAnalysisResults
 from static_analyzer.config import Language
+from static_analyzer.engine.call_graph_builder import SymbolIndexTimeoutError
 from static_analyzer.engine.language_adapter import LanguageAdapter
 
 
@@ -165,6 +166,17 @@ class TestStartClientsGracefulDegradation:
         results.add_source_files(Language.PYTHON, [str(tmp_path / "app.py")])
 
         analyzer._validate_analysis_results(results)
+
+    def test_symbol_index_timeout_is_fatal(self, analyzer: StaticAnalyzer, tmp_path: Path) -> None:
+        java_adapter = _make_adapter("Java", language_enum=Language.JAVA, fail_on_empty_symbols=True)
+        source_file = tmp_path / "Main.java"
+        source_file.write_text("class Main {}")
+        config = EngineConfig(java_adapter, tmp_path, source_files=[source_file])
+
+        with patch("static_analyzer.CallGraphBuilder") as builder_cls:
+            builder_cls.return_value.build.side_effect = SymbolIndexTimeoutError("Java symbol index unavailable")
+            with pytest.raises(StaticAnalysisFatalError, match="Java symbol index unavailable"):
+                analyzer._run_full_analysis(config, MagicMock())
 
     def test_all_success_records_no_failures(self, analyzer: StaticAnalyzer, tmp_path: Path) -> None:
         py_adapter = _make_adapter("Python")


### PR DESCRIPTION
## Summary

- require Java's synchronization probe to return symbols before analysis begins
- retry empty JDTLS responses across real Java source documents within the existing bounded indexing timeout
- reject and avoid caching a non-empty Java project that produces zero symbols
- cover early `ServiceReady`, permanent empty-index timeout, fatal propagation, and Java probe selection

Split from #521 so the DeepSeek default update can merge independently.

## Root cause

JDTLS can emit `ServiceReady` before its symbol index is usable. The synchronization barrier treated an immediate empty `documentSymbol` response as success, then phase one queried every source file too early. Java also had not enabled the existing zero-symbol guard, allowing a plausible-looking empty result to be cached.

## Verification

- targeted static-analyzer unit tests — 38 passed
- private Java integration marker — 16 passed, 1 expected xfail
- Mockito fixture — 3,668 references, 3,147 graph nodes, 5,516 edges across 489 files
- full suite — 2,227 passed, 28 skipped, 83.80% coverage
- `mypy .` — no issues in 339 source files
- `black .` — 339 files unchanged

Closes #523


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Java analysis reliability by waiting for symbol indexes to become available before proceeding.
  * Added retries and better source-file selection when language services report readiness prematurely.
  * Analysis now fails clearly when required symbols remain unavailable, preserving the underlying error details.

* **Tests**
  * Added coverage for symbol-index readiness, retry behavior, timeout handling, and Java probe selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->