### PR TITLE
Add F# support via FsAutoComplete

### DIFF
--- a/static_analyzer/__init__.py
+++ b/static_analyzer/__init__.py
@@ -21,6 +21,7 @@ from static_analyzer.engine.lsp_recycler import default_memory_budget, per_engin
 from static_analyzer.engine.result_converter import convert_to_codeboarding_format
 from static_analyzer.engine.source_inspector import SourceInspector
 from static_analyzer.engine.utils import uri_to_path
+from static_analyzer.fsharp_config_scanner import FSharpConfigScanner
 from static_analyzer.incremental_orchestrator import update_cfg_for_changed_files
 from static_analyzer.java_config_scanner import JavaConfigScanner
 from static_analyzer.lsp_client.diagnostics import FileDiagnosticsMap
@@ -207,6 +208,20 @@ def _create_engine_configs(
                 else:
                     logger.info("No C# projects detected")
 
+            elif adapter_name == AdapterName.FSHARP:
+                fsharp_scanner = FSharpConfigScanner(repository_path, ignore_manager=ignore_manager)
+                fsharp_projects = fsharp_scanner.scan()
+
+                if fsharp_projects:
+                    for fsharp_config in fsharp_projects:
+                        logger.info(
+                            f"Creating engine config for FSharp ({fsharp_config.project_type}) at: "
+                            f"{fsharp_config.root.relative_to(repository_path)}"
+                        )
+                        configs.append(EngineConfig(adapter, fsharp_config.root))
+                else:
+                    logger.info("No F# projects detected")
+
             else:
                 configs.append(EngineConfig(adapter, repository_path))
 
@@ -223,6 +238,7 @@ def _lang_to_adapter_name(language: str) -> str | None:
         Language.TYPESCRIPT: AdapterName.TYPESCRIPT,
         Language.JAVASCRIPT: AdapterName.JAVASCRIPT,
         Language.CSHARP: AdapterName.CSHARP,
+        Language.FSHARP: AdapterName.FSHARP,
         Language.GO: AdapterName.GO,
         Language.JAVA: AdapterName.JAVA,
         Language.PHP: AdapterName.PHP,
@@ -231,6 +247,7 @@ def _lang_to_adapter_name(language: str) -> str | None:
         "tsx": AdapterName.TYPESCRIPT,
         "jsx": AdapterName.JAVASCRIPT,
         "c#": AdapterName.CSHARP,
+        "f#": AdapterName.FSHARP,
     }
     return mapping.get(language.lower())
 

--- a/static_analyzer/config.py
+++ b/static_analyzer/config.py
@@ -24,6 +24,7 @@ class Language(StrEnum):
     PHP = "php"
     RUST = "rust"
     CSHARP = "csharp"
+    FSHARP = "fsharp"
     CPP = "cpp"
 
 
@@ -34,6 +35,7 @@ class AdapterName(StrEnum):
     TYPESCRIPT = "TypeScript"
     JAVASCRIPT = "JavaScript"
     CSHARP = "CSharp"
+    FSHARP = "FSharp"
     GO = "Go"
     JAVA = "Java"
     PHP = "PHP"
@@ -57,6 +59,7 @@ class SourceSuffix(StrEnum):
     PHP = ".php"
     RS = ".rs"
     CS = ".cs"
+    FS = ".fs"
     CPP = ".cpp"
     CC = ".cc"
     CXX = ".cxx"
