### PR TITLE
chore: prepare release 0.13.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "codeboarding"
-version = "0.13.10"
+version = "0.13.11"
 description = "Interactive Diagrams for Code"
 readme = "PYPI.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -290,7 +290,7 @@ wheels = [
 
 [[package]]
 name = "codeboarding"
-version = "0.13.10"
+version = "0.13.11"
 source = { editable = "." }
 dependencies = [
     { name = "docker" },


### PR DESCRIPTION
## What

- Bump the package version from `0.13.10` to `0.13.11` in `pyproject.toml`.
- Update the local `codeboarding` package version in `uv.lock`.

## Validation

- `uv sync --locked`
- Python 3.12 metadata consistency check
- `uv lock --check`
- `git diff --check`
- `pre-commit run --files pyproject.toml uv.lock`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project version to 0.13.11.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->