### PR TITLE
fix(naming): stop a C# sibling type being named as a member

### DIFF
--- a/static_analyzer/analysis_cache.py
+++ b/static_analyzer/analysis_cache.py
@@ -60,9 +60,11 @@ _LEGACY_CACHE_SUBDIR = "cache"
 # .tsx is no longer parsed as type assertions; one engine owns the family, so the degraded
 # second bucket is gone; calls are credited to the enclosing declaration; and a call in a
 # declaration's body or initialiser counts as an edge.
-# v6: every Java qualified name changes. The Maven/Gradle source root no longer prefixes
-# a name, and the file stem is gone, so a top-level type is no longer doubled and its
-# members can reach it.
+# v6: C#/Java qualified names change. For Java the Maven/Gradle source root no longer
+# prefixes a name and the file stem is gone, so a top-level type is no longer doubled and
+# its members can reach it; for C# a file declaring more than one top-level type keeps the
+# stem as a segment, so a sibling is no longer named as a member of the type the file is
+# named after.
 # Older pickles are treated as cache misses and re-run.
 _TAG_VERSION = "v6"
 

--- a/static_analyzer/engine/adapters/csharp_adapter.py
+++ b/static_analyzer/engine/adapters/csharp_adapter.py
@@ -118,9 +118,26 @@ def _single_target_framework_env(project_root: Path) -> dict[str, str]:
 
 class CSharpAdapter(LanguageAdapter):
 
+    def __init__(self) -> None:
+        super().__init__()
+        # Files declaring more than one top-level type, keyed by (project root, path). Why:
+        # the file stem names a single type or none, and only these files need it kept as a
+        # segment. Why the root: this one adapter serves every C# engine config, which the
+        # bounded pass can run concurrently, and two roots can hold the same file.
+        self._files_with_sibling_types: set[tuple[str, str]] = set()
+
     @property
     def include_references_on_declaration_line(self) -> bool:
         return True
+
+    def record_document_symbols(self, file_path: Path, symbols: list[dict], project_root: Path) -> None:
+        # Discarded as well as added: the same adapter can re-analyse a file after a sibling
+        # was deleted, and it must then name it the way a cold run would.
+        key = (str(project_root), str(file_path))
+        if len(self._top_level_types(symbols)) > 1:
+            self._files_with_sibling_types.add(key)
+        else:
+            self._files_with_sibling_types.discard(key)
 
     @property
     def language(self) -> str:
@@ -191,42 +208,28 @@ class CSharpAdapter(LanguageAdapter):
         project_root: Path,
         detail: str = "",
     ) -> str:
-        """Build namespace-based qualified names for C#.
+        """Build ``<directory>.<file stem>.<declaring types>.<symbol>``.
 
-        csharp-ls returns: File (kind=1) > Namespace (kind=3) > Class > Members.
-        The namespace's ``detail`` has the full namespace, but only the
-        namespace symbol itself receives it -- children get ``detail=""``.
-
-        Strategy: use namespace detail when available (for namespace
-        symbols themselves), otherwise reconstruct from file path,
-        skipping ``src/`` prefix and deduplicating filename/class.
+        C# has no file scope, so a file may declare several top-level types. The stem then
+        names none of them and stays a plain segment. Folding it in, as a file declaring one
+        type can, would give a sibling the same name as a type nested inside the one the
+        file is named after -- and the two would overwrite each other.
         """
-        # Namespace symbol itself — detail has the full namespace
+        # The namespace symbol itself is the only one csharp-ls gives the full name to.
         if detail and symbol_kind == NodeType.NAMESPACE:
             return detail
 
-        # Build from file path, stripping 'src' prefix
         rel = file_path.relative_to(project_root)
-        parts = [p for p in rel.with_suffix("").parts if p != "src"]
-        module = ".".join(parts)
-
-        # Filter parents: skip File (kind=1) and Namespace (kind=3) —
-        # the namespace is already encoded in the file path for C#
+        module = ".".join(p for p in rel.with_suffix("").parts if p != "src")
+        # Skip File and Namespace: the namespace is encoded in the path for C#.
         code_parents = [name for name, kind in parent_chain if kind not in (NodeType.FILE, NodeType.NAMESPACE)]
 
-        if code_parents:
-            # Deduplicate first parent if it matches filename
-            module_last = module.rsplit(".", 1)[-1] if "." in module else module
-            if code_parents[0] == module_last:
+        if (str(project_root), str(file_path)) not in self._files_with_sibling_types:
+            if code_parents and code_parents[0] == rel.stem:
                 code_parents = code_parents[1:]
-            if code_parents:
-                return f"{module}.{'.'.join(code_parents)}.{symbol_name}"
-
-        # Deduplicate filename/class (one type per file convention)
-        module_last = module.rsplit(".", 1)[-1] if "." in module else module
-        if symbol_name == module_last:
-            return module
-        return f"{module}.{symbol_name}"
+            if not code_parents and symbol_name == rel.stem:
+                return module
+        return ".".join((module, *code_parents, symbol_name))
 
     def extract_package(self, qualified_name: str) -> str:
         """Extract namespace as all-but-last-two dot-separated components.
