### PR TITLE
fix(naming): name a Java type by its package, not by its file path

### DIFF
--- a/static_analyzer/analysis_cache.py
+++ b/static_analyzer/analysis_cache.py
@@ -60,8 +60,11 @@ _LEGACY_CACHE_SUBDIR = "cache"
 # .tsx is no longer parsed as type assertions; one engine owns the family, so the degraded
 # second bucket is gone; calls are credited to the enclosing declaration; and a call in a
 # declaration's body or initialiser counts as an edge.
+# v6: every Java qualified name changes. The Maven/Gradle source root no longer prefixes
+# a name, and the file stem is gone, so a top-level type is no longer doubled and its
+# members can reach it.
 # Older pickles are treated as cache misses and re-run.
-_TAG_VERSION = "v5"
+_TAG_VERSION = "v6"
 
 
 class StaticAnalysisCache:

--- a/static_analyzer/engine/adapters/java_adapter.py
+++ b/static_analyzer/engine/adapters/java_adapter.py
@@ -21,6 +21,9 @@ from utils import CODEBOARDING_DIR_NAME, get_config
 
 logger = logging.getLogger(__name__)
 
+# The languages a JVM source root can be named for, in ``src/<source set>/<language>``.
+JVM_SOURCE_LANGUAGES = frozenset({"java", "kotlin", "groovy", "scala"})
+
 
 class JavaAdapter(LanguageAdapter):
 
@@ -139,23 +142,29 @@ class JavaAdapter(LanguageAdapter):
         project_root: Path,
         detail: str = "",
     ) -> str:
-        rel = file_path.relative_to(project_root)
-        module = ".".join(rel.with_suffix("").parts)
-        clean_name = self._clean_symbol_name(symbol_name)
+        """Build ``<module>.<source set>.<package>.<declaring types>.<symbol>``.
 
-        if parent_chain:
-            # In Java, the filename IS the top-level class name (e.g., Dog.java -> module "...Dog").
-            # Skip the first parent if it matches the last module component to avoid
-            # doubled names like "core.Dog.Dog.speak()" -> "core.Dog.speak()".
-            module_last = module.rsplit(".", 1)[-1] if "." in module else module
-            effective_parents = list(parent_chain)
-            if effective_parents and self._clean_symbol_name(effective_parents[0][0]) == module_last:
-                effective_parents = effective_parents[1:]
+        Why no file stem: Java requires it to equal the top-level type, so folding it in
+        made that type a sibling of its own members and CONTAINS could not link them.
+        """
+        segments = [self._clean_symbol_name(name) for name, _ in parent_chain]
+        segments.append(self._clean_symbol_name(symbol_name))
+        return ".".join(part for part in (self.get_package_for_file(file_path, project_root), *segments) if part)
 
-            if effective_parents:
-                clean_parents = ".".join(self._clean_symbol_name(name) for name, _ in effective_parents)
-                return f"{module}.{clean_parents}.{clean_name}"
-        return f"{module}.{clean_name}"
+    def get_package_for_file(self, file_path: Path, project_root: Path) -> str:
+        """The directory holding the file, without the Maven or Gradle source root.
+
+        Why: ``src/main/java`` names no package, and prefixed every symbol in a Maven tree
+        with three segments the compiler does not recognise. The source set itself is kept
+        unless it is ``main``, because ``src/test/java`` and ``src/main/java`` can hold the
+        same package and the same type name.
+        """
+        parts = file_path.relative_to(project_root).parent.parts
+        for i in range(len(parts) - 2):
+            if parts[i] == "src" and parts[i + 2] in JVM_SOURCE_LANGUAGES:
+                source_set = () if parts[i + 1] == "main" else (parts[i + 1],)
+                return ".".join(parts[:i] + source_set + parts[i + 3 :])
+        return ".".join(parts)
 
     @staticmethod
     def _clean_symbol_name(name: str) -> str:
@@ -234,38 +243,6 @@ class JavaAdapter(LanguageAdapter):
             params.append("".join(current))
         return params
 
