### PR TITLE
fix(engine): key a constructor on the class that declares it

### DIFF
--- a/static_analyzer/engine/adapters/java_adapter.py
+++ b/static_analyzer/engine/adapters/java_adapter.py
@@ -285,6 +285,11 @@ class JavaAdapter(LanguageAdapter):
         """Use definition-based edges — JDTLS serializes references requests."""
         return EdgeStrategy.DEFINITIONS
 
+    @property
+    def expands_constructors(self) -> bool:
+        """JDTLS resolves ``new Dog()`` to the class, so the constructor needs adding."""
+        return True
+
     def should_track_for_edges(self, symbol_kind: int) -> bool:
         return symbol_kind in (CALLABLE_KINDS | CLASS_LIKE_KINDS | {NodeType.VARIABLE, NodeType.CONSTANT})
 

--- a/static_analyzer/engine/call_graph_builder.py
+++ b/static_analyzer/engine/call_graph_builder.py
@@ -303,18 +303,39 @@ class CallGraphBuilder:
 
         # Constructor expansion: when a class has real constructors in the
         # symbol table, add edges to those constructors alongside the class edge.
+        if not self._adapter.expands_constructors:
+            return edge_set
+
         constructor_edges: EdgeMap = {}
         for src, dst in edge_set:
             dst_sym = st.symbols.get(dst)
-            if dst_sym and self._adapter.is_class_like(dst_sym.kind):
-                ctors = st.class_to_ctors.get(dst)
-                if ctors:
-                    for ctor_name in ctors:
-                        ctor_key = (src, ctor_name)
-                        sites = constructor_edges.setdefault(ctor_key, list(edge_set.get(ctor_key, [])))
-                        for site in edge_set[(src, dst)]:
-                            if site not in sites:
-                                sites.append(site)
+            if not dst_sym or not self._adapter.is_class_like(dst_sym.kind):
+                continue
+            ctors = st.class_to_ctors.get(dst)
+            if not ctors:
+                continue
+            # Only where the source constructs, and only where the server has not already
+            # named the constructor itself. A definition query resolves `dog.speak()` to the
+            # class as well as the method, and expanding there would invent a call for a line
+            # that runs none; where the server did resolve `new Dog("Rex", 5)` to
+            # `Dog(String, int)`, fanning the class edge out would add every other overload
+            # beside it. Judged per site: one caller can construct on one line and call a
+            # member on the next.
+            resolved = {(site.file, site.line, site.column) for ctor in ctors for site in edge_set.get((src, ctor), [])}
+            construction_sites = [
+                site
+                for site in edge_set[(src, dst)]
+                if (site.file, site.line, site.column) not in resolved
+                and self._source_inspector.is_construction_site(site)
+            ]
+            if not construction_sites:
+                continue
+            for ctor_name in ctors:
+                ctor_key = (src, ctor_name)
+                sites = constructor_edges.setdefault(ctor_key, list(edge_set.get(ctor_key, [])))
+                for site in construction_sites:
+                    if site not in sites:
+                        sites.append(site)
         for edge, sites in constructor_edges.items():
             edge_set[edge] = sites
 

--- a/static_analyzer/engine/language_adapter.py
+++ b/static_analyzer/engine/language_adapter.py
@@ -357,6 +357,14 @@ class LanguageAdapter(ABC):
         return False
 
     @property