@@ -398,3 +401,14 @@ class CSharpAdapter(LanguageAdapter):
     def get_all_packages(self, source_files: list[Path], project_root: Path) -> set[str]:
         """Get all directory prefixes as packages (namespace-based, like PHP)."""
         return self._get_hierarchical_packages(source_files, project_root)
+
+    def _top_level_types(self, symbols: list[dict]) -> list[str]:
+        """The type declarations a file makes outside any other type."""
+        found: list[str] = []
+        for sym in symbols:
+            kind = sym.get("kind", 0)
+            if kind in (NodeType.FILE, NodeType.NAMESPACE):
+                found.extend(self._top_level_types(sym.get("children", [])))
+            elif self.is_class_like(kind):
+                found.append(sym.get("name", ""))
+        return found

--- a/static_analyzer/engine/call_graph_builder.py
+++ b/static_analyzer/engine/call_graph_builder.py
@@ -190,6 +190,7 @@ class CallGraphBuilder:
                 symbols = self._lsp.document_symbol(file_path, timeout=probe_timeout)
             else:
                 symbols = self._lsp.document_symbol(file_path)
+            self._adapter.record_document_symbols(file_path, symbols, self._root)
             self._symbol_table.register_symbols(file_path, symbols, parent_chain=[], project_root=self._root)
             pbar.set_postfix(symbols=len(self._symbol_table.symbols))
             pbar.update(1)

--- a/static_analyzer/engine/language_adapter.py
+++ b/static_analyzer/engine/language_adapter.py
@@ -356,6 +356,14 @@ class LanguageAdapter(ABC):
         once per element, rather than only constructing the type."""
         return False
 
+    def record_document_symbols(self, file_path: Path, symbols: list[dict], project_root: Path) -> None:
+        """Take note of a file's symbol tree before its names are built.
+
+        Why: a name is built one symbol at a time and cannot see the rest of the file. Keyed
+        by *project_root* as well, since one adapter instance serves every engine config and
+        two of them can hold the same file with different symbols.
+        """
+
     @property
     def expands_constructors(self) -> bool:
         """Whether an edge to a class should also reach that class's constructors.

--- a/tests/static_analyzer/test_csharp_adapter.py
+++ b/tests/static_analyzer/test_csharp_adapter.py
@@ -199,6 +199,119 @@ class TestBuildQualifiedName:
         assert result == "Contoso.Core.Models.Media"
 
 
