### PR TITLE
fix(relations): give the scope gate the whole hierarchy's ownership

### DIFF
--- a/agents/abstraction_agent.py
+++ b/agents/abstraction_agent.py
@@ -13,7 +13,7 @@ from agents.agent_responses import (
     MetaAnalysisInsights,
     assign_relation_ids,
 )
-from agents.component_ownership import group_ids_by_name
+from agents.component_ownership import ComponentOwnershipIndex, group_ids_by_name
 from agents.llm_renderers import (
     cluster_group_descriptions,
     cluster_group_ids,
@@ -58,10 +58,12 @@ class AbstractionAgent(StaticAnalysisEnricherMixin, CodeBoardingAgent):
         meta_context: MetaAnalysisInsights,
         agent_llm: BaseChatModel,
         parsing_llm: BaseChatModel,
+        component_ownership: ComponentOwnershipIndex,
     ):
         system_message = format_project_system_message(get_system_message(), project_name, meta_context)
         super().__init__(repo_dir, static_analysis, system_message, agent_llm, parsing_llm)
 
+        self.component_ownership = component_ownership
         self.project_name = project_name
         self.meta_context = meta_context
 

--- a/agents/component_ownership.py
+++ b/agents/component_ownership.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 from collections.abc import Collection
 from dataclasses import dataclass
 
-from agents.agent_responses import AnalysisInsights, Component, SourceCodeReference
+from agents.agent_responses import Component, SourceCodeReference
+from static_analyzer.clustering import ClusterScopeResult
 
 
 def group_ids_by_name(components: list[Component], valid_group_ids: Collection[str]) -> dict[str, str]:
@@ -26,15 +27,21 @@ class ComponentOwnershipIndex:
     candidates_by_leaf: dict[str, list[tuple[str, str]]]
 
     @classmethod
-    def from_analysis(cls, analysis: AnalysisInsights) -> ComponentOwnershipIndex:
-        candidates_by_leaf: dict[str, list[tuple[str, str]]] = {}
-        for component in analysis.components:
-            for file_methods in component.file_methods:
-                for method in file_methods.methods:
-                    candidates_by_leaf.setdefault(method.qualified_name.rsplit(".", 1)[-1], []).append(
-                        (method.qualified_name, component.component_id)
-                    )
-        return cls(candidates_by_leaf)
+    def from_clustering_hierarchy(cls, hierarchy: ClusterScopeResult) -> ComponentOwnershipIndex:
+        """Index every symbol at every depth against the deepest group that owns it.
+
+        Why: component IDs are group IDs, so the hierarchy already knows the owner of every
+        symbol in the repo, not only the ones in the scope an agent happens to be naming. A
+        symbol belongs to its leaf group and to every ancestor of it, so a flat union over
+        all depths would leave almost every symbol with several owners and blank out
+        ``owner_of``; the deepest group is the single answer, the same one
+        ``build_global_node_to_component_map`` gives for the expanded frontier.
+        """
+        owner_by_symbol: dict[str, str] = {}
+        for group_id, group in sorted(hierarchy.clustering_groups.items(), key=lambda item: item[0].count(".")):
+            for qualified_name in group.qualified_names:
+                owner_by_symbol[qualified_name] = group_id
+        return cls.from_node_owners(owner_by_symbol)
 
     @classmethod
     def from_node_owners(cls, node_owners: dict[str, str]) -> ComponentOwnershipIndex:

--- a/agents/details_agent.py
+++ b/agents/details_agent.py
@@ -14,7 +14,7 @@ from agents.agent_responses import (
     MetaAnalysisInsights,
     assign_relation_ids,
 )
-from agents.component_ownership import group_ids_by_name
+from agents.component_ownership import ComponentOwnershipIndex, group_ids_by_name
 from agents.prompts import (
     get_system_details_message,
     get_details_message,
@@ -58,9 +58,11 @@ class DetailsAgent(StaticAnalysisEnricherMixin, CodeBoardingAgent):
         meta_context: MetaAnalysisInsights,
         agent_llm: BaseChatModel,
         parsing_llm: BaseChatModel,
+        component_ownership: ComponentOwnershipIndex,
     ):
         system_message = format_project_system_message(get_system_details_message(), project_name, meta_context)
         super().__init__(repo_dir, static_analysis, system_message, agent_llm, parsing_llm)
