### PR TITLE
fix(analysis): preserve same-line callback ownership

### DIFF
--- a/diagram_analysis/file_index.py
+++ b/diagram_analysis/file_index.py
@@ -27,7 +27,7 @@ def build_file_methods_from_nodes(
     source_cache: SourceCache | None = None,
 ) -> list[FileMethodGroup]:
     """Build sorted file/method groups from assigned CFG nodes."""
-    by_file: dict[str, dict[tuple[int, int, str, str], MethodEntry]] = defaultdict(dict)
+    by_file: dict[str, dict[tuple[int, int, int, str, str], MethodEntry]] = defaultdict(dict)
     file_cache = source_cache if source_cache is not None else {}
 
     for node in nodes:
@@ -35,7 +35,7 @@ def build_file_methods_from_nodes(
             continue
         file_path = normalize_repo_path(node.file_path, repo_dir)
         method_name = node.fully_qualified_name.split(".")[-1]
-        dedupe_key = (node.line_start, node.line_end, node.type.name, method_name)
+        dedupe_key = (node.line_start, node.line_end, node.col_start, node.type.name, method_name)
         candidate = MethodEntry(
             qualified_name=node.fully_qualified_name,
             start_line=node.line_start,

--- a/tests/agents/test_static_analysis_enricher_mixin.py
+++ b/tests/agents/test_static_analysis_enricher_mixin.py
@@ -196,6 +196,31 @@ class TestFileMethodMaterialization(unittest.TestCase):
         self.assertEqual(len(groups[0].methods), 1)
         self.assertEqual(groups[0].methods[0].qualified_name, duplicate_specific.fully_qualified_name)
 
+    def test_preserves_same_line_callbacks_at_different_columns(self):
+        outer_callback = Node(
+            "src.components.DiffViewer.existingByLine.groupByLine() callback",
+            NodeType.FUNCTION,
+            "/repo/src/components/DiffViewer.tsx",
+            606,
+            606,
+            col_start=81,
+        )
+        inner_callback = Node(
+            "src.components.DiffViewer.DiffViewer.existingByLine.groupByLine() callback",
+            NodeType.FUNCTION,
+            "/repo/src/components/DiffViewer.tsx",
+            606,
+            606,
+            col_start=97,
+        )
+
+        groups = build_file_methods_from_nodes([outer_callback, inner_callback], Path("/repo"))
+
+        self.assertCountEqual(
+            [method.qualified_name for method in groups[0].methods],
+            [outer_callback.fully_qualified_name, inner_callback.fully_qualified_name],
+        )
+
 
 class TestClusterConnectionRendering(unittest.TestCase):
     def test_group_description_includes_members_assigned_outside_leaf_clusters(self):


### PR DESCRIPTION
## Root cause

The Webview review run failed on a valid scope-containment invariant: child component `2.1` owned methods missing from parent component `2`.

The static analyzer had not assigned methods outside the parent scope. It correctly emitted distinct TypeScript callback nodes whose source ranges share a line but start at different columns. The lossy transition happened in `build_file_methods_from_nodes`: its physical-symbol dedupe key included line range, node type, and leaf name, but omitted `col_start`.

That made hierarchy materialization non-monotonic. Materializing all parent nodes together collapsed same-line callbacks. Materializing separately partitioned child groups retained callbacks that the parent had dropped, creating an impossible persisted tree. Trimming the child or weakening containment would only mask that corruption.

## Fix

Include `col_start` in the file-method dedupe identity. Exact-location qualified-name aliases still deduplicate, while distinct callbacks at different columns remain owned at every hierarchy level.

The regression uses the real shape from the failed Webview analysis: two `groupByLine() callback` nodes on line 606 at columns 81 and 97. Before the fix, the test retained only one callback. After the fix, both survive.

Original failure: https://github.com/CodeBoarding/CodeBoarding-webview/actions/runs/33026096587/job/98367654139

## Verification

- Regression test observed failing before the production change
- `black .`
- `mypy .` (334 source files)
- Relevant suites: 47 passed
- Deterministic depth-2 analysis of Webview base `a80f5ec`: zero parent-child containment violations after the fix
- Full suite: 2213 passed, 28 skipped, 1 environment-only failure because this orb has no `dotnet`; coverage 83.68%. The failure is `tests/test_registry_coverage.py::TestHasRequiredToolsCoversEveryKind::test_missing_artifact_is_detected_for_every_kind`, which intentionally skips C# artifact validation when `dotnet` is unavailable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved method detection so same-line callbacks at different positions are kept distinct.
  * More accurately distinguishes duplicate methods during static analysis.

* **Tests**
  * Added regression coverage for same-line callbacks with different column positions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->