+    def expands_constructors(self) -> bool:
+        """Whether an edge to a class should also reach that class's constructors.
+
+        Why: only where the server resolves ``new Foo()`` to the type, not the constructor.
+        """
+        return False
+
+    @property
     def extra_client_capabilities(self) -> dict:
         """Vendor-specific keys to shallow-merge into the LSP ``initialize``
         capabilities (e.g. ``{"experimental": {...}}``). Default ``{}`` keeps

--- a/static_analyzer/engine/models.py
+++ b/static_analyzer/engine/models.py
@@ -26,6 +26,9 @@ class SymbolInfo:
     # Promoted to CLASS for having callable children: a namespace object, or a
     # `const raw = await fn(() => ...)` wrapper that is a scope rather than a name.
     promoted_from_variable: bool = False
+    # Empty for a top-level symbol and for every alias.
+    # Why: slicing a qualified name finds the real owner only by luck of the naming scheme.
+    owner_qualified_name: str = ""
 
     @property
     def definition_location(self) -> tuple[str, int, int]:

--- a/static_analyzer/engine/source_inspector.py
+++ b/static_analyzer/engine/source_inspector.py
@@ -74,6 +74,15 @@ _OBJECT_INITIALIZER_NODE_TYPES = frozenset({"assignment_expression"})
 # Loops whose ``right`` field is a value whose type gets enumerated.
 _ITERATION_NODE_TYPES = frozenset({"foreach_statement", "for_each_statement", "enhanced_for_statement"})
 _METHOD_REFERENCE_NODE_TYPES = frozenset({"method_reference"})
+# Nodes that run a constructor. Java's `super(...)`/`this(...)` is a call node rather than a
+# creation one, and `Dog::new` is a method reference that has to be told from `Dog::speak`.
+_CONSTRUCTION_NODE_TYPES = (
+    _CONSTRUCTOR_NODE_TYPES
+    | _IMPLICIT_CONSTRUCTOR_NODE_TYPES
+    | _CONSTRUCTOR_INITIALIZER_NODE_TYPES
+    | _ATTRIBUTE_NODE_TYPES
+    | frozenset({"explicit_constructor_invocation"})
+)
 _CALLABLE_USAGE_ANCESTORS = frozenset({"argument_list", "arguments"})
 _NAME_NODE_TYPES = frozenset(
     {
@@ -148,6 +157,7 @@ class ParsedSource:
 class SourceUsageIndex:
     invocation_end_positions: set[tuple[int, int]]
     callable_ranges: set[tuple[int, int, int]]
+    construction_start_positions: set[tuple[int, int]]
 
 
 class SourceInspector:
@@ -203,6 +213,18 @@ class SourceInspector:
         if usage_index is None:
             return True
         return (ref_line, ref_end_char) in usage_index.invocation_end_positions
+
+    def is_construction_site(self, site: CallSite) -> bool:
+        """Whether the call at *site* runs a constructor.
+
+        Why not permissive when the file cannot be parsed, as ``is_invocation`` is: this
+        gates *synthesising* constructor edges, so an unreadable file should add none rather
+        than one for every class a caller merely mentions.
+        """
+        usage_index = self._usage_index(Path(site.file))
+        if usage_index is None:
+            return False
+        return (site.line - 1, site.column - 1) in usage_index.construction_start_positions
 
     def is_callable_usage(self, file_path: Path, ref_line: int, ref_start_char: int, ref_end_char: int) -> bool:
         """Check whether a variable/constant reference is used in a callable context."""
@@ -451,11 +473,14 @@ class SourceInspector:
 
         invocation_end_positions: set[tuple[int, int]] = set()
         callable_ranges: set[tuple[int, int, int]] = set()
+        construction_start_positions: set[tuple[int, int]] = set()
         for node in self._walk(parsed.tree.root_node):
             target = self._call_target_node(node)
             if target is not None:
                 invocation_end_positions.add((target.end_point.row, target.end_point.column))
                 callable_ranges.add((target.start_point.row, target.start_point.column, target.end_point.column))
+                if self._runs_a_constructor(node):
+                    construction_start_positions.add((target.start_point.row, target.start_point.column))
                 continue
 
             if not node.is_named:
@@ -466,6 +491,7 @@ class SourceInspector:
         usage_index = SourceUsageIndex(
             invocation_end_positions=invocation_end_positions,
             callable_ranges=callable_ranges,
+            construction_start_positions=construction_start_positions,
         )
         self._usage_index_cache[file_key] = usage_index
         return usage_index
@@ -480,6 +506,15 @@ class SourceInspector:
             parser.language = TreeSitterLanguage(factory())
             self._parser_by_suffix[suffix] = parser
         return self._parser_by_suffix[suffix]
+
+    def _runs_a_constructor(self, node: TreeSitterNode) -> bool:
+        """Whether this call node constructs, rather than merely naming, a type."""
+        if node.type in _CONSTRUCTION_NODE_TYPES:
+            return True
+        # `Dog::new` constructs; `Dog::speak` does not.
+        if node.type in _METHOD_REFERENCE_NODE_TYPES:
+            return any(child.type == "new" for child in node.children)
+        return False
 
     def _call_target_node(self, node: TreeSitterNode) -> TreeSitterNode | None:
         if node.type in _CALL_NODE_TYPES:

--- a/static_analyzer/engine/symbol_table.py
+++ b/static_analyzer/engine/symbol_table.py
@@ -64,6 +64,7 @@ class SymbolTable:
         symbols: list[dict],
         parent_chain: list[tuple[str, int]],
         project_root: Path,
+        owner_qualified_name: str = "",
     ) -> None:
         """Recursively register symbols with dual registration."""
         for sym in symbols:
@@ -113,6 +114,7 @@ class SymbolTable:
                 promoted_from_variable=promoted,
             )
             info.parent_chain = list(parent_chain)
+            info.owner_qualified_name = owner_qualified_name
 
             self._symbols[qualified_name] = info
             ref_key = self._naming.build_reference_key(qualified_name)
@@ -169,7 +171,7 @@ class SymbolTable:
             children = sym.get("children", [])
             if children:
                 child_chain = parent_chain + [(name, kind)]
-                self.register_symbols(file_path, children, child_chain, project_root)
+                self.register_symbols(file_path, children, child_chain, project_root, qualified_name)
 
     def build_indices(self) -> None:
         """Build optimized lookup indices after symbol registration.