+        self.component_ownership = component_ownership
         self.project_name = project_name
         self.meta_context = meta_context
 

--- a/agents/incremental_agent.py
+++ b/agents/incremental_agent.py
@@ -26,7 +26,7 @@ from agents.agent_responses import (
     assign_relation_ids,
     iter_components,
 )
-from agents.component_ownership import group_ids_by_name
+from agents.component_ownership import ComponentOwnershipIndex, group_ids_by_name
 from agents.content_hash import SourceCache
 from agents.file_index_models import FileMethodGroup, MethodEntry
 from agents.incremental_results import ScopeRelationContext, ScopeUpdateResult
@@ -63,12 +63,14 @@ class IncrementalAgent(StaticAnalysisEnricherMixin, CodeBoardingAgent):
         meta_context: MetaAnalysisInsights | None,
         agent_llm: BaseChatModel,
         parsing_llm: BaseChatModel,
+        component_ownership: ComponentOwnershipIndex,
         changes: ChangeSet | None = None,
     ):
         system_message = format_project_system_message(get_system_message(), project_name, meta_context)
         super().__init__(repo_dir, static_analysis, system_message, agent_llm, parsing_llm)
         if changes is not None:
             self.toolkit.context.changes = changes
+        self.component_ownership = component_ownership
         self.project_name = project_name
         self.meta_context = meta_context
         self.prompts = {
@@ -584,6 +586,7 @@ class IncrementalAgent(StaticAnalysisEnricherMixin, CodeBoardingAgent):
             meta_context=self.meta_context,
             agent_llm=self.agent_llm,
             parsing_llm=self.parsing_llm,
+            component_ownership=self.component_ownership,
             changes=self.toolkit.context.changes,
         )
 

--- a/agents/static_analysis_enricher_mixin.py
+++ b/agents/static_analysis_enricher_mixin.py
@@ -19,6 +19,7 @@ from agents.relation_edges import (
 from clustering_ids import CodeBoardingClusterIds
 from constants import DEFAULT_STATIC_RELATION_LABEL
 from diagram_analysis.file_index import build_file_methods_from_nodes, build_files_index
+from static_analyzer.analysis_result import StaticAnalysisResults
 from static_analyzer.cfg import Edge
 from static_analyzer.clustering import ClusterScopeResult, GroupConnection
 
@@ -29,6 +30,11 @@ class StaticAnalysisEnricherMixin:
     """Enrich LLM output from one authoritative clustering scope."""
 
     repo_dir: Path
+    static_analysis: StaticAnalysisResults
+    #: Symbol ownership for the WHOLE hierarchy, not just the scope being enriched: an
+    #: endpoint owned by a component in another branch of the tree can only be judged
+    #: against a map that covers that branch.
+    component_ownership: ComponentOwnershipIndex
 
     @staticmethod
     def assemble_one_component_per_group(
@@ -99,12 +105,10 @@ class StaticAnalysisEnricherMixin:
         total = sum(len(group.qualified_names) for group in scope.groups)
         logger.info("Component symbol coverage: %d/%d assigned", assigned, total)
 
-    @staticmethod
-    def merge_scope_relations(analysis: AnalysisInsights, scope: ClusterScopeResult) -> None:
+    def merge_scope_relations(self, analysis: AnalysisInsights, scope: ClusterScopeResult) -> None:
         """Merge LLM relations with precomputed scope connection evidence."""
         merged: list[Relation] = []
         matched_pairs: set[tuple[str, str]] = set()
-        ownership = ComponentOwnershipIndex.from_analysis(analysis)
 
         for llm_relation in analysis.components_relations:
             source = analysis.component_by_id(llm_relation.src_id) or analysis.component_by_name(llm_relation.src_name)
@@ -112,16 +116,11 @@ class StaticAnalysisEnricherMixin:
             src_id = source.component_id if source is not None else ""
             dst_id = target.component_id if target is not None else ""
             connection = scope.connection_between(src_id, dst_id)
-            static_edges = StaticAnalysisEnricherMixin._connection_edges(scope, connection)
+            static_edges = self._connection_edges(scope, connection)
             key_edges = [
                 edge
                 for edge in llm_relation.key_edges
-                if edge_crosses_components(
-                    edge,
-                    ownership.owner_of,
-                    src_id,
-                    dst_id,
-                )
+                if edge_crosses_components(edge, self.component_ownership.owner_of, src_id, dst_id)
             ]
             has_evidence = bool(llm_relation.evidence.strip())
             if not static_edges and not key_edges and not has_evidence:
@@ -157,7 +156,7 @@ class StaticAnalysisEnricherMixin:
             pair = (connection.source_group_id, connection.target_group_id)
             if pair in matched_pairs:
                 continue
-            edges = StaticAnalysisEnricherMixin._connection_edges(scope, connection)
+            edges = self._connection_edges(scope, connection)
             if not edges:
                 continue
             source = analysis.component_by_id(connection.source_group_id)
@@ -183,17 +182,16 @@ class StaticAnalysisEnricherMixin:
             sum(1 for relation in analysis.components_relations if not relation.is_static),
         )
 
-    @staticmethod
     def prune_relations(
+        self,
         analysis: AnalysisInsights,
         keep_edge: Callable[[RelationEdge], bool],
         changed_members: set[str] | None = None,
     ) -> None:
         """Re-apply static edge filters after incremental relation preservation."""
-        ownership = ComponentOwnershipIndex.from_analysis(analysis)
         analysis.components_relations = prune_ungrounded_edges(
             analysis.components_relations,
-            ownership.owner_of,
+            self.component_ownership.owner_of,
             keep_edge,
             changed_members,
         )

--- a/diagram_analysis/diagram_generator.py
+++ b/diagram_analysis/diagram_generator.py
@@ -1046,6 +1046,10 @@ class DiagramGenerator:
         parsing_llm: BaseChatModel,
     ) -> None:
         """Initialize agents that depend on static analysis and project metadata."""
