### PR TITLE
fix(incremental): credit a call site to its innermost owner

### DIFF
--- a/static_analyzer/incremental_orchestrator.py
+++ b/static_analyzer/incremental_orchestrator.py
@@ -183,7 +183,7 @@ def _restore_cross_boundary_edges(
                 refs = []
             references_cache[dst_name] = refs
 
-        call_sites = _edge_reference_call_sites(src_node, dst_node, refs, adapter, source_inspector)
+        call_sites = _edge_reference_call_sites(call_graph, src_node, dst_node, refs, adapter, source_inspector)
         if call_sites:
             try:
                 call_graph.add_edge(src_name, dst_name, call_sites=call_sites)
@@ -282,12 +282,21 @@ def _restore_inbound_edges_via_definitions(
 
 
 def _edge_reference_call_sites(
+    call_graph: CallGraph,
     src_node: Node,
     dst_node: Node,
     refs: list[dict],
     adapter: LanguageAdapter,
     source_inspector: SourceInspector,
 ) -> list[dict[str, str | int]]:
+    """Call sites in ``src_node`` that this reference list credits to the edge.
+
+    Why innermost and not containment: a nested closure sits inside its enclosing
+    function's range, so a plain range test hands the child's calls to the parent
+    as well. The full rebuild credits the innermost containing symbol only, and
+    this path has to agree or the cached edge comes back wider than the one a
+    full run would build.
+    """
     call_sites: list[dict[str, str | int]] = []
     for ref in refs:
         ref_file = uri_to_path(ref.get("uri", ""))
@@ -300,7 +309,7 @@ def _edge_reference_call_sites(
         ref_line = ref_start.get("line", -1)
         ref_char = ref_start.get("character", -1)
         ref_end_char = ref_end.get("character", -1)
-        if not _position_inside_node(src_node, ref_line, ref_char):
+        if _containing_source_node(call_graph, ref_file, ref_line, ref_char) is not src_node:
             continue
         if not _reference_matches_edge_kind(
             dst_node, ref_file, ref_line, ref_char, ref_end_char, adapter, source_inspector

--- a/tests/static_analyzer/test_analysis_cache_inmem.py
+++ b/tests/static_analyzer/test_analysis_cache_inmem.py
@@ -56,6 +56,60 @@ def _analysis_data(result: dict) -> AnalysisData:
     return AnalysisData.from_dict(result)
 
 
+def _nested_closure_graph() -> tuple[CallGraph, Node, Node, Node]:
+    """An unchanged caller holding a nested closure, plus the changed destination both call."""
+    caller_file = "/repo/caller.py"
+    target_file = "/repo/target.py"
+    outer = Node(
+        fully_qualified_name="caller.outer",
+        node_type=NodeType.FUNCTION,
+        file_path=caller_file,
+        line_start=1,
+        line_end=20,
+    )
+    inner = Node(
+        fully_qualified_name="caller.outer.inner",
+        node_type=NodeType.FUNCTION,
+        file_path=caller_file,
+        line_start=10,
+        line_end=13,
+        col_start=4,
+    )
+    target = Node(
+        fully_qualified_name="target.echo",
+        node_type=NodeType.FUNCTION,
+        file_path=target_file,
+        line_start=1,
+        line_end=2,
+    )
+    call_graph = CallGraph(language="python")
+    for node in (outer, inner, target):
+        call_graph.add_node(node)
+    return call_graph, outer, inner, target
+
+
+def _references_client(zero_based_lines: list[int]) -> MagicMock:
+    engine_client = MagicMock()
+    engine_client.references.return_value = [
+        {
+            "uri": Path("/repo/caller.py").as_uri(),
+            "range": {
+                "start": {"line": line, "character": 8},
+                "end": {"line": line, "character": 12},
+            },
+        }
+        for line in zero_based_lines
+    ]
+    return engine_client
+
+
+def _inbound_adapter() -> MagicMock:
+    adapter = MagicMock()
+    adapter.language_id = "python"
+    adapter.is_class_like.return_value = False
+    return adapter
+
+
 class TestInvalidateFiles(unittest.TestCase):
     def test_drops_nodes_from_changed_files(self) -> None:
         cg = CallGraph(language="python")
@@ -634,6 +688,40 @@ class TestWarmStartOutboundEdges(unittest.TestCase):
                 call_graph.edges[0].call_sites,
                 [{"file": str(changed_file), "line": 2, "column": 12}],
             )
+
+    def test_nested_closure_call_sites_are_not_credited_to_the_enclosing_function(self) -> None:
+        call_graph, outer, inner, target = _nested_closure_graph()
+
+        _restore_cross_boundary_edges(
+            call_graph,
+            [
+                (outer.fully_qualified_name, target.fully_qualified_name, outer, target, []),
+                (inner.fully_qualified_name, target.fully_qualified_name, inner, target, []),
+            ],
+            {target.file_path},
+            _inbound_adapter(),
+            _references_client([10, 15]),
+            SourceInspector(),
+        )
+
+        self.assertEqual(
+            {edge.get_source(): [site["line"] for site in edge.call_sites] for edge in call_graph.edges},
+            {"caller.outer": [16], "caller.outer.inner": [11]},
+        )
+
+    def test_enclosing_function_edge_is_dropped_when_only_the_closure_calls_the_destination(self) -> None:
+        call_graph, outer, _inner, target = _nested_closure_graph()
+
+        _restore_cross_boundary_edges(
+            call_graph,
+            [(outer.fully_qualified_name, target.fully_qualified_name, outer, target, [])],
+            {target.file_path},
+            _inbound_adapter(),
+            _references_client([10]),
+            SourceInspector(),
+        )
+
+        self.assertEqual(call_graph.edges, [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## The defect

In the incremental inbound restore path, a call site was credited to **any** node whose line range contained it. A nested closure sits inside its enclosing function's range, so the parent claimed the child's calls as well — and the child kept them, so the same site was counted twice under two symbols.

Caught in the eval corpus, `incremental/luna-main/referenced-symbol-deleted`:

```
src.click.termui.prompt -> src.click.utils.echo
  base (full run):        178, 180, 191            (correct)
  head (incremental):     140, 149, 178, 180, 191  (+2)

src.click.termui.prompt.prompt_func -> src.click.utils.echo
  base and head:          140, 149                 (unchanged — still owns them)
```

`prompt` spans termui.py 82-191; `prompt_func` spans 135-150. All four endpoint methods are byte-identical between base and head, and the commit touches neither `termui.py` nor the bodies involved — the edge came back wider purely from re-derivation.

## Why the full path is unaffected

`edge_builder.py:265` resolves through `SymbolTable.find_containing_symbol`, which scores every containing symbol by span size and keeps the smallest, then rolls up only unnameable symbols. The incremental path has no symbol table, so `_edge_reference_call_sites` used a bare `_position_inside_node` containment test.

`_containing_source_node` already performs the innermost lookup, and the **outbound** incremental path already calls it. This points the inbound path at the same helper rather than adding a second implementation. `_position_inside_node` stays — it is still used by `_most_specific_node_at_position`.

## Measured impact

Replayed both versions over the 8,215 CFG edges in the eval corpus's 8 committed `luna-main` pickles:

| outcome | edges |
|---|---:|
| identical | 8,183 |
| narrowed by this change | **32** |
| widened | **0** |
| emptied (a delete) | **0** |
| disjoint | **0** |

**All 71 removed call sites are re-attributed**, not lost: for each one there is another edge in the same graph whose source is the innermost node and whose destination is identical, and it keeps the site. Shapes are nested closures and decorators — `prompt`→`prompt_func`, `Command`→`Command.__call__`, `Context`→`Context.forward`, `trace`→`trace.decorator`.

Of the 32, **23 are Python and real**; 9 are serilog and hypothetical — C# short-circuits to `_restore_inbound_edges_via_definitions` at `incremental_orchestrator.py:146` and never reaches this function.

A per-site differential against the shipped guard over all 9,701 recorded call sites: 9,233 accepted by both, 468 rejected by both, and **0 that the shipped guard accepts and this one rejects**. No regression.

Rendered impact across the 32 committed incremental documents: 2 call sites on 1 edge.

## Relationship to #505

#505 established that CFG-backed edges must always come from the fresh rebuild, and removed the two helpers that were rewriting structure in the preservation layer. This change is in `static_analyzer/`, reinstates no baseline copy-forward, and makes the fresh rebuild agree with what a full run produces — it serves that contract rather than reversing it.

The one thing worth checking in review: `_restore_cross_boundary_edges` only calls `add_edge` when the site list is non-empty, so a stricter guard could in principle turn a narrowing into a silent delete. Measured at 0 emptied edges above.

## Tests

Two regression tests in `tests/static_analyzer/test_analysis_cache_inmem.py`: a nested closure's sites are not credited to its parent, and the parent's edge is dropped rather than confirmed when only the child's sites remain. Both RED at `81fc8941`, green here. No LSP, ~1.3s.

Suite: `3 failed, 2222 passed, 28 skipped` against baseline's `3 failed, 2220 passed` — the same three pre-existing `test_cli_parser` failures (a macOS `/private/tmp` symlink artifact). mypy and black clean.

## Open review points

1. **`is not src_node` is an identity comparison.** It holds today — `_most_specific_node_at_position` returns objects out of `call_graph.nodes` and there are no duplicate-span node groups across 5,955 nodes — but the failure mode is silent: if `.nodes` ever yields copies, every restored edge vanishes with no log line. Comparing `fully_qualified_name` is equally cheap and fails loudly. Left as-is so the measurements above describe exactly this diff; happy to change it.
2. **Two asymmetries with the full path remain, both pre-existing and neither introduced here.** There is no `attribution_symbol` roll-up for anonymous/promoted symbols (TS/JS-shaped; the eval corpus has no TS or JS subject, so it is unmeasurable here), and no decorator-line heuristic — the full path re-attributes a reference 1-4 lines above a method to that method, and the incremental path does not. The latter accounts for 468 call sites / 465 edges the full run records and the incremental restore cannot recover **under either version of this guard**. Worth its own ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for references inside nested closures.
  * Ensured references are attributed to the innermost applicable function, matching full analysis behavior.
  * Corrected stale enclosing-function references when only a nested closure calls the destination.

* **Tests**
  * Added coverage for restoring cross-boundary call relationships involving nested closures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->