### PR TITLE
Use capabilities to gate model sampling parameters

### DIFF
--- a/agents/llm_config.py
+++ b/agents/llm_config.py
@@ -12,7 +12,7 @@ from langchain_ollama import ChatOllama
 from langchain_openai import ChatOpenAI
 
 from agents.constants import LLMDefaults, ModelCapabilities
-from agents.model_capabilities import ContextWindow, get_context_window
+from agents.model_capabilities import ContextWindow, get_context_window, model_accepts_sampling_parameters
 from agents.prompts.prompt_factory import LLMType, initialize_global_factory
 from monitoring.callbacks import MonitoringCallback
 
@@ -24,24 +24,6 @@ MONITORING_CALLBACK = MonitoringCallback(stats_container=RunStats())
 logger = logging.getLogger(__name__)
 
 _OPENROUTER_FALLBACK_CONTEXT_WINDOW = ContextWindow(1_048_576, 65_536, is_fallback=True)
-
-# Model families that reject sampling params (temperature/top_p/top_k) with HTTP 400.
-# Why: newer Anthropic models deprecate them; sending temperature (even 0) 400s.
-# Substrings match bare IDs and Bedrock-prefixed forms (e.g. us.anthropic.claude-opus-4-8-v1:0).
-_SAMPLING_PARAM_FREE_MODEL_SUBSTRINGS = (
-    "claude-opus-4-7",
-    "claude-opus-4-8",
-    "claude-opus-5",
-    "claude-sonnet-5",
-    "claude-fable-5",
-    "claude-mythos-5",
-)
-
-
-def _model_accepts_temperature(model_name: str) -> bool:
-    """False for models that reject sampling params; temperature must be omitted for those."""
-    lowered = model_name.lower()
-    return not any(s in lowered for s in _SAMPLING_PARAM_FREE_MODEL_SUBSTRINGS)
 
 
 # ---------------------------------------------------------------------------