+        assert self.clustering_hierarchy is not None
+        # One index for the whole run: every scope agent judges its relation edges against
+        # the full hierarchy, not against the handful of components it is naming.
+        component_ownership = ComponentOwnershipIndex.from_clustering_hierarchy(self.clustering_hierarchy)
         self.details_agent = DetailsAgent(
             repo_dir=self.repo_location,
             project_name=self.repo_name,
@@ -1053,6 +1057,7 @@ class DiagramGenerator:
             meta_context=meta_context,
             agent_llm=agent_llm,
             parsing_llm=parsing_llm,
+            component_ownership=component_ownership,
         )
         self.abstraction_agent = AbstractionAgent(
             repo_dir=self.repo_location,
@@ -1061,6 +1066,7 @@ class DiagramGenerator:
             meta_context=meta_context,
             agent_llm=agent_llm,
             parsing_llm=parsing_llm,
+            component_ownership=component_ownership,
         )
         self.incremental_agent = IncrementalAgent(
             repo_dir=self.repo_location,
@@ -1069,6 +1075,7 @@ class DiagramGenerator:
             meta_context=meta_context,
             agent_llm=agent_llm,
             parsing_llm=parsing_llm,
+            component_ownership=component_ownership,
             changes=self.changes,
         )
         self._monitoring_agents.update(

--- a/tests/agents/test_abstraction_agent.py
+++ b/tests/agents/test_abstraction_agent.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from agents.abstraction_agent import AbstractionAgent
+from agents.component_ownership import ComponentOwnershipIndex
 from agents.agent_responses import (
     AnalysisInsights,
     Component,
@@ -61,6 +62,7 @@ class TestAbstractionAgent(unittest.TestCase):
             meta_context=self.mock_meta_context,
             agent_llm=mock_llm,
             parsing_llm=mock_parsing_llm,
+            component_ownership=ComponentOwnershipIndex({}),
         )
 
         self.assertEqual(agent.project_name, self.project_name)
@@ -75,6 +77,7 @@ class TestAbstractionAgent(unittest.TestCase):
             meta_context=self.mock_meta_context,
             agent_llm=MagicMock(),
             parsing_llm=MagicMock(),
+            component_ownership=ComponentOwnershipIndex({}),
         )
 
     def test_run_uses_the_precomputed_groups(self):
@@ -113,6 +116,7 @@ class TestAbstractionAgent(unittest.TestCase):
             meta_context=self.mock_meta_context,
             agent_llm=mock_llm,
             parsing_llm=mock_parsing_llm,
