### PR TITLE
feat(clustering): partition by qualified name

### DIFF
--- a/agents/agent_responses.py
+++ b/agents/agent_responses.py
@@ -661,6 +661,28 @@ class MetaAnalysisInsights(LLMBaseModel):
         return title + content
 
 
+class ComponentNaming(LLMBaseModel):
+    """One component the naming model proposes, and the vocabulary it owns."""
+
+    name: str = Field(description="One responsibility, never two joined by 'and'")
+    owns: list[str] = Field(description="Domain words naming this component, as they appear in identifiers")
+
+    def llm_str(self):
+        return f"{self.name}: {', '.join(self.owns)}"
+
+
+class NamingModelInsights(LLMBaseModel):
+    """How a repo's own vocabulary divides it, decided once per full analysis."""
+
+    components: list[ComponentNaming] = Field(description="The top-level components the identifiers name")
+    machinery: list[str] = Field(description="Words naming how software is built rather than what this system is about")
+    notes: str = Field(default="", description="What the vocabulary says about the repo's shape")
+
+    def llm_str(self):
+        lines = [f"- {component.llm_str()}" for component in self.components]
+        return "# Naming model\n" + "\n".join(lines) + f"\n\nMachinery: {', '.join(self.machinery)}\n{self.notes}"
+
+
 class FileClassification(LLMBaseModel):
     """Classification of a file to a component."""
 

--- a/agents/naming_model_agent.py
+++ b/agents/naming_model_agent.py
@@ -1,0 +1,88 @@
+"""Read a repo's components out of its own identifiers, once per full analysis."""
+
+import logging
+from collections import Counter
+from pathlib import Path
+
+from langchain_core.language_models import BaseChatModel
+from langchain_core.prompts import PromptTemplate
+
+from agents.agent import CodeBoardingAgent
+from agents.agent_responses import NamingModelInsights
+from agents.prompts import get_naming_model_message, get_system_message
+from monitoring import trace
+from static_analyzer.analysis_result import StaticAnalysisResults
+from static_analyzer.clustering.naming import ComponentVocabulary, NamingModel, scope_of, tokenize
+
+logger = logging.getLogger(__name__)
+
+VOCABULARY_SAMPLE = 120
+IDENTIFIER_SAMPLE = 120
+
+
+class NamingModelAgent(CodeBoardingAgent):
+    """Decides which components a repo's vocabulary names, and which words are machinery.
+
+    Run on a full analysis only. An incremental run reuses the stored answer, so the
+    partition cannot move underneath unchanged code.
+    """
+
+    def __init__(
+        self,
+        repo_dir: Path,
+        static_analysis: StaticAnalysisResults,
+        agent_llm: BaseChatModel,
+        parsing_llm: BaseChatModel,
+    ):
+        super().__init__(repo_dir, static_analysis, get_system_message(), agent_llm, parsing_llm)
+        self.prompt = PromptTemplate(
+            template=get_naming_model_message(),
+            input_variables=["scopes", "vocabulary", "identifiers"],
+        )
+
+    @trace
+    def read_naming_model(self) -> NamingModel:
+        scopes, vocabulary, identifiers = self._evidence()
+        if not identifiers:
+            logger.warning("[NamingModelAgent] No identifiers to read; returning an empty model")
+            return NamingModel(components=(), machinery=frozenset())
+
+        insights = self._parse_invoke(
+            self.prompt.format(
+                scopes="\n".join(scopes),
+                vocabulary=", ".join(f"{word}({count})" for word, count in vocabulary),
+                identifiers="\n".join(identifiers),
+            ),
+            NamingModelInsights,
+        )
+        model = NamingModel(
+            components=tuple(
+                ComponentVocabulary(component.name, tuple(component.owns)) for component in insights.components
+            ),
+            machinery=frozenset(insights.machinery),
+        )
+        logger.info(
+            "[NamingModelAgent] %d components, %d machinery words, scopes lead: %s",
+            len(model.components),
+            len(model.machinery),
+            model.scopes_are_components(set(scopes)),
+        )
+        return model
+
+    def _evidence(self) -> tuple[list[str], list[tuple[str, int]], list[str]]:
+        """The scopes, the commonest words, and a sample of identifiers. Never the answer."""
+        scopes: set[str] = set()
+        words: Counter[str] = Counter()
+        identifiers: set[str] = set()
+        for node in self.static_analysis.iter_reference_nodes():
+            scope = scope_of(node.file_path)
+            if scope:
+                scopes.add(scope)
+            name = node.fully_qualified_name.rsplit(".", 1)[-1]
+            identifiers.add(name)
+            words.update(tokenize(name))
+        return (
+            sorted(scopes),
+            words.most_common(VOCABULARY_SAMPLE),
+            sorted(identifiers)[:IDENTIFIER_SAMPLE],
+        )