@@ -183,14 +185,12 @@ class SymbolTable:
                 idx_key = (file_key, sym.name)
                 self._file_name_index.setdefault(idx_key, []).append(sym)
 
-        # Build class -> constructor index
-        for qname, sym in self._symbols.items():
-            if sym.kind == NodeType.CONSTRUCTOR:
-                # Find the class this constructor belongs to by stripping the params
-                paren_idx = qname.find("(")
-                if paren_idx != -1:
-                    class_qname = qname[:paren_idx]
-                    self._class_to_ctors.setdefault(class_qname, []).append(qname)
+        # Class -> constructors, keyed on the declaring symbol.
+        # Why not a slice at the first "(": that names the class only where the scheme
+        # doubles it, and it cannot tell a primary symbol from an alias.
+        for sym in (s for syms in self._primary_file_symbols.values() for s in syms):
+            if sym.kind == NodeType.CONSTRUCTOR and sym.owner_qualified_name:
+                self._class_to_ctors.setdefault(sym.owner_qualified_name, []).append(sym.qualified_name)
 
     def find_containing_symbol(self, file_path: Path, line: int, character: int) -> SymbolInfo | None:
         """Find the innermost symbol whose range contains the given position.

--- a/tests/static_analyzer/test_call_graph_builder.py
+++ b/tests/static_analyzer/test_call_graph_builder.py
@@ -308,56 +308,115 @@ class TestBuildEdges:
 class TestPostprocessEdges:
     """Tests for _postprocess_edges on CallGraphBuilder (constructor expansion, dedup)."""
 
-    def test_constructor_expansion(self):
-        """When an edge targets a class, constructor edges should be added."""
-        lsp = _make_lsp()
+    SOURCE = """package app;
+
+class Main {
+    static void main() {
+        Dog dog = new Dog("Rex");
+        System.out.println(dog.speak());
+    }
+}
+"""
+    CONSTRUCTION = CallSite(file="", line=5, column=23)
+    MEMBER_ACCESS = CallSite(file="", line=6, column=32)
+
+    def _builder(self, tmp_path: Path, expands_constructors: bool = True) -> tuple[CallGraphBuilder, Path]:
+        """A builder over a real Java file, so the AST can say which site constructs."""
+        source = tmp_path / "Main.java"
+        source.write_text(self.SOURCE)
         adapter = _make_adapter()
-        builder = CallGraphBuilder(lsp, adapter, Path("/project"))
+        adapter.expands_constructors = expands_constructors
+        builder = CallGraphBuilder(_make_lsp(), adapter, tmp_path)
 
-        caller = SymbolInfo("main", "app.main", NodeType.FUNCTION, Path("/project/app.py"), 0, 0, 20, 0)
-        cls = SymbolInfo("Dog", "app.Dog", NodeType.CLASS, Path("/project/app.py"), 25, 0, 50, 0)
-        ctor = SymbolInfo("__init__", "app.Dog(__init__)", NodeType.CONSTRUCTOR, Path("/project/app.py"), 30, 4, 40, 0)
+        caller = SymbolInfo("main", "app.main", NodeType.FUNCTION, source, 3, 4, 7, 0)
+        cls = SymbolInfo("Dog", "app.Dog", NodeType.CLASS, source, 25, 0, 50, 0)
+        ctor = SymbolInfo("Dog", "app.Dog.Dog(String)", NodeType.CONSTRUCTOR, source, 30, 4, 40, 0)
+        ctor.owner_qualified_name = "app.Dog"
         st = builder._symbol_table
-        st._symbols["app.main"] = caller
-        st._symbols["app.Dog"] = cls
-        st._symbols["app.Dog(__init__)"] = ctor
-        file_key = str(Path("/project/app.py"))
-        st._file_symbols[file_key] = [caller, cls, ctor]
-        st._primary_file_symbols[file_key] = [caller, cls, ctor]
+        for symbol in (caller, cls, ctor):
+            st._symbols[symbol.qualified_name] = symbol
+        st._file_symbols[str(source)] = [caller, cls, ctor]
+        st._primary_file_symbols[str(source)] = [caller, cls, ctor]
         st.build_indices()
+        return builder, source
 
-        edge_set: EdgeMap = {("app.main", "app.Dog"): []}
-        result = builder._postprocess_edges(edge_set)
+    def _site(self, template: CallSite, source: Path) -> CallSite:
+        return CallSite(file=str(source), line=template.line, column=template.column)
+
+    def test_a_construction_site_reaches_the_constructor(self, tmp_path: Path):
+        builder, source = self._builder(tmp_path)
+        construction = self._site(self.CONSTRUCTION, source)
+
+        result = builder._postprocess_edges({("app.main", "app.Dog"): [construction]})
 
         assert ("app.main", "app.Dog") in result
-        assert ("app.main", "app.Dog(__init__)") in result
+        assert result[("app.main", "app.Dog.Dog(String)")] == [construction]
 
-    def test_constructor_expansion_preserves_existing_ctor_call_sites(self):
-        lsp = _make_lsp()
-        adapter = _make_adapter()
-        builder = CallGraphBuilder(lsp, adapter, Path("/project"))
+    def test_a_member_access_site_is_not_a_construction(self, tmp_path: Path):
+        """`dog.speak()` resolves to the class as well as the method, and runs no constructor."""
+        builder, source = self._builder(tmp_path)
+        construction = self._site(self.CONSTRUCTION, source)
+        member_access = self._site(self.MEMBER_ACCESS, source)
 
-        caller = SymbolInfo("main", "app.main", NodeType.FUNCTION, Path("/project/app.py"), 0, 0, 20, 0)
-        cls = SymbolInfo("Dog", "app.Dog", NodeType.CLASS, Path("/project/app.py"), 25, 0, 50, 0)
-        ctor = SymbolInfo("__init__", "app.Dog(__init__)", NodeType.CONSTRUCTOR, Path("/project/app.py"), 30, 4, 40, 0)
+        result = builder._postprocess_edges({("app.main", "app.Dog"): [construction, member_access]})
+
+        assert result[("app.main", "app.Dog.Dog(String)")] == [construction]
+
+    def test_a_caller_that_only_touches_members_constructs_nothing(self, tmp_path: Path):
+        builder, source = self._builder(tmp_path)
+
+        result = builder._postprocess_edges({("app.main", "app.Dog"): [self._site(self.MEMBER_ACCESS, source)]})
+
+        assert ("app.main", "app.Dog.Dog(String)") not in result
+
+    def test_constructor_expansion_preserves_existing_ctor_call_sites(self, tmp_path: Path):
+        builder, source = self._builder(tmp_path)
+        construction = self._site(self.CONSTRUCTION, source)
+        direct = CallSite(file=str(source), line=2, column=5)
+
+        result = builder._postprocess_edges(
+            {
+                ("app.main", "app.Dog.Dog(String)"): [direct],
+                ("app.main", "app.Dog"): [construction],
+            }
+        )
+
+        assert result[("app.main", "app.Dog.Dog(String)")] == [direct, construction]
+
+    def test_a_constructor_the_server_already_named_is_not_fanned_out(self, tmp_path: Path):
+        """`new Dog("Rex")` resolved to one overload must not gain the others beside it."""
+        builder, source = self._builder(tmp_path)
+        construction = self._site(self.CONSTRUCTION, source)
+        other_overload = SymbolInfo("Dog", "app.Dog.Dog()", NodeType.CONSTRUCTOR, source, 33, 4, 35, 0)
+        other_overload.owner_qualified_name = "app.Dog"
         st = builder._symbol_table
-        st._symbols["app.main"] = caller
-        st._symbols["app.Dog"] = cls
-        st._symbols["app.Dog(__init__)"] = ctor
-        file_key = str(Path("/project/app.py"))
-        st._file_symbols[file_key] = [caller, cls, ctor]
-        st._primary_file_symbols[file_key] = [caller, cls, ctor]
+        st._symbols["app.Dog.Dog()"] = other_overload
+        st._primary_file_symbols[str(source)].append(other_overload)
+        st._class_to_ctors.clear()
         st.build_indices()
 
-        direct_site = CallSite(file="/project/app.py", line=2, column=5)
-        class_site = CallSite(file="/project/app.py", line=3, column=9)
-        edge_set: EdgeMap = {
-            ("app.main", "app.Dog(__init__)"): [direct_site],
-            ("app.main", "app.Dog"): [class_site],
-        }
-        result = builder._postprocess_edges(edge_set)
+        result = builder._postprocess_edges(
+            {
+                ("app.main", "app.Dog"): [construction],
+                ("app.main", "app.Dog.Dog(String)"): [construction],
+            }
+        )
 
-        assert result[("app.main", "app.Dog(__init__)")] == [direct_site, class_site]
+        assert ("app.main", "app.Dog.Dog()") not in result
+
+    def test_a_class_edge_with_no_call_site_expands_to_nothing(self, tmp_path: Path):
+        builder, _ = self._builder(tmp_path)
+
+        result = builder._postprocess_edges({("app.main", "app.Dog"): []})
+
+        assert ("app.main", "app.Dog.Dog(String)") not in result
+
+    def test_an_adapter_that_does_not_ask_for_expansion_gets_none(self, tmp_path: Path):
+        builder, source = self._builder(tmp_path, expands_constructors=False)
+
+        result = builder._postprocess_edges({("app.main", "app.Dog"): [self._site(self.CONSTRUCTION, source)]})
+
+        assert ("app.main", "app.Dog.Dog(String)") not in result
 
 
 class TestBuildPackageDeps:

--- a/tests/static_analyzer/test_source_inspector.py
+++ b/tests/static_analyzer/test_source_inspector.py
@@ -94,6 +94,58 @@ class TestIsInvocation:
         assert si.is_invocation(f, 0, 7) is False
 
 
+class TestIsConstructionSite:
+    """Which call sites run a constructor, for constructor expansion."""
+
+    def _site(self, source: Path, line: int, column: int) -> CallSite:
+        return CallSite.from_lsp_position(file=str(source), line=line, column=column)
+
+    def test_java_new(self, tmp_path: Path):
+        f = tmp_path / "Main.java"
+        f.write_text("class Main {\n    void run() {\n        Dog dog = new Dog();\n    }\n}\n")
+        assert SourceInspector().is_construction_site(self._site(f, 2, 22)) is True
+
+    def test_a_member_call_is_not_a_construction(self, tmp_path: Path):
+        f = tmp_path / "Main.java"
+        f.write_text("class Main {\n    void run() {\n        dog.speak();\n    }\n}\n")
+        assert SourceInspector().is_construction_site(self._site(f, 2, 12)) is False
+
+    def test_an_argument_inside_a_construction_is_not_itself_one(self, tmp_path: Path):
+        """The position has to be the type being constructed, not merely inside the `new`."""
+        f = tmp_path / "Main.java"
+        f.write_text("class Main {\n    void run() {\n        new Dog(cat.name());\n    }\n}\n")
+        assert SourceInspector().is_construction_site(self._site(f, 2, 20)) is False
+
+    def test_java_super_call(self, tmp_path: Path):
+        f = tmp_path / "Cat.java"
+        f.write_text("class Cat extends Animal {\n    Cat(String n) {\n        super(n);\n    }\n}\n")
+        assert SourceInspector().is_construction_site(self._site(f, 2, 8)) is True
+
+    def test_java_constructor_reference(self, tmp_path: Path):
+        f = tmp_path / "Main.java"
+        f.write_text("class Main {\n    void run() {\n        make(Dog::new);\n    }\n}\n")
+        assert SourceInspector().is_construction_site(self._site(f, 2, 13)) is True
+
+    def test_java_method_reference_is_not_a_construction(self, tmp_path: Path):
+        f = tmp_path / "Main.java"
+        f.write_text("class Main {\n    void run() {\n        each(Dog::speak);\n    }\n}\n")
+        assert SourceInspector().is_construction_site(self._site(f, 2, 18)) is False
+
+    def test_csharp_target_typed_new(self, tmp_path: Path):
+        f = tmp_path / "Holder.cs"
+        f.write_text("class Holder\n{\n    private Settings s = new(5);\n}\n")
+        assert SourceInspector().is_construction_site(self._site(f, 2, 25)) is True
+
+    def test_csharp_base_initializer(self, tmp_path: Path):
+        f = tmp_path / "Derived.cs"
+        f.write_text("class Derived : Settings\n{\n    public Derived(int n) : base(n) { }\n}\n")
+        assert SourceInspector().is_construction_site(self._site(f, 2, 28)) is True
+
+    def test_conservative_on_missing_file(self):
+        site = CallSite.from_lsp_position(file="/nonexistent.java", line=0, column=0)
+        assert SourceInspector().is_construction_site(site) is False
+
+
 class TestIsCallableUsage:
     def test_direct_invocation(self, tmp_path: Path):
         f = tmp_path / "test.py"

--- a/tests/static_analyzer/test_symbol_table.py
+++ b/tests/static_analyzer/test_symbol_table.py
@@ -54,6 +54,19 @@ def _sym(
     return info
 
 
+def _class_with_child(child_name: str, child_kind: int) -> list[dict]:
+    """A ``MyClass`` declaring one member, in the document-symbol shape the LSP returns."""
+    span = {"start": {"line": 0, "character": 0}, "end": {"line": 20, "character": 0}}
+    return [
+        {
+            "name": "MyClass",
+            "kind": NodeType.CLASS,
+            "range": span,
+            "children": [{"name": child_name, "kind": child_kind, "range": span}],
+        }
+    ]
+
+
 # ---- register_symbols ----
 
 
@@ -182,21 +195,27 @@ class TestBuildIndices:
     def test_builds_class_to_ctor_index(self):
         adapter = _make_adapter()
         st = SymbolTable(adapter)
-        ctor_sym = _sym("__init__", "mod.MyClass(__init__)", NodeType.CONSTRUCTOR, start_line=5, end_line=10)
-        st._symbols["mod.MyClass(__init__)"] = ctor_sym
+        st.register_symbols(Path("mod.py"), _class_with_child("__init__", NodeType.CONSTRUCTOR), [], Path("/root"))
 
         st.build_indices()
-        assert "mod.MyClass" in st._class_to_ctors
-        assert "mod.MyClass(__init__)" in st._class_to_ctors["mod.MyClass"]
+        assert st._class_to_ctors["mod.MyClass"] == ["MyClass.__init__"]
 
-    def test_no_ctor_without_parens(self):
+    def test_indexes_only_constructors(self):
         adapter = _make_adapter()
         st = SymbolTable(adapter)
-        method_sym = _sym("do_stuff", "mod.MyClass.do_stuff", NodeType.METHOD)
-        st._symbols["mod.MyClass.do_stuff"] = method_sym
+        st.register_symbols(Path("mod.py"), _class_with_child("do_stuff", NodeType.METHOD), [], Path("/root"))
 
         st.build_indices()
         assert "mod.MyClass" not in st._class_to_ctors
+
+    def test_does_not_index_the_alias_beside_its_constructor(self):
+        """The unqualified alias shares the constructor's kind but declares no owner."""
+        adapter = _make_adapter()
+        st = SymbolTable(adapter)
+        st.register_symbols(Path("mod.py"), _class_with_child("__init__", NodeType.CONSTRUCTOR), [], Path("/root"))
+
+        st.build_indices()
+        assert sum(len(ctors) for ctors in st._class_to_ctors.values()) == 1
 
 
 # ---- find_containing_symbol ----