+            component_ownership=ComponentOwnershipIndex({}),
         )
 
         scope = ClusterScopeResult(

--- a/tests/agents/test_component_ownership.py
+++ b/tests/agents/test_component_ownership.py
@@ -1,0 +1,56 @@
+from agents.agent_responses import SourceCodeReference
+from agents.component_ownership import ComponentOwnershipIndex
+from static_analyzer.clustering import ClusterGroup, ClusterScopeResult
+
+
+def hierarchy() -> ClusterScopeResult:
+    """Two top-level groups; the first one splits into two children at depth two."""
+    child_scope = ClusterScopeResult(
+        scope_id="1",
+        groups=[
+            ClusterGroup(group_id="1.1", cluster_ids=[1], symbol_members_by_language={"python": {"pkg.a.one"}}),
+            ClusterGroup(group_id="1.2", cluster_ids=[2], symbol_members_by_language={"python": {"pkg.a.two"}}),
+        ],
+    )
+    root = ClusterScopeResult(
+        scope_id="root",
+        groups=[
+            ClusterGroup(
+                group_id="1",
+                cluster_ids=[1, 2],
+                symbol_members_by_language={"python": {"pkg.a.one", "pkg.a.two"}},
+                children=child_scope,
+            ),
+            ClusterGroup(group_id="2", cluster_ids=[3], symbol_members_by_language={"python": {"pkg.b.three"}}),
+        ],
+    )
+    root.index_hierarchy()
+    return root
+
+
+def reference(qualified_name: str) -> SourceCodeReference:
+    return SourceCodeReference(qualified_name=qualified_name, reference_file="pkg.py")
+
+
+def test_from_clustering_hierarchy_resolves_every_depth_to_its_deepest_owner() -> None:
+    index = ComponentOwnershipIndex.from_clustering_hierarchy(hierarchy())
+
+    assert index.owner_of(reference("pkg.a.one")) == "1.1"
+    assert index.owner_of(reference("pkg.a.two")) == "1.2"
+    assert index.owner_of(reference("pkg.b.three")) == "2"
+
+
+def test_from_clustering_hierarchy_covers_symbols_outside_any_single_scope() -> None:
+    """The whole point: a scope naming 1.1 and 1.2 can still resolve an endpoint owned by 2."""
+    index = ComponentOwnershipIndex.from_clustering_hierarchy(hierarchy())
+    scope_only = ComponentOwnershipIndex.from_node_owners({"pkg.a.one": "1.1", "pkg.a.two": "1.2"})
+
+    assert scope_only.owner_of(reference("pkg.b.three")) == ""
+    assert index.owner_of(reference("pkg.b.three")) == "2"
+
+
+def test_ancestor_groups_never_make_their_own_members_ambiguous() -> None:
+    """A flat union over all depths would give pkg.a.one two owners and blank the index out."""
+    index = ComponentOwnershipIndex.from_clustering_hierarchy(hierarchy())
+
+    assert index.owner_of(reference("pkg.a.one")) == "1.1"

--- a/tests/agents/test_details_agent.py
+++ b/tests/agents/test_details_agent.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from unittest.mock import ANY, MagicMock, patch
 
 from agents.details_agent import DetailsAgent
+from agents.component_ownership import ComponentOwnershipIndex
 from agents.agent_responses import (
     AnalysisInsights,
     Component,
@@ -90,6 +91,7 @@ class TestDetailsAgent(unittest.TestCase):
             meta_context=self.mock_meta_context,
             agent_llm=MagicMock(),
             parsing_llm=MagicMock(),
+            component_ownership=ComponentOwnershipIndex({}),
         )
 
     def test_init(self):
@@ -103,6 +105,7 @@ class TestDetailsAgent(unittest.TestCase):
             meta_context=self.mock_meta_context,
             agent_llm=mock_llm,
             parsing_llm=mock_parsing_llm,
+            component_ownership=ComponentOwnershipIndex({}),
         )
 
         self.assertEqual(agent.project_name, self.project_name)
@@ -153,6 +156,7 @@ class TestDetailsAgent(unittest.TestCase):
             meta_context=self.mock_meta_context,
             agent_llm=mock_llm,
             parsing_llm=mock_parsing_llm,