--- a/agents/naming_model_agent.py
+++ b/agents/naming_model_agent.py
@@ -23,8 +23,8 @@ IDENTIFIER_SAMPLE = 120
 class NamingModelAgent(CodeBoardingAgent):
     """Decides which components a repo's vocabulary names, and which words are machinery.
 
-    Run on a full analysis only. An incremental run reuses the stored answer, so the
-    partition cannot move underneath unchanged code.
+    Run on a full analysis only; an incremental run reads the stored answer back rather than
+    re-asking, so the vocabulary cannot move underneath unchanged code.
     """
 
     def __init__(
@@ -70,12 +70,16 @@ class NamingModelAgent(CodeBoardingAgent):
         return model
 
     def _evidence(self) -> tuple[list[str], list[tuple[str, int]], list[str]]:
-        """The scopes, the commonest words, and a sample of identifiers. Never the answer."""
+        """The scopes, the commonest words, and a sample of identifiers. Never the answer.
+
+        Why the root: nodes carry absolute paths, so without it every file's outermost part is
+        the filesystem root and the model is shown one scope for the whole repo.
+        """
         scopes: set[str] = set()
         words: Counter[str] = Counter()
         identifiers: set[str] = set()
         for node in self.static_analysis.iter_reference_nodes():
-            scope = scope_of(node.file_path)
+            scope = scope_of(node.file_path, str(self.repo_dir))
             if scope:
                 scopes.add(scope)
             name = node.fully_qualified_name.rsplit(".", 1)[-1]

--- a/agents/naming_model_agent.py
+++ b/agents/naming_model_agent.py
@@ -75,18 +75,34 @@ class NamingModelAgent(CodeBoardingAgent):
         Why the root: nodes carry absolute paths, so without it every file's outermost part is
         the filesystem root and the model is shown one scope for the whole repo.
         """
-        scopes: set[str] = set()
         words: Counter[str] = Counter()
-        identifiers: set[str] = set()
+        by_scope: dict[str, set[str]] = {}
         for node in self.static_analysis.iter_reference_nodes():
             scope = scope_of(node.file_path, str(self.repo_dir))
-            if scope:
-                scopes.add(scope)
             name = node.fully_qualified_name.rsplit(".", 1)[-1]
-            identifiers.add(name)
+            by_scope.setdefault(scope, set()).add(name)
             words.update(tokenize(name))
         return (
-            sorted(scopes),
+            sorted(scope for scope in by_scope if scope),
             words.most_common(VOCABULARY_SAMPLE),
-            sorted(identifiers)[:IDENTIFIER_SAMPLE],
+            self._identifier_sample(by_scope),
         )
+
+    @staticmethod
+    def _identifier_sample(by_scope: dict[str, set[str]]) -> list[str]:
+        """A sample that reaches every scope, taken round-robin.
+
+        Why not the first N of a sorted set: that is an alphabetical slice. On eShop it showed
+        the model identifiers from A to C only -- nothing named Order, Payment or Webhook --
+        so the sample argued for components the repo does not have and stayed silent on the
+        ones it does.
+        """
+        queues = [sorted(names) for _, names in sorted(by_scope.items())]
+        sample: list[str] = []
+        for index in range(max((len(q) for q in queues), default=0)):
+            for queue in queues:
+                if index < len(queue):
+                    sample.append(queue[index])
+                    if len(sample) == IDENTIFIER_SAMPLE:
+                        return sample
+        return sample

--- a/agents/prompts/__init__.py
+++ b/agents/prompts/__init__.py
@@ -29,6 +29,7 @@ from .prompt_factory import (
     get_scope_relations_message,
     get_api_surfaces_message,
     get_relation_analysis_message,
+    get_naming_model_message,
 )
 
 

--- a/agents/prompts/abstract_prompt_factory.py
+++ b/agents/prompts/abstract_prompt_factory.py
@@ -6,6 +6,33 @@ Defines the abstract base class for prompt factories with all prompt methods.
 
 from abc import ABC, abstractmethod
 
+NAMING_MODEL_MESSAGE = """You are reading a codebase through its identifiers only.
+
+Name the top-level architectural components a maintainer of this repo would name, and the
+vocabulary each one owns.
+
+Rules:
+- `machinery` is vocabulary naming how software is built rather than what this system is
+  about: Handler, Repository, Controller, View, Context, Dto, Options, Factory, Entry, Item,
+  Event, Service. A machinery word must never own a component, or every handler in the system
+  lands in one box -- which is a layer, not a component.
+- A component's `owns` is domain vocabulary: the words naming the problem this system solves.
+  Use words that actually appear in the identifiers below.
+- Every component must be one responsibility. Never name a component by joining two things
+  with "and" or "&".
+- Where a scope below is named after part of the problem, name a component after it too, so
+  that the scope and the vocabulary agree.
+
+Top-level scopes:
+{scopes}
+
+Most frequent identifier words, with counts:
+{vocabulary}
+
+A sample of identifiers:
+{identifiers}
+"""
+
 
 class AbstractPromptFactory(ABC):
     """Abstract base class for prompt factories."""
@@ -61,3 +88,11 @@ class AbstractPromptFactory(ABC):
     @abstractmethod
     def get_relation_analysis_message(self) -> str:
         pass
+
+    def get_naming_model_message(self) -> str:
+        """Read a repo's architecture out of its identifiers.
+
+        Concrete rather than abstract: this asks for a structured reading of a vocabulary,
+        not for prose, so no provider needs its own wording.
+        """
+        return NAMING_MODEL_MESSAGE

--- a/agents/prompts/prompt_factory.py
+++ b/agents/prompts/prompt_factory.py
@@ -181,3 +181,7 @@ def get_api_surfaces_message() -> str:
 
 def get_relation_analysis_message() -> str:
     return get_global_factory()._prompt_factory.get_relation_analysis_message()
+
+
+def get_naming_model_message() -> str:
+    return get_global_factory()._prompt_factory.get_naming_model_message()

--- a/diagram_analysis/analysis_json.py
+++ b/diagram_analysis/analysis_json.py
@@ -111,6 +111,12 @@ class AnalysisMetadata(BaseModel):
         ),
         description="Lightweight file coverage counts.",
     )
+    naming_model: dict = Field(
+        default_factory=dict,
+        description="The components this repo's identifiers name, and its machinery vocabulary. "
+        "Decided on a full analysis; an incremental run reuses it so the partition cannot "
+        "move underneath unchanged code. Empty on an analysis written before this existed.",
+    )
 
 
 class ComponentFileMethodGroupJson(BaseModel):
@@ -453,6 +459,7 @@ def build_unified_analysis_json(
     depth_cap: int,
     sub_analyses: dict[str, tuple[AnalysisInsights, list[Component]]] | None = None,
     file_coverage_summary: FileCoverageSummary | None = None,
+    naming_model: dict | None = None,
 ) -> str:
     """Build the full unified analysis JSON with metadata and nested sub-analyses.
 
@@ -488,6 +495,7 @@ def build_unified_analysis_json(
             depth_level=_compute_depth_level(sub_analyses),
             depth_cap=depth_cap,
             file_coverage_summary=summary,
+            naming_model=naming_model or {},
         ),
         description=analysis.description,
         files=_build_file_entry_json_from_files(files_index),

--- a/diagram_analysis/diagram_generator.py
+++ b/diagram_analysis/diagram_generator.py
@@ -56,6 +56,8 @@ from diagram_analysis.exceptions import (
 from diagram_analysis.file_coverage import FileCoverage
 from diagram_analysis.file_index import build_files_index, refresh_method_spans_from_cfg
 from diagram_analysis.io_utils import load_analysis_metadata, save_analysis, write_fingerprint
+from agents.naming_model_agent import NamingModelAgent
+from static_analyzer.clustering.naming import NamingModel
 from diagram_analysis.incremental_changes import compute_changed_members
 from repo_utils.path_utils import normalize_repo_path
 from diagram_analysis.scope_plan import plan_scope_result_update
@@ -572,6 +574,10 @@ class DiagramGenerator:
         self.details_agent: DetailsAgent | None = None
         self.static_analysis: StaticAnalysisResults | None = None  # Cache static analysis for reuse
         self.clustering_hierarchy: ClusterScopeResult | None = None
+        # What this repo's identifiers say its components are. Read once on a full analysis
+        # and stored in the analysis metadata; an incremental run reuses it verbatim.
+        self.naming_model: NamingModel | None = None
+        self._naming_llms: tuple[BaseChatModel, BaseChatModel] | None = None
         self._pending_cluster_caches: dict[str, ClusterCache] | None = None
         self._incremental_preparation: _IncrementalPreparation | None = None
         self.abstraction_agent: AbstractionAgent | None = None
@@ -622,6 +628,8 @@ class DiagramGenerator:
         self._pending_cluster_caches = None
         pending_cluster_caches = self._stage_cluster_caches()
         depth = hierarchy_depth if hierarchy_depth is not None else self.depth_level
+        self.naming_model = self._resolve_naming_model(static_analysis, incremental)
+        repo_root = str(self.repo_location)
         if incremental:
             root_analysis = persisted_scopes.get(ROOT_SCOPE_ID)
             if root_analysis is None:
@@ -631,7 +639,7 @@ class DiagramGenerator:
             }
             self._incremental_preparation = self._prepare_incremental_clustering(root_analysis, sub_analyses, depth)
         elif target_component is None:
-            self.clustering_hierarchy = ClusteringService().build_full_hierarchy(
+            self.clustering_hierarchy = ClusteringService(self.naming_model, repo_root).build_full_hierarchy(
                 static_analysis, depth, pending_cluster_caches
             )
         else:
@@ -665,6 +673,30 @@ class DiagramGenerator:
                 json.dump(static_stats, f, indent=2)
             logger.debug(f"Written code_stats.json to {code_stats_file}")
 
+    def _resolve_naming_model(self, static_analysis: StaticAnalysisResults, incremental: bool) -> NamingModel | None:
+        """The components this repo's identifiers name.
+
+        Read once on a full analysis and stored in the analysis metadata; an incremental run
+        reuses it verbatim, so the partition cannot move underneath unchanged code. Returns
+        None when no LLM is configured or the read fails, and clustering falls back to the
+        graph partitioner.
+        """
+        if incremental:
+            stored = (load_analysis_metadata(Path(self.output_dir)) or {}).get("naming_model")
+            if stored:
+                return NamingModel.from_dict(stored)
+            logger.info("[Naming] No stored model on the baseline; keeping the graph partitioner")
+            return None
+        if self._naming_llms is None:
+            return None
+        agent_llm, parsing_llm = self._naming_llms
+        try:
+            return NamingModelAgent(self.repo_location, static_analysis, agent_llm, parsing_llm).read_naming_model()
+        except Exception:
+            # A partition is better than no analysis: fall back rather than fail the run.
+            logger.exception("[Naming] Could not read a naming model; keeping the graph partitioner")
+            return None
+
     def agent_init(self) -> None:
         """Initialize the LLM-backed agents after deterministic analysis."""
         assert self.static_analysis is not None
@@ -695,6 +727,7 @@ class DiagramGenerator:
             return
 
         agent_llm, parsing_llm = initialize_llms()
+        self._naming_llms = (agent_llm, parsing_llm)
         self._initialize_meta_agent(agent_llm, parsing_llm)
         assert self.meta_agent is not None
         with ThreadPoolExecutor(max_workers=1) as executor:
@@ -801,7 +834,9 @@ class DiagramGenerator:
             repo_dir=self.repo_location,
         )
         baseline_membership = _capture_membership_baseline(root_analysis, sub_analyses)
-        self.clustering_hierarchy = ClusteringService().build_incremental_hierarchy(
+        self.clustering_hierarchy = ClusteringService(
+            self.naming_model, str(self.repo_location)
+        ).build_incremental_hierarchy(
             self.static_analysis,
             hierarchy_depth,
             delta.cluster_results(),
@@ -1109,7 +1144,7 @@ class DiagramGenerator:
             raise ClusteringScopeUnavailableError(component.component_id, "no owned CFG nodes")
 
         remaining_depth = max(1, hierarchy_depth - _component_depth(component.component_id))
-        scope = ClusteringService().build_scope_hierarchy(
+        scope = ClusteringService(self.naming_model, str(self.repo_location)).build_scope_hierarchy(
             self.static_analysis,
             graphs,
             remaining_depth,
@@ -1185,6 +1220,7 @@ class DiagramGenerator:
                                 expandable_component_ids=expandable_ids,
                                 sub_expandable_ids=sub_expandable_ids,
                                 depth_cap=self.depth_level,
+                                naming_model=self.naming_model.to_dict() if self.naming_model else None,
                             )
 
                         if new_components and level + 1 < self.depth_level:
@@ -1370,6 +1406,7 @@ class DiagramGenerator:
                 expandable_component_ids=expandable_component_ids,
                 sub_expandable_ids=sub_expandable_ids,
                 depth_cap=self.depth_level,
+                naming_model=self.naming_model.to_dict() if self.naming_model else None,
             ).resolve()
         except Exception:
             self._pending_cluster_caches = None

--- a/diagram_analysis/io_utils.py
+++ b/diagram_analysis/io_utils.py
@@ -152,7 +152,13 @@ class _AnalysisFileStore:
         expandable = [c for c in analysis.components if c.component_id in expandable_ids]
 
         # Preserve existing metadata fields from disk when not explicitly provided
-        if sub_analyses is None or file_coverage_summary is None or not repo_name or depth_cap is None:
+        if (
+            sub_analyses is None
+            or file_coverage_summary is None
+            or not repo_name
+            or depth_cap is None
+            or naming_model is None
+        ):
             existing = self.read()
             if existing:
                 _, existing_subs, existing_data = existing
@@ -161,6 +167,10 @@ class _AnalysisFileStore:
                 metadata = existing_data.get("metadata", {})
                 if not repo_name:
                     repo_name = metadata.get("repo_name", "")
+                if naming_model is None:
+                    # Dropping it would strand every later incremental run, which requires
+                    # the model the persisted partition was built from.
+                    naming_model = metadata.get("naming_model")
                 if file_coverage_summary is None:
                     raw_summary = metadata.get("file_coverage_summary")
                     if raw_summary:

--- a/diagram_analysis/io_utils.py
+++ b/diagram_analysis/io_utils.py
@@ -101,6 +101,7 @@ class _AnalysisFileStore:
         file_coverage_summary: FileCoverageSummary | None = None,
         sub_expandable_ids: dict[str, list[str]] | None = None,
         depth_cap: int | None = None,
+        naming_model: dict | None = None,
     ) -> Path:
         """Write the full analysis to ``analysis.json`` with file locking.
 
@@ -120,6 +121,7 @@ class _AnalysisFileStore:
                 file_coverage_summary,
                 sub_expandable_ids,
                 depth_cap,
+                naming_model,
             )
 
     def _write_with_lock_held(
@@ -133,6 +135,7 @@ class _AnalysisFileStore:
         file_coverage_summary: FileCoverageSummary | None = None,
         sub_expandable_ids: dict[str, list[str]] | None = None,
         depth_cap: int | None = None,
+        naming_model: dict | None = None,
     ) -> Path:
         """Write ``analysis.json`` — caller must already hold ``self._lock``."""
         # A caller-provided set is authoritative: it already reflects the run's expansion
@@ -219,6 +222,7 @@ class _AnalysisFileStore:
             depth_cap=depth_cap,
             sub_analyses=sub_analyses_tuples,
             file_coverage_summary=file_coverage_summary,
+            naming_model=naming_model,
         )
         write_text_atomic(self._analysis_path, payload)
         return self._analysis_path
@@ -341,6 +345,7 @@ def save_analysis(
     file_coverage_summary: FileCoverageSummary | None = None,
     sub_expandable_ids: dict[str, list[str]] | None = None,
     depth_cap: int | None = None,
+    naming_model: dict | None = None,
 ) -> Path:
     """Save the analysis to a unified analysis.json file with file locking.
 
@@ -359,4 +364,5 @@ def save_analysis(
         file_coverage_summary,
         sub_expandable_ids,
         depth_cap,
+        naming_model,
     )

--- a/static_analyzer/clustering/grouping.py
+++ b/static_analyzer/clustering/grouping.py
@@ -22,10 +22,13 @@ logger = logging.getLogger(__name__)
 class GroupingService:
     """Group leaf clusters without retaining graph or partition state."""
 
-    def __init__(self, naming_model: NamingModel | None = None) -> None:
+    def __init__(self, naming_model: NamingModel | None = None, repo_root: str = "") -> None:
         self._naming_model = naming_model
         """What the repo's identifiers say its components are, decided once per full
         analysis. Absent, grouping falls back to the modularity peak over the call graph."""
+        self._repo_root = repo_root
+        """Nodes carry absolute paths, so the scope of a file is only readable against the
+        root. Without it one scope covers the repo and the structural half cannot lead."""
 
     def group(
         self,
@@ -39,7 +42,7 @@ class GroupingService:
         combined = combine_cluster_results(cluster_results)
         combined_cfg: nx.DiGraph = nx.compose_all(list(cfg_graphs.values())) if cfg_graphs else nx.DiGraph()
         if self._naming_model is not None and not subcomponents:
-            groups, partition = group_leaf_clusters(cluster_results, self._naming_model)
+            groups, partition = group_leaf_clusters(cluster_results, self._naming_model, repo_root=self._repo_root)
             if groups:
                 logger.info(
                     "[Naming] %d components from names (%s half), %.0f%% of clusters placed",

--- a/static_analyzer/clustering/grouping.py
+++ b/static_analyzer/clustering/grouping.py
@@ -13,6 +13,7 @@ from static_analyzer.config import (
     GroupingConfig,
 )
 from static_analyzer.clustering.models import AnchoredGrouping, ClusterResult
+from static_analyzer.clustering.naming import NamingModel, group_leaf_clusters
 from static_analyzer.leiden_utils import find_partition
 
 logger = logging.getLogger(__name__)
@@ -20,6 +21,11 @@ logger = logging.getLogger(__name__)
 
 class GroupingService:
     """Group leaf clusters without retaining graph or partition state."""
+
+    def __init__(self, naming_model: NamingModel | None = None) -> None:
+        self._naming_model = naming_model
+        """What the repo's identifiers say its components are, decided once per full
+        analysis. Absent, grouping falls back to the modularity peak over the call graph."""
 
     def group(
         self,
@@ -32,6 +38,18 @@ class GroupingService:
         config = SUBCOMPONENT_GROUPING_CONFIG if subcomponents else DEFAULT_GROUPING_CONFIG
         combined = combine_cluster_results(cluster_results)
         combined_cfg: nx.DiGraph = nx.compose_all(list(cfg_graphs.values())) if cfg_graphs else nx.DiGraph()
+        if self._naming_model is not None and not subcomponents:
+            groups, partition = group_leaf_clusters(cluster_results, self._naming_model)
+            if groups:
+                logger.info(
+                    "[Naming] %d components from names (%s half), %.0f%% of clusters placed",
+                    len(groups),
+                    "structural" if partition.by_structure else "lexical",
+                    partition.coverage * 100,
+                )
+                # Modularity over the same meta-graph the peak search uses, so the number a
+                # caller compares against is like for like.
+                return groups, _modularity(_build_meta_graph(combined, combined_cfg), groups)
         return _group_by_modularity_peak(combined, combined_cfg, config)
 
     def anchored_group(

--- a/static_analyzer/clustering/naming.py
+++ b/static_analyzer/clustering/naming.py
@@ -9,8 +9,13 @@ identifiers, and grouping by scope reproduces the layering.
 
 The components, the vocabulary each owns, the machinery vocabulary and the per-scope
 feature/layer call arrive as a :class:`NamingModel` decided once per full analysis.
-Everything here is arithmetic over names, so an incremental run reusing the model reproduces
-the same partition exactly.
+Everything here is arithmetic over names, so the same model over the same files always
+yields the same partition.
+
+Incremental runs do not re-run this. An existing scope keeps its components by ownership
+anchoring in ``grouping._anchored_group``, which never consults the model; only a scope with
+no previous owner is partitioned here. Extending the name path over the incremental one is
+still outstanding.
 """
 
 from __future__ import annotations

--- a/static_analyzer/clustering/naming.py
+++ b/static_analyzer/clustering/naming.py
@@ -113,6 +113,22 @@ class NamingModel:
     """Vocabulary naming how software is built rather than what this system is about. It
     never owns a component, so ``Handler`` cannot gather every handler into one box."""
 
+    def to_dict(self) -> dict:
+        """Serializable form, so an incremental run reuses the decision rather than re-asking."""
+        return {
+            "components": [{"name": c.name, "owns": list(c.owns)} for c in self.components],
+            "machinery": sorted(self.machinery),
+        }
+
+    @classmethod
+    def from_dict(cls, raw: Mapping) -> NamingModel:
+        return cls(
+            components=tuple(
+                ComponentVocabulary(c["name"], tuple(c.get("owns", ()))) for c in raw.get("components", ())
+            ),
+            machinery=frozenset(raw.get("machinery", ())),
+        )
+
     def owner_by_word(self) -> dict[str, str]:
         owner: dict[str, str] = {}
         machinery = {word.casefold() for word in self.machinery}

--- a/static_analyzer/clustering/naming.py
+++ b/static_analyzer/clustering/naming.py
@@ -65,9 +65,19 @@ def stem(word: str) -> str:
     return lowered
 
 
-def scope_of(file_path: str) -> str:
-    """The outermost scope a file is declared under, ignoring build roots."""
-    parts = [part for part in PurePosixPath(file_path).parts[:-1] if part.casefold() not in BUILD_ROOTS]
+def scope_of(file_path: str, repo_root: str = "") -> str:
+    """The outermost scope a file is declared under, ignoring build roots.
+
+    *file_path* may be absolute -- the engine's nodes carry absolute paths -- in which case
+    *repo_root* is stripped first. Without it every file's outermost part is ``/``, one scope
+    covers the repo, and the structural half can never lead.
+    """
+    path = PurePosixPath(file_path)
+    if repo_root:
+        root = PurePosixPath(repo_root)
+        if path.is_relative_to(root):
+            path = path.relative_to(root)
+    parts = [part for part in path.parts[:-1] if part.casefold() not in BUILD_ROOTS and part != "/"]
     return parts[0] if parts else ""
 
 
@@ -161,11 +171,12 @@ def partition_by_name(
     model: NamingModel,
     *,
     delimiter: str = ".",
+    repo_root: str = "",
 ) -> NamePartition:
     """Assign each unit to a component, by whichever half of its names carries the architecture."""
-    scope_names = {scope_of(path) for unit in units.values() for path in unit.files}
+    scope_names = {scope_of(path, repo_root) for unit in units.values() for path in unit.files}
     if model.scopes_are_components(scope_names):
-        return _by_scope(units, model, scope_names)
+        return _by_scope(units, model, scope_names, repo_root)
     return _by_vocabulary(units, model, delimiter)
 
 
@@ -174,6 +185,7 @@ def group_leaf_clusters(
     model: NamingModel,
     *,
     delimiter: str = ".",
+    repo_root: str = "",
 ) -> tuple[list[set[ClusterId]], NamePartition]:
     """Group leaf clusters into components by name, for ``GroupingService``.
 
@@ -189,14 +201,14 @@ def group_leaf_clusters(
                 qualified_names=tuple(sorted(qualified_names)),
             )
 
-    partition = partition_by_name(units, model, delimiter=delimiter)
+    partition = partition_by_name(units, model, delimiter=delimiter, repo_root=repo_root)
     by_component: dict[str, set[ClusterId]] = {}
     for unit_id, component in partition.assignment.items():
         by_component.setdefault(component, set()).add(int(unit_id))
     return [members for _, members in sorted(by_component.items()) if members], partition
 
 
-def _by_scope(units: dict[str, Unit], model: NamingModel, scope_names: set[str]) -> NamePartition:
+def _by_scope(units: dict[str, Unit], model: NamingModel, scope_names: set[str], repo_root: str = "") -> NamePartition:
     """Group by the scope a unit sits in, merging scopes that share their own word.
 
     The scope is a grouping key, not a vocabulary lookup: a scope the model never enumerated
@@ -211,7 +223,7 @@ def _by_scope(units: dict[str, Unit], model: NamingModel, scope_names: set[str])
     placed = 0
 
     for unit_id, unit in units.items():
-        scopes = Counter(scope_of(path) for path in unit.files if scope_of(path))
+        scopes = Counter(s for path in unit.files if (s := scope_of(path, repo_root)))
         if not scopes:
             assignment[unit_id] = INFRASTRUCTURE
             continue

--- a/static_analyzer/clustering/naming.py
+++ b/static_analyzer/clustering/naming.py
@@ -37,6 +37,10 @@ _GENERIC_ARITY = re.compile(r"`\d+$")
 _INTERFACE_PREFIX = re.compile(r"^I(?=[A-Z])")
 _INFLECTIONS = ("ing", "ies", "es", "s")
 
+SCOPES_ARE_COMPONENTS_RATIO = 0.25
+"""How many scopes the components must name before the structural half leads. The measured
+gap is wide -- 0.00 against 0.50 -- so the exact value is not load-bearing."""
+
 
 def tokenize(identifier: str) -> tuple[str, ...]:
     """Split an identifier into its words.
@@ -79,7 +83,7 @@ def ubiquitous_words(scope_names: set[str]) -> frozenset[str]:
 
 
 @dataclass(frozen=True)
-class Component:
+class ComponentVocabulary:
     """A component the naming model proposes, and the vocabulary it owns."""
 
     name: str
@@ -90,14 +94,10 @@ class Component:
 class NamingModel:
     """The per-repo decision an incremental run reuses verbatim."""
 
-    components: tuple[Component, ...]
+    components: tuple[ComponentVocabulary, ...]
     machinery: frozenset[str]
     """Vocabulary naming how software is built rather than what this system is about. It
     never owns a component, so ``Handler`` cannot gather every handler into one box."""
-    scope_kinds: dict[str, str]
-    """Each top-level scope as ``"feature"`` or ``"layer"``. Asked per scope because "is
-    ``Beacon.Domain`` a feature or a layer" is checkable, where "how structural is this
-    repo, 0 to 1" is not -- and the latter moved between 0.3 and 0.8 across draws."""
 
     def owner_by_word(self) -> dict[str, str]:
         owner: dict[str, str] = {}
@@ -109,12 +109,23 @@ class NamingModel:
                     owner.setdefault(key, component.name)
         return owner
 
-    def scopes_are_features(self, scope_names: set[str]) -> bool:
-        named = [name for name in scope_names if name]
+    def scopes_are_components(self, scope_names: set[str]) -> bool:
+        """Whether this model's own components name the scopes.
+
+        The structural half leads only when they do. A model proposing Incidents,
+        Escalation and Analytics while the scopes are ``Beacon.Application`` and
+        ``Beacon.Infrastructure`` is contradicting itself, and grouping by scope there
+        reproduces the layering -- which scores below not partitioning at all. Measured
+        across rulers: 0.00 on a layered repo, 0.50 and 1.00 on feature-shaped ones.
+        """
+        named = {name for name in scope_names if name}
         if not named:
             return False
-        features = sum(1 for name in named if self.scope_kinds.get(name, "feature") == "feature")
-        return features / len(named) >= 0.5
+        owner = self.owner_by_word()
+        machinery = {word.casefold() for word in self.machinery}
+        ubiquitous = ubiquitous_words(named)
+        matched = sum(1 for name in named if _distinctive_word(name, machinery, ubiquitous) in owner)
+        return matched / len(named) >= SCOPES_ARE_COMPONENTS_RATIO
 
 
 @dataclass(frozen=True)
@@ -153,7 +164,7 @@ def partition_by_name(
 ) -> NamePartition:
     """Assign each unit to a component, by whichever half of its names carries the architecture."""
     scope_names = {scope_of(path) for unit in units.values() for path in unit.files}
-    if model.scopes_are_features(scope_names):
+    if model.scopes_are_components(scope_names):
         return _by_scope(units, model, scope_names)
     return _by_vocabulary(units, model, delimiter)
 

--- a/static_analyzer/clustering/naming.py
+++ b/static_analyzer/clustering/naming.py
@@ -22,6 +22,7 @@ from dataclasses import dataclass
 from pathlib import PurePosixPath
 
 from clustering_ids import ClusterId
+from static_analyzer.cfg import CallGraph
 from static_analyzer.clustering.models import ClusterResult
 
 INFRASTRUCTURE = "Infrastructure"
@@ -36,6 +37,9 @@ _TOKEN = re.compile(r"[A-Z]+(?![a-z])|[A-Z][a-z0-9]*|[a-z0-9]+")
 _GENERIC_ARITY = re.compile(r"`\d+$")
 _INTERFACE_PREFIX = re.compile(r"^I(?=[A-Z])")
 _INFLECTIONS = ("ing", "ies", "es", "s")
+
+FILE_STRATEGY = "file_leaves"
+"""Recorded on a ``ClusterResult`` whose leaves are files rather than graph communities."""
 
 SCOPES_ARE_COMPONENTS_RATIO = 0.25
 """How many scopes the components must name before the structural half leads. The measured
@@ -178,6 +182,31 @@ def partition_by_name(
     if model.scopes_are_components(scope_names):
         return _by_scope(units, model, scope_names, repo_root)
     return _by_vocabulary(units, model, delimiter)
+
+
+def file_leaf_clusters(graph: CallGraph) -> ClusterResult:
+    """One leaf cluster per file, for a partition that groups on names.
+
+    Why not Leiden's clusters: they are drawn from the call graph and cross the boundaries a
+    name partition wants to keep. Measured on Beacon, 7 of 21 held symbols from more than one
+    component, which caps *any* grouping over them at 0.34 against a ruler the same names
+    reach 0.90 on. A file crosses no boundary in either ruler, and pools its identifiers, so
+    it carries more vocabulary than a lone symbol does.
+    """
+    clusters: dict[ClusterId, set[str]] = {}
+    cluster_to_files: dict[ClusterId, set[str]] = {}
+    file_to_clusters: dict[str, set[ClusterId]] = {}
+    for cluster_id, file_path in enumerate(sorted({node.file_path for node in graph.nodes.values() if node.file_path})):
+        members = {name for name, node in graph.nodes.items() if node.file_path == file_path}
+        clusters[cluster_id] = members
+        cluster_to_files[cluster_id] = {file_path}
+        file_to_clusters[file_path] = {cluster_id}
+    return ClusterResult(
+        clusters=clusters,
+        cluster_to_files=cluster_to_files,
+        file_to_clusters=file_to_clusters,
+        strategy=FILE_STRATEGY,
+    )
 
 
 def group_leaf_clusters(

--- a/static_analyzer/clustering/naming.py
+++ b/static_analyzer/clustering/naming.py
@@ -1,0 +1,268 @@
+"""Partition symbols by what their qualified names say.
+
+A qualified name has two halves. ``src/Catalog.API/Model/CatalogItem`` is structural
+(``Catalog.API``, ``Model``) and lexical (``Catalog``, ``Item``). Which half carries the
+architecture is a property of the repo, not of the algorithm: where the top-level scopes are
+features the structural half is the answer, and where they are layers -- ``Api``,
+``Application``, ``Domain``, ``Infrastructure`` -- the feature survives only in the
+identifiers, and grouping by scope reproduces the layering.
+
+The components, the vocabulary each owns, the machinery vocabulary and the per-scope
+feature/layer call arrive as a :class:`NamingModel` decided once per full analysis.
+Everything here is arithmetic over names, so an incremental run reusing the model reproduces
+the same partition exactly.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+
+from clustering_ids import ClusterId
+from static_analyzer.clustering.models import ClusterResult
+
+INFRASTRUCTURE = "Infrastructure"
+"""Where symbols carrying no domain vocabulary go. One named component rather than a
+scattering: a symbol the vocabulary cannot place is evidence of absence, and spreading it
+across the others invents membership the names do not support."""
+
+BUILD_ROOTS = frozenset({"src", "lib", "source", "sources", "packages", "apps", "modules", "pkg"})
+"""Directories that name a build layout rather than a scope, so they are no part of a name."""
+
+_TOKEN = re.compile(r"[A-Z]+(?![a-z])|[A-Z][a-z0-9]*|[a-z0-9]+")
+_GENERIC_ARITY = re.compile(r"`\d+$")
+_INTERFACE_PREFIX = re.compile(r"^I(?=[A-Z])")
+_INFLECTIONS = ("ing", "ies", "es", "s")
+
+
+def tokenize(identifier: str) -> tuple[str, ...]:
+    """Split an identifier into its words.
+
+    Handles CamelCase, snake_case and runs of capitals (``HTTPServer`` -> ``HTTP``,
+    ``Server``). Drops a parameter list, generic arguments, a C# generic arity suffix, and
+    the ``I`` a C#/Java interface name starts with.
+    """
+    name = identifier.split("(", 1)[0]
+    name = _GENERIC_ARITY.sub("", name)
+    name = re.sub(r"<[^<>]*>", "", name)
+    name = _INTERFACE_PREFIX.sub("", name.strip())
+    return tuple(_TOKEN.findall(name))
+
+
+def stem(word: str) -> str:
+    """Fold the inflections a name carries, so ``Ordering`` and ``Order`` are one word."""
+    lowered = word.casefold()
+    for suffix in _INFLECTIONS:
+        if len(lowered) > len(suffix) + 2 and lowered.endswith(suffix):
+            return lowered[: -len(suffix)]
+    return lowered
+
+
+def scope_of(file_path: str) -> str:
+    """The outermost scope a file is declared under, ignoring build roots."""
+    parts = [part for part in PurePosixPath(file_path).parts[:-1] if part.casefold() not in BUILD_ROOTS]
+    return parts[0] if parts else ""
+
+
+def ubiquitous_words(scope_names: set[str]) -> frozenset[str]:
+    """Words every scope carries, which therefore distinguish no scope from another.
+
+    ``Modulify.Catalog``, ``Modulify.Player`` and ``Modulify.Library`` all start with
+    ``Modulify``; keeping it leaves every scope one word and collapses the repo to a single
+    component.
+    """
+    per_scope = [{stem(word) for word in tokenize(name)} for name in scope_names if name]
+    return frozenset(set.intersection(*per_scope)) if per_scope else frozenset()
+
+
+@dataclass(frozen=True)
+class Component:
+    """A component the naming model proposes, and the vocabulary it owns."""
+
+    name: str
+    owns: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class NamingModel:
+    """The per-repo decision an incremental run reuses verbatim."""
+
+    components: tuple[Component, ...]
+    machinery: frozenset[str]
+    """Vocabulary naming how software is built rather than what this system is about. It
+    never owns a component, so ``Handler`` cannot gather every handler into one box."""
+    scope_kinds: dict[str, str]
+    """Each top-level scope as ``"feature"`` or ``"layer"``. Asked per scope because "is
+    ``Beacon.Domain`` a feature or a layer" is checkable, where "how structural is this
+    repo, 0 to 1" is not -- and the latter moved between 0.3 and 0.8 across draws."""
+
+    def owner_by_word(self) -> dict[str, str]:
+        owner: dict[str, str] = {}
+        machinery = {word.casefold() for word in self.machinery}
+        for component in self.components:
+            for word in component.owns:
+                key = stem(word)
+                if key not in machinery and word.casefold() not in machinery:
+                    owner.setdefault(key, component.name)
+        return owner
+
+    def scopes_are_features(self, scope_names: set[str]) -> bool:
+        named = [name for name in scope_names if name]
+        if not named:
+            return False
+        features = sum(1 for name in named if self.scope_kinds.get(name, "feature") == "feature")
+        return features / len(named) >= 0.5
+
+
+@dataclass(frozen=True)
+class NamePartition:
+    """An assignment plus the evidence for how far to trust it."""
+
+    assignment: dict[str, str]
+    placed: int
+    total: int
+    by_structure: bool
+
+    @property
+    def coverage(self) -> float:
+        """Fraction of units the vocabulary could place.
+
+        Low coverage is the signal that a repo has no domain vocabulary to cluster on -- a
+        compiler whose every noun is Node, Visitor and Context. Callers must surface it
+        rather than let ``Infrastructure`` quietly swallow the repo.
+        """
+        return self.placed / self.total if self.total else 0.0
+
+
+@dataclass(frozen=True)
+class Unit:
+    """One thing to place: a leaf cluster, or a single symbol."""
+
+    files: tuple[str, ...]
+    qualified_names: tuple[str, ...]
+
+
+def partition_by_name(
+    units: dict[str, Unit],
+    model: NamingModel,
+    *,
+    delimiter: str = ".",
+) -> NamePartition:
+    """Assign each unit to a component, by whichever half of its names carries the architecture."""
+    scope_names = {scope_of(path) for unit in units.values() for path in unit.files}
+    if model.scopes_are_features(scope_names):
+        return _by_scope(units, model, scope_names)
+    return _by_vocabulary(units, model, delimiter)
+
+
+def group_leaf_clusters(
+    cluster_results: Mapping[str, ClusterResult],
+    model: NamingModel,
+    *,
+    delimiter: str = ".",
+) -> tuple[list[set[ClusterId]], NamePartition]:
+    """Group leaf clusters into components by name, for ``GroupingService``.
+
+    Returns groups that are exhaustive over every cluster id and disjoint, which is what
+    ``_assign_symbol_members`` asserts. A component the names leave empty is dropped, so a
+    scope can never produce a group with nothing in it.
+    """
+    units: dict[str, Unit] = {}
+    for result in cluster_results.values():
+        for cluster_id, qualified_names in result.clusters.items():
+            units[str(cluster_id)] = Unit(
+                files=tuple(sorted(result.cluster_to_files.get(cluster_id, set()))),
+                qualified_names=tuple(sorted(qualified_names)),
+            )
+
+    partition = partition_by_name(units, model, delimiter=delimiter)
+    by_component: dict[str, set[ClusterId]] = {}
+    for unit_id, component in partition.assignment.items():
+        by_component.setdefault(component, set()).add(int(unit_id))
+    return [members for _, members in sorted(by_component.items()) if members], partition
+
+
+def _by_scope(units: dict[str, Unit], model: NamingModel, scope_names: set[str]) -> NamePartition:
+    """Group by the scope a unit sits in, merging scopes that share their own word.
+
+    The scope is a grouping key, not a vocabulary lookup: a scope the model never enumerated
+    is still a component. Scopes merge on their own distinctive word rather than on a
+    component's ``owns``, which keeps ``Ordering.API``, ``Ordering.Domain`` and
+    ``OrderProcessor`` together while leaving ``PaymentProcessor`` alone -- letting ``owns``
+    do it instead pulled payments into ordering and the web app into the mobile client.
+    """
+    machinery = {word.casefold() for word in model.machinery}
+    ubiquitous = ubiquitous_words(scope_names)
+    assignment: dict[str, str] = {}
+    placed = 0
+
+    for unit_id, unit in units.items():
+        scopes = Counter(scope_of(path) for path in unit.files if scope_of(path))
+        if not scopes:
+            assignment[unit_id] = INFRASTRUCTURE
+            continue
+        scope = max(sorted(scopes), key=lambda name: (scopes[name], name))
+        assignment[unit_id] = _distinctive_word(scope, machinery, ubiquitous) or scope
+        placed += 1
+
+    return NamePartition(assignment, placed, len(units), by_structure=True)
+
+
+def _by_vocabulary(units: dict[str, Unit], model: NamingModel, delimiter: str) -> NamePartition:
+    """Group by the domain words the identifiers carry."""
+    owner = model.owner_by_word()
+    machinery = {word.casefold() for word in model.machinery}
+    assignment: dict[str, str] = {}
+    placed = 0
+
+    for unit_id, unit in units.items():
+        votes: Counter[str] = Counter()
+        for qualified_name in unit.qualified_names:
+            for part in _segments(qualified_name, delimiter):
+                words = tokenize(part)
+                for position, word in enumerate(words):
+                    key = stem(word)
+                    if word.casefold() in machinery or key in machinery or key not in owner:
+                        continue
+                    # A noun phrase modifies rightwards, so a word nearer the head weighs
+                    # more. That reads `IncidentResolvedMetricsHandler` as metrics: it
+                    # reacts to the incident event rather than being about incidents.
+                    votes[owner[key]] += 2.0 ** (position - (len(words) - 1))
+        if votes:
+            assignment[unit_id] = max(sorted(votes), key=lambda name: (votes[name], name))
+            placed += 1
+        else:
+            assignment[unit_id] = INFRASTRUCTURE
+
+    return NamePartition(assignment, placed, len(units), by_structure=False)
+
+
+def _distinctive_word(scope_name: str, machinery: set[str], ubiquitous: frozenset[str]) -> str:
+    """The first word of a scope name that names this scope rather than every scope."""
+    for word in tokenize(scope_name):
+        folded = stem(word)
+        if word.casefold() not in machinery and folded not in machinery and folded not in ubiquitous:
+            return folded
+    return ""
+
+
+def _segments(qualified_name: str, delimiter: str) -> list[str]:
+    """Split on *delimiter*, keeping parameter lists and generics whole."""
+    out: list[str] = []
+    depth = 0
+    current: list[str] = []
+    for char in qualified_name:
+        if char in "(<":
+            depth += 1
+        elif char in ")>":
+            depth -= 1
+        if char == delimiter and depth == 0:
+            out.append("".join(current))
+            current = []
+        else:
+            current.append(char)
+    out.append("".join(current))
+    return [part for part in out if part]

--- a/static_analyzer/clustering/service.py
+++ b/static_analyzer/clustering/service.py
@@ -26,6 +26,7 @@ from static_analyzer.clustering.grouping import (
     reindex_across_languages,
     reindex_cluster_result,
 )
+from static_analyzer.clustering.naming import NamingModel, file_leaf_clusters
 from static_analyzer.clustering.models import (
     METHOD_LEVEL_STRATEGY,
     ClusterConnectionEdge,
@@ -64,7 +65,16 @@ def _unseeded_scope(_scope_id: ScopeId, _graphs: Mapping[str, CallGraph]) -> Clu
 class ClusteringService:
     """Build deterministic clustering results and hierarchies."""
 
+    def __init__(self, naming_model: NamingModel | None = None, repo_root: str = "") -> None:
+        self._naming_model = naming_model
+        self._repo_root = repo_root
+
     def cluster(self, graph: CallGraph) -> ClusterResult:
+        # With a naming model the leaves are files: Leiden's communities are drawn from the
+        # call graph and cross the boundaries a name partition wants to keep, which caps any
+        # grouping over them far below what the same names reach on a file.
+        if self._naming_model is not None:
+            return file_leaf_clusters(graph)
         return cluster_graph(graph.to_networkx(DEFAULT_REFERENCE_KINDS), delimiter=graph.delimiter)
 
     def build_full_hierarchy(
@@ -252,7 +262,7 @@ class ClusteringService:
                     )[0]
 
         nx_graphs = {language: graph.to_networkx(DEFAULT_REFERENCE_KINDS) for language, graph in graphs.items()}
-        grouping_service = GroupingService()
+        grouping_service = GroupingService(self._naming_model, self._repo_root)
         subcomponents = scope_id != ROOT_SCOPE_ID
         if previous_owner:
             grouping = grouping_service.anchored_group(

--- a/tests/agents/test_naming_model_agent.py
+++ b/tests/agents/test_naming_model_agent.py
@@ -50,6 +50,16 @@ class TestNamingModelAgentEvidence(unittest.TestCase):
         scopes, _, _ = self._agent()._evidence()
         self.assertEqual(scopes, ["Catalog.API", "Ordering.API"])
 
+    def test_the_identifier_sample_reaches_every_scope(self):
+        """An alphabetical slice showed eShop's model identifiers from A to C only, so it
+        argued for components the repo does not have and stayed silent on the ones it does."""
+        nodes = [
+            (f"Alpha.API.Aardvark{i}", str(self.repo_dir / f"src/Alpha.API/Aardvark{i}.cs")) for i in range(200)
+        ] + [("Zeta.API.ZuluApi", str(self.repo_dir / "src/Zeta.API/ZuluApi.cs"))]
+        agent = NamingModelAgent(self.repo_dir, _analysis(nodes), MagicMock(), MagicMock())
+        _, _, identifiers = agent._evidence()
+        self.assertIn("ZuluApi", identifiers)
+
     def test_evidence_carries_vocabulary_and_identifiers(self):
         scopes, vocabulary, identifiers = self._agent()._evidence()
         self.assertIn("OrdersApi", identifiers)

--- a/tests/agents/test_naming_model_agent.py
+++ b/tests/agents/test_naming_model_agent.py
@@ -1,0 +1,94 @@
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from agents.agent_responses import ComponentNaming, NamingModelInsights
+from agents.naming_model_agent import NamingModelAgent
+from static_analyzer.analysis_result import StaticAnalysisResults
+from static_analyzer.cfg import CallGraph
+from static_analyzer.config import Language, NodeType
+from static_analyzer.node import Node
+
+
+def _analysis(nodes: list[tuple[str, str]]) -> StaticAnalysisResults:
+    graph = CallGraph(language="csharp")
+    for index, (qualified_name, file_path) in enumerate(nodes):
+        graph.add_node(Node(qualified_name, NodeType.CLASS, file_path, index + 1, index + 2))
+    results = StaticAnalysisResults()
+    results.add_cfg(Language.CSHARP, graph)
+    results.add_references(Language.CSHARP, list(graph.nodes.values()))
+    return results
+
+
+class TestNamingModelAgentEvidence(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.repo_dir = Path(self.temp_dir) / "eShop"
+        (self.repo_dir / "src" / "Ordering.API").mkdir(parents=True)
+        (self.repo_dir / "src" / "Catalog.API").mkdir(parents=True)
+
+        self.static_analysis = _analysis(
+            [
+                ("Ordering.API.Apis.OrdersApi", str(self.repo_dir / "src/Ordering.API/OrdersApi.cs")),
+                ("Catalog.API.Apis.CatalogApi", str(self.repo_dir / "src/Catalog.API/CatalogApi.cs")),
+            ]
+        )
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def _agent(self) -> NamingModelAgent:
+        llm = MagicMock()
+        llm.model_name = "test-model"
+        return NamingModelAgent(self.repo_dir, self.static_analysis, llm, llm)
+
+    def test_scopes_are_read_against_the_repo_root(self):
+        """Nodes carry absolute paths; without the root every scope collapses to a filesystem
+        component and the model is shown one scope for the whole repo."""
+        scopes, _, _ = self._agent()._evidence()
+        self.assertEqual(scopes, ["Catalog.API", "Ordering.API"])
+
+    def test_evidence_carries_vocabulary_and_identifiers(self):
+        scopes, vocabulary, identifiers = self._agent()._evidence()
+        self.assertIn("OrdersApi", identifiers)
+        self.assertIn("Api", dict(vocabulary))
+        self.assertTrue(scopes)
+
+
+class TestNamingModelAgentParsing(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.repo_dir = Path(self.temp_dir) / "repo"
+        self.repo_dir.mkdir(parents=True)
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_empty_repository_yields_an_empty_model(self):
+        llm = MagicMock()
+        llm.model_name = "test-model"
+        model = NamingModelAgent(self.repo_dir, _analysis([]), llm, llm).read_naming_model()
+        self.assertEqual(model.components, ())
+        self.assertEqual(model.machinery, frozenset())
+
+    def test_insights_become_a_naming_model(self):
+        analysis = _analysis([("Ordering.Order", str(self.repo_dir / "src/Ordering/Order.cs"))])
+        llm = MagicMock()
+        llm.model_name = "test-model"
+        agent = NamingModelAgent(self.repo_dir, analysis, llm, llm)
+        agent._parse_invoke = MagicMock(
+            return_value=NamingModelInsights(
+                components=[ComponentNaming(name="Ordering", owns=["Order", "Payment"])],
+                machinery=["Handler", "Repository"],
+            )
+        )
+        model = agent.read_naming_model()
+        self.assertEqual([c.name for c in model.components], ["Ordering"])
+        self.assertEqual(model.components[0].owns, ("Order", "Payment"))
+        self.assertEqual(model.machinery, frozenset({"Handler", "Repository"}))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/diagram_analysis/test_diagram_analysis.py
+++ b/tests/diagram_analysis/test_diagram_analysis.py
@@ -1568,6 +1568,7 @@ class TestDiagramGenerator(unittest.TestCase):
             depth_cap,
             sub_analyses,
             file_coverage_summary,
+            naming_model,
         ):
             captured["expandable_components"] = expandable_components
             return "{}"

--- a/tests/static_analyzer/test_clustering_naming.py
+++ b/tests/static_analyzer/test_clustering_naming.py
@@ -71,6 +71,17 @@ class TestScopeOf:
     def test_a_root_level_file_has_no_scope(self):
         assert scope_of("Program.cs") == ""
 
+    def test_an_absolute_path_needs_the_repo_root(self):
+        """The engine's nodes carry absolute paths.
+
+        Without the root every file's outermost part is `/`, one scope covers the whole
+        repo, and the structural half can never lead -- which on eShop is the difference
+        between 0.9991 and 0.32.
+        """
+        absolute = "/home/me/checkouts/eShop/src/Catalog.API/Model/CatalogItem.cs"
+        assert scope_of(absolute, "/home/me/checkouts/eShop") == "Catalog.API"
+        assert scope_of(absolute) != "/"
+
 
 class TestUbiquitousWords:
     def test_a_shared_product_name_is_ubiquitous(self):

--- a/tests/static_analyzer/test_clustering_naming.py
+++ b/tests/static_analyzer/test_clustering_naming.py
@@ -4,13 +4,18 @@ Each case here is a failure that was measured on a real ruler before it was fixe
 scores are in the PR description.
 """
 
+from static_analyzer.cfg import CallGraph
 from static_analyzer.clustering.grouping import GroupingService
 from static_analyzer.clustering.models import ClusterResult
+from static_analyzer.config import NodeType
+from static_analyzer.node import Node
 from static_analyzer.clustering.naming import (
+    FILE_STRATEGY,
     INFRASTRUCTURE,
     ComponentVocabulary,
     NamingModel,
     Unit,
+    file_leaf_clusters,
     group_leaf_clusters,
     partition_by_name,
     scope_of,
@@ -276,3 +281,39 @@ class TestGroupingServiceUsesTheModel:
         naming = model([("Incidents", ("Incident",))], ("Handler",))
         groups, _ = GroupingService(naming).group(self._results(), {}, subcomponents=True)
         assert sorted(cid for group in groups for cid in group) == [1, 2, 3]
+
+
+class TestFileLeafClusters:
+    """The leaves a name partition wants: one per file, crossing no component boundary."""
+
+    def _graph(self):
+        graph = CallGraph()
+        for line, (qname, path) in enumerate(
+            (
+                ("Beacon.Application.Incidents.OpenIncidentHandler", "Beacon.Application/Incidents/Open.cs"),
+                ("Beacon.Application.Incidents.OpenIncidentHandler.Handle", "Beacon.Application/Incidents/Open.cs"),
+                ("Beacon.Api.Endpoints.IncidentEndpoints", "Beacon.Api/Endpoints/Incident.cs"),
+            )
+        ):
+            graph.add_node(Node(qname, NodeType.CLASS, path, line * 10, line * 10 + 5))
+        return graph
+
+    def test_one_cluster_per_file(self):
+        result = file_leaf_clusters(self._graph())
+        assert len(result.clusters) == 2
+        assert result.strategy == FILE_STRATEGY
+
+    def test_every_symbol_in_a_file_lands_in_that_file_s_cluster(self):
+        result = file_leaf_clusters(self._graph())
+        by_file = {next(iter(files)): cid for cid, files in result.cluster_to_files.items()}
+        members = result.clusters[by_file["Beacon.Application/Incidents/Open.cs"]]
+        assert members == {
+            "Beacon.Application.Incidents.OpenIncidentHandler",
+            "Beacon.Application.Incidents.OpenIncidentHandler.Handle",
+        }
+
+    def test_cluster_ids_do_not_depend_on_node_order(self):
+        """Files are sorted, so the same tree yields the same ids run to run."""
+        first = file_leaf_clusters(self._graph())
+        second = file_leaf_clusters(self._graph())
+        assert first.clusters == second.clusters

--- a/tests/static_analyzer/test_clustering_naming.py
+++ b/tests/static_analyzer/test_clustering_naming.py
@@ -1,0 +1,225 @@
+"""Tests for partitioning by qualified name.
+
+Each case here is a failure that was measured on a real ruler before it was fixed; the
+scores are in the PR description.
+"""
+
+from static_analyzer.clustering.models import ClusterResult
+from static_analyzer.clustering.naming import (
+    INFRASTRUCTURE,
+    Component,
+    NamingModel,
+    Unit,
+    group_leaf_clusters,
+    partition_by_name,
+    scope_of,
+    stem,
+    tokenize,
+    ubiquitous_words,
+)
+
+
+def model(components, machinery=(), scope_kinds=None) -> NamingModel:
+    return NamingModel(
+        components=tuple(Component(name, tuple(owns)) for name, owns in components),
+        machinery=frozenset(machinery),
+        scope_kinds=scope_kinds or {},
+    )
+
+
+class TestTokenize:
+    def test_camel_case(self):
+        assert tokenize("IncidentRepository") == ("Incident", "Repository")
+
+    def test_run_of_capitals_is_one_word(self):
+        assert tokenize("HTTPServerFactory") == ("HTTP", "Server", "Factory")
+
+    def test_snake_case(self):
+        assert tokenize("open_incident_handler") == ("open", "incident", "handler")
+
+    def test_interface_prefix_is_dropped(self):
+        assert tokenize("IScheduleQuery") == ("Schedule", "Query")
+
+    def test_a_word_starting_with_i_is_not_an_interface(self):
+        assert tokenize("Incident") == ("Incident",)
+
+    def test_parameter_list_is_dropped(self):
+        assert tokenize("Add(int value)") == ("Add",)
+
+    def test_generic_arguments_are_dropped(self):
+        assert tokenize("Repository<TEntity>") == ("Repository",)
+
+    def test_generic_arity_suffix_is_dropped(self):
+        assert tokenize("Repository`1") == ("Repository",)
+
+
+class TestStem:
+    def test_folds_an_inflection(self):
+        assert stem("Ordering") == stem("Order")
+
+    def test_folds_a_plural(self):
+        assert stem("Postmortems") == stem("Postmortem")
+
+    def test_leaves_a_short_word_alone(self):
+        assert stem("Bus") == "bus"
+
+
+class TestScopeOf:
+    def test_build_root_is_not_a_scope(self):
+        assert scope_of("src/Catalog.API/Model/CatalogItem.cs") == "Catalog.API"
+
+    def test_a_root_level_file_has_no_scope(self):
+        assert scope_of("Program.cs") == ""
+
+
+class TestUbiquitousWords:
+    def test_a_shared_product_name_is_ubiquitous(self):
+        assert "modulify" in ubiquitous_words({"Modulify.Catalog", "Modulify.Player", "Modulify.Library"})
+
+    def test_a_word_only_some_scopes_carry_is_not(self):
+        assert "catalog" not in ubiquitous_words({"Modulify.Catalog", "Modulify.Player"})
+
+
+class TestPartitionByScope:
+    """Where the scopes are features, the scope is the component."""
+
+    KINDS = {
+        "Catalog.API": "feature",
+        "Ordering.API": "feature",
+        "Ordering.Domain": "feature",
+        "OrderProcessor": "feature",
+        "PaymentProcessor": "feature",
+    }
+    MACHINERY = ("API", "Domain", "Processor", "Item", "Dto")
+
+    def _units(self):
+        return {
+            "catalog": Unit(("src/Catalog.API/CatalogItem.cs",), ("Catalog.API.CatalogItem",)),
+            "order-api": Unit(("src/Ordering.API/OrderController.cs",), ("Ordering.API.OrderController",)),
+            "order-domain": Unit(("src/Ordering.Domain/Order.cs",), ("Ordering.Domain.Order",)),
+            "order-proc": Unit(("src/OrderProcessor/Worker.cs",), ("OrderProcessor.Worker",)),
+            "payment": Unit(("src/PaymentProcessor/Worker.cs",), ("PaymentProcessor.Worker",)),
+        }
+
+    def test_scopes_sharing_their_own_word_merge(self):
+        result = partition_by_name(self._units(), model([], self.MACHINERY, self.KINDS))
+        assert result.by_structure
+        assert result.assignment["order-api"] == result.assignment["order-domain"]
+        assert result.assignment["order-proc"] == result.assignment["order-api"]
+
+    def test_a_scope_with_its_own_word_stays_separate(self):
+        """`PaymentProcessor` must not be absorbed into ordering."""
+        result = partition_by_name(self._units(), model([], self.MACHINERY, self.KINDS))
+        assert result.assignment["payment"] != result.assignment["order-api"]
+        assert result.assignment["catalog"] != result.assignment["order-api"]
+
+    def test_a_shared_product_prefix_does_not_collapse_the_repo(self):
+        units = {
+            "a": Unit(("Modulify.Catalog/Facade.cs",), ("Modulify.Catalog.Facade",)),
+            "b": Unit(("Modulify.Player/Service.cs",), ("Modulify.Player.Service",)),
+            "c": Unit(("Modulify.Library/Store.cs",), ("Modulify.Library.Store",)),
+        }
+        kinds = {"Modulify.Catalog": "feature", "Modulify.Player": "feature", "Modulify.Library": "feature"}
+        result = partition_by_name(units, model([], ("Facade", "Service", "Store"), kinds))
+        assert len(set(result.assignment.values())) == 3
+
+
+class TestPartitionByVocabulary:
+    """Where the scopes are layers, the feature is only in the identifiers."""
+
+    KINDS = {"Beacon.Api": "layer", "Beacon.Application": "layer", "Beacon.Infrastructure": "layer"}
+    COMPONENTS = [
+        ("Incidents", ("Incident", "Timeline")),
+        ("Escalation", ("Escalation", "Policy")),
+        ("Analytics", ("Metrics", "Reliability")),
+    ]
+    MACHINERY = ("Handler", "Repository", "Endpoints", "Get", "Create")
+
+    def _partition(self, units):
+        return partition_by_name(units, model(self.COMPONENTS, self.MACHINERY, self.KINDS))
+
+    def test_layers_are_not_used_as_components(self):
+        units = {
+            "a": Unit(("Beacon.Api/Endpoints/IncidentEndpoints.cs",), ("Beacon.Api.Endpoints.IncidentEndpoints",)),
+            "b": Unit(
+                ("Beacon.Application/Incidents/OpenIncidentHandler.cs",),
+                ("Beacon.Application.Incidents.OpenIncidentHandler",),
+            ),
+        }
+        result = self._partition(units)
+        assert not result.by_structure
+        assert result.assignment["a"] == "Incidents"
+        assert result.assignment["b"] == "Incidents"
+
+    def test_a_reactor_belongs_to_what_it_produces_not_what_it_consumes(self):
+        """`IncidentResolvedMetricsHandler` reacts to an incident event; it is about metrics."""
+        units = {
+            "reactor": Unit(
+                ("Beacon.Application/Analytics/IncidentResolvedMetricsHandler.cs",), ("IncidentResolvedMetricsHandler",)
+            ),
+        }
+        assert self._partition(units).assignment["reactor"] == "Analytics"
+
+    def test_a_unit_with_no_domain_word_is_infrastructure_and_counted(self):
+        units = {
+            "incident": Unit(("Beacon.Application/Incidents/OpenIncidentHandler.cs",), ("OpenIncidentHandler",)),
+            "plumbing": Unit(("Beacon.Infrastructure/EfRepository.cs",), ("EfRepository",)),
+        }
+        result = self._partition(units)
+        assert result.assignment["plumbing"] == INFRASTRUCTURE
+        assert result.coverage == 0.5
+
+    def test_machinery_never_owns_a_component(self):
+        """Otherwise every Handler in the system lands in one box, which is a layer."""
+        owned = model(self.COMPONENTS + [("Wrong", ("Handler",))], self.MACHINERY, self.KINDS).owner_by_word()
+        assert "handler" not in owned
+
+
+class TestGroupLeafClusters:
+    """The seam GroupingService consumes: sets of cluster ids."""
+
+    def _results(self):
+        return {
+            "CSharp": ClusterResult(
+                clusters={
+                    1: {"Beacon.Application.Incidents.OpenIncidentHandler"},
+                    2: {"Beacon.Api.Endpoints.IncidentEndpoints"},
+                    3: {"Beacon.Application.Escalation.EscalationPlanner"},
+                    4: {"Beacon.Platform.EfRepository"},
+                },
+                cluster_to_files={
+                    1: {"Beacon.Application/Incidents/OpenIncidentHandler.cs"},
+                    2: {"Beacon.Api/Endpoints/IncidentEndpoints.cs"},
+                    3: {"Beacon.Application/Escalation/EscalationPlanner.cs"},
+                    4: {"Beacon.Platform/EfRepository.cs"},
+                },
+            )
+        }
+
+    def _model(self):
+        return model(
+            [("Incidents", ("Incident",)), ("Escalation", ("Escalation",))],
+            ("Handler", "Endpoints", "Repository", "Ef", "Planner"),
+            {"Beacon.Application": "layer", "Beacon.Api": "layer", "Beacon.Platform": "layer"},
+        )
+
+    def test_groups_are_exhaustive_and_disjoint(self):
+        groups, _ = group_leaf_clusters(self._results(), self._model())
+        members = [cid for group in groups for cid in group]
+        assert sorted(members) == [1, 2, 3, 4]
+        assert len(members) == len(set(members))
+
+    def test_clusters_of_one_feature_land_together_across_layers(self):
+        groups, _ = group_leaf_clusters(self._results(), self._model())
+        owner = {cid: index for index, group in enumerate(groups) for cid in group}
+        assert owner[1] == owner[2]
+        assert owner[3] != owner[1]
+
+    def test_coverage_reports_what_the_names_could_not_place(self):
+        _, partition = group_leaf_clusters(self._results(), self._model())
+        assert partition.assignment["4"] == INFRASTRUCTURE
+        assert partition.coverage == 0.75
+
+    def test_no_group_is_empty(self):
+        groups, _ = group_leaf_clusters(self._results(), self._model())
+        assert all(groups)

--- a/tests/static_analyzer/test_clustering_naming.py
+++ b/tests/static_analyzer/test_clustering_naming.py
@@ -4,6 +4,7 @@ Each case here is a failure that was measured on a real ruler before it was fixe
 scores are in the PR description.
 """
 
+from static_analyzer.clustering.grouping import GroupingService
 from static_analyzer.clustering.models import ClusterResult
 from static_analyzer.clustering.naming import (
     INFRASTRUCTURE,
@@ -224,3 +225,43 @@ class TestGroupLeafClusters:
     def test_no_group_is_empty(self):
         groups, _ = group_leaf_clusters(self._results(), self._model())
         assert all(groups)
+
+
+class TestGroupingServiceUsesTheModel:
+    """The seam: a model present replaces the modularity peak, absent changes nothing."""
+
+    def _results(self):
+        return {
+            "CSharp": ClusterResult(
+                clusters={
+                    1: {"Beacon.Application.Incidents.OpenIncidentHandler"},
+                    2: {"Beacon.Api.Endpoints.IncidentEndpoints"},
+                    3: {"Beacon.Application.Escalation.EscalationPlanner"},
+                },
+                cluster_to_files={
+                    1: {"Beacon.Application/Incidents/OpenIncidentHandler.cs"},
+                    2: {"Beacon.Api/Endpoints/IncidentEndpoints.cs"},
+                    3: {"Beacon.Application/Escalation/EscalationPlanner.cs"},
+                },
+            )
+        }
+
+    def test_a_model_groups_by_name(self):
+        naming = model(
+            [("Incidents", ("Incident",)), ("Escalation", ("Escalation",))],
+            ("Handler", "Endpoints", "Planner", "Application", "Api", "Beacon"),
+        )
+        groups, _ = GroupingService(naming).group(self._results(), {})
+        owner = {cid: index for index, group in enumerate(groups) for cid in group}
+        assert owner[1] == owner[2]
+        assert owner[3] != owner[1]
+
+    def test_without_a_model_nothing_changes(self):
+        groups, _ = GroupingService().group(self._results(), {})
+        assert sorted(cid for group in groups for cid in group) == [1, 2, 3]
+
+    def test_sub_scopes_keep_the_graph_partitioner(self):
+        """Only the top level is name-driven; a sub-scope has no scopes to read."""
+        naming = model([("Incidents", ("Incident",))], ("Handler",))
+        groups, _ = GroupingService(naming).group(self._results(), {}, subcomponents=True)
+        assert sorted(cid for group in groups for cid in group) == [1, 2, 3]

--- a/tests/static_analyzer/test_clustering_naming.py
+++ b/tests/static_analyzer/test_clustering_naming.py
@@ -7,7 +7,7 @@ scores are in the PR description.
 from static_analyzer.clustering.models import ClusterResult
 from static_analyzer.clustering.naming import (
     INFRASTRUCTURE,
-    Component,
+    ComponentVocabulary,
     NamingModel,
     Unit,
     group_leaf_clusters,
@@ -19,11 +19,10 @@ from static_analyzer.clustering.naming import (
 )
 
 
-def model(components, machinery=(), scope_kinds=None) -> NamingModel:
+def model(components, machinery=()) -> NamingModel:
     return NamingModel(
-        components=tuple(Component(name, tuple(owns)) for name, owns in components),
+        components=tuple(ComponentVocabulary(name, tuple(owns)) for name, owns in components),
         machinery=frozenset(machinery),
-        scope_kinds=scope_kinds or {},
     )
 
 
@@ -83,13 +82,7 @@ class TestUbiquitousWords:
 class TestPartitionByScope:
     """Where the scopes are features, the scope is the component."""
 
-    KINDS = {
-        "Catalog.API": "feature",
-        "Ordering.API": "feature",
-        "Ordering.Domain": "feature",
-        "OrderProcessor": "feature",
-        "PaymentProcessor": "feature",
-    }
+    COMPONENTS = [("Catalog", ("Catalog",)), ("Ordering", ("Order",)), ("Payments", ("Payment",))]
     MACHINERY = ("API", "Domain", "Processor", "Item", "Dto")
 
     def _units(self):
@@ -102,14 +95,14 @@ class TestPartitionByScope:
         }
 
     def test_scopes_sharing_their_own_word_merge(self):
-        result = partition_by_name(self._units(), model([], self.MACHINERY, self.KINDS))
+        result = partition_by_name(self._units(), model(self.COMPONENTS, self.MACHINERY))
         assert result.by_structure
         assert result.assignment["order-api"] == result.assignment["order-domain"]
         assert result.assignment["order-proc"] == result.assignment["order-api"]
 
     def test_a_scope_with_its_own_word_stays_separate(self):
         """`PaymentProcessor` must not be absorbed into ordering."""
-        result = partition_by_name(self._units(), model([], self.MACHINERY, self.KINDS))
+        result = partition_by_name(self._units(), model(self.COMPONENTS, self.MACHINERY))
         assert result.assignment["payment"] != result.assignment["order-api"]
         assert result.assignment["catalog"] != result.assignment["order-api"]
 
@@ -119,15 +112,14 @@ class TestPartitionByScope:
             "b": Unit(("Modulify.Player/Service.cs",), ("Modulify.Player.Service",)),
             "c": Unit(("Modulify.Library/Store.cs",), ("Modulify.Library.Store",)),
         }
-        kinds = {"Modulify.Catalog": "feature", "Modulify.Player": "feature", "Modulify.Library": "feature"}
-        result = partition_by_name(units, model([], ("Facade", "Service", "Store"), kinds))
+        components = [("Catalog", ("Catalog",)), ("Player", ("Player",)), ("Library", ("Library",))]
+        result = partition_by_name(units, model(components, ("Facade", "Service", "Store")))
         assert len(set(result.assignment.values())) == 3
 
 
 class TestPartitionByVocabulary:
-    """Where the scopes are layers, the feature is only in the identifiers."""
+    """Where the model's own components do not name the scopes, the identifiers lead."""
 
-    KINDS = {"Beacon.Api": "layer", "Beacon.Application": "layer", "Beacon.Infrastructure": "layer"}
     COMPONENTS = [
         ("Incidents", ("Incident", "Timeline")),
         ("Escalation", ("Escalation", "Policy")),
@@ -136,7 +128,17 @@ class TestPartitionByVocabulary:
     MACHINERY = ("Handler", "Repository", "Endpoints", "Get", "Create")
 
     def _partition(self, units):
-        return partition_by_name(units, model(self.COMPONENTS, self.MACHINERY, self.KINDS))
+        return partition_by_name(units, model(self.COMPONENTS, self.MACHINERY))
+
+    def test_a_layered_scope_does_not_lead(self):
+        """Grouping Beacon by Api/Application/Domain scores below not partitioning at all."""
+        assert not model(self.COMPONENTS, self.MACHINERY).scopes_are_components(
+            {"Beacon.Api", "Beacon.Application", "Beacon.Domain", "Beacon.Infrastructure"}
+        )
+
+    def test_a_feature_scope_does_lead(self):
+        components = [("Catalog", ("Catalog",)), ("Ordering", ("Order",))]
+        assert model(components, ("API",)).scopes_are_components({"Catalog.API", "Ordering.API", "EventBus"})
 
     def test_layers_are_not_used_as_components(self):
         units = {
@@ -171,7 +173,7 @@ class TestPartitionByVocabulary:
 
     def test_machinery_never_owns_a_component(self):
         """Otherwise every Handler in the system lands in one box, which is a layer."""
-        owned = model(self.COMPONENTS + [("Wrong", ("Handler",))], self.MACHINERY, self.KINDS).owner_by_word()
+        owned = model(self.COMPONENTS + [("Wrong", ("Handler",))], self.MACHINERY).owner_by_word()
         assert "handler" not in owned
 
 
@@ -199,8 +201,7 @@ class TestGroupLeafClusters:
     def _model(self):
         return model(
             [("Incidents", ("Incident",)), ("Escalation", ("Escalation",))],
-            ("Handler", "Endpoints", "Repository", "Ef", "Planner"),
-            {"Beacon.Application": "layer", "Beacon.Api": "layer", "Beacon.Platform": "layer"},
+            ("Handler", "Endpoints", "Repository", "Ef", "Planner", "Application", "Api", "Platform", "Beacon"),
         )
 
     def test_groups_are_exhaustive_and_disjoint(self):


### PR DESCRIPTION
Top-level components now come from **what files are called**, not from who calls whom.

Stacked: #540 (qualified names) → **#539** → #542 (delete the graph partitioner).

## How it works

1. **One leaf per file.** Leiden's communities straddle component boundaries — on Beacon 7 of 21 held symbols from two different components, capping *any* grouping over them at 0.34 where the same names over files reach 0.94.
2. **The LLM reads a naming model, once per full analysis** — component names, the vocabulary each owns, and a machinery list. Stored in `analysis.json`.
3. **A gate picks which half of the name carries the architecture.** If the model's components name the directories, the **structural** half leads; if they contradict them, the **lexical** half does. eShop matched 8 of 20 scopes → structural. A layered repo (`Application`, `Infrastructure`, `Api`) matches 0 → lexical, because grouping *that* by directory just reproduces the layering, which scores below not partitioning at all.
4. **Assignment is arithmetic over strings — no edge is read.** The call graph still supplies every arrow, and still shapes everything below depth 1.

The two halves read **different inputs**: structural reads the *file path* and only the outermost directory (`src/A/B/C/x.cs` → `A`); lexical reads the *qualified name*, where every segment votes, weighted `2^(pos − last)` within its segment so the head noun wins — `IncidentResolvedMetricsHandler` → Analytics, not Incidents.

## How depth is decided — and why the formula no longer fits

Depth is not a fixed number. A component expands if `load ≥ 1.0` (>12 files or >120 methods) **or** it splits into ≥2 groups **and** has ≥30 methods **and** modularity ≥ `0.15 × (1 − load)`. The bar *falls as a component grows*. `--depth-level` is a ceiling, never a target.

On CodeBoarding this stops at depth 2 for 7 of 13: three forced open by size, three cleared a low bar; `Caching` (23 methods) and `Plugin Registry` (16) are under the 30-method floor and can never expand, while `Health Checks`, `Output Generators`, `Telemetry` and `Tool Registry` passed it but were too cohesive to split.

**This gate was not updated for the rewrite, and it asks a graph question.** `modularity(name_groups, call_graph)` was self-consistent while Leiden produced the groups — Leiden maximises exactly that quantity. Now the groups come from names, so modularity is an external judge that was never asked to agree: a correct name split in a chatty codebase scores low and gets suppressed.

The name-native replacement asks what the partition actually answers — does the next level of names divide this component, and does the division carry mass? Both are already computed before the gate runs:

> expand if `load ≥ 1.0`, or if `keys ≥ 2` **and** `(files − largest_child) / files ≥ 0.25 × (1 − load)`

Same shape, measuring name dispersion instead of edge density.

## Depth as recursion

Sub-scopes are Leiden at every depth today, **on full runs too** — names shape only the root. The intended design is that depth *N* is depth 1 applied to a sub-tree: re-run the gate for that scope, partition by the winning half, expand if the split carries mass.

Applying the depth-1 structural rule one level down on CodeBoarding shows why the gate must be **per scope**, not once per repo:

| component | files | keys at depth 2 | outside largest | shipped |
|---|---:|---:|---:|---|
| Static Analysis Engine | 55 | 5 (`engine`, `clustering`, `cfg`, `lsp_client`) | 56% | expanded |
| LLM Agents | 46 | 4 (`tools`, `prompts`, `llm_renderers`) | 52% | expanded |
| Analysis Orchestration | 10 | 3 (`commands`, `sources`) | 50% | expanded |
| Health Checks | 6 | 2 (`checks`) | 50% | **leaf** |
| Diagram Analysis | 12 | **1** — all files sit directly in the dir | 0% | expanded |
| Application Configuration | 10 | **1** | 0% | expanded |
| Repository Utilities | 7 | **1** | 0% | expanded |
| Execution Monitoring | 6 | **1** | 0% | expanded |

Four of the seven currently-expanded components have **nothing structural to split on** — Leiden expanded them on call-graph communities alone. That is not a reason to stop: `diagram_analysis/` has no sub-directories, but `diagram_generator`, `file_index`, `file_coverage`, `scope_plan` carry plenty of vocabulary. One structural key means *go lexical here*, not *stop*.

## Results

**eShop — pair-F1 = 1.0000** vs `codeboarding_evals/reference/eshop-depth-1.mmd` (P 1.0000, R 1.0000, 390 files, all-in-one floor 0.3311). Each of the 9 reference boxes maps to exactly one component. The 3 extra components are directories the reference doesn't model. *Caveat: 77 of 467 files sit outside the reference; it judges depth 1 only.*

```mermaid
graph LR
    Basket_API["Basket API"]
    Catalog_API["Catalog API"]
    Mobile_Client_App["Mobile Client App"]
    Aspire_AppHost_and_Service_Defaults["Aspire AppHost and Service Defaults"]
    Event_Bus["Event Bus"]
    Hybrid_App["Hybrid App"]
    Identity_API["Identity API"]
    Integration_Event_Log["Integration Event Log"]
    Ordering_Service["Ordering Service"]
    Payment_Processor["Payment Processor"]
    Web_Application["Web Application"]
    Webhook_Client["Webhook Client"]
    Basket_API -- "calls" --> Aspire_AppHost_and_Service_Defaults
    Payment_Processor -- "Publishes payment result events" --> Event_Bus
    Web_Application -- "Calls basket gRPC/REST endpoints" --> Basket_API
    Web_Application -- "Queries catalog REST API" --> Catalog_API
    Web_Application -- "Authenticates users via OIDC/OAuth" --> Identity_API
    Web_Application -- "Submits orders via REST API" --> Ordering_Service
    Web_Application -- "Invokes shared catalog utilities" --> Hybrid_App
    Web_Application -- "calls" --> Aspire_AppHost_and_Service_Defaults
    Webhook_Client -- "calls" --> Aspire_AppHost_and_Service_Defaults
    Catalog_API -- "Persists events via transactional outbox" --> Integration_Event_Log
    Mobile_Client_App -- "Manages basket via gRPC/REST" --> Basket_API
    Mobile_Client_App -- "Browses catalog via REST" --> Catalog_API
    Mobile_Client_App -- "Authenticates via Identity API" --> Identity_API
    Mobile_Client_App -- "Places orders via REST" --> Ordering_Service
    Event_Bus -- "Dispatches order-started events" --> Basket_API
    Event_Bus -- "Dispatches stock-confirmed events" --> Payment_Processor
    Event_Bus -- "Dispatches payment confirmation events" --> Ordering_Service
    Hybrid_App -- "Calls basket gRPC/REST endpoints" --> Basket_API
    Hybrid_App -- "Queries catalog REST API" --> Catalog_API
    Hybrid_App -- "Authenticates via Identity API" --> Identity_API
    Hybrid_App -- "Submits orders via REST" --> Ordering_Service
    Integration_Event_Log -- "Publishes integration events" --> Event_Bus
    Ordering_Service -- "Persists events via transactional outbox" --> Integration_Event_Log
    Ordering_Service -- "calls" --> Aspire_AppHost_and_Service_Defaults
    click Catalog_API href "./Catalog_API.md" "Details"
    click Mobile_Client_App href "./Mobile_Client_App.md" "Details"
    click Hybrid_App href "./Hybrid_App.md" "Details"
    click Identity_API href "./Identity_API.md" "Details"
    click Ordering_Service href "./Ordering_Service.md" "Details"
    click Web_Application href "./Web_Application.md" "Details"
    click Webhook_Client href "./Webhook_Client.md" "Details"
```

**CodeBoarding** — 13 components, each resolving to exactly one source directory, 94% coverage.

```mermaid
graph LR
    Application_Configuration["Application Configuration"]
    LLM_Agents["LLM Agents"]
    Caching_Layer["Caching Layer"]
    Analysis_Orchestration["Analysis Orchestration"]
    Plugin_Registry["Plugin Registry"]
    Diagram_Analysis["Diagram Analysis"]
    Health_Checks["Health Checks"]
    Execution_Monitoring["Execution Monitoring"]
    Output_Generators["Output Generators"]
    Repository_Utilities["Repository Utilities"]
    Static_Analysis_Engine["Static Analysis Engine"]
    Telemetry["Telemetry"]
    Tool_Registry["Tool Registry"]
    Application_Configuration -- "Invokes static health checks" --> Static_Analysis_Engine
    Application_Configuration -- "Bootstraps external tools" --> Tool_Registry
    Application_Configuration -- "Manages remote repository lifecycle" --> Repository_Utilities
    Application_Configuration -- "Dispatches analysis pipelines" --> Analysis_Orchestration
    Application_Configuration -- "Resolves analysis metadata" --> Diagram_Analysis
    Application_Configuration -- "Renders documentation outputs" --> Output_Generators
    Application_Configuration -- "Triggers health diagnostics" --> Health_Checks
    Repository_Utilities -- "Provides source tree hashes" --> LLM_Agents
    Repository_Utilities -- "Supplies change fingerprints" --> Diagram_Analysis
    Static_Analysis_Engine -- "Reads analysis configuration" --> Application_Configuration
    Static_Analysis_Engine -- "Accesses repository file system" --> Repository_Utilities
    Static_Analysis_Engine -- "Emits analysis telemetry" --> Telemetry
    Static_Analysis_Engine -- "Provisions language servers and tools" --> Tool_Registry
    Static_Analysis_Engine -- "Builds component relations via agent models" --> LLM_Agents
    Telemetry -- "Forwards token usage stats" --> Execution_Monitoring
    Tool_Registry -- "Resolves executable paths" --> Application_Configuration
    LLM_Agents -- "calls" --> Application_Configuration
    LLM_Agents -- "Traces agent execution steps" --> Execution_Monitoring
    LLM_Agents -- "calls" --> Repository_Utilities
    LLM_Agents -- "Consumes static analysis artifacts" --> Static_Analysis_Engine
    LLM_Agents -- "Populates diagram indexes" --> Diagram_Analysis
    LLM_Agents -- "Caches metadata and model settings" --> Caching_Layer
    LLM_Agents -- "calls" --> Plugin_Registry
    Caching_Layer -- "Resolves cache directories" --> Application_Configuration
    Caching_Layer -- "calls" --> Repository_Utilities
    Caching_Layer -- "calls" --> LLM_Agents
    Analysis_Orchestration -- "Consumes global configuration" --> Application_Configuration
    Analysis_Orchestration -- "Introspects repository state" --> Repository_Utilities
    Analysis_Orchestration -- "Configures probabilistic analysis layer" --> LLM_Agents
    Analysis_Orchestration -- "Discovers and loads plugins" --> Plugin_Registry
    Analysis_Orchestration -- "Manages analysis artifact lifecycle" --> Diagram_Analysis
    Analysis_Orchestration -- "Instruments pipeline execution" --> Execution_Monitoring
    Analysis_Orchestration -- "Triggers documentation generation" --> Output_Generators
    Diagram_Analysis -- "calls" --> Application_Configuration
    Diagram_Analysis -- "Normalizes paths and change sets" --> Repository_Utilities
    Diagram_Analysis -- "Orchestrates deterministic analysis" --> Static_Analysis_Engine
    Diagram_Analysis -- "Reports analysis progress" --> Telemetry
    Diagram_Analysis -- "Enriches artifacts with semantic insights" --> LLM_Agents
    Diagram_Analysis -- "Triggers repository health diagnostics" --> Health_Checks
    Diagram_Analysis -- "Initializes monitoring streams" --> Execution_Monitoring
    Health_Checks -- "Applies repository ignore rules" --> Repository_Utilities
    Health_Checks -- "Inspects code structure" --> Static_Analysis_Engine
    Health_Checks -- "Executes plugin health checks" --> Plugin_Registry
    Execution_Monitoring -- "calls" --> Application_Configuration
    Output_Generators -- "Sanitizes output content" --> Application_Configuration
    Output_Generators -- "Resolves language labels" --> Static_Analysis_Engine
    Output_Generators -- "Incorporates LLM-generated narratives" --> LLM_Agents
    Output_Generators -- "Consumes unified analysis JSON" --> Diagram_Analysis
    click Application_Configuration href "./Application_Configuration.md" "Details"
    click LLM_Agents href "./LLM_Agents.md" "Details"
    click Analysis_Orchestration href "./Analysis_Orchestration.md" "Details"
    click Diagram_Analysis href "./Diagram_Analysis.md" "Details"
    click Execution_Monitoring href "./Execution_Monitoring.md" "Details"
    click Repository_Utilities href "./Repository_Utilities.md" "Details"
    click Static_Analysis_Engine href "./Static_Analysis_Engine.md" "Details"
```

## The two halves fail in opposite directions

They look like the same idea. They are not: they read different inputs, and each breaks where the other works. Every file assigned both ways on three real repos:

| repo | files | scopes | gate | disagree | why |
|---|---:|---:|---|---:|---|
| Modulify | 28 | 4 | structural | **0%** | each feature has its own directory *and* its own vocabulary — either half works |
| eShop | 527 | 21 | structural | **21%** | domain words leak across service boundaries |
| Beacon | 111 | 6 | lexical | **70%** | every feature is spread across four layer directories |

Modulify is the case where they agree completely — which is why they look interchangeable.

**eShop, where lexical is wrong.** `src/WebApp/Services/BasketService.cs` → structural `Web App`, lexical `Basket`. It is the web app's *client* for the basket service; the word `Basket` is there because of what it talks to. Lexical also swept `Program.cs` / `Extensions.cs` / `GlobalUsings.cs` from every service into one Infrastructure bucket, collapsing 10 structural boxes into 1 (70% coverage).

**Beacon, where structural is wrong.** `Beacon.Application/Analytics/IncidentResolvedMetricsHandler.cs` → structural `Beacon.Application`, lexical `Analytics`. The outermost directory is a layer, so structural puts Analytics, Escalation, Alerts and Incidents in one box.

> **Rule of thumb.** Structural fails when *one directory holds many domains* (a layer). Lexical fails when *one domain word appears in many directories* (a client, UI, test, or shared contract naming what it talks to).

This is the sharpest argument for a **per-scope** gate: eShop is structural at depth 1 but would need lexical at depth 2 inside `Ordering.API`, whose sub-directories are `Application` and `Infrastructure` — Beacon's problem one level down, in a repo whose top level had the opposite shape.

## Where a per-layer decision must live

**Not implemented.** The recursion is designed, not built: the gate runs once over top-level scopes, and sub-scopes never use names.

When built, the decision cannot be recomputed per run — it depends on the scope set, which changes as files are added, so a repo could flip structural→lexical mid-life and reshuffle every box. It goes in `analysis.json` metadata beside the model, keyed by scope id (already the component id):

```json
"naming_model": {
  "components": [...],          // global — a repo has one vocabulary
  "machinery":  [...],          // global
  "decisions": {                // per scope, replayed verbatim
    "root": {"half": "structural", "matched": 0.40},
    "11":   {"half": "lexical",    "matched": 0.00},
    "11.2": {"half": "structural", "matched": 0.67}
  }
}
```

Keeping `matched` makes a surprising box explainable after the fact. The static-analysis pickle is the wrong home: it caches derived facts about code, and this is a presentation decision that must outlive cache invalidation.

## Incremental — read this before approving

The naming model is loaded on an incremental run, is **required**, and is then **never consulted**. `_anchored_group` carries ownership forward and places new files by the call graph; a new component appears only if Leiden isolates ≥2 new leaf clusters, so **a single new file can never create one**. A drift budget can re-derive the whole scope from the modularity peak, silently discarding the name-derived shape.

Sub-scopes are Leiden at every depth, **on full runs too** — names shape only the root scope today.

**Making incremental add a component is mostly deterministic.** A component key *is* a directory's distinctive word, so the component set is a pure function of the directory set: a new directory whose word matches no existing key **is** a new component; one that loses its last file **is** retired. No model call. Only the lexical half needs the LLM, and only for files that drew no votes. Generalising to any depth needs `scope_of` to return the *d*-th path segment rather than `parts[0]`, plus the gate evaluated **per scope** — inside `Ordering.API` the second level is `Application`/`Infrastructure`, layers again, so depth 2 there must go lexical.

Also missing: `NamingModel.to_dict` persists components and machinery but **not** the structural/lexical decision, so it would be recomputed and could flip a repo mid-life.

## Known gaps

- `NamePartition.coverage` reaches only a `logger.info`, never a caller — and that log is gated off exactly when everything falls into `Infrastructure`.
- A scope whose every word is machinery falls back to its raw mixed-case name, which can never collide with a lowercase stem — a guaranteed singleton component that still counts as "placed".

## Verified

`pytest` 2278 passed; mypy and black clean. Private suite green on all 12 jobs (8 languages × 3 platforms) via CodeBoarding-tests#25, which pairs with the #542 branch and therefore covers this PR plus the deletion.