-    def extract_package(self, qualified_name: str) -> str:
-        parts = qualified_name.split(".")
-
-        java_idx = None
-        for i, part in enumerate(parts):
-            if part == "java" and i >= 1 and parts[i - 1] == "main":
-                java_idx = i
-                break
-
-        if java_idx is None:
-            try:
-                java_idx = parts.index("java")
-            except ValueError:
-                return parts[0]
-
-        after_root = parts[java_idx + 1 :]
-        if not after_root:
-            return parts[0]
-
-        pkg_parts = []
-        for part in after_root:
-            clean = part.split("(")[0]
-            if clean in ("package-info", "module-info"):
-                break
-            if clean and clean[0].isupper():
-                break
-            pkg_parts.append(part)
-
-        if pkg_parts:
-            return ".".join(pkg_parts)
-        return after_root[0]
-
     def get_workspace_settings(self) -> dict | None:
         # JDTLS defaults these to "ignore"; raising to "warning" is required
         # for unused-code diagnostics.
@@ -292,11 +269,6 @@ class JavaAdapter(LanguageAdapter):
 
     def should_track_for_edges(self, symbol_kind: int) -> bool:
         return symbol_kind in (CALLABLE_KINDS | CLASS_LIKE_KINDS | {NodeType.VARIABLE, NodeType.CONSTANT})
-
-    def get_package_for_file(self, file_path: Path, project_root: Path) -> str:
-        """Get Java package from file path by stripping src/main/java/ prefix."""
-        qname = self.build_qualified_name(file_path, "", 0, [], project_root)
-        return self.extract_package(qname)
 
     def get_all_packages(self, source_files: list[Path], project_root: Path) -> set[str]:
         packages: set[str] = set()

--- a/tests/static_analyzer/test_java_adapter.py
+++ b/tests/static_analyzer/test_java_adapter.py
@@ -1,0 +1,80 @@
+"""Naming for the Java adapter: what a symbol is called, and which package it sits in."""
+
+from pathlib import Path
+
+from static_analyzer.config import NodeType
+from static_analyzer.engine.adapters.java_adapter import JavaAdapter
+
+ROOT = Path("/repo")
+
+
+def _name(rel: str, symbol: str, kind: int = NodeType.CLASS, parents: list[tuple[str, int]] | None = None) -> str:
+    return JavaAdapter().build_qualified_name(ROOT / rel, symbol, kind, parents or [], ROOT)
+
+
+class TestBuildQualifiedName:
+    def test_maven_source_root_names_no_package(self):
+        assert (
+            _name("mockito-core/src/main/java/org/mockito/Answers.java", "Answers")
+            == "mockito-core.org.mockito.Answers"
+        )
+
+    def test_a_type_is_not_doubled_by_its_own_file(self):
+        """The stem equals the top-level type, so folding it in made the class its own parent."""
+        assert _name("core/Animal.java", "Animal") == "core.Animal"
+
+    def test_a_member_is_prefixed_by_its_class(self):
+        member = _name("core/Animal.java", "speak()", NodeType.METHOD, [("Animal", NodeType.CLASS)])
+        assert member == "core.Animal.speak()"
+        assert member.startswith(_name("core/Animal.java", "Animal") + ".")
+
+    def test_a_nested_type_keeps_the_whole_chain(self):
+        parents: list[tuple[str, int]] = [("Outer", NodeType.CLASS), ("Middle", NodeType.CLASS)]
+        assert _name("core/Outer.java", "Inner", NodeType.CLASS, parents) == "core.Outer.Middle.Inner"
+
+    def test_a_package_private_sibling_is_not_named_as_a_nested_type(self):
+        assert _name("core/Animal.java", "Dog") == "core.Dog"
+
+    def test_a_test_source_set_stays_in_the_name(self):
+        """`src/main/java` and `src/test/java` can hold the same package and type name."""
+        assert (
+            _name("core/src/test/java/org/mockito/Fixture.java", "Fixture") == "core.test.org.mockito.Fixture"
+        ) and _name("core/src/main/java/org/mockito/Fixture.java", "Fixture") == "core.org.mockito.Fixture"
+
+    def test_an_arbitrary_gradle_source_set_is_recognised(self):
+        """Gradle names its own: `integrationTest`, Android's `androidTest`."""
+        name = _name("app/src/integrationTest/java/com/acme/SmokeTest.java", "SmokeTest")
+        assert name == "app.integrationTest.com.acme.SmokeTest"
+
+    def test_a_kotlin_source_root_is_stripped(self):
+        assert _name("app/src/main/kotlin/com/acme/Main.kt", "Main") == "app.com.acme.Main"
+
+    def test_a_flat_layout_keeps_every_directory(self):
+        assert _name("com/acme/Widget.java", "Widget") == "com.acme.Widget"
+
+    def test_a_file_at_the_root_has_no_prefix(self):
+        assert _name("Widget.java", "Widget") == "Widget"
+
+    def test_a_directory_named_src_alone_is_not_a_source_root(self):
+        assert _name("src/com/acme/Widget.java", "Widget") == "src.com.acme.Widget"
+
+    def test_generics_are_stripped_from_parameters(self):
+        method = _name("core/Zoo.java", "feed(List<Animal>)", NodeType.METHOD, [("Zoo", NodeType.CLASS)])
+        assert method == "core.Zoo.feed(List)"
+
+
+class TestGetPackageForFile:
+    def test_package_matches_the_prefix_of_the_names_in_the_file(self):
+        adapter = JavaAdapter()
+        source = ROOT / "mockito-core/src/main/java/org/mockito/Answers.java"
+        package = adapter.get_package_for_file(source, ROOT)
+        assert package == "mockito-core.org.mockito"
+        assert adapter.build_qualified_name(source, "Answers", NodeType.CLASS, [], ROOT).startswith(package + ".")
+
+    def test_every_package_is_collected(self):
+        adapter = JavaAdapter()
+        sources = [
+            ROOT / "a/src/main/java/com/acme/One.java",
+            ROOT / "b/src/main/java/com/acme/Two.java",
+        ]
+        assert adapter.get_all_packages(sources, ROOT) == {"a.com.acme", "b.com.acme"}