+            component_ownership=ComponentOwnershipIndex({}),
         )
         mock_response = AnalysisInsights(
             description="Structure analysis",
@@ -206,6 +210,7 @@ class TestDetailsAgent(unittest.TestCase):
             meta_context=self.mock_meta_context,
             agent_llm=mock_llm,
             parsing_llm=mock_parsing_llm,
+            component_ownership=ComponentOwnershipIndex({}),
         )
         self.test_component.component_id = "1"
         sub_cluster_result = ClusterResult(clusters={1: {"n1"}}, strategy="test")

--- a/tests/agents/test_incremental_agent.py
+++ b/tests/agents/test_incremental_agent.py
@@ -2,6 +2,7 @@ import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+from agents.component_ownership import ComponentOwnershipIndex
 from agents.agent_responses import (
     AnalysisInsights,
     ComponentApiSurface,
@@ -563,6 +564,7 @@ class TestIncrementalRelations(unittest.TestCase):
                 meta_context=None,
                 agent_llm=MagicMock(),
                 parsing_llm=MagicMock(),
+                component_ownership=ComponentOwnershipIndex({}),
             )
         agent._parse_invoke = MagicMock(return_value=api_surfaces)
         agent._invoke_validate = MagicMock(return_value=relation_result)

--- a/tests/agents/test_relation_edges.py
+++ b/tests/agents/test_relation_edges.py
@@ -2,7 +2,11 @@ from pathlib import Path
 
 from agents.agent_responses import AnalysisInsights, Relation, RelationEdge, SourceCodeReference
 from agents.file_index_models import FileEntry, MethodEntry
-from agents.relation_edges import _edge_touches_changed_method, index_relation_endpoints
+from agents.component_ownership import ComponentOwnershipIndex
+from agents.relation_edges import (
+    _edge_touches_changed_method,
+    index_relation_endpoints,
+)
 from static_analyzer.config import NodeType
 
 
@@ -129,3 +133,10 @@ def test_a_new_call_to_an_untouched_function_still_counts() -> None:
     # The commonest way a real dependency appears: a caller edited to call something that
     # already existed. Requiring BOTH ends to change would suppress it.
     assert _edge_touches_changed_method(_changed_edge("pkg.caller", "pkg.old"), {"pkg.caller"})
+
+
+def _edge(source_file: str, source_name: str, target_file: str, target_name: str) -> RelationEdge:
+    return RelationEdge(
+        source=SourceCodeReference(qualified_name=source_name, reference_file=source_file),
+        target=SourceCodeReference(qualified_name=target_name, reference_file=target_file),
+    )

--- a/tests/agents/test_static_analysis_enricher_mixin.py
+++ b/tests/agents/test_static_analysis_enricher_mixin.py
@@ -1,8 +1,19 @@
+import os
 import tempfile
 import unittest
+from collections.abc import Collection
 from pathlib import Path
+from unittest import mock
 
-from agents.agent_responses import AnalysisInsights, Component, ComponentArchitecture, Relation, SourceCodeReference
+from agents.agent_responses import (
+    AnalysisInsights,
+    Component,
+    ComponentArchitecture,
+    Relation,
+    RelationEdge,
+    SourceCodeReference,
+)
+from agents.component_ownership import ComponentOwnershipIndex
 from agents.file_index_models import FileMethodGroup, MethodEntry
 from agents.llm_renderers import render_scope_connections
 from agents.static_analysis_enricher_mixin import StaticAnalysisEnricherMixin
@@ -17,7 +28,8 @@ from static_analyzer.clustering import (
     ClusterScopeResult,
     GroupConnection,
 )
-from static_analyzer.config import NodeType
+from static_analyzer.analysis_result import StaticAnalysisResults
+from static_analyzer.config import Language, NodeType
 from static_analyzer.node import Node
 
 
@@ -25,9 +37,19 @@ def component(component_id: str, name: str) -> Component:
     return Component(name=name, description=name, key_entities=[], component_id=component_id)
 
 
-def enricher(repo_dir: Path = Path("/repo")) -> StaticAnalysisEnricherMixin:
+def enricher(
+    repo_dir: Path = Path("/repo"),
+    component_ownership: ComponentOwnershipIndex = ComponentOwnershipIndex({}),
+    indexed_files: Collection[str] = (),
+) -> StaticAnalysisEnricherMixin:
     instance = StaticAnalysisEnricherMixin()
     instance.repo_dir = repo_dir