+class TestFilesDeclaringSeveralTypes:
+    """A C# file may declare several top-level types; the stem then names none of them."""
+
+    root = Path("/repo")
+
+    def _adapter_for(self, *type_names: str) -> CSharpAdapter:
+        adapter = CSharpAdapter()
+        adapter.record_document_symbols(
+            Path("/repo/Models/Animal.cs"),
+            [
+                {
+                    "name": "Zoo",
+                    "kind": NodeType.NAMESPACE,
+                    "children": [{"name": name, "kind": NodeType.CLASS} for name in type_names],
+                }
+            ],
+            self.root,
+        )
+        return adapter
+
+    def test_a_sibling_is_not_named_as_a_member_of_the_file_named_type(self):
+        adapter = self._adapter_for("Animal", "Dog")
+        source = Path("/repo/Models/Animal.cs")
+
+        animal = adapter.build_qualified_name(source, "Animal", NodeType.CLASS, [], self.root)
+        dog = adapter.build_qualified_name(source, "Dog", NodeType.CLASS, [], self.root)
+
+        assert animal == "Models.Animal.Animal"
+        assert dog == "Models.Animal.Dog"
+        assert not dog.startswith(animal + ".")
+
+    def test_a_sibling_no_longer_collides_with_a_nested_type(self):
+        """`Models.Animal.Inner` named both, and the second registration destroyed the first."""
+        adapter = self._adapter_for("Animal", "Inner")
+        source = Path("/repo/Models/Animal.cs")
+
+        nested = adapter.build_qualified_name(source, "Inner", NodeType.CLASS, [("Animal", NodeType.CLASS)], self.root)
+        sibling = adapter.build_qualified_name(source, "Inner", NodeType.CLASS, [], self.root)
+
+        assert nested == "Models.Animal.Animal.Inner"
+        assert sibling == "Models.Animal.Inner"
+        assert nested != sibling
+
+    def test_a_member_still_shares_a_prefix_with_its_class(self):
+        """CONTAINS is dot-prefix arithmetic, so the class must remain a prefix of its members."""
+        adapter = self._adapter_for("Animal", "Dog")
+        source = Path("/repo/Models/Animal.cs")
+
+        dog = adapter.build_qualified_name(source, "Dog", NodeType.CLASS, [], self.root)
+        speak = adapter.build_qualified_name(source, "Speak", NodeType.METHOD, [("Dog", NodeType.CLASS)], self.root)
+
+        assert speak == "Models.Animal.Dog.Speak"
+        assert speak.startswith(dog + ".")
+
+    def test_one_type_per_file_is_unchanged(self):
+        adapter = self._adapter_for("Animal")
+        source = Path("/repo/Models/Animal.cs")
+
+        assert adapter.build_qualified_name(source, "Animal", NodeType.CLASS, [], self.root) == "Models.Animal"
+        assert (
+            adapter.build_qualified_name(source, "Speak", NodeType.METHOD, [("Animal", NodeType.CLASS)], self.root)
+            == "Models.Animal.Speak"
+        )
+
+    def test_an_enum_beside_a_class_counts_as_a_second_type(self):
+        adapter = CSharpAdapter()
+        source = Path("/repo/Models/Task.cs")
+        adapter.record_document_symbols(
+            source,
+            [
+                {"name": "Task", "kind": NodeType.CLASS},
+                {"name": "Priority", "kind": NodeType.ENUM},
+            ],
+            self.root,
+        )
+
+        enum_name = adapter.build_qualified_name(source, "Priority", NodeType.ENUM, [], self.root)
+        property_name = adapter.build_qualified_name(
+            source, "Priority", NodeType.PROPERTY, [("Task", NodeType.CLASS)], self.root
+        )
+
+        assert enum_name == "Models.Task.Priority"
+        assert property_name == "Models.Task.Task.Priority"
+
+    def test_a_file_that_loses_a_sibling_goes_back_to_the_collapsed_name(self):
+        """The same adapter can re-analyse a file, and must agree with a cold run."""
+        adapter = self._adapter_for("Animal", "Dog")
+        source = Path("/repo/Models/Animal.cs")
+        assert adapter.build_qualified_name(source, "Animal", NodeType.CLASS, [], self.root) == "Models.Animal.Animal"
+
+        adapter.record_document_symbols(source, [{"name": "Animal", "kind": NodeType.CLASS}], self.root)
+
+        assert adapter.build_qualified_name(source, "Animal", NodeType.CLASS, [], self.root) == "Models.Animal"
+
+    def test_two_engine_configs_do_not_share_a_file_classification(self):
+        """One adapter serves every C# config, and the bounded pass can run them together."""
+        adapter = CSharpAdapter()
+        source = Path("/repo/Models/Animal.cs")
+        other_root = Path("/other")
+        adapter.record_document_symbols(
+            source, [{"name": "Animal", "kind": NodeType.CLASS}, {"name": "Dog", "kind": NodeType.CLASS}], self.root
+        )
+        adapter.record_document_symbols(source, [{"name": "Animal", "kind": NodeType.CLASS}], other_root)
+
+        assert adapter.build_qualified_name(source, "Animal", NodeType.CLASS, [], self.root) == "Models.Animal.Animal"
+
+    def test_a_file_never_seen_keeps_the_single_type_naming(self):
+        adapter = CSharpAdapter()
+        source = Path("/repo/Models/Animal.cs")
+
+        assert adapter.build_qualified_name(source, "Animal", NodeType.CLASS, [], self.root) == "Models.Animal"
+
+
 class TestExtractPackage:
     """Tests for namespace/package extraction."""
 