### PR DESCRIPTION
First of three. Prerequisite for #544, the Java rename.

`class_to_ctors` found a constructor's class by slicing the qualified name at its first `(`:

```python
paren_idx = qname.find("(")
class_qname = qname[:paren_idx]
```

That names the real class only where the naming scheme happens to double it, which today is **Java alone**. `core/Animal.java` gives the class `src.main.java.core.Animal.Animal` because the file stem is folded in twice, and its constructor `…Animal.Animal(String)` slices back to exactly that. Every other language indexes nothing: C# collapses the stem so the slice overshoots by a segment, TypeScript's `constructor` has no parentheses, and Python reports `__init__` as a method.

Keying on the declaring symbol recorded during the walk says what was meant, and it cannot pick a dual-registration alias, which the slice could.

## Two gates on expansion

**Which languages expand at all.** Correct keying makes the index resolve for C# and TypeScript too, where it never had. Whether a class edge *should* fan out into that class's constructors is a different question from what a constructor is called — it is right only where the server resolves `new Foo()` to the type rather than to the constructor. So expansion is an adapter property, set for Java, and **the graph is unchanged in every language**.

**Which call sites count as construction — the source decides.** A definition query resolves

```java
public String purr() {
    return getName() + " purrs";   // Cat.java:36
}
```

