### PR TITLE
ci: name the LLM credentials the CodeBoarding workflows already use

### DIFF
--- a/.github/workflows/codeboarding-sync.yml
+++ b/.github/workflows/codeboarding-sync.yml
@@ -115,11 +115,9 @@ jobs:
           # Requires anything other than the free tier, which caps depth at 3.
           depth_level: 4
           # Named, not inferred: the action requires `llm` and fails rather than falling
-          # back, so this says outright what every run has actually used. Both secrets
-          # were already wired here and OPENROUTER_API_KEY took precedence, which is
-          # exactly what `llm: openrouter` keeps. The licence stays wired alongside it
-          # (the action reports that pair as `byok+license`) so the entitlement is still
-          # recorded; it is what lifts the free tier's depth cap off `depth_level: 4`.
-          llm: openrouter
-          openrouter_api_key: ${{ secrets.OPENROUTER_API_KEY }}
+          # back to anything. CodeBoarding's own repositories run on the CodeBoarding
+          # plan, which is also what lifts the free tier's depth cap off `depth_level: 4`.
+          # Both secrets used to be wired here at once and OPENROUTER_API_KEY silently
+          # won, so the plan was never actually spent; this is the deliberate choice.
+          llm: license
           license_key: ${{ secrets.CODEBOARDING_LICENSE }}

--- a/.github/workflows/codeboarding-sync.yml
+++ b/.github/workflows/codeboarding-sync.yml
@@ -25,7 +25,7 @@ on:
 
 permissions:
   contents: write   # commit the generated baseline + docs to the branch
-  id-token: write   # mint a GitHub OIDC token for the free hosted tier (omit if you set a key/license)
+  id-token: write   # mint a GitHub OIDC token; required by llm: license as well as the free tier
 
 concurrency:
   # Serialize against itself so a push landing mid-run can't make two commits.

--- a/.github/workflows/codeboarding-sync.yml
+++ b/.github/workflows/codeboarding-sync.yml
@@ -112,11 +112,14 @@ jobs:
           # Desired analysis depth for this repo. Sync is the baseline writer, so
           # setting it here re-seeds .codeboarding/analysis.json at depth 4 on the
           # next sync; review then inherits depth 4 from the committed baseline.
-          # Requires the licensed tier (license_key/llm_api_key) — the free tier
-          # caps depth at 3.
+          # Requires anything other than the free tier, which caps depth at 3.
           depth_level: 4
-          # Free tier needs no secret — these fall through to the hosted OIDC tier when
-          # unset. Add either repo secret (Settings → Secrets and variables → Actions)
-          # for more/unmetered usage; no YAML edit required.
-          llm_api_key: ${{ secrets.OPENROUTER_API_KEY }}   # BYO LLM provider key (OpenRouter)
-          license_key: ${{ secrets.CODEBOARDING_LICENSE }}  # CodeBoarding paid plan
+          # Named, not inferred: the action requires `llm` and fails rather than falling
+          # back, so this says outright what every run has actually used. Both secrets
+          # were already wired here and OPENROUTER_API_KEY took precedence, which is
+          # exactly what `llm: openrouter` keeps. The licence stays wired alongside it
+          # (the action reports that pair as `byok+license`) so the entitlement is still
+          # recorded; it is what lifts the free tier's depth cap off `depth_level: 4`.
+          llm: openrouter
+          openrouter_api_key: ${{ secrets.OPENROUTER_API_KEY }}
+          license_key: ${{ secrets.CODEBOARDING_LICENSE }}

--- a/.github/workflows/codeboarding.yml
+++ b/.github/workflows/codeboarding.yml
@@ -23,7 +23,7 @@ jobs:
       actions: read         # download the analysis an earlier run published, instead of re-deriving this PR every push
       pull-requests: write  # post the architecture-diff PR comment
       issues: write         # the /codeboarding issue_comment trigger + comment API