+    instance.component_ownership = component_ownership
+    graph = CallGraph(language="python")
+    for index, file_path in enumerate(indexed_files, start=1):
+        graph.add_node(Node(f"indexed.symbol{index}", NodeType.FUNCTION, file_path, index, index + 1))
+    instance.static_analysis = StaticAnalysisResults()
+    instance.static_analysis.add_cfg(Language.PYTHON, graph)
     return instance
 
 
@@ -418,5 +440,91 @@ class TestScopeContainment(unittest.TestCase):
         )
 
 
-if __name__ == "__main__":
-    unittest.main()
+class TestRelationEdgeSourceGate(unittest.TestCase):
+    """The gate a scope agent applies to its own LLM key edges, using the whole hierarchy."""
+
+    @staticmethod
+    def _hierarchy() -> ClusterScopeResult:
+        """Two branches: 1 splits into 1.1/1.2, and 2 owns c.func in a scope 1 never sees."""
+        branch = ClusterScopeResult(
+            scope_id="1",
+            groups=[
+                ClusterGroup(group_id="1.1", cluster_ids=[1], symbol_members_by_language={"python": {"a.func"}}),
+                ClusterGroup(group_id="1.2", cluster_ids=[2], symbol_members_by_language={"python": {"b.func"}}),
+            ],
+        )
+        root = ClusterScopeResult(
+            scope_id="root",
+            groups=[
+                ClusterGroup(
+                    group_id="1",
+                    cluster_ids=[1, 2],
+                    symbol_members_by_language={"python": {"a.func", "b.func"}},
+                    children=branch,
+                ),
+                ClusterGroup(group_id="2", cluster_ids=[3], symbol_members_by_language={"python": {"c.func"}}),
+            ],
+        )
+        root.index_hierarchy()
+        return root
+
+    @staticmethod
+    def _sub_scope() -> ClusterScopeResult:
+        graph = CallGraph(language="python")
+        graph.add_node(Node("a.func", NodeType.FUNCTION, "src/a.py", 1, 5))
+        graph.add_node(Node("b.func", NodeType.FUNCTION, "src/b.py", 1, 5))
+        return ClusterScopeResult(
+            scope_id="1",
+            graphs_by_language={"python": graph},
+            groups=[
+                ClusterGroup(group_id="1.1", cluster_ids=[1], symbol_members_by_language={"python": {"a.func"}}),
+                ClusterGroup(group_id="1.2", cluster_ids=[2], symbol_members_by_language={"python": {"b.func"}}),
+            ],
+        )
+
+    @staticmethod
+    def _analysis(target_qualified_name: str) -> AnalysisInsights:
+        return AnalysisInsights(
+            description="analysis",
+            components=[component("1.1", "A"), component("1.2", "B")],
+            components_relations=[
+                Relation(
+                    relation="delegates to",
+                    src_name="A",
+                    dst_name="B",
+                    evidence="wired at startup",
+                    key_edges=[
+                        RelationEdge(
+                            source=SourceCodeReference(qualified_name="a.func", reference_file="src/a.py"),
+                            target=SourceCodeReference(qualified_name=target_qualified_name, reference_file="src/c.py"),
+                        )
+                    ],
+                )
+            ],
+        )
+
+    def test_drops_a_key_edge_owned_by_a_component_outside_this_scope(self):
+        analysis = self._analysis("c.func")
+        ownership = ComponentOwnershipIndex.from_clustering_hierarchy(self._hierarchy())
+
+        enricher(component_ownership=ownership).merge_scope_relations(analysis, self._sub_scope())
+
+        self.assertEqual(len(analysis.components_relations), 1)
+        self.assertEqual(analysis.components_relations[0].all_edges, [])
+
+    def test_scope_only_ownership_cannot_judge_that_edge(self):
+        """Why the map had to change: the scope's own components leave c.func unresolved."""
+        analysis = self._analysis("c.func")
+        scope_only = ComponentOwnershipIndex.from_node_owners({"a.func": "1.1", "b.func": "1.2"})
+
+        enricher(component_ownership=scope_only).merge_scope_relations(analysis, self._sub_scope())
+
+        self.assertEqual(len(analysis.components_relations[0].all_edges), 1)
+
+    def test_keeps_a_key_edge_owned_by_a_descendant_of_the_declared_target(self):
+        analysis = self._analysis("b.func")
+        ownership = ComponentOwnershipIndex.from_clustering_hierarchy(self._hierarchy())
+
+        enricher(component_ownership=ownership).merge_scope_relations(analysis, self._sub_scope())
+
+        self.assertEqual(len(analysis.components_relations[0].all_edges), 1)