### PR DESCRIPTION
Second of three. Stacked on #543, which has to land first or this drops every Java construction edge.

A Java symbol was named by its path from the project root, file stem included. Two things were wrong with that.

**The stem doubled the top-level type.** Java requires the stem to equal it, so `core/Animal.java` gave the class `core.Animal.Animal` while its own method stayed `core.Animal.speak()`. The class was a *sibling* of its members, and CONTAINS — dot-prefix arithmetic in `result_converter` — could never link them. Dropping the stem is safe: a package cannot declare two types of the same name.

**The build layout named no package.** Every symbol under a Maven tree carried `src.main.java.`, three segments the compiler does not recognise.

```
mockito-core/src/main/java/org/mockito/Answers.java

  was   mockito-core.src.main.java.org.mockito.Answers.Answers
  now   mockito-core.org.mockito.Answers
```

## The source set is kept unless it is `main`

`src/main/java` and `src/test/java` can hold the same package *and* the same type name, and stripping both would have given them one name — a silent overwrite, since `_symbols[qname] = info` has no guard. So `main` is dropped and any other source set stays: `core.test.org.mockito.Fixture`. That also means an arbitrary Gradle or Android source set is recognised rather than falling through — `src/integrationTest/java` becomes `app.integrationTest.com.acme`, not `app.src.integrationTest.java.com.acme`.

## Why keep the module segment

Going all the way to the bare declared package loses declarations. Measured over 16,732 files:

| | mockito | junit4 | spring-boot | spring-framework |
|---|---|---|---|---|
| this PR | **0** | **0** | **0** | **0** |
| bare declared package | 1 | 0 | **129** | 2 |

It costs nothing in recognisability either: the declared package equals the directory tail in 100% of the files measured across those four repositories, so this *is* the package, without the layout.

## Package derivation moves with the name

`get_package_for_file` is that same directory, so a package agrees with the names built from it. It no longer round-trips through `extract_package` (building a qualified name with an empty symbol just to re-parse it), and that override's `src/main/java` scanning has nothing left to do, so it goes.

## Upgrade impact

Every Java name changes, so `_TAG_VERSION` goes to v6 and a stored baseline is re-analysed once. No first-party repo is affected — all four have Python/TypeScript baselines.

Adds the first unit tests for Java naming, which had none.

## Verified

`pytest tests/` → 2248 passed (3 pre-existing `test_cli_parser` failures deselected). `black`, `mypy` clean.

Against the real engine on `java_edge_cases_project` (CodeBoarding-tests#27): references 94 → 94 as an exact bijection, classes 20 → 20, edges 86 → 110 with **0 lost** and 24 gained, every one a genuine type usage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Java, Kotlin, Groovy, and Scala symbol identification across Maven, Gradle, flat, and root project layouts.
  - Corrected qualified names for top-level types, nested types, members, sibling classes, and generic parameters.
  - Improved handling of source sets and package detection for more accurate static-analysis results.
  - Updated analysis caching so results from older naming formats are safely reprocessed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->