@@ -100,6 +103,10 @@ LANGUAGE_EXTENSIONS: dict[Language, tuple[SourceSuffix, ...]] = {
     Language.PHP: (SourceSuffix.PHP,),
     Language.RUST: (SourceSuffix.RS,),
     Language.CSHARP: (SourceSuffix.CS,),
+    # Implementation files only. A ``.fsi`` signature file redeclares the symbols of its
+    # ``.fs`` sibling, so indexing both would double every public symbol; ``.fsx`` scripts
+    # belong to no ``.fsproj`` and would reach the server without a project context.
+    Language.FSHARP: (SourceSuffix.FS,),
     Language.CPP: (
         SourceSuffix.CPP,
         SourceSuffix.CC,

--- a/static_analyzer/engine/adapters/__init__.py
+++ b/static_analyzer/engine/adapters/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from static_analyzer.config import AdapterName
 from static_analyzer.engine.language_adapter import LanguageAdapter
 from static_analyzer.engine.adapters.csharp_adapter import CSharpAdapter
+from static_analyzer.engine.adapters.fsharp_adapter import FSharpAdapter
 from static_analyzer.engine.adapters.go_adapter import GoAdapter
 from static_analyzer.engine.adapters.java_adapter import JavaAdapter
 from static_analyzer.engine.adapters.php_adapter import PHPAdapter
@@ -17,6 +18,7 @@ ADAPTER_REGISTRY: dict[str, type[LanguageAdapter]] = {
     AdapterName.JAVASCRIPT: JavaScriptAdapter,
     AdapterName.TYPESCRIPT: TypeScriptAdapter,
     AdapterName.CSHARP: CSharpAdapter,
+    AdapterName.FSHARP: FSharpAdapter,
     AdapterName.GO: GoAdapter,
     AdapterName.JAVA: JavaAdapter,
     AdapterName.PHP: PHPAdapter,

--- a/static_analyzer/engine/adapters/fsharp_adapter.py
+++ b/static_analyzer/engine/adapters/fsharp_adapter.py
@@ -1,0 +1,302 @@
+"""F# language adapter using FsAutoComplete."""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+from pathlib import Path
+
+from repo_utils.ignore import RepoIgnoreManager
+from static_analyzer.config import CLASS_TYPES, Language, NodeType
+from static_analyzer.dotnet_sdk import DotnetSdkError, resolve_dotnet_sdk
+from static_analyzer.engine.language_adapter import LanguageAdapter
+from static_analyzer.engine.lsp_client import LSPClient
+from tool_registry import (
+    TOOL_REGISTRY,
+    ToolKind,
+    acquire_lock,
+    get_servers_dir,
+    install_package_manager_tools,
+    package_manager_tool_is_current,
+    package_manager_tool_path,
+)
+
+logger = logging.getLogger(__name__)
+
+# Symbol kinds that carry a declared F# scope rather than a code container.
+_SCOPE_KINDS = (NodeType.MODULE, NodeType.NAMESPACE)
+_PROJECT_GLOBS: tuple[str, ...] = ("*.sln", "*.slnx", "*.fsproj")
+
+
+def _bound(entry: dict, edge: str) -> tuple[int, int]:
+    """Return the (line, character) position of one edge of a symbol's range."""
+    point = entry.get("range", {}).get(edge, {})
+    return point.get("line", 0), point.get("character", 0)
+
+
+def _encloses(outer: dict, inner: dict) -> bool:
+    """Whether *outer* spans a strictly wider range than *inner*."""
+    outer_span = (_bound(outer, "start"), _bound(outer, "end"))
+    inner_span = (_bound(inner, "start"), _bound(inner, "end"))
+    if outer_span == inner_span:
+        return False
+    return outer_span[0] <= inner_span[0] and inner_span[1] <= outer_span[1]
+
+
+def _name_let_bindings(entries: list[dict], inside_type: bool) -> None:
+    """Rewrite module-level ``let`` bindings, reported as fields, into functions.
+
+    A ``let`` inside a type really is a field or member and stays one.
+    """
+    for entry in entries:
+        kind = entry.get("kind")
+        if kind == NodeType.FIELD and not inside_type:
+            entry["kind"] = NodeType.FUNCTION
+        _name_let_bindings(entry.get("children", []), inside_type or kind in CLASS_TYPES)
+
+
+class FSharpAdapter(LanguageAdapter):
+    """Static-analysis adapter for F# projects backed by FsAutoComplete."""
+
+    @property
+    def language(self) -> str:
+        return "FSharp"
+
+    @property
+    def language_enum(self) -> Language:
+        return Language.FSHARP
+
+    @property
+    def lsp_command(self) -> list[str]:
+        return ["fsautocomplete"]
+
+    @property
+    def language_id(self) -> str:
+        return "fsharp"
+
+    def get_lsp_command(self, project_root: Path) -> list[str]:
+        """Resolve the .NET SDK and ensure the managed FsAutoComplete install is current."""
+        try:
+            resolution = resolve_dotnet_sdk(project_root)
+        except DotnetSdkError as exc:
+            raise RuntimeError(str(exc)) from exc
+
+        self._ensure_fsautocomplete_installed(project_root, resolution.dotnet_path, resolution.env)
+        return super().get_lsp_command(project_root)
+
+    def build_qualified_name(
+        self,
+        file_path: Path,
+        symbol_name: str,
+        symbol_kind: int,
+        parent_chain: list[tuple[str, int]],
+        project_root: Path,
+        detail: str = "",
+    ) -> str:
+        """Build module-based qualified names for F#.
+
+        Why F# cannot reuse the C# path-based scheme: a file declares its own
+        ``namespace`` or ``module`` path, and that path need not match the
+        directory layout — ShArc's ``Source/Layer2.Relief.Common/String.fs``
+        declares ``module Layer2.Relief.Common.String``. The declared scope is
+        therefore authoritative, and the path only serves files that declare
+        none.
+
+        FsAutoComplete reports a file's leading module or namespace with its
+        full dotted path, but a module nested inside it only by its own short
+        name, so an enclosing scope still has to be prefixed.
+        """
+        scope = ".".join(name for name, kind in parent_chain if kind in _SCOPE_KINDS)
+
+        if symbol_kind in _SCOPE_KINDS:
+            return f"{scope}.{symbol_name}" if scope else symbol_name
+
+        if not scope:
+            rel = file_path.relative_to(project_root)
+            scope = ".".join(rel.with_suffix("").parts)
+
+        containers = [name for name, kind in parent_chain if kind not in (NodeType.FILE, *_SCOPE_KINDS)]
+        parts = [scope, *containers, symbol_name]
+        return ".".join(part for part in parts if part)
+
+    def normalize_symbols(self, symbols: list[dict]) -> list[dict]:
+        """Rebuild the nesting FsAutoComplete omits and name F# functions as such.
+
+        Why: it answers ``documentSymbol`` with a flat list carrying no
+        ``children``, so every symbol would register at file level and lose its
+        module path. The ranges still nest, and that is enough to rebuild the
+        tree. It also reports every ``let`` binding as a field, which nothing
+        downstream treats as callable — see ``_name_let_bindings``.
+        """
+        ordered = sorted(
+            symbols,
+            key=lambda entry: (_bound(entry, "start"), tuple(-value for value in _bound(entry, "end"))),
+        )
+
+        roots: list[dict] = []
+        open_scopes: list[dict] = []
+        for entry in ordered:
+            node = dict(entry)
+            node["children"] = []
+            while open_scopes and not _encloses(open_scopes[-1], node):
+                open_scopes.pop()
+            if open_scopes:
+                open_scopes[-1]["children"].append(node)
+            else:
+                roots.append(node)
+            open_scopes.append(node)
+
+        _name_let_bindings(roots, inside_type=False)
+        return roots
+
+    def get_lsp_init_options(self, ignore_manager: RepoIgnoreManager | None = None) -> dict:
+        """Make FsAutoComplete load the workspace on its own.
+
+        Why: unlike csharp-ls it loads no project until asked, and every
+        ``documentSymbol`` then fails with "Couldn't find <file> in
+        LoadedProjects". The alternative is driving its non-standard
+        ``fsharp/workspacePeek`` and ``fsharp/workspaceLoad`` requests.
+        """
+        return {"AutomaticWorkspaceInit": True}
+
+    def get_workspace_settings(self) -> dict | None:
+        """Repeat the workspace-init opt-in through the configuration channel,
+        which is the route Ionide itself uses."""
+        return {"FSharp": {"automaticWorkspaceInit": True}}
+
+    def extract_package(self, qualified_name: str) -> str:
+        """Extract the module path as all-but-last-two dot-separated components.
+
+        For ``Layer2.Relief.Common.String.trim`` the package is
+        ``Layer2.Relief.Common``.
+        """
+        return self._extract_deep_package(qualified_name)
+
+    def get_all_packages(self, source_files: list[Path], project_root: Path) -> set[str]:
+        """Use all directory prefixes as packages, matching the deep module paths."""
+        return self._get_hierarchical_packages(source_files, project_root)
+
+    def is_reference_worthy(self, symbol_kind: int) -> bool:
+        """Include modules: in F# a module, not a class, is the usual unit of code."""
+        return super().is_reference_worthy(symbol_kind) or symbol_kind == NodeType.MODULE
+
+    @property
+    def probe_before_open(self) -> bool:
+        """FsAutoComplete loads every project of the workspace through Ionide.ProjInfo,
+        so it must finish that load before bulk didOpen notifications arrive."""
+        return True
+
+    @property
+    def interleave_did_open_with_symbols(self) -> bool:
+        """Pair each didOpen with its own documentSymbol request.
+
+        Why: FsAutoComplete type-checks a file lazily and answers
+        documentSymbol only from what it has already checked, so a bulk open
+        followed by bulk queries returns a fraction of the symbols — one
+        module per file instead of its contents. Opening a file and querying
+        it immediately gives each type-check a response barrier.
+        """
+        return True
+
+    @property
+    def workspace_owns_documents(self) -> bool:
+        """FsAutoComplete answers position queries from the loaded projects, opened or not."""
+        return True
+
+    def get_lsp_default_timeout(self) -> int:
+        """MSBuild project loading for large .NET solutions is slow."""
+        return 120
+
+    def get_probe_timeout_minimum(self) -> int:
+        """Loading and type-checking every project of a large solution can exceed 5 minutes."""
+        return 600
+
+    def wait_for_diagnostics(self, client: LSPClient) -> None:
+        """FsAutoComplete type-checks after the project load and publishes diagnostics
+        asynchronously, with no enclosing readiness signal, so debounce the stream."""
+        client.wait_for_diagnostics_quiesce(idle_seconds=2.0, max_wait=30.0)
+
+    @property
+    def fail_on_empty_symbols(self) -> bool:
+        return True
+
+    def prepare_project(self, project_root: Path) -> None:
+        """Run ``dotnet restore`` so FsAutoComplete can resolve framework references.
+
+        Why: the server loads projects through MSBuild, which needs
+        ``obj/project.assets.json`` to find the reference assemblies. Without
+        it every file type-checks against nothing and the analysis yields no
+        symbols. Restore is idempotent and only writes under ``obj/``.
+        """
+        target = next((match for glob in _PROJECT_GLOBS for match in project_root.glob(glob)), None)
+        if target is None:
+            logger.debug("No solution/project file found at %s; skipping restore", project_root)
+            return
+
+        try:
+            resolution = resolve_dotnet_sdk(project_root)
+        except DotnetSdkError as exc:
+            raise RuntimeError(str(exc)) from exc
+
+        env = os.environ.copy()
+        env.update(resolution.env)
+        try:
+            result = subprocess.run(
+                [resolution.dotnet_path, "restore", str(target.name), "--nologo", "--verbosity", "minimal"],
+                cwd=str(project_root),
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=600,
+            )
+            if result.returncode != 0:
+                logger.warning(
+                    "dotnet restore failed for %s (exit %d): %s",
+                    target.name,
+                    result.returncode,
+                    (result.stderr or result.stdout)[-500:],
+                )
+            else:
+                logger.info("dotnet restore completed for %s", target.name)
+        except subprocess.TimeoutExpired:
+            logger.warning("dotnet restore timed out after 600s for %s", target.name)
+        except OSError as exc:
+            logger.warning("dotnet restore could not be invoked: %s", exc)
+
+    def get_lsp_env(self, project_root: Path | None = None) -> dict[str, str]:
+        """Return the .NET environment FsAutoComplete needs to load projects."""
+        if project_root is None:
+            return {}
+        try:
+            return resolve_dotnet_sdk(project_root).env
+        except DotnetSdkError as exc:
+            raise RuntimeError(str(exc)) from exc
+
+    def _ensure_fsautocomplete_installed(
+        self, project_root: Path, dotnet_path: str, dotnet_env: dict[str, str]
+    ) -> None:
+        dep = next((d for d in TOOL_REGISTRY if d.key == "fsharp" and d.kind is ToolKind.PACKAGE_MANAGER), None)
+        if dep is None:
+            return
+
+        servers_dir = get_servers_dir()
+        if package_manager_tool_path(servers_dir, dep) is not None and package_manager_tool_is_current(
+            servers_dir, dep
+        ):
+            return
+
+        servers_dir.mkdir(parents=True, exist_ok=True)
+        lock_path = servers_dir / ".download.lock"
+        env = os.environ.copy()
+        env.update(dotnet_env)
+        with open(lock_path, "w") as lock_fd:
+            acquire_lock(lock_fd)
+            if package_manager_tool_is_current(servers_dir, dep):
+                return
+            install_package_manager_tools(servers_dir, [dep], manager_overrides={"dotnet": dotnet_path}, env=env)
+        if not package_manager_tool_is_current(servers_dir, dep):
+            raise RuntimeError(
+                "fsautocomplete could not be installed. CodeBoarding needs FsAutoComplete and a .NET SDK "
+                "to analyze F# projects."
+            )

--- a/static_analyzer/engine/call_graph_builder.py
+++ b/static_analyzer/engine/call_graph_builder.py
@@ -190,6 +190,7 @@ class CallGraphBuilder:
                 symbols = self._lsp.document_symbol(file_path, timeout=probe_timeout)
             else:
                 symbols = self._lsp.document_symbol(file_path)
+            symbols = self._adapter.normalize_symbols(symbols)
             self._symbol_table.register_symbols(file_path, symbols, parent_chain=[], project_root=self._root)
             pbar.set_postfix(symbols=len(self._symbol_table.symbols))
             pbar.update(1)

--- a/static_analyzer/engine/language_adapter.py
+++ b/static_analyzer/engine/language_adapter.py
@@ -114,6 +114,15 @@ class LanguageAdapter(ABC):
             return f"{module}.{parents}.{symbol_name}"
         return f"{module}.{symbol_name}"
 
+    def normalize_symbols(self, symbols: list[dict]) -> list[dict]:
+        """Reshape a ``documentSymbol`` response before it is registered.
+
+        Default: pass through. Override for a server that returns a flat list
+        where the protocol permits nesting, or that reports a symbol kind the
+        rest of the pipeline cannot act on.
+        """
+        return symbols
+
     def build_reference_key(self, qualified_name: str) -> str:
         """Build the reference key from a qualified name.
 

--- a/static_analyzer/fsharp_config_scanner.py
+++ b/static_analyzer/fsharp_config_scanner.py
@@ -1,0 +1,116 @@
+"""Scanner for F# / .NET project configurations.
+
+Detects solution files (.sln/.slnx), project files (.fsproj), and standalone
+F# source trees to support mono-repo analysis with FsAutoComplete.
+"""
+
+import logging
+from pathlib import Path
+
+from repo_utils.ignore import RepoIgnoreManager
+
+logger = logging.getLogger(__name__)
+
+SOLUTION_GLOBS: tuple[str, ...] = ("*.sln", "*.slnx")
+
+
+class FSharpProjectConfig:
+    """Describes a discovered F# project root and its type."""
+
+    def __init__(
+        self,
+        root: Path,
+        project_type: str,  # "solution", "project", or "none"
+    ):
+        self.root = root
+        self.project_type = project_type
+
+    def __repr__(self) -> str:
+        return f"FSharpProjectConfig(root={self.root}, project_type={self.project_type})"
+
+
+class FSharpConfigScanner:
+    """Scan a repository for F# / .NET project configurations.
+
+    Scanning priority:
+        1. ``.sln`` / ``.slnx`` files — solution-level roots, which
+           FsAutoComplete uses to discover all referenced projects.
+        2. Standalone ``.fsproj`` files not already covered by a solution.
+        3. Fallback to the repository root when ``.fs`` files exist but no
+           solution or project files are found.
+
+    Why the ``.fs`` filter matters here: a solution carries both languages, so
+    the C# scanner sees every F#-only solution and this one sees every C#-only
+    solution. Dropping roots that ship none of our own sources keeps each
+    scanner to the solutions it can actually say something about.
+    """
+
+    def __init__(self, repo_path: Path, ignore_manager: RepoIgnoreManager | None = None):
+        self.repo_path = repo_path
+        self.ignore_manager = ignore_manager if ignore_manager else RepoIgnoreManager(repo_path)
+
+    def scan(self) -> list[FSharpProjectConfig]:
+        """Return a list of F# project roots found in the repository."""
+        configs: list[FSharpProjectConfig] = []
+
+        # 1. Solution files (highest priority)
+        for root in self._find_solution_roots():
+            if not self.ignore_manager.should_ignore(root):
+                configs.append(FSharpProjectConfig(root, "solution"))
+
+        # 2. Standalone .fsproj files not covered by a solution
+        for root in self._find_project_roots():
+            if self.ignore_manager.should_ignore(root):
+                continue
+            if any(self._is_subpath(root, c.root) for c in configs):
+                continue
+            configs.append(FSharpProjectConfig(root, "project"))
+
+        # A root with no F# source still costs a dotnet restore and a full
+        # workspace load to produce nothing.
+        sourceless = [c for c in configs if not self._has_fs_files(c.root)]
+        if sourceless:
+            configs = [c for c in configs if c not in sourceless]
+            logger.info(
+                "Skipping %d F# project root(s) with no .fs files: %s",
+                len(sourceless),
+                ", ".join(str(c.root.name) for c in sourceless[:5]) + ("..." if len(sourceless) > 5 else ""),
+            )
+
+        # 3. Fallback: .fs files exist but no project infrastructure
+        if not configs and self._has_fs_files(self.repo_path):
+            logger.warning(
+                f"No .sln/.slnx or .fsproj found in {self.repo_path}, but F# files detected. "
+                "Analysis will be limited."
+            )
+            configs.append(FSharpProjectConfig(self.repo_path, "none"))
+
+        return configs
+
+    def _find_solution_roots(self) -> list[Path]:
+        """Find directories containing ``.sln`` or ``.slnx`` files."""
+        roots: set[Path] = set()
+        for pattern in SOLUTION_GLOBS:
+            roots.update(p.parent for p in self.repo_path.rglob(pattern) if p.is_file())
+        return sorted(roots)
+
+    def _find_project_roots(self) -> list[Path]:
+        """Find directories containing .fsproj files."""
+        return sorted({p.parent for p in self.repo_path.rglob("*.fsproj") if p.is_file()})
+
+    def _has_fs_files(self, directory: Path) -> bool:
+        """Whether the directory holds any .fs file the analysis would read.
+
+        Ignored paths do not count, so a repo whose only F# sits in a vendored
+        directory does not drag the whole root into the analysis.
+        """
+        return any(not self.ignore_manager.should_ignore(path) for path in directory.rglob("*.fs"))
+
+    @staticmethod
+    def _is_subpath(path: Path, parent: Path) -> bool:
+        """Check if path is a subpath of (or equal to) parent."""
+        try:
+            path.relative_to(parent)
+            return True
+        except ValueError:
+            return False

--- a/tests/static_analyzer/test_fsharp_adapter.py
+++ b/tests/static_analyzer/test_fsharp_adapter.py
@@ -1,0 +1,210 @@
+"""Tests for the F# language adapter."""
+
+from pathlib import Path
+
+from static_analyzer.config import Language, NodeType
+from static_analyzer.engine.adapters import get_adapter
+from static_analyzer.engine.adapters.csharp_adapter import CSharpAdapter
+from static_analyzer.engine.adapters.fsharp_adapter import FSharpAdapter, _bound, _encloses
+
+
+def _symbol(name: str, kind: NodeType, start: tuple[int, int], end: tuple[int, int]) -> dict:
+    return {
+        "name": name,
+        "kind": kind,
+        "range": {
+            "start": {"line": start[0], "character": start[1]},
+            "end": {"line": end[0], "character": end[1]},
+        },
+    }
+
+
+class TestFSharpAdapterProperties:
+    """Basic adapter property tests."""
+
+    def test_language(self):
+        assert FSharpAdapter().language == "FSharp"
+
+    def test_language_enum(self):
+        assert FSharpAdapter().language_enum is Language.FSHARP
+
+    def test_file_extensions(self):
+        assert FSharpAdapter().file_extensions == (".fs",)
+
+    def test_lsp_command(self):
+        assert FSharpAdapter().lsp_command == ["fsautocomplete"]
+
+    def test_language_id(self):
+        assert FSharpAdapter().language_id == "fsharp"
+
+    def test_registry_returns_fsharp_adapter(self):
+        assert isinstance(get_adapter("FSharp"), FSharpAdapter)
+
+    def test_interleaves_did_open_with_symbols(self):
+        """FsAutoComplete type-checks lazily, so each file needs its own barrier."""
+        assert FSharpAdapter().interleave_did_open_with_symbols is True
+
+    def test_probes_before_open(self):
+        assert FSharpAdapter().probe_before_open is True
+
+    def test_workspace_owns_documents(self):
+        assert FSharpAdapter().workspace_owns_documents is True
+
+    def test_fails_on_empty_symbols(self):
+        assert FSharpAdapter().fail_on_empty_symbols is True
+
+    def test_modules_are_reference_worthy(self):
+        """A module, not a class, is F#'s usual unit of code."""
+        assert FSharpAdapter().is_reference_worthy(NodeType.MODULE) is True
+
+    def test_init_options_request_automatic_workspace_init(self):
+        """Without this, every documentSymbol fails with 'not in LoadedProjects'."""
+        assert FSharpAdapter().get_lsp_init_options() == {"AutomaticWorkspaceInit": True}
+
+    def test_workspace_settings_repeat_the_workspace_init_opt_in(self):
+        assert FSharpAdapter().get_workspace_settings() == {"FSharp": {"automaticWorkspaceInit": True}}
+
+
+class TestRangeHelpers:
+    """Tests for the range helpers behind the nesting reconstruction."""
+
+    def test_bound_reads_a_range_edge(self):
+        symbol = _symbol("M", NodeType.MODULE, (3, 4), (9, 1))
+        assert _bound(symbol, "start") == (3, 4)
+        assert _bound(symbol, "end") == (9, 1)
+
+    def test_bound_defaults_to_origin_when_the_range_is_absent(self):
+        assert _bound({"name": "M"}, "start") == (0, 0)
+
+    def test_encloses_detects_containment(self):
+        outer = _symbol("Outer", NodeType.MODULE, (0, 0), (10, 0))
+        inner = _symbol("Inner", NodeType.FUNCTION, (2, 4), (3, 0))
+        assert _encloses(outer, inner) is True
+        assert _encloses(inner, outer) is False
+
+    def test_identical_ranges_do_not_enclose_each_other(self):
+        """Otherwise a symbol reported twice at one range would parent itself."""
+        first = _symbol("A", NodeType.MODULE, (1, 0), (2, 0))
+        second = _symbol("B", NodeType.FUNCTION, (1, 0), (2, 0))
+        assert _encloses(first, second) is False
+
+    def test_partial_overlap_does_not_enclose(self):
+        first = _symbol("A", NodeType.MODULE, (0, 0), (5, 0))
+        second = _symbol("B", NodeType.MODULE, (3, 0), (8, 0))
+        assert _encloses(first, second) is False
+
+
+class TestNormalizeSymbols:
+    """FsAutoComplete answers with a flat list, so the adapter rebuilds the tree."""
+
+    def test_empty_input(self):
+        assert FSharpAdapter().normalize_symbols([]) == []
+
+    def test_nesting_is_rebuilt_from_ranges(self):
+        flat = [
+            _symbol("isEligible", NodeType.FIELD, (7, 8), (7, 76)),
+            _symbol("Probe.Domain", NodeType.MODULE, (0, 0), (10, 60)),
+            _symbol("Rules", NodeType.MODULE, (4, 0), (7, 76)),
+        ]
+
+        roots = FSharpAdapter().normalize_symbols(flat)
+
+        assert [root["name"] for root in roots] == ["Probe.Domain"]
+        rules = roots[0]["children"][0]
+        assert rules["name"] == "Rules"
+        assert [child["name"] for child in rules["children"]] == ["isEligible"]
+
+    def test_a_sibling_after_a_nested_module_stays_at_module_level(self):
+        """``describe`` follows ``Rules`` in the file but is not inside it."""
+        flat = [
+            _symbol("Probe.Domain", NodeType.MODULE, (0, 0), (10, 60)),
+            _symbol("Rules", NodeType.MODULE, (4, 0), (7, 76)),
+            _symbol("describe", NodeType.FIELD, (9, 4), (10, 60)),
+        ]
+
+        roots = FSharpAdapter().normalize_symbols(flat)
+
+        assert [child["name"] for child in roots[0]["children"]] == ["Rules", "describe"]
+
+    def test_module_level_let_becomes_a_function(self):
+        """Nothing downstream treats a field as callable, so a module-level
+        ``let`` — how F# declares a function — has to be named one."""
+        flat = [
+            _symbol("Probe.Domain", NodeType.MODULE, (0, 0), (5, 0)),
+            _symbol("describe", NodeType.FIELD, (2, 4), (3, 0)),
+        ]
+
+        roots = FSharpAdapter().normalize_symbols(flat)
+
+        assert roots[0]["children"][0]["kind"] == NodeType.FUNCTION
+
+    def test_let_inside_a_type_stays_a_field(self):
+        flat = [
+            _symbol("Probe.Domain", NodeType.MODULE, (0, 0), (5, 0)),
+            _symbol("Customer", NodeType.CLASS, (2, 5), (2, 46)),
+            _symbol("Name", NodeType.FIELD, (2, 18), (2, 30)),
+        ]
+
+        roots = FSharpAdapter().normalize_symbols(flat)
+
+        customer = roots[0]["children"][0]
+        assert customer["name"] == "Customer"
+        assert customer["children"][0]["kind"] == NodeType.FIELD
+
+    def test_the_input_symbols_are_not_mutated(self):
+        flat = [_symbol("describe", NodeType.FIELD, (0, 0), (1, 0))]
+
+        FSharpAdapter().normalize_symbols(flat)
+
+        assert flat[0]["kind"] == NodeType.FIELD
+        assert "children" not in flat[0]
+
+    def test_the_hook_is_opt_in_for_other_languages(self):
+        symbols = [_symbol("Program", NodeType.CLASS, (0, 0), (1, 0))]
+        assert CSharpAdapter().normalize_symbols(symbols) == symbols
+
+
+class TestBuildQualifiedName:
+    """F# declares its module path in source, so that path wins over the file path."""
+
+    def test_leading_module_is_its_own_qualified_name(self):
+        name = FSharpAdapter().build_qualified_name(
+            Path("/repo/Domain.fs"), "Probe.Domain", NodeType.MODULE, [], Path("/repo")
+        )
+        assert name == "Probe.Domain"
+
+    def test_nested_module_is_prefixed_with_its_scope(self):
+        """The server reports a nested module by its short name only."""
+        name = FSharpAdapter().build_qualified_name(
+            Path("/repo/Domain.fs"), "Rules", NodeType.MODULE, [("Probe.Domain", NodeType.MODULE)], Path("/repo")
+        )
+        assert name == "Probe.Domain.Rules"
+
+    def test_function_inside_nested_modules(self):
+        name = FSharpAdapter().build_qualified_name(
+            Path("/repo/Domain.fs"),
+            "isEligible",
+            NodeType.FUNCTION,
+            [("Probe.Domain", NodeType.MODULE), ("Rules", NodeType.MODULE)],
+            Path("/repo"),
+        )
+        assert name == "Probe.Domain.Rules.isEligible"
+
+    def test_type_member_keeps_its_containing_type(self):
+        name = FSharpAdapter().build_qualified_name(
+            Path("/repo/Domain.fs"),
+            "Name",
+            NodeType.FIELD,
+            [("Probe.Domain", NodeType.MODULE), ("Customer", NodeType.CLASS)],
+            Path("/repo"),
+        )
+        assert name == "Probe.Domain.Customer.Name"
+
+    def test_falls_back_to_the_file_path_without_a_declared_scope(self):
+        name = FSharpAdapter().build_qualified_name(
+            Path("/repo/src/Helpers.fs"), "trim", NodeType.FUNCTION, [], Path("/repo")
+        )
+        assert name == "src.Helpers.trim"
+
+    def test_extract_package_drops_the_symbol_and_its_container(self):
+        assert FSharpAdapter().extract_package("Layer2.Common.String.trim") == "Layer2.Common"

--- a/tests/static_analyzer/test_fsharp_config_scanner.py
+++ b/tests/static_analyzer/test_fsharp_config_scanner.py
@@ -1,0 +1,93 @@
+"""Tests for F# project configuration scanner."""
+
+from pathlib import Path
+
+from static_analyzer.fsharp_config_scanner import FSharpConfigScanner, FSharpProjectConfig
+
+
+class TestFSharpProjectConfig:
+    """Tests for FSharpProjectConfig data class."""
+
+    def test_init(self):
+        config = FSharpProjectConfig(Path("/project"), "solution")
+        assert config.root == Path("/project")
+        assert config.project_type == "solution"
+
+    def test_repr(self):
+        config = FSharpProjectConfig(Path("/project"), "project")
+        assert "FSharpProjectConfig" in repr(config)
+        assert "project" in repr(config)
+
+
+class TestFSharpConfigScanner:
+    """Tests for FSharpConfigScanner."""
+
+    def test_scan_no_projects(self, tmp_path: Path):
+        assert FSharpConfigScanner(tmp_path).scan() == []
+
+    def test_scan_solution_file(self, tmp_path: Path):
+        (tmp_path / "MyApp.sln").write_text("Microsoft Visual Studio Solution File")
+        (tmp_path / "Library.fs").write_text("module Library")
+
+        projects = FSharpConfigScanner(tmp_path).scan()
+
+        assert len(projects) == 1
+        assert projects[0].root == tmp_path
+        assert projects[0].project_type == "solution"
+
+    def test_scan_slnx_solution_file(self, tmp_path: Path):
+        (tmp_path / "MyApp.slnx").write_text("<Solution/>")
+        (tmp_path / "Library.fs").write_text("module Library")
+
+        projects = FSharpConfigScanner(tmp_path).scan()
+
+        assert len(projects) == 1
+        assert projects[0].project_type == "solution"
+
+    def test_scan_fsproj_file(self, tmp_path: Path):
+        (tmp_path / "MyApp.fsproj").write_text('<Project Sdk="Microsoft.NET.Sdk"/>')
+        (tmp_path / "Library.fs").write_text("module Library")
+
+        projects = FSharpConfigScanner(tmp_path).scan()
+
+        assert len(projects) == 1
+        assert projects[0].root == tmp_path
+        assert projects[0].project_type == "project"
+
+    def test_project_below_a_solution_is_not_scanned_twice(self, tmp_path: Path):
+        (tmp_path / "MyApp.sln").write_text("Microsoft Visual Studio Solution File")
+        (tmp_path / "Root.fs").write_text("module Root")
+        nested = tmp_path / "src" / "Library"
+        nested.mkdir(parents=True)
+        (nested / "Library.fsproj").write_text("<Project/>")
+        (nested / "Library.fs").write_text("module Library")
+
+        projects = FSharpConfigScanner(tmp_path).scan()
+
+        assert [p.root for p in projects] == [tmp_path]
+
+    def test_solution_without_fsharp_sources_is_skipped(self, tmp_path: Path):
+        """A C#-only solution must not reach the F# engine: both languages share
+        solution files, so this filter is what keeps each scanner to its own."""
+        (tmp_path / "MyApp.sln").write_text("Microsoft Visual Studio Solution File")
+        (tmp_path / "Program.cs").write_text("class Program {}")
+
+        assert FSharpConfigScanner(tmp_path).scan() == []
+
+    def test_fallback_to_repo_root_without_project_files(self, tmp_path: Path):
+        (tmp_path / "Script.fs").write_text("module Script")
+
+        projects = FSharpConfigScanner(tmp_path).scan()
+
+        assert len(projects) == 1
+        assert projects[0].root == tmp_path
+        assert projects[0].project_type == "none"
+
+    def test_ignored_sources_do_not_trigger_the_fallback(self, tmp_path: Path):
+        """F# hidden inside an ignored directory must not drag the whole root in."""
+        (tmp_path / ".gitignore").write_text("vendor/\n")
+        vendored = tmp_path / "vendor"
+        vendored.mkdir()
+        (vendored / "Vendored.fs").write_text("module Vendored")
+
+        assert FSharpConfigScanner(tmp_path).scan() == []

--- a/tests/test_registry_coverage.py
+++ b/tests/test_registry_coverage.py
@@ -286,6 +286,7 @@ class TestLspAdapterAndLanguageEnumParity(unittest.TestCase):
         "go": "Go",
         "php": "PHP",
         "csharp": "CSharp",
+        "fsharp": "FSharp",
         "java": "Java",
         "rust": "Rust",
     }

--- a/tool_registry/registry.py
+++ b/tool_registry/registry.py
@@ -235,6 +235,27 @@ TOOL_REGISTRY: list[ToolDependency] = [
         ),
         archive_subdir="csharp-ls",
     ),
+    # FsAutoComplete ships only as a NuGet dotnet-tool, same as csharp-ls.
+    ToolDependency(
+        key="fsharp",
+        binary_name="fsautocomplete",
+        kind=ToolKind.PACKAGE_MANAGER,
+        config_section=ConfigSection.LSP_SERVERS,
+        source=PackageManagerToolSource(
+            tag="0.84.0",
+            manager_binary="dotnet",
+            install_args=(
+                "tool",
+                "install",
+                "fsautocomplete",
+                "--version",
+                "{tag}",
+                "--tool-path",
+                "{tool_path}",
+            ),
+        ),
+        archive_subdir="fsautocomplete",
+    ),
     ToolDependency(
         key="java",
         binary_name="java",

--- a/vscode_constants.py
+++ b/vscode_constants.py
@@ -113,6 +113,15 @@ VSCODE_CONFIG = {
             # tool_registry. Full migration mode targets .NET 10.
             "install_commands": "codeboarding-setup (installs csharp-ls automatically; requires .NET SDK 10.0+)",
         },
+        "fsharp": {
+            "name": "FsAutoComplete Language Server",
+            "command": ["fsautocomplete"],
+            "languages": ["fsharp"],
+            "file_extensions": [".fs"],
+            # fsautocomplete is installed via `dotnet tool install --tool-path`
+            # by tool_registry; the install_commands string is informational only.
+            "install_commands": "codeboarding-setup (installs fsautocomplete automatically; requires a .NET SDK)",
+        },
         "java": {
             "name": "Eclipse JDT Language Server",
             "command": ["java"],  # Placeholder - will be resolved by update_command_paths()


### PR DESCRIPTION
## What

Adds F# as a supported language, analysed through [FsAutoComplete](https://github.com/ionide/FsAutoComplete).

New: `FSharpAdapter`, `FSharpConfigScanner`, the `fsharp` LSP dependency, and the `FSHARP` members of `Language`, `AdapterName` and `SourceSuffix`. Registered in `ADAPTER_REGISTRY`, `_lang_to_adapter_name()`, `VSCODE_CONFIG`, `TOOL_REGISTRY` and the parity test's mapping, following CONTRIBUTING §5 with PR #276 (Rust) as the model.

One change outside the new language, discussed under *Open question* below: `LanguageAdapter` gains a `normalize_symbols` hook, passing through by default.

## Why

An F# repository produced **no analysis at all**. `.fs` was absent from `SourceSuffix`, so the files were never collected, and a run over an F#-only solution ended in:

```
StaticAnalysisFatalError: FSharp analysis produced 0 symbols across N source files
```

F# is not a niche case inside .NET repositories, and `csharp_adapter` already recognises `.fsproj` for its restore step, so the gap shows up as a silent hole rather than an unsupported-language message.

## How

FsAutoComplete ships only as a NuGet dotnet-tool, so it registers as `ToolKind.PACKAGE_MANAGER` exactly like csharp-ls, and `resolve_dotnet_sdk` provides the SDK. Three server behaviours needed handling, each found by running the pipeline rather than by reading docs:

**1. It loads no project until asked.** Every `documentSymbol` failed with `Couldn't find <file> in LoadedProjects`. The adapter requests `AutomaticWorkspaceInit` through both the init options and the configuration channel, which avoids driving the non-standard `fsharp/workspacePeek` and `fsharp/workspaceLoad` requests.

**2. It answers `documentSymbol` with a flat list and no `children`.** Every symbol would register at file level and lose its module path. The ranges still nest, so the adapter rebuilds the tree from them. F# also declares its module path in source, and that path need not match the directory layout — one file here declares `module Layer2.Common.Array` while sitting in a differently named folder — so the declared path is authoritative for qualified names, with the file path as fallback.

**3. It reports every `let` binding as a field.** Nothing downstream treats a field as callable, so F#'s ordinary way of declaring a function produced no call graph. A module-level `let` becomes a function; a `let` inside a type stays a field.

It also type-checks lazily and answers only from what it has already checked, so the adapter opts into the existing `interleave_did_open_with_symbols`. That alone raised the numbers below by roughly 75%.

## How it was tested

`uv run pytest` — 41 new tests, covering every branch of the scanner and of the adapter's symbol reshaping and name building. `black --check` clean. `mypy` reports no new errors.

Beyond unit tests, the static-analysis stage was run against real F# code, a 56-file project in a production codebase:

| | before | after |
|---|---|---|
| symbols | 0 (fatal) | 271 |
| references | 0 | 145 |
| graph nodes | 0 | 87 |
| call edges | 0 | 22 |
| duration | — | 11.7 s |

Qualified names were verified by hand against the source on a purpose-built fixture exercising nested modules, records, classes and cross-file calls; all 15 symbols came out correct, e.g. `Probe.Domain.Rules.isEligible` and `Probe.Service.CustomerReport.Summary`.

Note: I develop on Windows, where 76 tests already fail on unmodified `main` (path separators, `chmod`, POSIX-only APIs) and `--cov` cannot run at all because coverage and numpy's C extension conflict. My branch adds no failure beyond those 76, but I could not measure coverage locally — worth a look in CI.

## Integration fixtures (§5e)

This adds a language, so it needs fixtures. For the pinned real-world repo I would suggest **[fsprojects/Paket](https://github.com/fsprojects/Paket)**: a real tool rather than a library, moderate size, and idiomatic F# structure with file-level namespaces plus modules — which is exactly the shape that exposed behaviours 2 and 3 above. **[fsprojects/FSharpPlus](https://github.com/fsprojects/FSharpPlus)** would be a good second, being far more module- and generic-heavy.

## Open question

The `normalize_symbols` hook touches `LanguageAdapter` and one line of `CallGraphBuilder`. I added it because reshaping a server's response has no existing seam, and without it F# support has no call graph at all. If you would rather see that discussed in an issue first, or solved differently, I am happy to rework it — the F#-specific parts are unaffected either way.

## Known limitation

FsAutoComplete sometimes reports a file's leading module with a degenerate range (line 0 to line 0). Nothing can nest under such a symbol, so those files keep a short module name instead of a fully qualified one. Names stay correct and unique within a project, but inconsistent across it. `.fsi` signature files and `.fsx` scripts are deliberately out of scope: a `.fsi` redeclares the symbols of its `.fs` sibling and would double them, and a `.fsx` belongs to no project. Both are worth a follow-up.
