### PR TITLE
fix(relations): gate sub-scope edges on frontier-wide ownership

### DIFF
--- a/agents/relation_edges.py
+++ b/agents/relation_edges.py
@@ -141,6 +141,40 @@ def edge_crosses_components(
     return True
 
 
+def drop_misattributed_edges(
+    relations: list[Relation],
+    owner_of: Callable[[SourceCodeReference], str],
+) -> list[Relation]:
+    """Drop edges whose owning component contradicts the relation's declared pair.
+
+    Why: the per-scope ownership index sees only that scope's own components, so an
+    out-of-scope endpoint resolves to nothing and the edge survives its own gate. A
+    frontier-wide owner map resolves it and rejects the mismatch. A relation stripped of
+    every edge is kept: it still stands on its evidence prose, the ordinary shape of an
+    inferred relation.
+    """
+    filtered: list[Relation] = []
+    for relation in relations:
+        all_edges = [
+            edge
+            for edge in relation.all_edges
+            if edge_crosses_components(edge, owner_of, relation.src_id, relation.dst_id)
+        ]
+        if len(all_edges) == len(relation.all_edges):
+            filtered.append(relation)
+            continue
+        surviving = {edge.identity() for edge in all_edges}
+        filtered.append(
+            relation.model_copy(
+                update={
+                    "all_edges": all_edges,
+                    "key_edges": [edge for edge in relation.key_edges if edge.identity() in surviving],
+                }
+            )
+        )
+    return filtered
+
+
 def prune_ungrounded_edges(
     relations: list[Relation],
     owner_of: Callable[[SourceCodeReference], str],

--- a/diagram_analysis/diagram_generator.py
+++ b/diagram_analysis/diagram_generator.py
@@ -36,7 +36,12 @@ from agents.llm_config import initialize_llms
 from agents.llm_errors import LLMAuthError
 from agents.meta_agent import MetaAgent
 from agents.planner_agent import get_expandable_components
-from agents.relation_edges import index_relation_endpoints, preserve_unchanged_relations, prune_ungrounded_edges
+from agents.relation_edges import (
+    drop_misattributed_edges,
+    index_relation_endpoints,
+    preserve_unchanged_relations,
+    prune_ungrounded_edges,
+)
 from agents.scope_ids import ROOT_SCOPE_ID
 from agents.content_hash import SourceCache, hash_repo_source_files, tree_hash_from_file_hashes
 from diagram_analysis.analysis_json import (
@@ -1252,12 +1257,16 @@ class DiagramGenerator:
 
         Walks the full CFG with a global node->deepest-component-id map so we
         catch edges like ``1.1.1 -> 2.1.2`` that per-level analysis cannot see.
-        Mutates ``root_analysis.components_relations`` in place.
+        Mutates ``root_analysis.components_relations`` in place, and applies the same
+        frontier-wide ownership gate to every sub-scope's relations.
         """
         if not self.static_analysis:
             return []
         cfg_graphs = {str(lang): self.static_analysis.get_cfg(lang) for lang in self.static_analysis.get_languages()}
         global_relations = build_global_relations(root_analysis, sub_analyses, cfg_graphs)
+        ownership = ComponentOwnershipIndex.from_node_owners(
+            build_global_node_to_component_map(root_analysis, sub_analyses)
+        )
         if self._baseline_global_relations is not None:
             # Incremental: the wholesale rebuild would relabel edges between two untouched
             # components, so carry those over verbatim from the baseline.
@@ -1290,9 +1299,6 @@ class DiagramGenerator:
             )
             # Same reason as the per-scope path: preservation re-injects baseline edges after
             # the grounding filters ran, so the assembled list is filtered once more.
-            ownership = ComponentOwnershipIndex.from_node_owners(
-                build_global_node_to_component_map(root_analysis, sub_analyses)
-            )
             global_relations = prune_ungrounded_edges(
                 global_relations,
                 ownership.owner_of,
@@ -1300,6 +1306,10 @@ class DiagramGenerator:
                 self._changed_members,
             )
         root_analysis.components_relations = global_relations
+        for sub_analysis in sub_analyses.values():
+            sub_analysis.components_relations = drop_misattributed_edges(
+                sub_analysis.components_relations, ownership.owner_of
+            )
         return global_relations
 
     def finalize_for_save(

--- a/tests/diagram_analysis/test_diagram_analysis.py
+++ b/tests/diagram_analysis/test_diagram_analysis.py
@@ -2355,5 +2355,111 @@ class TestDiagramGenerator(unittest.TestCase):
         self.assertIsNot(mock_absorb.call_args.args[2][0], live_cache)
 
 
+class TestSubScopeRelationsAreGloballyGated(unittest.TestCase):
+    """A sub-scope agent indexes only its own components, so an edge naming a symbol owned
+    elsewhere in the tree resolves to nothing there and survives. ``rebuild_global_relations``
+    runs at the complete expansion frontier with canonical endpoints, which is the only place
+    that owner is knowable."""
+
+    def _generator(self) -> DiagramGenerator:
+        gen = DiagramGenerator.__new__(DiagramGenerator)
+        gen.static_analysis = StaticAnalysisResults()
+        gen.static_analysis.add_cfg(Language.PYTHON, CallGraph(edges=[]))
+        gen.repo_location = Path(".")
+        gen._baseline_global_relations = None
+        return gen
+
+    def _tree(self) -> tuple[AnalysisInsights, dict[str, AnalysisInsights]]:
+        def component(component_id: str, qualified_name: str) -> Component:
+            return Component(
+                name=f"c{component_id}",
+                description="d",
+                key_entities=[],
+                component_id=component_id,
+                file_methods=[
+                    FileMethodGroup(
+                        file_path="src/a.py",
+                        methods=[
+                            MethodEntry(
+                                qualified_name=qualified_name,
+                                start_line=1,
+                                end_line=5,
+                                node_type="FUNCTION",
+                            )
+                        ],
+                    )
+                ],
+            )
+
+        root = AnalysisInsights(
+            description="d",
+            components=[component("1", "pkg.one"), component("2", "pkg.two")],
+            components_relations=[],
+        )
+        subs = {
+            "1": AnalysisInsights(
+                description="d",
+                components=[component("1.1", "pkg.one.a"), component("1.2", "pkg.one.b")],
+                components_relations=[],
+            ),
+            "2": AnalysisInsights(
+                description="d",
+                components=[component("2.1", "pkg.two.a")],
+                components_relations=[],
+            ),
+        }
+        return root, subs
+
+    def _relation(self, source: str, target: str) -> Relation:
+        edge = RelationEdge(
+            source=SourceCodeReference(qualified_name=source, reference_file="src/a.py"),
+            target=SourceCodeReference(qualified_name=target, reference_file="src/a.py"),
+        )
+        return Relation(
+            relation="calls",
+            src_name="A",
+            dst_name="B",
+            evidence="stated in prose too",
+            src_id="1.1",
+            dst_id="1.2",
+            key_edges=[edge],
+            all_edges=[edge],
+        )
+
+    def test_an_edge_owned_by_another_scope_is_dropped_from_a_sub_analysis(self):
+        gen = self._generator()
+        root, subs = self._tree()
+        subs["1"].components_relations = [self._relation("pkg.one.a", "pkg.two.a")]
+
+        gen.rebuild_global_relations(root, subs)
+
+        self.assertEqual(subs["1"].components_relations[0].all_edges, [])
+        self.assertEqual(subs["1"].components_relations[0].key_edges, [])
+
+    def test_the_stripped_relation_is_kept_on_its_evidence(self):
+        gen = self._generator()
+        root, subs = self._tree()
+        subs["1"].components_relations = [self._relation("pkg.one.a", "pkg.two.a")]
+
+        gen.rebuild_global_relations(root, subs)
+
+        self.assertEqual(
+            [(rel.src_id, rel.dst_id, rel.evidence) for rel in subs["1"].components_relations],
+            [("1.1", "1.2", "stated in prose too")],
+        )
+
+    def test_an_edge_that_does_connect_the_declared_pair_survives(self):
+        gen = self._generator()
+        root, subs = self._tree()
+        subs["1"].components_relations = [self._relation("pkg.one.a", "pkg.one.b")]
+
+        gen.rebuild_global_relations(root, subs)
+
+        self.assertEqual(
+            [edge.target.qualified_name for edge in subs["1"].components_relations[0].all_edges],
+            ["pkg.one.b"],
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/static_analyzer/test_cluster_relations.py
+++ b/tests/static_analyzer/test_cluster_relations.py
@@ -14,6 +14,7 @@ from agents.agent_responses import (
 from agents.component_ownership import ComponentOwnershipIndex
 from agents.file_index_models import FileMethodGroup, MethodEntry
 from agents.relation_edges import (
+    drop_misattributed_edges,
     drop_reverse_duplicates,
     edge_crosses_components,
     ground_relation_edges,
@@ -296,6 +297,69 @@ class TestGroundRelationEdges(unittest.TestCase):
         key_edges, all_edges = ground_relation_edges([], [dup, dup])
         self.assertEqual(len(all_edges), 1)
         self.assertEqual(key_edges, [])
+
+
+class TestDropMisattributedEdges(unittest.TestCase):
+    """A sub-scope agent indexes only its own scope, so an out-of-scope endpoint resolves to
+    nothing and its edge survives that scope's own gate. The frontier-wide owner map resolves
+    it and rejects the mismatch."""
+
+    NODES = {"pkg.a.caller": "1.1", "pkg.a.helper": "1.1", "pkg.b.callee": "1.2", "pkg.c.far": "3.4"}
+
+    def _relation(self, edges, evidence="", src_id="1.1", dst_id="1.2"):
+        return Relation(
+            relation="calls",
+            src_name="A",
+            dst_name="B",
+            src_id=src_id,
+            dst_id=dst_id,
+            evidence=evidence,
+            key_edges=list(edges),
+            all_edges=list(edges),
+        )
+
+    def _drop(self, relations):
+        return drop_misattributed_edges(relations, _owner_of(self.NODES))
+
+    def test_an_edge_owned_outside_the_declared_pair_is_dropped(self):
+        rel = self._relation([_make_relation_edge("pkg.a.caller", "pkg.c.far")])
+        self.assertEqual(self._drop([rel])[0].all_edges, [])
+
+    def test_a_dropped_edge_leaves_the_relation_standing_on_its_evidence(self):
+        # 33 of 42 inferred relations in the eval corpus already serialize with no edges, so
+        # an edgeless relation is ordinary output — the prose is the claim.
+        rel = self._relation([_make_relation_edge("pkg.a.caller", "pkg.c.far")], evidence="over the queue")
+        kept = self._drop([rel])
+        self.assertEqual([(r.src_id, r.dst_id, r.evidence) for r in kept], [("1.1", "1.2", "over the queue")])
+
+    def test_a_dropped_edge_is_dropped_from_key_edges_too(self):
+        rel = self._relation([_make_relation_edge("pkg.a.caller", "pkg.c.far")])
+        self.assertEqual(self._drop([rel])[0].key_edges, [])
+
+    def test_a_crossing_edge_survives(self):
+        rel = self._relation([_make_relation_edge("pkg.a.caller", "pkg.b.callee")])
+        kept = self._drop([rel])
+        self.assertEqual([e.target.qualified_name for e in kept[0].all_edges], ["pkg.b.callee"])
+        self.assertEqual(len(kept[0].key_edges), 1)
+
+    def test_an_edge_owned_by_a_descendant_of_the_declared_component_survives(self):
+        # The global map owns a symbol at the deepest expanded level; a relation declared one
+        # level up is still the connection that edge makes.
+        owner_of = _owner_of({"pkg.a.caller": "1.1.3", "pkg.b.callee": "1.2.1"})
+        rel = self._relation([_make_relation_edge("pkg.a.caller", "pkg.b.callee")])
+        self.assertEqual(len(drop_misattributed_edges([rel], owner_of)[0].all_edges), 1)
+
+    def test_an_endpoint_no_component_owns_is_left_alone(self):
+        # An external library call is legitimate evidence for a runtime relation.
+        rel = self._relation([_make_relation_edge("pkg.a.caller", "third_party.lib.send")])
+        self.assertEqual(len(self._drop([rel])[0].all_edges), 1)
+
+    def test_no_relation_is_ever_removed(self):
+        rels = [
+            self._relation([_make_relation_edge("pkg.a.caller", "pkg.c.far")]),
+            self._relation([], src_id="1.2", dst_id="1.1"),
+        ]
+        self.assertEqual([(r.src_id, r.dst_id) for r in self._drop(rels)], [("1.1", "1.2"), ("1.2", "1.1")])
 
 
 class TestPruneUngroundedEdges(unittest.TestCase):


### PR DESCRIPTION
## What ships today

A real relation from `click-before-get-strerror-removal`, scope 5:

> **"Command Construction and Terminal Launch Helpers" (5.3) → "Parser Usage Validation and Argument Error Model" (5.1)**
> *"Command metadata feeds parser configuration"*

Four code references are attached as its backing. Here is where those symbols actually live:

| cited backing edge | caller owned by | callee owned by |
|---|---|---|
| `decorators._make_command -> core.Command` | 5.3 ✓ | **2.2.2** ✗ |
| `decorators.option -> core.Option` | **1.3.3** ✗ | **1.3.2** ✗ |
| `decorators.argument -> core.Argument` | **1.3.3** ✗ | **1.1** ✗ |
| `core.Command -> parser.OptionParser` | **2.2.2** ✗ | 5.1 ✓ |

None connects the pair it is attached to; two have neither endpoint in either component. All four carry `call_sites: []`. A reader following that arrow to the code is sent to three other components.

## Why the existing gate misses it

`edge_crosses_components` (`agents/relation_edges.py:128-141`) is exactly the right predicate, and it already runs. The problem is the index it consults: inside a scope, `ComponentOwnershipIndex.from_analysis` (`agents/component_ownership.py:29-37`) is built from that scope's own components only. `owner_of` returns `""` for anything it cannot uniquely resolve, and the guard reads `if owner and component_id and not is_self_or_descendant(...)` — a falsy owner **keeps** the edge.

It is not a blanket no-op: the gate judges ~98.7% of non-root edges and abstains on 36 of 2708. But 15 of those 36 abstentions are these findings — an edge naming symbols from another subtree is precisely the case a scope-local index cannot see.

The correct map already exists. `build_global_relations` (`static_analyzer/cluster_relations.py:208-224`) applies the same predicate against `ComponentOwnershipIndex.from_node_owners(build_global_node_to_component_map(...))`, post-resolution and at the complete expansion frontier. It is applied only to `root_analysis.components_relations` — which is why **0 of the 17 findings are root-scope, in either eval tag**.

## The change

Two files, +49/−5.

**`agents/relation_edges.py`** — new `drop_misattributed_edges(relations, owner_of)`: per relation, keep the `all_edges` that pass the untouched `edge_crosses_components`, intersect `key_edges` against the survivors by `identity()`, and return the relation object unchanged when nothing was lost. No relation is ever removed and no edge is moved.

**`diagram_analysis/diagram_generator.py`** — `rebuild_global_relations` hoists the `ComponentOwnershipIndex.from_node_owners(...)` construction a few lines earlier so the existing incremental `prune_ungrounded_edges` call and this one share one map, then runs each `sub_analysis.components_relations` through the new filter. Root behaviour is byte-identical.

`edge_crosses_components` and `is_self_or_descendant` are untouched. Keeping the strict `is_self_or_descendant(owner, component_id)` predicate is deliberate — relaxing it to a symmetric path test is what would let internal-call-mislabelled edges through.

## Measured impact

Re-scored with the evals harness's own check code over the 16 committed full-run `analysis.json` (both `luna` tags):

| | before | after |
|---|---:|---:|
| `relations.edges_cross_declared_components` | **17** (15 main / 2 pre-refactor) | **0** |
| `relations.edge_endpoints_are_known_symbols` | 12 | 12 (untouched) |
| any other registered check going 0 → non-zero | — | none |
| edges removed | — | **17** |

The 17 removed are **exactly** the flagged set, document by document, 0/16 mismatched in either direction — out of 6,917 serialized `all_edges` entries.

Widened to all 48 documents including the 32 incremental base/head pairs:

- **59** edges dropped: **53 carry no call sites at all**, 6 have one.
- Of those 6: three are `CliRunner.invoke -> Command.main`, which survives correctly at root (`6.1 -> 2.1`, `is_static:true`) while only the duplicate sub-scope copy goes; three are `File.shell_complete -> CompletionItem` with **both endpoints owned by 4.1.2** — an internal call, which `drop_internal_self_relations` already excludes by design. **No information that belongs in a relation is lost.**
- **0** `is_static:true` relations left with zero edges, out of **1,281** static sub-scope relations. That is the pathology #505 fixed, and this does not reproduce it.
- Inferred relations left edgeless: 75 → 82 of 162. Relations left with neither edges nor prose: **0**, before and after.

All four in-repo output generators (`markdown`, `html`, `mdx`, `sphinx`) label an arrow from `rel.relation` and never read `all_edges`, so a stripped relation still renders.

## Relationship to #505

Not a reinstatement of `_filter_edges_touched_by_change`. That gated on `changed_members` — commit-diff membership, which #505 correctly said belongs to the diff layer. This gates on structural ownership, never consults `changed_members`, and runs on full analyses as well as incremental. It is closest to the `prune_ungrounded_edges` that already lives in this file and already uses `owner_of`.

The hollowing question is measured above: 0 of 1,281.

## Tests

10 new tests, 0 existing assertions changed:

- `test_cluster_relations.py` — the predicate itself: an edge owned outside the declared pair is dropped, one owned by a descendant survives, a crossing edge survives, an endpoint no component owns is left alone, key edges follow, a dropped edge leaves the relation standing on its evidence, and no relation is ever removed.
- `test_diagram_analysis.py` — the wiring: an edge owned by another scope is dropped from a sub-analysis, and the stripped relation is kept.

Suite: `3 failed, 2230 passed, 28 skipped` against baseline's `3 failed, 2220 passed` — the same three pre-existing `test_cli_parser` failures (a macOS `/private/tmp` symlink artifact). mypy and black clean.

## Review points

1. **Ordering.** The gate runs inside `rebuild_global_relations`, which `finalize_for_save` calls immediately before `absorb_single_child_components` — and absorption re-parents components and rewrites ids. Worth knowing: this is the **pre-existing** position, not a new one. The shipped code already builds this same index at this same point for `prune_ungrounded_edges`; this change only hoists the construction a few lines so both share it. The impact numbers above were derived from finished, post-absorption documents, so they describe the post-absorption id space rather than bit-for-bit the map the engine gates with. If a single-child absorption merges a declared endpoint with its child, an edge judged misattributed before the merge would be fine after it.
2. **Reach.** `owner_of` abstains on 21 of 5,416 sub-scope endpoints where a leaf name is ambiguous between two components; those edges are kept unjudged.
3. **Frontier-relative by construction.** If a component is expanded deeper in a later run and an edge's owner moves sideways into another subtree, that edge newly fails. Correct behaviour, surprising diff.
4. **Scope.** This fixes **misattribution**, not invention. Of the 17, six are pairs the model made up outright and eight are real relationships the call graph cannot currently see (`ArgumentClass(...)` construction through a class-object variable, `self.type(...)` dispatch through an attribute). This stops them pointing at the wrong component; it does not stop them being generated. The grounding-matcher rollup in `_qualified_names_match` and the two call-graph recall gaps are the follow-ups that address that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected relation diagrams to remove edges attributed to components outside the declared relationship.
  * Preserved relation evidence and declared component relationships even when all associated edges are removed.
  * Continued displaying valid crossing, descendant, and externally owned connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->