### PR DESCRIPTION
Last of three, now based on `main` with #543 and #544 merged.

C# has no file scope, so a file may declare several top-level types. The adapter folded the file stem into the module and then collapsed the type whose name matched it, which left every *other* top-level type named as a **member of the type the file is named after**:

```
Models/Animal.cs  declaring Animal, Dog and Cat as siblings

  was   Models.Animal,        Models.Animal.Dog,  Models.Animal.Cat
  now   Models.Animal.Animal, Models.Animal.Dog,  Models.Animal.Cat
```

This was not cosmetic:

- `internal_references.is_self_or_container_edge` tests dot-prefixes, so a real dependency between two types in one file read as containment and was deleted.
- CONTAINS attached a sibling to a class that does not declare it.
- It **destroyed a symbol outright**. `Task.cs` declaring `enum Priority` beside `class Task { Priority Priority }` named both `Models.Task.Priority`, and `SymbolTable._symbols[qname] = info` has no guard.

That last one is demonstrated rather than argued: against the real engine the C# edge-case project goes from **97 references to 98**, and the extra one is `Models.Task.Task.Priority` — the property that used to lose the collision. See CodeBoarding-tests#27.

A file declaring one type — the overwhelming case — is **byte-identical**. `Models/User.cs` still gives `Models.User` and `Models.User.Name`.

## Measured

Share of top-level types that get a new name, and collisions before and after:

| | types | renamed | | collisions before | after |
|---|---|---|---|---|---|
| eShop | 552 | 34 | 6.2% | 0 | 0 |
| abp | 9199 | 337 | 3.8% | 0 | 0 |
| Polly | 941 | 59 | 6.6% | 0 | 0 |
| AutoMapper | 3750 | 53 | 5.4% | 0 | 0 |
| serilog | 262 | 21 | 8.0% | 0 | 0 |

## Why the stem is not simply dropped

Dropping it for every type — the obvious smaller change, and what #540 did first — reads better but loses declarations, because the stem is what separates two same-named types in one directory: eShop 10, abp 160, Polly 105, AutoMapper 7, serilog 1. Keeping it exactly where it is load-bearing costs nothing.

## Why the adapter is handed the symbol tree

What *else* a file declares cannot come from a name built one symbol at a time, so `record_document_symbols` gives the adapter the file's tree once, before its names are built. It is called from the single production registration path, and it both records and discards, so a warm re-analysis of a file that lost a sibling agrees with a cold run. A name stays a pure function of one file, which is what keeps it stable on an incremental run.

## No cache tag bump

v6 already covers this. It landed in #544 and ships in the same release, so the note beside it now names both halves of the C#/Java rename instead of adding a v7 nobody would ever see on its own.

## Verified

`pytest tests/` → 2258 passed (3 pre-existing `test_cli_parser` failures deselected; identical on a clean `main`). `black`, `mypy` clean. Against the real engine, all 9 C# edge-case integration tests pass on the migrated fixtures (CodeBoarding-tests#27), including two edges corrected rather than renamed: `: base(size)` and `new(5)` call `Settings(int size)`, never the parameterless `Settings()` the old fixture pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved C# code analysis for files containing multiple top-level types, keeping sibling and nested type names distinct.
  - Preserved existing qualified-name behavior for files containing a single top-level type.
  - Re-analysis now updates qualified names when a file’s type structure changes.
  - Enums are correctly accounted for when determining file type structure.

- **Documentation**
  - Updated cache-format documentation to describe qualified-name behavior changes while retaining cache version `v6`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->