to both the inherited `Animal.getName()` *and* its declaring class `Animal`. The class half was then expanded into a constructor call, so the graph claimed `Cat.purr() -> Animal.Animal(String)` at a line that runs no constructor.

`SourceInspector` already parses the file and already knows every shape of construction — `new X()`, C#'s target-typed `new(...)` and `: base(...)`, Java's `super(...)`, an applied attribute, and `Dog::new` as against `Dog::speak`. It now answers `is_construction_site(site)` directly, populated **in the same tree walk that builds the usage index**, so it costs no extra parsing and reuses the per-file cache. No qualified-name parsing and no graph inference are involved.

Expansion additionally skips a site where the server has already named a constructor itself: where jdtls resolved `new Dog("Rex", 5)` to `Dog(String, int)`, fanning the class edge out would add every *other* overload beside it. The question is per site, because one caller can construct on one line and call a member on the next.

## Verified against the real engine

On `java_edge_cases_project`, this PR leaves the graph **identical to `main`** — 94 references and 86 edges, the same sets.

It becomes load-bearing under #544, where the recovered class edges would otherwise invent **nine** constructor calls from methods that construct nothing. With it: 110 edges, 0 lost, 24 gained, 0 invented — which is what CodeBoarding-tests#27 pins.

## Verified

`pytest tests/` → 2258 passed on the stack tip (3 pre-existing `test_cli_parser` failures deselected; they fail identically on a clean `main`). `black`, `mypy` clean. 18/18 C# and Java edge-case integration tests pass against the real engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved call-graph accuracy for Java constructors and object creation.
  * Prevented member access, non-constructor symbols, and aliases from being incorrectly treated as constructor calls.
  * Improved ownership tracking for nested symbols and constructors.
  * Added more reliable detection of constructor usage across supported languages.
  * Disabled constructor expansion for languages that do not require it.

* **Tests**
  * Added coverage for constructor edge expansion, construction detection, and symbol indexing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->