### PR TITLE
Fix .codeboardingignore path with custom output directories

### DIFF
--- a/codeboarding_cli/commands/full_analysis.py
+++ b/codeboarding_cli/commands/full_analysis.py
@@ -96,7 +96,7 @@ def _run_local(args: argparse.Namespace) -> None:
 
     should_monitor = args.enable_monitoring or monitoring_enabled()
     run_paths.output_dir.mkdir(parents=True, exist_ok=True)
-    initialize_codeboardingignore(run_paths.output_dir)
+    initialize_codeboardingignore(run_paths.repo_path)
 
     def scope(src: SourceContext, run_context: RunContext) -> None:
         run_full(
@@ -172,7 +172,7 @@ def _process_one_remote(
     def scope(src: SourceContext, run_context: RunContext) -> None:
         repo_output_dir = workspace_root / src.project_name / CODEBOARDING_DIR_NAME
         repo_output_dir.mkdir(parents=True, exist_ok=True)
-        initialize_codeboardingignore(repo_output_dir)
+        initialize_codeboardingignore(src.repo_path)
 
         monitoring_dir = get_monitoring_run_dir(run_context.log_path, create=should_monitor)
         with monitor_execution(

--- a/codeboarding_cli/commands/partial_analysis.py
+++ b/codeboarding_cli/commands/partial_analysis.py
@@ -46,7 +46,7 @@ def run_from_args(args: argparse.Namespace, parser: argparse.ArgumentParser) -> 
     logger.info("Starting CodeBoarding partial component update...")
 
     run_paths.output_dir.mkdir(parents=True, exist_ok=True)
-    initialize_codeboardingignore(run_paths.output_dir)
+    initialize_codeboardingignore(run_paths.repo_path)
 
     def scope(src: SourceContext, run_context: RunContext) -> None:
         run_partial(

--- a/repo_utils/ignore.py
+++ b/repo_utils/ignore.py
@@ -335,16 +335,14 @@ class RepoIgnoreManager:
             return "other"
 
 
-def initialize_codeboardingignore(output_dir: Path) -> None:
-    """Initialize .codeboardingignore file in the .codeboarding directory if it doesn't exist.
-
-    Args:
-        output_dir: Path to the .codeboarding directory
-    """
-    codeboardingignore_path = output_dir / CODEBOARDINGIGNORE_FILENAME
+def initialize_codeboardingignore(repo_root: Path) -> None:
+    """Initialize the repository's .codeboardingignore file if it doesn't exist."""
+    codeboarding_dir = repo_root / CODEBOARDING_DIR_NAME
+    codeboardingignore_path = codeboarding_dir / CODEBOARDINGIGNORE_FILENAME
 
     if not codeboardingignore_path.exists():
         try:
+            codeboarding_dir.mkdir(parents=True, exist_ok=True)
             codeboardingignore_path.write_text(CODEBOARDINGIGNORE_TEMPLATE, encoding="utf-8")
             logger.debug(f"Created .codeboardingignore file at {codeboardingignore_path}")
         except Exception as e:

--- a/tests/repo_utils/test_ignore.py
+++ b/tests/repo_utils/test_ignore.py
@@ -5,8 +5,20 @@ import unittest
 import shutil
 from pathlib import Path
 
-from repo_utils.ignore import RepoIgnoreManager
+from constants import CODEBOARDINGIGNORE_FILENAME
+from repo_utils.ignore import CODEBOARDINGIGNORE_TEMPLATE, RepoIgnoreManager, initialize_codeboardingignore
 from utils import CODEBOARDING_DIR_NAME
+
+
+def test_initialize_codeboardingignore_uses_repository_path(tmp_path: Path) -> None:
+    custom_output_dir = tmp_path / "custom-output"
+    custom_output_dir.mkdir()
+
+    initialize_codeboardingignore(tmp_path)
+
+    ignore_path = tmp_path / CODEBOARDING_DIR_NAME / CODEBOARDINGIGNORE_FILENAME
+    assert ignore_path.read_text(encoding="utf-8") == CODEBOARDINGIGNORE_TEMPLATE
+    assert not (custom_output_dir / CODEBOARDINGIGNORE_FILENAME).exists()
 
 
 class TestRepoIgnoreManagerRealWorldScenario(unittest.TestCase):


### PR DESCRIPTION
## Summary
- initialize `.codeboardingignore` under the repository's `.codeboarding` directory
- keep rendered artifacts independent from repository ignore configuration
- cover repository-relative initialization with a focused regression test

## Verification
- `pytest tests/repo_utils/test_ignore.py tests/test_cli_parser.py -q` — 40 passed
- `pytest --cov=. --cov-report=term --cov-fail-under=80` — 2263 passed, 28 skipped; 84.31% coverage (with a temporary `dotnet` presence stub because the orb does not include the user-provided .NET toolchain)
- `black .` — 335 files unchanged
- `mypy .` — no issues in 335 source files

Fixes #535