-      id-token: write       # mint a GitHub OIDC token for the free hosted tier (write is the only level for id-token)
+      id-token: write       # mint a GitHub OIDC token; both hosted tiers, free and licensed, need it
     if: >
       (github.event_name == 'pull_request' && github.event.action != 'closed' &&
        github.event.pull_request.draft == false &&

--- a/.github/workflows/codeboarding.yml
+++ b/.github/workflows/codeboarding.yml
@@ -40,11 +40,9 @@ jobs:
           # Requires the licensed tier (the free tier caps depth at 3).
           depth_level: 4
           # Named, not inferred: the action requires `llm` and fails rather than falling
-          # back, so this says outright what every run has actually used. Both secrets
-          # were already wired here and OPENROUTER_API_KEY took precedence, which is
-          # exactly what `llm: openrouter` keeps. The licence stays wired alongside it
-          # (the action reports that pair as `byok+license`) so the entitlement is still
-          # recorded; it is what lifts the free tier's depth cap off `depth_level: 4`.
-          llm: openrouter
-          openrouter_api_key: ${{ secrets.OPENROUTER_API_KEY }}
+          # back to anything. CodeBoarding's own repositories run on the CodeBoarding
+          # plan, which is also what lifts the free tier's depth cap off `depth_level: 4`.
+          # Both secrets used to be wired here at once and OPENROUTER_API_KEY silently
+          # won, so the plan was never actually spent; this is the deliberate choice.
+          llm: license
           license_key: ${{ secrets.CODEBOARDING_LICENSE }}

--- a/.github/workflows/codeboarding.yml
+++ b/.github/workflows/codeboarding.yml
@@ -39,8 +39,12 @@ jobs:
           # that runs before the first depth-4 sync still analyzes at depth 4.
           # Requires the licensed tier (the free tier caps depth at 3).
           depth_level: 4
-          # Free tier needs no secret — these fall through to the hosted OIDC tier when
-          # unset. Add either repo secret (Settings → Secrets and variables → Actions)
-          # for more/unmetered usage; no YAML edit required.
-          llm_api_key: ${{ secrets.OPENROUTER_API_KEY }}   # BYO LLM provider key (OpenRouter)
-          license_key: ${{ secrets.CODEBOARDING_LICENSE }}  # CodeBoarding paid plan
+          # Named, not inferred: the action requires `llm` and fails rather than falling
+          # back, so this says outright what every run has actually used. Both secrets
+          # were already wired here and OPENROUTER_API_KEY took precedence, which is
+          # exactly what `llm: openrouter` keeps. The licence stays wired alongside it
+          # (the action reports that pair as `byok+license`) so the entitlement is still
+          # recorded; it is what lifts the free tier's depth cap off `depth_level: 4`.
+          llm: openrouter
+          openrouter_api_key: ${{ secrets.OPENROUTER_API_KEY }}
+          license_key: ${{ secrets.CODEBOARDING_LICENSE }}


### PR DESCRIPTION
Pairs with **CodeBoarding/CodeBoarding-action#104**, which makes the `llm` input required and stops the action falling back to our hosted tier when a named provider's key is missing. Merge that first; without this, both workflows here fail on their next run.

## What was happening

Both files wired two credentials at once and let the action's precedence pick:

```yaml
llm_api_key: ${{ secrets.OPENROUTER_API_KEY }}
license_key: ${{ secrets.CODEBOARDING_LICENSE }}
```

Both secrets exist on this repo, and `llm_api_key` won. So every run has used the **OpenRouter key**, and `CODEBOARDING_LICENSE` has never been spent. Nothing said so.

## What this changes

Nothing about what runs. `llm: openrouter` states the resolution that was already happening:

```yaml
llm: openrouter
openrouter_api_key: ${{ secrets.OPENROUTER_API_KEY }}
license_key: ${{ secrets.CODEBOARDING_LICENSE }}
```

The licence stays wired. The action reports that pair as `byok+license` and accepts it deliberately: it means "my CodeBoarding plan, my own tokens", and it is what lifts the free tier's depth cap off `depth_level: 4`.

**Worth a second opinion:** if the intent was ever to spend the licence rather than the OpenRouter key, this is the commit to say so, and the change is one line, `llm: license`. I kept what runs today rather than what the comments implied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved the reliability and consistency of automated code analysis and synchronization.
  - Updated automation to use the designated licensed AI service.
  - Preserved deeper analysis capabilities for synchronization tasks.
  - Streamlined authentication for automated processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->