### PR DESCRIPTION
**Alternative to #526. Same defect, same 17 edges removed, fixed at the source instead of at finalize. Only one of the two should merge.**

## The defect

An edge stored under a relation is evidence only if it runs between the components the relation declares. `edge_crosses_components` (`agents/relation_edges.py:128-141`) is exactly that predicate, and it already runs inside `merge_scope_relations`. The bug is the **map** it is given.

`merge_scope_relations` built `ComponentOwnershipIndex.from_analysis(analysis)` — indexed from that one scope's own components. `owner_of` returns `""` for anything it cannot uniquely resolve, and the guard reads `if owner and component_id and not is_self_or_descendant(...)`, so **a blank owner keeps the edge**. An endpoint owned anywhere else in the tree was therefore never judged.

Measured: the per-scope map rejects **2** of the 17 edges the eval corpus flags. The other **15 are structurally invisible to it**.

What ships today, from `click-before-get-strerror-removal` scope 5 — relation `5.3 → 5.1`, *"Command metadata feeds parser configuration"*, with four code references attached as backing:

| cited edge | caller owned by | callee owned by |
|---|---|---|
| `decorators._make_command -> core.Command` | 5.3 ✓ | **2.2.2** ✗ |
| `decorators.option -> core.Option` | **1.3.3** ✗ | **1.3.2** ✗ |
| `decorators.argument -> core.Argument` | **1.3.3** ✗ | **1.1** ✗ |
| `core.Command -> parser.OptionParser` | **2.2.2** ✗ | 5.1 ✓ |

None connects the pair it is attached to; two have neither endpoint in either component.

## The map already exists, before any LLM call

- `ClusteringService._cluster_hierarchy` ends `root.index_hierarchy(); return root`, and **both** `build_full_hierarchy` and `build_incremental_hierarchy` route through it.
- `index_hierarchy` recurses `group.children` and fills `clustering_groups` at **every depth**. On a real serilog pickle: 41 groups across depths 1-3, 823 distinct `qualified_names` against 840 CFG nodes.
- `static_analysis_enricher_mixin.py:65` — `component.component_id = group.group_id`. **Component ids are group ids.** The LLM labels fixed groups; it never creates or renumbers them.
- `build_full_hierarchy` is called at `diagram_generator.py:629`; the abstraction agent does not run until `:1231`.

So a complete, full-depth symbol → component map is available before the first scope agent runs. There is no need to repair the artifact afterwards.

## The change

**7 source files, +114/−33** (plus tests).

- **`agents/component_ownership.py`** — `from_clustering_hierarchy(hierarchy)` iterates `clustering_groups` sorted by `group_id.count(".")` ascending so the **deepest** group wins, giving one owner per symbol. A flat union over all depths would leave nearly every symbol with several owners and blank `owner_of` out entirely — strictly worse than today; there is a test pinning that. `from_analysis` is **deleted** along with its last caller. `from_node_owners` stays; `rebuild_global_relations` and `build_component_relations` still use it, and the new constructor delegates to it.
- **`agents/static_analysis_enricher_mixin.py`** — `merge_scope_relations` and `prune_relations` become instance methods reading `self.component_ownership`. The per-call `from_analysis` at `:107` and `:193` is gone. The predicate call itself is unchanged.
- **`diagram_analysis/diagram_generator.py`** — `_initialize_agents` builds the index **once per run** and injects it into `DetailsAgent`, `AbstractionAgent`, `IncrementalAgent` as a **required** kwarg, so a missed construction site is a `TypeError` rather than a silently dead gate. `IncrementalAgent._clone_for_worker` forwards it.

The three `merge_scope_relations` call sites did not change textually — the root hierarchy reaches the agents through construction, not through the scope argument. No global, no threading through `run()`.

`edge_crosses_components` and `is_self_or_descendant` are untouched, and no downstream filter is added.

## Measured impact

Re-scored with the evals harness's own check code over the 16 committed full-run `analysis.json` in CodeBoarding-evals:

| | baseline | this PR | #526 |
|---|---:|---:|---:|
| `relations.edges_cross_declared_components` | **17** | **0** | 0 |
| `relations.edge_endpoints_are_known_symbols` | 12 | 12 | 12 |
| edges removed | — | **17** | 17 |
| non-flagged edges lost | — | **0** | 0 |
| relations deleted | — | 0 | 0 |
| edgeless inferred relations (of 162) | 75 | 82 | 82 |
| relations with neither edges nor prose | 0 | **0** | 0 |

**It removes the same 17 edges as #526 — set identity, verified in both directions**, not merely the same count. Every removal lands on an `is_static:false` relation; no CFG-derived edge is touched. All other registered checks stay at 0.

The map strictly dominates the one it replaces. Over all 13,834 `all_edges` endpoints:

| | count |
|---|---:|
| blank under old map | 61 |
| blank under new map | 42 |
| old blank → new resolved | 19 |
| **old resolved → new blank** | **0** |
| **both resolve, different branch** | **0** |
| keep→reject flips at sub-scopes | 19 endpoints → 17 edges |
| **reject→keep flips** | **0** |

It never contradicts the old map — it only refines or fills in. That is the strongest available evidence that moving to it cannot regress a judgement the current code gets right.

## Tests

`3 failed, 2226 passed, 28 skipped` against baseline's `3 failed, 2220 passed` — the same three pre-existing `test_cli_parser` failures (a macOS `/private/tmp` symlink artifact; they should pass on Linux CI). mypy clean on 340 files, black clean.

New tests cover the deepest-owner rule, the ancestor-ambiguity trap, injection into all three agents, and the gate rejecting an out-of-branch endpoint.

## Review points

1. **`--target-component` builds a partial map.** `deterministic_analysis` (`:633-635`) constructs a bare `ClusterScopeResult` and registers only the target subtree, so `clustering_groups` covers that subtree alone. Harmless here — out-of-subtree endpoints blank and are kept, which is today's behaviour — but the "every analysed symbol has an owner" premise is false on that path. Worth either building a full-repo map there or having the constructor refuse a hierarchy that does not cover the CFG. **I would take this as a follow-up, not a blocker, but it should be a conscious decision.**
2. **`prune_relations` gets a behaviour change beyond the stated defect.** It now uses the full map, so `find_relation_pair_for_edge` resolves endpoints it previously blanked and an edge can be classified internal and dropped. Bounded to the same 17 edges; on this corpus it is **one extra deletion** (2 → 3 dropped as internal), further gated by `changed_members`.
3. **Absorption is safe, analysed rather than assumed.** `absorb_single_child_components` collapses only a single-component scope and `reroot_indexes` raises on id collision, so ids are rewritten along one ancestor chain and sibling branches never merge — a different-branch verdict is preserved. Both consumers run during agent execution, before `finalize_for_save`.
4. **`assert self.clustering_hierarchy is not None`** at `:1049` is control flow via assert, stripped under `python -O`.
5. **Scope.** This fixes **misattribution**, not invention. It cannot reach `edge_endpoints_are_known_symbols` by construction — an invented endpoint resolves to `""` and the guard keeps it. See below.

## What this deliberately does not include

I built and measured a reject-unknown rule (drop an edge whose endpoint matches no indexed symbol) and **removed it before opening this PR**. It drove criterion 2 to 0, but **4 of its 12 drops are real Serilog methods**: `candidates_by_leaf` keys on `rsplit(".", 1)[-1]`, and 707 of serilog's 840 CFG keys carry a parameter list, so the key is `Equals(object x, object y)` while a signature-less reference keys on `Equals` and misses. `ByReferenceStringComparer.Equals` exists twice in the CFG and the rule would have deleted it.

The useful finding stands and is worth its own issue: **the baseline 12 is 8 real inventions plus 4 measurement artifacts**, and the cheaper first move on criterion 2 is fixing the suffix matcher (`_qualified_names_match` / `candidates_by_leaf`) to roll up class↔member and tolerate signatures — which would also recover a real CFG edge currently flagged as ungrounded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved component ownership tracking across nested project hierarchies.
  * More accurately filters and preserves relationship data based on ownership and scope.
  * Ensured ownership information remains consistent during parallel and incremental processing.

* **Tests**
  * Added coverage for nested ownership resolution, ambiguous memberships, and scope-based relationship filtering.
  * Updated agent and relationship tests to reflect the enhanced ownership handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->