@@ -398,7 +380,7 @@ def _initialize_llm(
     logger.info(f"Using {name.title()} {log_prefix}LLM with model: {model_name}")
 
     kwargs: dict[str, Any] = {"model": model_name}
-    if _model_accepts_temperature(model_name):
+    if model_accepts_sampling_parameters(name, model_name):
         kwargs["temperature"] = getattr(config, temperature_attr)
     kwargs.update(config.get_resolved_extra_args())
 

--- a/agents/model_capabilities.py
+++ b/agents/model_capabilities.py
@@ -14,6 +14,13 @@ from utils import get_cache_dir
 logger = logging.getLogger(__name__)
 
 _BEDROCK_REGION = re.compile(r"^(us|eu|apac|global|au|ca|us-gov)\.")
+# Known Anthropic families that retain sampling controls; unknown models omit them to avoid HTTP 400 responses.
+_ANTHROPIC_SAMPLING_MODEL_PATTERNS = (
+    re.compile(r"^claude-(?:instant|v?[12])(?:[.-]|$)"),
+    re.compile(r"^claude-3(?:[.-]\d+)?-(?:haiku|sonnet|opus)(?:-|$)"),
+    re.compile(r"^claude-(?:haiku|sonnet)-4(?:-|$)"),
+    re.compile(r"^claude-opus-4(?:$|-(?:[0-6](?:-|$)|20\d{6}(?:-|$)))"),
+)
 
 # Why: cached by hand (not via @lru_cache) so a transient Ollama outage -- user starts the
 # app before `ollama serve` is up -- doesn't memoize None for the rest of the process.
@@ -25,6 +32,22 @@ class ContextWindow:
     input_tokens: int
     output_tokens: int
     is_fallback: bool = False
+
+
+def model_accepts_sampling_parameters(provider: str, model_name: str) -> bool:
+    """Return whether the provider/model combination accepts sampling parameters."""
+    lowered = model_name.lower()
+    is_anthropic = provider == "anthropic" or (
+        provider == "aws" and ("anthropic." in lowered or lowered.startswith("claude-"))
+    )
+    if not is_anthropic:
+        return True
+
+    claude_start = lowered.find("claude-")
+    if claude_start == -1:
+        return False
+    canonical_name = lowered[claude_start:]
+    return any(pattern.match(canonical_name) for pattern in _ANTHROPIC_SAMPLING_MODEL_PATTERNS)
 
 
 def get_context_window(provider: str, model_name: str) -> ContextWindow:

--- a/tests/agents/test_llm_config.py
+++ b/tests/agents/test_llm_config.py
@@ -10,7 +10,6 @@ from agents.llm_config import (
     LLM_PROVIDERS,
     LLM_PROVIDER_ENV_VARS,
     LLMConfigError,
-    _model_accepts_temperature,
     initialize_agent_llm,
     initialize_llms,
     initialize_parsing_llm,
@@ -639,30 +638,6 @@ class TestEnvironmentVariables:
 
 class TestTemperatureGating:
     """temperature must be omitted for Anthropic models that reject sampling params."""
-
-    @pytest.mark.parametrize(
-        "model_name",
-        [
-            "claude-opus-4-7",
-            "claude-opus-4-8",
-            "claude-opus-5",
-            "claude-sonnet-5",
-            "claude-fable-5",
-            "claude-mythos-5",
-            "anthropic.claude-opus-4-8",  # Bedrock prefix
-            "us.anthropic.claude-opus-4-8-v1:0",  # Bedrock with region
-            "CLAUDE-OPUS-4-8",  # case-insensitive
-        ],
-    )
-    def test_sampling_param_free_models_omit_temperature(self, model_name):
-        assert _model_accepts_temperature(model_name) is False
-
-    @pytest.mark.parametrize(
-        "model_name",
-        ["claude-sonnet-4-6", "claude-haiku-4-5", "anthropic.claude-sonnet-4-6", "gpt-4o", "gemini-3-flash"],
-    )
-    def test_other_models_accept_temperature(self, model_name):
-        assert _model_accepts_temperature(model_name) is True
 
     @patch("agents.prompts.prompt_factory.initialize_global_factory")
     @patch("agents.agent.MONITORING_CALLBACK")

--- a/tests/agents/test_model_capabilities.py
+++ b/tests/agents/test_model_capabilities.py
@@ -1,4 +1,4 @@
-"""Hermetic unit tests for the context-window resolver. Catalogs are mocked — no network."""
+"""Hermetic unit tests for model-capability resolution. Catalogs are mocked — no network."""
 
 import io
 import json
@@ -11,6 +11,7 @@ from agents.model_capabilities import (
     _parse_num_ctx,
     _resolve_ollama,
     get_context_window,
+    model_accepts_sampling_parameters,
 )
 from utils import CODEBOARDING_DIR_NAME
 
@@ -50,6 +51,45 @@ _FAKE_OPENROUTER = {
         "top_provider": {"max_completion_tokens": 128_000},
     },
 }
+
+
+class TestSamplingParameters:
+    @pytest.mark.parametrize(
+        "provider,model_name",
+        [
+            ("anthropic", "claude-opus-4-7"),
+            ("anthropic", "claude-opus-4-8"),
+            ("anthropic", "claude-opus-5"),
+            ("anthropic", "claude-sonnet-5"),
+            ("anthropic", "claude-haiku-5"),
+            ("anthropic", "claude-fable-5"),
+            ("anthropic", "claude-mythos-5"),
+            ("anthropic", "CLAUDE-OPUS-4-8"),
+            ("anthropic", "unknown-deployment"),
+            ("aws", "anthropic.claude-opus-4-8"),
+            ("aws", "us.anthropic.claude-opus-4-8-v1:0"),
+            ("aws", "claude-opus-5"),
+        ],
+    )
+    def test_anthropic_models_without_sampling_capability(self, provider: str, model_name: str) -> None:
+        assert model_accepts_sampling_parameters(provider, model_name) is False
+
+    @pytest.mark.parametrize(
+        "provider,model_name",
+        [
+            ("anthropic", "claude-2.1"),
+            ("anthropic", "claude-3-5-sonnet-20241022"),
+            ("anthropic", "claude-3.5-sonnet-20241022"),
+            ("anthropic", "claude-opus-4-1-20250805"),
+            ("anthropic", "claude-sonnet-4-6"),
+            ("anthropic", "claude-haiku-4-5"),
+            ("aws", "anthropic.claude-sonnet-4-6"),
+            ("openai", "gpt-4o"),
+            ("google", "gemini-3-flash"),
+        ],
+    )
+    def test_models_with_sampling_capability(self, provider: str, model_name: str) -> None:
+        assert model_accepts_sampling_parameters(provider, model_name) is True
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- replace the release-by-release Anthropic sampling denylist with a provider-aware capability allowlist
- preserve sampling parameters for known older Claude families and non-Anthropic providers
- omit sampling parameters for unknown/new Anthropic and Bedrock Claude models to avoid provider-side HTTP 400 responses
- cover canonical, case-insensitive, legacy, unknown, and Bedrock-prefixed model IDs

## Verification
- `pytest tests/agents/test_model_capabilities.py tests/agents/test_llm_config.py -q` — 172 passed
- `pytest --cov=. --cov-report=term --cov-fail-under=80` — 2269 passed, 28 skipped; 84.31% coverage (with a temporary `dotnet` presence stub because the orb does not include the user-provided .NET toolchain)
- `black .` — 335 files unchanged
- `mypy .` — no issues in 335 source files

Fixes #518
