### PR TITLE
feat(clustering): partition by qualified names, the core and its design

### DIFF
--- a/docs/design/name-tree.md
+++ b/docs/design/name-tree.md
@@ -1,0 +1,269 @@
+# Partitioning by qualified names: one tree, three decisions
+
+**Status.** Design for the `feat/name-tree-*` stack. Supersedes the clustering half of
+PR #539 and the deletion in #542; builds on the merged naming fixes #543, #544, #545.
+Evidence is summarised in §7 and lives in the research artifact
+"One Tree, Three Decisions" (2 Sep 2026).
+
+## 1. The problem in one paragraph
+
+Components today come from the call graph twice over: Leiden communities at every depth,
+a modularity peak to group them, seeded Leiden plus ownership anchoring on incremental
+runs, and a modularity gate to decide expansion. Measured against the only independent
+ground truth we have (eShop's published architecture), the call graph provably cannot
+generate the maintainers' boxes: 204 connected components against 10 boxes, and no
+resolution keeps one box both whole and separated. The shipped pipeline scores below the
+all-in-one floor on two of four held-out rulers. What *does* reach the maintainers'
+drawings is what files are called: the trie of qualified-name prefixes, which is the
+directory tree in every language today, plus the words in the identifiers. PR #539 showed
+that on the C# rulers; it broke on mono-repos, layered repos and path-derived languages
+because its decisions were made at the wrong altitude (one gate for the whole repo, one
+directory level, one sink, Leiden below the root). This design makes the same decisions
+per scope, from the same names, writes them down once, and replays them everywhere.
+
+## 2. The contract
+
+- **Input.** The call graph's node keys (`CallGraph.nodes`, split on `graph.delimiter`)
+  and, per node, the file it was declared in. The file path is an opaque unit identity and
+  is never parsed: the partition reads no filesystem and no path segment. Only what static
+  analysis emitted is partitioned; tests, docs and tooling that survive the ignore file are
+  ordinary names, nothing else is special-cased.
+- **Output.** A `TreeSpec`: per scope, an ordered list of `ComponentRule`s (the prefixes
+  of the trie a component owns, the words it owns, a last-resort prefix, and the candidates
+  it was grouped from), or no rules and a reason, meaning the scope is a leaf. Persisted in
+  `analysis.json` metadata as `tree_spec`.
+- **The one function.** `replay(units, scope_rules) -> Partition` assigns every unit of a
+  scope to exactly one rule by: the longest matching prefix, then a head-noun-weighted vote
+  over the words the rules own, then the longest matching fallback prefix. What no rule
+  claims is *unplaced*: drawn in a reserved bucket, reported, never invented into a
+  neighbour. Replay is used at draft time, on every incremental run, and on every partial
+  expansion, so the three paths cannot disagree.
+- **Invariants.** (1) A unit's box depends only on its own names and the rules: no
+  collection statistic participates in replay, so a file added beside it cannot move it.
+  (2) The walk emits rules, never assignments. (3) A grouper sees candidates, never units,
+  so a wrong grouping can only merge boxes, never move a file. (4) The graph never places
+  a file; it draws the arrows and audits the boxes. (5) Never refuse: a scope with one box
+  falls through the ladder; a scope nothing splits is an honest leaf that says why.
+
+## 3. The parts (`static_analyzer/clustering/names/`)
+
+### 3.1 Units and the trie (`inventory.py`)
+
+A **unit** is a file: the set of qualified names declared in it. Its **position** is the
+longest prefix its names share, less a trailing symbol (a file declaring one class shares
+that class across every member). The engine emits no module node, so this is how the
+module of a Python file, the package of a Java type and the directory of a C# type are read
+off the names alone. The **trie** is the prefix tree of positions; a dotted directory name
+(`Ordering.API`) nests as two segments, which is what lets `Ordering.API`, `Ordering.Domain`
+and `Ordering.Infrastructure` sit under one `Ordering` node that is never split along its
+role-named children.
+
+### 3.2 The frontier walk (`frontier.py`)
+
+Per node, in order:
+
+| node | rule |
+|---|---|
+| one child, no units | pass through |
+| child is a layout word (`src`, `packages`, `pkg`, …) or holds ≥ 80% of the parent | step through, whatever it is called; this is decided before the layered test below |
+| children mostly (≥ 60%) role-named, ≥ 3 of them | **layered**: if a feature name recurs under ≥ 2 distinct layer children, **transpose** onto those features; else one box |
+| child is role-named | a box, never a way in |
+| feature-named child holding ≥ 25% of the scope, with mostly feature-named children | open it |
+| feature-named child holding ≥ 25% of the scope, with ≥ 3 mostly role-named children | layered, as above |
+| anything else | a box; a one-unit child is a loose unit of its parent |
+| a node the walk entered that has only units and one-unit children | one box (a flat scope) |
+
+Role words are a fixed closed class (`ROLE_WORDS`, ~95 stems: Api, Domain, Models,
+Services, Handlers, …) plus a per-repo tail the planner may add; measured, this list cannot
+be learned from identifier frequencies. Ubiquity (a product namesake carried by most
+siblings) is by frequency over ≥ 2 siblings, never by set intersection.
+
+The walk emits **candidates**, each a bundle of rules: a *box* owns its trie path; a
+*feature* of a transposed node owns the shallowest feature-named directory under each
+layer plus its word; a *residual* owns a layer directory as a fallback; *loose* units of a
+node own the node's path as a fallback. Loose units therefore vote with their words before
+falling back to their directory: the per-unit fall-through that every replacement rule in
+the edge-case study converged on. A fallback-only rule is the scope's last resort: it is
+never absorbed into a neighbour and never counted by the guard, so it stays its own small
+box, and a unit it catches is still reported as a new-scope candidate (§4).
+
+### 3.3 The grouper (`draft.py`, `Grouper`)
+
+The one judgement in the tree: turn the candidates of a rung into named components. Two
+implementations behind one protocol, switchable by configuration and kept side by side:
+
+- `KinshipGrouper` (deterministic, this PR): merge candidates sharing their distinctive
+  word (`Ordering` + `OrderProcessor`, `Webhooks` + `WebhookClient`, `EventBus` +
+  `EventBusRabbitMQ`). Recovers eShop's depth-1 drawing at 1.000 with no model.
+- The planner (LLM, next PR): reads the kinship-merged candidates (names, unit counts, a
+  sample of identifiers) and returns groups toward a 5–9 preference, names, and machinery
+  words. It may merge across words (`apiserver` + `apimachinery`; django's docs themes),
+  which no formula over names can. Its answer is validated (every candidate in exactly one
+  group) and replayed verbatim. No silent fallback: a failed call fails the run.
+
+### 3.4 The specification (`spec.py`)
+
+`TreeSpec` = `{scopes: {scope_id: ScopeSpec}, machinery, grouper, version}`. A
+`ScopeSpec` present with no rules is a leaf by decision; a scope absent from the spec was
+never drafted (below the depth cap). Rule ids are the component ids (`1`, `1.2`), allocated
+largest-first at draft time and stable thereafter; a new id is always above every id the
+scope has used, never a refilled gap. Serialisation stores prefixes as segment lists, so a
+segment may contain a dot or a generic argument list. Replay also depends on the tokenizer,
+the stemmer and the fixed role words; a change to any of them bumps `version`, and a spec
+of an older version is redrafted by the next full run.
+
+### 3.5 The ladder (`draft.py`, `draft_scope`)
+
+The first rung that yields two children wins; a rung yields children only if at least two
+rules with a prefix or a word each hold `max(2, int(5% of the parent))` units, and a smaller
+one is absorbed by the largest (the measured guard; fallback-only rules are exempt). The
+root takes no guard on its frontier: a box the names draw is a box, and small ones are the
+grouper's to merge. Ties in the word vote go to the rule that comes first in the scope,
+never to an id's spelling, so ordering and numbering cannot move a unit.
+
+| scope | rungs, in order |
+|---|---|
+| root | frontier of the trie → words of the units (only if the frontier gave one box) |
+| component ≤ 135 units | un-merge: the candidates the grouper merged into it → leaf ("cohesive") |
+| component > 135 units | un-merge → frontier of its own sub-trie → words of its units → leaf ("exhausted") |
+
+Why the cap: on the one maintainer-drawn depth-2 ruler, un-merge alone scores 0.999 and
+over-splits 1 of 7 leaf parents; the next-segment and vocabulary rungs score 0.50 and 0.55
+and over-split all 7. 135 units is the largest box any maintainer has left unsplit
+(eShop's client app). Above it a box is too large to read, so every name coordinate is
+tried before it becomes a leaf. There is no graph tier: Leiden is retired at every depth.
+
+## 4. Full, incremental, partial: one function, three entry points
+
+**Full run.** Units from every language's graph → `draft_tree(units, grouper, depth_cap)`
+→ `TreeSpec` persisted in `analysis.json` metadata → per scope, `replay` gives the
+`ClusterGroup`s the agents already consume (one component per group, file leaves as the
+cluster ids, connections from the graph's edges). The abstraction and details agents keep
+naming and describing components; nothing in the agent contract changes.
+
+**Incremental run.** No anchoring, no seeded Leiden, no drift budget. The frozen spec is
+replayed over the live graph's names (the incremental engine carries the same keys for
+changed and unchanged files). Per scope, walking the tree top-down:
+
+1. `replay(units, scope)`. A component whose rule still claims units keeps its id and
+   membership; `previous_component_id` is the rule id, so the existing scope plan emits
+   UPDATE only where members or bodies changed, and nothing else moves. Measured: 0.00%
+   of unchanged files move across 27 repositories and four edit types.
+2. **New components.** Every unit that no prefix and no word claims, whether a fallback
+   rule caught it or nothing did, is reported in `Partition.new_scopes` under the prefix at
+   which its position first leaves every prefix a rule owns: a new top-level directory
+   diverges at that directory; a new file deep inside a known one is claimed by its
+   ancestor's rule and never gets here. A group of ≥ 2 units whose members are all new to
+   the analysis (absent from the baseline membership) becomes a new rule appended to the
+   scope, prefix only and without words so no existing unit can be re-voted, with a fresh id
+   above every id the scope has ever used; the scope plan then emits CREATE and the
+   incremental agent names it. A group that also holds units the baseline knew is a rule's
+   residue and stays where it is. A lone new unit stays where its fallback put it, or in the
+   unplaced bucket, which is created on demand. This is the same at every depth: a new
+   sub-directory inside component `3` surfaces in scope `3` on the next run, as a new `3.k`;
+   today it needed ≥ 16 files to isolate two Leiden clusters before it could appear at all.
+3. **Retired components.** A rule that claims nothing is deleted by the existing scope
+   plan (DELETE), and its child scope with it.
+4. A component whose child scope was never drafted (the depth cap was raised) is drafted
+   now with the configured grouper; its membership at its own level is unchanged.
+
+A baseline without a `tree_spec` cannot support an incremental run and raises
+`IncrementalCacheMissingError` (run a full analysis first), as today for a missing cluster
+baseline. The cluster lineage in the pickle is no longer read.
+
+**Partial run (expand one component).** Replay the stored spec for that scope; if the
+scope is absent, draft it from the component's units. A leaf by decision stays a leaf: the
+API reports it as not expandable with its reason.
+
+**Depth.** `--depth-level` is the cap on how many scopes are drafted up front, never a
+target. `expandable` on a group is "its scope has rules" (drafted and split) or "its scope
+is absent and it exceeds the leaf cap or has parts to un-merge" (would split if drafted).
+The modularity expansion gate and the size-based `scope_load` are retired.
+
+## 5. What the graph does
+
+Arrows: `GroupConnection`s from call and reference edges between groups, exactly as today,
+at every depth. Audit (follow-up, not in this stack): per component, leakage, islands,
+name-versus-call disagreements and residuals, persisted for the health layer and the
+extension. The conjunction-name metric is not shipped (signal-to-noise ≈ 1).
+
+## 6. What goes
+
+| piece | verdict | why |
+|---|---|---|
+| `clustering/engine.py` (Leiden level-up search) | delete | leaves are files; no community is ever computed |
+| `grouping.py`: modularity peak, seeds, absorption, `_anchored_group`, drift budget | delete | grouping is names; incremental is replay |
+| `delta.py`, `snapshot.py` (seeded Leiden, cluster snapshots) | delete | no partition is diffed; the spec is replayed |
+| `ClusterCache` lineage in the pickle, `_record_scopes`, `LanguageResults.clusters` | delete | the partition is a pure function of names and spec; nothing to persist. Removes the "no cluster baseline" failure mode, the top user-facing error |
+| `expansion.py` modularity gate, `ClusteringConfig.EXPAND_MODULARITY_THRESHOLD`, `MIN_METHODS_TO_EXPAND`, `MAX_LEAF_*`, `GroupingConfig` | delete | expansion is a ladder decision recorded in the spec |
+| `leiden_utils.py`, `igraph`, `leidenalg` | delete | no caller left |
+| `ClusterScopeResult.modularity`, `unanchored_*`, `regrouped`, `AnchoredGrouping` | delete | nothing reads them once the scope plan stops reporting drift |
+| `reindex_*`, `combine_cluster_results`, `group_symbols`, `ClusterResult`, `ClusterGroup`, `ClusterScopeResult`, `GroupConnection`, `scope_plan`, `tree_shape` | keep | the agent and incremental contracts are unchanged: file leaves are cluster ids |
+| #539's `naming.py` | replaced | `tokenize`, `stem`, head-noun voting and the distinctive-word merge survive in `tokens.py` and `replay.py`; `scope_of`, `BUILD_ROOTS`, the repo-wide gate and the `Infrastructure` sink do not |
+
+## 7. Measured
+
+The implementation in this PR, fed the eight rulers with units synthesised the way each
+adapter names things (no LLM, no LSP; harness in the research scratchpad), against the
+zero-LLM probe the design was drawn from. Pair-F1 at file granularity / boxes.
+
+| ruler | probe frontier | this frontier | kinship | probe kinship | depth 2 |
+|---|---|---|---|---|---|
+| beacon (layered C#) | 0.889 / 13 | 0.889 / 13 | 0.889 / 13 | 0.889 | leaves |
+| eShop depth 1 | 0.979 / 12 | 0.979 / 12 | **1.000 / 9** | 1.000 | |
+| eShop depth 2 | 0.999 / 12 | 0.999 / 12 | 0.980 / 9 | 0.980 | **0.999 / 12** |
+| modulify | 1.000 / 4 | 1.000 / 4 | 1.000 / 4 | 1.000 | |
+| django (Python) | 0.714 / 28 | 0.714 / 26 | 0.714 / 26 | 0.714 | |
+| kubernetes (Go) | 0.240 / 74 | 0.240 / 75 | 0.252 / 64 | 0.273 | |
+| mermaid (TypeScript) | 0.670 / 33 | 0.670 / 33 | 0.624 / 30 | 0.661 | |
+| spring-framework (Java) | 1.000 / 22 | 1.000 / 23 | 0.974 / 21 | 0.974 | |
+
+Shipped pipeline on the same rulers: eShop 0.667, django 0.235, mermaid 0.083 (both below
+the all-in-one floor), Beacon 0.351. Phase-1 exit criteria from the artifact (django ≥ 0.70,
+mermaid ≥ 0.65, spring 1.00, Beacon ≥ 0.85, eShop and modulify unchanged, eShop depth 2
+≥ 0.99) are all met by the deterministic path alone; kubernetes (ceiling 0.88 after a
+perfect grouping) is the planner's to reach.
+
+## 8. Decisions taken
+
+- **No graph tier.** An exhausted box is an honest leaf with a reason; Leiden and its
+  dependencies go. A call-derived "implementation view" outside the tree is a possible
+  follow-up.
+- **Full qualified names vote.** Every segment of every name a unit declares (module,
+  class, method) contributes to the word vote, head noun heaviest.
+- **Two groupers, one interface**, selected by configuration; both stay until one is
+  chosen on evidence. The deterministic one is the draft the planner edits.
+- **Only static-analysis names are partitioned.** No support-scope carve-out.
+- **Never refuse.** One box at the root falls through to the words; nothing splits it,
+  one box is drawn and the structure diagnostics say so.
+- **Aggressive rungs only above the leaf cap** (§3.5), because both over-split every
+  maintainer-drawn leaf on the only depth-2 ruler.
+
+## 9. The stack
+
+1. **`feat/name-tree-core` (this PR).** This document; the `names` package (tokens,
+   inventory, frontier, spec, draft, replay); unit tests over ruler-shaped layouts. No
+   pipeline change; nothing is wired.
+2. **`feat/name-tree-pipeline`.** `ClusteringService` on the partition for full, partial
+   and incremental runs (file leaves, spec drafting, replay, new-scope detection, expansion
+   from the ladder); the planner agent as the LLM `Grouper` with #539's prompt and
+   evidence sampling; the `grouper` configuration switch; `tree_spec` in `analysis.json`
+   with the read-back rules of #539/#542 (a run building on a baseline reuses the stored
+   spec, never re-reads). Companion `CodeBoarding-tests` branch of the same name.
+3. **`feat/name-tree-cleanup`.** Everything in §6 marked delete, the pickle tag bump, the
+   dependency removal, and the tests that only exercised the deleted code.
+
+## 10. Open items
+
+- Kubernetes-scale repos over-produce root boxes (64–75 against 16 sigs); grouping them
+  is the planner's job and its variance must be measured across draws before it ships.
+- The vocabulary rung without a model over-splits; a planner-owned vocabulary (as in the
+  measurements) would make it usable below the leaf cap. Not attempted here.
+- The stemmer is crude (`spring` → `spr`); it is consistent with the measurements and
+  ubiquity absorbs most of the damage, but it should be replaced when a ruler shows it
+  costing something.
+- Declared namespaces as merge hints (C#) once an adapter carries them as a side table.
+- The weakness surface (§5 audit) and its rendering.
+- The zero-LLM ruler harness and the four held-out truths (django, kubernetes, mermaid,
+  spring) live in a research scratchpad; they belong in `CodeBoarding-evals` beside the
+  eShop reference so the numbers in §7 can be re-run in CI.

--- a/docs/design/name-tree.md
+++ b/docs/design/name-tree.md
@@ -32,8 +32,8 @@ per scope, from the same names, writes them down once, and replays them everywhe
   of the trie a component owns, the words it owns, a last-resort prefix, and the candidates
   it was grouped from), or no rules and a reason, meaning the scope is a leaf. Persisted in
   `analysis.json` metadata as `tree_spec`.
-- **The one function.** `replay(units, scope_rules) -> Partition` assigns every unit of a
-  scope to exactly one rule by: the longest matching prefix, then a head-noun-weighted vote
+- **The one function.** `replay(units, scope, role_words) -> Partition` (the role words
+  being `role_words_for(spec.machinery)`) assigns every unit of a scope to exactly one rule by: the longest matching prefix, then a head-noun-weighted vote
   over the words the rules own, then the longest matching fallback prefix. What no rule
   claims is *unplaced*: drawn in a reserved bucket, reported, never invented into a
   neighbour. Replay is used at draft time, on every incremental run, and on every partial

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,7 @@ packages = [
     "static_analyzer",
     "static_analyzer.cfg",
     "static_analyzer.clustering",
+    "static_analyzer.clustering.names",
     "static_analyzer.engine",
     "static_analyzer.engine.adapters",
     "static_analyzer.lsp_client",

--- a/static_analyzer/clustering/names/__init__.py
+++ b/static_analyzer/clustering/names/__init__.py
@@ -1,10 +1,6 @@
 """Partition a repository by what its qualified names say: one tree, replayed everywhere.
 
-``inventory`` reads units (files) and their positions off the call graph's names; ``frontier``
-walks the trie of those positions and emits candidate rules; ``draft`` groups candidates into
-components rung by rung and writes the result as a ``spec``; ``replay`` is the one pure
-function from units and a scope's rules to a partition, used at draft time and on every
-incremental and partial run after it. See ``docs/design/name-tree.md``.
+See ``docs/design/name-tree.md``.
 """
 
 from static_analyzer.clustering.names.draft import (
@@ -23,6 +19,8 @@ from static_analyzer.clustering.names.spec import ComponentRule, ScopeSpec, Tree
 from static_analyzer.clustering.names.tokens import LAYOUT_WORDS, ROLE_WORDS, stem, tokenize
 
 __all__ = [
+    "LAYOUT_WORDS",
+    "ROLE_WORDS",
     "Candidate",
     "CandidateGroup",
     "ComponentRule",
@@ -30,9 +28,7 @@ __all__ = [
     "Grouper",
     "GroupingContext",
     "KinshipGrouper",
-    "LAYOUT_WORDS",
     "Partition",
-    "ROLE_WORDS",
     "ScopeSpec",
     "TreeSpec",
     "Trie",

--- a/static_analyzer/clustering/names/__init__.py
+++ b/static_analyzer/clustering/names/__init__.py
@@ -1,0 +1,50 @@
+"""Partition a repository by what its qualified names say: one tree, replayed everywhere.
+
+``inventory`` reads units (files) and their positions off the call graph's names; ``frontier``
+walks the trie of those positions and emits candidate rules; ``draft`` groups candidates into
+components rung by rung and writes the result as a ``spec``; ``replay`` is the one pure
+function from units and a scope's rules to a partition, used at draft time and on every
+incremental and partial run after it. See ``docs/design/name-tree.md``.
+"""
+
+from static_analyzer.clustering.names.draft import (
+    CandidateGroup,
+    Grouper,
+    GroupingContext,
+    KinshipGrouper,
+    draft_scope,
+    draft_tree,
+    role_words_for,
+)
+from static_analyzer.clustering.names.frontier import Candidate, Frontier, walk
+from static_analyzer.clustering.names.inventory import Trie, Unit, unit_position, units_from_graph, units_from_graphs
+from static_analyzer.clustering.names.replay import Partition, replay
+from static_analyzer.clustering.names.spec import ComponentRule, ScopeSpec, TreeSpec
+from static_analyzer.clustering.names.tokens import LAYOUT_WORDS, ROLE_WORDS, stem, tokenize
+
+__all__ = [
+    "Candidate",
+    "CandidateGroup",
+    "ComponentRule",
+    "Frontier",
+    "Grouper",
+    "GroupingContext",
+    "KinshipGrouper",
+    "LAYOUT_WORDS",
+    "Partition",
+    "ROLE_WORDS",
+    "ScopeSpec",
+    "TreeSpec",
+    "Trie",
+    "Unit",
+    "draft_scope",
+    "draft_tree",
+    "replay",
+    "role_words_for",
+    "stem",
+    "tokenize",
+    "unit_position",
+    "units_from_graph",
+    "units_from_graphs",
+    "walk",
+]

--- a/static_analyzer/clustering/names/draft.py
+++ b/static_analyzer/clustering/names/draft.py
@@ -1,0 +1,362 @@
+"""The ladder: how a scope's rules are drafted one rung at a time, and where it stops.
+
+The root reads the frontier of its trie, then its units' words if that gave one box. A
+component splits back into the candidates that were grouped into it; only a component above
+``LEAF_CAP`` goes on to the frontier of its own sub-trie and then to its units' words. A rung
+counts when at least two children each clear the guard; a scope no rung can split is a leaf
+that says why. Every rung is candidates in, rules out: ``replay`` places the units, at draft
+time as on every later run.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Callable, Iterable, Sequence
+from dataclasses import dataclass, replace
+from typing import Protocol
+
+from clustering_ids import ROOT_SCOPE_ID, ScopeId
+from static_analyzer.clustering.names.frontier import BOX, LOOSE, RESIDUAL, SHARE, WORD, Candidate, walk
+from static_analyzer.clustering.names.inventory import Trie, Unit
+from static_analyzer.clustering.names.replay import Partition, replay
+from static_analyzer.clustering.names.spec import (
+    UNPLACED,
+    ComponentRule,
+    ScopeSpec,
+    TreeSpec,
+    is_root,
+)
+from static_analyzer.clustering.names.tokens import (
+    ROLE_WORDS,
+    distinctive_word,
+    segments,
+    stem,
+    tokenize,
+    ubiquitous_words,
+)
+from static_analyzer.config import ClusteringConfig
+
+MIN_UNITS = 2
+GUARD_SHARE = 0.05
+LEAF_CAP = 135
+"""Units a component may hold and still be a leaf without reading its sub-tree or its words."""
+UNPLACED_NAME = "Unassigned"
+
+UNMERGE = "unmerge"
+FRONTIER = "frontier"
+VOCABULARY = "vocabulary"
+SEGMENT = "segment"
+LEAF = "leaf"
+
+
+@dataclass(frozen=True)
+class GroupingContext:
+    scope_id: ScopeId
+    role_words: frozenset[str]
+    unit_count: int
+    rung: str
+
+
+@dataclass(frozen=True)
+class CandidateGroup:
+    """Candidates one component is made of. ``terms`` are words the group owns beyond theirs."""
+
+    name: str
+    keys: tuple[str, ...]
+    terms: tuple[str, ...] = ()
+
+
+class Grouper(Protocol):
+    """Turns the candidates of one rung into named components: the one judgement in the tree.
+
+    A grouper sees candidates, never units, so a wrong answer can only merge boxes. Every
+    candidate key must land in exactly one group.
+    """
+
+    name: str
+
+    def group(self, candidates: Sequence[Candidate], context: GroupingContext) -> list[CandidateGroup]: ...
+
+
+class KinshipGrouper:
+    """Merge candidates that share their distinctive word: ``Ordering`` with ``OrderProcessor``."""
+
+    name = "kinship"
+
+    def group(self, candidates: Sequence[Candidate], context: GroupingContext) -> list[CandidateGroup]:
+        ubiquitous = ubiquitous_words(candidate.label for candidate in candidates if candidate.label)
+        by_word: dict[str, list[Candidate]] = {}
+        solo: list[Candidate] = []
+        for candidate in candidates:
+            word = distinctive_word(candidate.label, context.role_words, ubiquitous) if candidate.label else ""
+            if word:
+                by_word.setdefault(word, []).append(candidate)
+            else:
+                solo.append(candidate)
+        groups = [
+            CandidateGroup(_plainest(members), tuple(candidate.key for candidate in members), (word,))
+            for word, members in by_word.items()
+        ]
+        groups.extend(CandidateGroup(candidate_name(candidate), (candidate.key,)) for candidate in solo)
+        return groups
+
+
+def candidate_name(candidate: Candidate) -> str:
+    if candidate.kind == LOOSE:
+        return "Loose files"
+    if candidate.kind == RESIDUAL:
+        return f"{candidate.label} (residual)"
+    if candidate.kind == WORD:
+        return candidate.label.capitalize()
+    if candidate.kind == BOX and not candidate.label:
+        return "All files"
+    return candidate.label
+
+
+def role_words_for(machinery: Iterable[str]) -> frozenset[str]:
+    return ROLE_WORDS | frozenset(stem(word) for word in machinery)
+
+
+def draft_tree(
+    units: Iterable[Unit],
+    grouper: Grouper,
+    max_depth: int,
+    *,
+    machinery: Iterable[str] = (),
+    share: float = SHARE,
+) -> TreeSpec:
+    """Draft the root and every scope below it down to ``max_depth``."""
+    if max_depth < 1:
+        raise ValueError("max_depth must be at least 1")
+    machinery = frozenset(machinery)
+    spec = TreeSpec(machinery=machinery, grouper=grouper.name)
+    role_words = role_words_for(machinery)
+
+    def build(scope_id: ScopeId, scope_units: list[Unit], parts: tuple[ComponentRule, ...], depth: int) -> None:
+        scope, partition = draft_scope(scope_id, scope_units, role_words, grouper, parts=parts, share=share)
+        spec.set_scope(scope)
+        if depth >= max_depth:
+            return
+        for rule in scope.components:
+            build(rule.component_id, partition.members[rule.component_id], rule.parts, depth + 1)
+
+    build(ROOT_SCOPE_ID, list(units), (), 1)
+    return spec
+
+
+def draft_scope(
+    scope_id: ScopeId,
+    units: Iterable[Unit],
+    role_words: frozenset[str],
+    grouper: Grouper,
+    *,
+    parts: tuple[ComponentRule, ...] = (),
+    share: float = SHARE,
+) -> tuple[ScopeSpec, Partition]:
+    """Draft one scope's rules from its units: the first rung that splits it wins."""
+    scope_units = list(units)
+    rungs: list[tuple[str, Callable[[], tuple[list[ComponentRule], str]]]] = []
+    if len(parts) >= 2:
+        rungs.append((UNMERGE, lambda: (list(parts), "structural")))
+    if is_root(scope_id):
+        rungs.append((FRONTIER, lambda: _frontier_rules(scope_id, scope_units, role_words, grouper, share, FRONTIER)))
+        rungs.append((VOCABULARY, lambda: _vocabulary_rules(scope_id, scope_units, role_words, grouper)))
+    elif len(scope_units) > LEAF_CAP:
+        rungs.append((SEGMENT, lambda: _frontier_rules(scope_id, scope_units, role_words, grouper, share, SEGMENT)))
+        rungs.append((VOCABULARY, lambda: _vocabulary_rules(scope_id, scope_units, role_words, grouper)))
+    produced: dict[str, tuple[list[ComponentRule], str]] = {}
+    for rung, produce in rungs:
+        produced[rung] = rules, axis = produce()
+        settled = _settle(scope_id, scope_units, rules, role_words, guard=rung != FRONTIER)
+        if settled is None:
+            continue
+        scope, partition = settled
+        scope.axis = axis
+        scope.rung = rung
+        return scope, partition
+    if is_root(scope_id) and scope_units:
+        # Never refuse: a root nothing splits is drawn as the one box the frontier gave it.
+        rules, axis = produced[FRONTIER]
+        settled = _settle(scope_id, scope_units, rules, role_words, guard=False, min_rules=1)
+        if settled is not None:
+            scope, partition = settled
+            scope.axis = axis
+            scope.rung = FRONTIER
+            return scope, partition
+    return ScopeSpec(
+        scope_id, rung=LEAF, leaf_reason=_leaf_reason(scope_id, len(scope_units), parts, rungs)
+    ), Partition(scope_id)
+
+
+def _leaf_reason(
+    scope_id: ScopeId, unit_count: int, parts: tuple[ComponentRule, ...], rungs: Sequence[tuple[str, object]]
+) -> str:
+    if is_root(scope_id):
+        return f"no rung ({', '.join(rung for rung, _ in rungs)}) yields two children of {unit_count} units"
+    unmerge = "un-merge failed the guard" if len(parts) >= 2 else "nothing to un-merge"
+    if unit_count <= LEAF_CAP:
+        return f"cohesive: {unit_count} units, at most {LEAF_CAP}; {unmerge}"
+    return f"exhausted: {unmerge}; neither the sub-tree nor the words yield two children of {unit_count} units"
+
+
+def _frontier_rules(
+    scope_id: ScopeId,
+    units: list[Unit],
+    role_words: frozenset[str],
+    grouper: Grouper,
+    share: float,
+    rung: str,
+) -> tuple[list[ComponentRule], str]:
+    frontier = walk(Trie(units), role_words, share=share)
+    candidates = sorted(frontier.candidates, key=lambda candidate: candidate.key)
+    if not candidates:
+        return [], frontier.axis
+    context = GroupingContext(scope_id, role_words, len(units), rung)
+    return _rules_from_groups(grouper.group(candidates, context), candidates), frontier.axis
+
+
+def _vocabulary_rules(
+    scope_id: ScopeId,
+    units: list[Unit],
+    role_words: frozenset[str],
+    grouper: Grouper,
+) -> tuple[list[ComponentRule], str]:
+    """One candidate per word the units' own names elect, head noun weighing most."""
+    counts: Counter[str] = Counter()
+    for unit in units:
+        counts.update(_unit_stems(unit))
+    ubiquitous = frozenset(word for word, count in counts.items() if count >= 2 and count >= len(units) / 2)
+    keys = sorted({key for unit in units if (key := _vocabulary_key(unit, role_words, ubiquitous))})
+    candidates = [Candidate(f"{WORD}:{key}", WORD, key, terms=(key,)) for key in keys]
+    if len(candidates) < 2:
+        return [], VOCABULARY
+    context = GroupingContext(scope_id, role_words, len(units), VOCABULARY)
+    return _rules_from_groups(grouper.group(candidates, context), candidates), VOCABULARY
+
+
+def _unit_stems(unit: Unit) -> set[str]:
+    return {
+        stem(word)
+        for name in unit.names
+        for part in segments(name, ClusteringConfig.QUALIFIED_NAME_DELIMITER)
+        for word in tokenize(part)
+    }
+
+
+def _vocabulary_key(unit: Unit, role_words: frozenset[str], ubiquitous: frozenset[str]) -> str:
+    votes: Counter[str] = Counter()
+    for name in unit.names:
+        for part in segments(name, ClusteringConfig.QUALIFIED_NAME_DELIMITER):
+            words = tokenize(part)
+            for position, word in enumerate(words):
+                key = stem(word)
+                if key not in role_words and key not in ubiquitous:
+                    votes[key] += 2.0 ** (position - (len(words) - 1))
+    return max(sorted(votes), key=lambda key: (votes[key], key)) if votes else ""
+
+
+def _plainest(members: list[Candidate]) -> str:
+    """``Ordering`` over ``OrderProcessor``: the member with the fewest words names the group."""
+    return candidate_name(min(members, key=lambda candidate: (len(tokenize(candidate.label)), candidate.label)))
+
+
+def _rules_from_groups(groups: list[CandidateGroup], candidates: Sequence[Candidate]) -> list[ComponentRule]:
+    by_key = {candidate.key: candidate for candidate in candidates}
+    seen: Counter[str] = Counter(key for group in groups for key in group.keys)
+    missing = sorted(set(by_key) - set(seen))
+    unknown = sorted(set(seen) - set(by_key))
+    repeated = sorted(key for key, count in seen.items() if count > 1)
+    if missing or unknown or repeated:
+        raise ValueError(
+            f"grouping must cover every candidate once: missing={missing} unknown={unknown} repeated={repeated}"
+        )
+    rules: list[ComponentRule] = []
+    for group in groups:
+        members = [by_key[key] for key in group.keys]
+        rules.append(
+            ComponentRule(
+                component_id="",
+                name=group.name,
+                prefixes=tuple(prefix for candidate in members for prefix in candidate.prefixes),
+                terms=_dedupe(group.terms + tuple(term for candidate in members for term in candidate.terms)),
+                fallback_prefixes=tuple(prefix for candidate in members for prefix in candidate.fallback_prefixes),
+                parts=tuple(_candidate_rule(candidate) for candidate in members) if len(members) > 1 else (),
+                origin="grouped" if len(members) > 1 else members[0].kind,
+            )
+        )
+    return rules
+
+
+def _candidate_rule(candidate: Candidate) -> ComponentRule:
+    return ComponentRule(
+        component_id="",
+        name=candidate_name(candidate),
+        prefixes=candidate.prefixes,
+        terms=candidate.terms,
+        fallback_prefixes=candidate.fallback_prefixes,
+        origin=candidate.kind,
+    )
+
+
+def _settle(
+    scope_id: ScopeId,
+    units: list[Unit],
+    rules: list[ComponentRule],
+    role_words: frozenset[str],
+    *,
+    guard: bool,
+    min_rules: int = 2,
+) -> tuple[ScopeSpec, Partition] | None:
+    """Replay the rules, apply the guard, number the survivors, and bucket what is left.
+
+    The guard: at least ``min_rules`` rules with a prefix or a word must each hold
+    ``max(MIN_UNITS, int(GUARD_SHARE * parent))`` units; a smaller one is absorbed by the
+    largest. A fallback-only rule (loose files, a layer's residue) is neither counted nor
+    absorbed: it is the scope's last resort and stays its own box however small.
+    """
+    if len(rules) < min_rules:
+        return None
+    provisional = [replace(rule, component_id=f"?{index}") for index, rule in enumerate(rules)]
+    partition = replay(units, ScopeSpec(scope_id, provisional), role_words)
+    sizes = {rule.component_id: partition.size(rule.component_id) for rule in provisional}
+    floor = _floor(len(units)) if guard else 1
+    claimants = [rule for rule in provisional if not rule.is_fallback_only]
+    strong = [rule for rule in claimants if sizes[rule.component_id] >= floor]
+    if len(strong) < min_rules:
+        return None
+    kept = {rule.component_id: rule for rule in provisional if rule in strong or rule.is_fallback_only}
+    largest = max(strong, key=lambda rule: sizes[rule.component_id]).component_id
+    for weak in (rule for rule in claimants if rule not in strong and sizes[rule.component_id]):
+        kept[largest] = _merge_rules(kept[largest], weak)
+        sizes[largest] += sizes[weak.component_id]
+    ordered = sorted(kept.values(), key=lambda rule: (-sizes[rule.component_id], rule.name))
+    scope = ScopeSpec(scope_id)
+    for rule in ordered:
+        scope.rules.append(replace(rule, component_id=scope.next_id()))
+    partition = replay(units, scope, role_words)
+    if partition.unplaced:
+        scope.rules.append(ComponentRule(scope.next_id(), UNPLACED_NAME, origin=UNPLACED, kind=UNPLACED))
+        partition = replay(units, scope, role_words)
+    return scope, partition
+
+
+def _floor(unit_count: int) -> int:
+    return max(MIN_UNITS, int(GUARD_SHARE * unit_count))
+
+
+def _merge_rules(target: ComponentRule, weak: ComponentRule) -> ComponentRule:
+    return replace(
+        target,
+        prefixes=target.prefixes + weak.prefixes,
+        terms=_dedupe(target.terms + weak.terms),
+        fallback_prefixes=target.fallback_prefixes + weak.fallback_prefixes,
+        parts=(target.parts or (_as_part(target),)) + (weak.parts or (_as_part(weak),)),
+    )
+
+
+def _as_part(rule: ComponentRule) -> ComponentRule:
+    return replace(rule, component_id="", parts=())
+
+
+def _dedupe(terms: tuple[str, ...]) -> tuple[str, ...]:
+    return tuple(dict.fromkeys(terms))

--- a/static_analyzer/clustering/names/frontier.py
+++ b/static_analyzer/clustering/names/frontier.py
@@ -17,6 +17,7 @@ from static_analyzer.clustering.names.inventory import Trie, TrieNode
 from static_analyzer.clustering.names.spec import Prefix
 from static_analyzer.clustering.names.tokens import (
     LAYOUT_WORDS,
+    distinctive_word,
     is_role_named,
     stems,
     ubiquitous_words,
@@ -132,15 +133,16 @@ def _layered(
     top: bool = False,
 ) -> None:
     """A node whose children are layers: transpose onto the features recurring under two of them."""
+    layers = sorted(node.children.items())
+    ubiquitous = ubiquitous | ubiquitous_words(name for _, layer in layers for name in layer.children)
     layers_by_feature: dict[str, set[str]] = {}
     display: dict[str, str] = {}
-    for layer_name, layer in sorted(node.children.items()):
-        for grandchild_name in sorted(layer.children):
-            if not is_role_named(grandchild_name, role_words, ubiquitous):
-                feature = _first_stem(grandchild_name)
-                layers_by_feature.setdefault(feature, set()).add(layer_name)
-                display.setdefault(feature, grandchild_name)
-    features = sorted(feature for feature, layers in layers_by_feature.items() if len(layers) >= 2)
+    for layer_name, layer in layers:
+        for name, _ in _feature_directories(layer, role_words, ubiquitous):
+            feature = _feature_stem(name, role_words, ubiquitous)
+            layers_by_feature.setdefault(feature, set()).add(layer_name)
+            display.setdefault(feature, name)
+    features = sorted(feature for feature, feature_layers in layers_by_feature.items() if len(feature_layers) >= 2)
     if len(features) < 2:
         out.notes.append(f"{_dotted(node.path) or '<root>'}: role-named children, no recurring features; one box")
         if top:
@@ -151,7 +153,7 @@ def _layered(
         out.axis = "transposed"
     out.notes.append(f"transposed {_dotted(node.path) or '<root>'} onto {', '.join(features)}")
     prefixes_by_feature: dict[str, list[Prefix]] = {feature: [] for feature in features}
-    for _, layer in sorted(node.children.items()):
+    for _, layer in layers:
         _collect_feature_prefixes(layer, set(features), role_words, ubiquitous, prefixes_by_feature)
     for feature in features:
         out.candidates.append(
@@ -165,7 +167,7 @@ def _layered(
         )
     if node.units:
         out.candidates.append(_loose(node))
-    for name, layer in sorted(node.children.items()):
+    for name, layer in layers:
         out.candidates.append(
             Candidate(
                 key=f"{RESIDUAL}:{_dotted(layer.path)}",
@@ -174,6 +176,19 @@ def _layered(
                 fallback_prefixes=(layer.path,),
             )
         )
+
+
+def _feature_directories(
+    node: TrieNode, role_words: frozenset[str], ubiquitous: frozenset[str]
+) -> list[tuple[str, TrieNode]]:
+    """The shallowest feature-named directories under a layer, looking through its role-named ones."""
+    found: list[tuple[str, TrieNode]] = []
+    for name, child in sorted(node.children.items()):
+        if is_role_named(name, role_words, ubiquitous):
+            found.extend(_feature_directories(child, role_words, ubiquitous))
+        else:
+            found.append((name, child))
+    return found
 
 
 def _collect_feature_prefixes(
@@ -185,7 +200,7 @@ def _collect_feature_prefixes(
 ) -> None:
     """The shallowest node under a layer whose first word is a feature keys its subtree."""
     for name, child in sorted(node.children.items()):
-        feature = _first_stem(name)
+        feature = _feature_stem(name, role_words, ubiquitous)
         if not is_role_named(name, role_words, ubiquitous) and feature in features:
             prefixes_by_feature[feature].append(child.path)
             continue
@@ -202,9 +217,10 @@ def _loose(node: TrieNode) -> Candidate:
     return Candidate(key=f"{LOOSE}:{_dotted(node.path)}", kind=LOOSE, label="", fallback_prefixes=(node.path,))
 
 
-def _first_stem(name: str) -> str:
+def _feature_stem(name: str, role_words: frozenset[str], ubiquitous: frozenset[str]) -> str:
+    """The word a directory is about: its first word that is neither a role nor the product's name."""
     words = stems(name)
-    return words[0] if words else name.casefold()
+    return distinctive_word(name, role_words, ubiquitous) or (words[0] if words else name.casefold())
 
 
 def _dotted(path: Prefix) -> str:

--- a/static_analyzer/clustering/names/frontier.py
+++ b/static_analyzer/clustering/names/frontier.py
@@ -1,0 +1,211 @@
+"""The frontier: where the walk down the trie stops, and what it emits there.
+
+Per node: step through a single child, a layout word, or a child holding nearly everything;
+a node whose children are mostly role-named is layered, and is transposed when feature names
+recur under at least two of its layers, else it is one box; a feature-named child is opened
+only while it holds a share of the scope; a role-named child is a box, never a way in; every
+other child is a box, and a box of one unit is a loose unit of its parent. The walk emits
+rules, never assignments: ``replay`` decides which unit lands where, on this run and every
+later one.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from static_analyzer.clustering.names.inventory import Trie, TrieNode
+from static_analyzer.clustering.names.spec import Prefix
+from static_analyzer.clustering.names.tokens import (
+    LAYOUT_WORDS,
+    is_role_named,
+    stems,
+    ubiquitous_words,
+)
+
+SHARE = 0.25
+"""A feature-named child is opened only while it holds this share of the scope's units."""
+
+NEARLY_ALL = 0.8
+"""A child holding this share of its parent is stepped through whatever it is called."""
+
+ROLE_SHARE = 0.6
+"""A node this much of whose units sit under role-named children is a layered node."""
+
+MIN_LAYERS = 3
+
+BOX = "box"
+FEATURE = "feature"
+LOOSE = "loose"
+RESIDUAL = "residual"
+WORD = "word"
+
+
+@dataclass(frozen=True)
+class Candidate:
+    """One thing the frontier proposes as a box, before any grouping."""
+
+    key: str
+    kind: str
+    label: str
+    prefixes: tuple[Prefix, ...] = ()
+    fallback_prefixes: tuple[Prefix, ...] = ()
+    terms: tuple[str, ...] = ()
+
+
+@dataclass
+class Frontier:
+    candidates: list[Candidate] = field(default_factory=list)
+    axis: str = "flat"
+    notes: list[str] = field(default_factory=list)
+
+
+def walk(trie: Trie, role_words: frozenset[str], *, share: float = SHARE) -> Frontier:
+    frontier = Frontier()
+    top = trie.root
+    while len(top.children) == 1 and not top.units:
+        top = next(iter(top.children.values()))
+    _visit(top, top.count, role_words, share, frontier, top=True)
+    return frontier
+
+
+def _visit(
+    node: TrieNode, total: int, role_words: frozenset[str], share: float, out: Frontier, *, top: bool = False
+) -> None:
+    children = sorted(node.children.items())
+    if len(children) == 1 and not node.units:
+        _visit(children[0][1], total, role_words, share, out, top=top)
+        return
+    ubiquitous = ubiquitous_words(name for name, _ in children)
+    stepped = {name for name, child in children if _stepped_through(name, child, node)}
+    role_units = sum(child.count for name, child in children if is_role_named(name, role_words, ubiquitous))
+    if not stepped and len(children) >= MIN_LAYERS and node.count and role_units / node.count >= ROLE_SHARE:
+        _layered(node, ubiquitous, role_words, out, top=top)
+        return
+    if top:
+        out.axis = "structural"
+    loose = bool(node.units)
+    scopes = 0
+    for name, child in children:
+        if child.count == 1:
+            loose = True
+            continue
+        scopes += 1
+        if name in stepped:
+            _visit(child, total, role_words, share, out)
+            continue
+        if is_role_named(name, role_words, ubiquitous):
+            out.candidates.append(_box(child))
+            continue
+        child_names = sorted(child.children)
+        child_ubiquitous = ubiquitous_words(child_names)
+        child_role_units = sum(
+            grandchild.count
+            for grandchild_name, grandchild in child.children.items()
+            if is_role_named(grandchild_name, role_words, child_ubiquitous)
+        )
+        child_role_share = child_role_units / child.count if child.count else 1.0
+        dominant = total > 0 and child.count / total >= share
+        if dominant and child_names and child_role_share < ROLE_SHARE:
+            out.notes.append(f"opened {_dotted(child.path)} ({child.count} units)")
+            _visit(child, total, role_words, share, out)
+        elif dominant and len(child_names) >= MIN_LAYERS and child_role_share >= ROLE_SHARE:
+            _layered(child, child_ubiquitous, role_words, out)
+        else:
+            out.candidates.append(_box(child))
+    if not scopes:
+        # Only units and one-unit children: a flat scope is one box, not a pile of loose files.
+        out.candidates.append(_box(node))
+    elif loose:
+        out.candidates.append(_loose(node))
+
+
+def _stepped_through(name: str, child: TrieNode, parent: TrieNode) -> bool:
+    return name.casefold() in LAYOUT_WORDS or child.count >= NEARLY_ALL * parent.count
+
+
+def _layered(
+    node: TrieNode,
+    ubiquitous: frozenset[str],
+    role_words: frozenset[str],
+    out: Frontier,
+    *,
+    top: bool = False,
+) -> None:
+    """A node whose children are layers: transpose onto the features recurring under two of them."""
+    layers_by_feature: dict[str, set[str]] = {}
+    display: dict[str, str] = {}
+    for layer_name, layer in sorted(node.children.items()):
+        for grandchild_name in sorted(layer.children):
+            if not is_role_named(grandchild_name, role_words, ubiquitous):
+                feature = _first_stem(grandchild_name)
+                layers_by_feature.setdefault(feature, set()).add(layer_name)
+                display.setdefault(feature, grandchild_name)
+    features = sorted(feature for feature, layers in layers_by_feature.items() if len(layers) >= 2)
+    if len(features) < 2:
+        out.notes.append(f"{_dotted(node.path) or '<root>'}: role-named children, no recurring features; one box")
+        if top:
+            out.axis = "structural"
+        out.candidates.append(_box(node))
+        return
+    if top:
+        out.axis = "transposed"
+    out.notes.append(f"transposed {_dotted(node.path) or '<root>'} onto {', '.join(features)}")
+    prefixes_by_feature: dict[str, list[Prefix]] = {feature: [] for feature in features}
+    for _, layer in sorted(node.children.items()):
+        _collect_feature_prefixes(layer, set(features), role_words, ubiquitous, prefixes_by_feature)
+    for feature in features:
+        out.candidates.append(
+            Candidate(
+                key=f"{FEATURE}:{_dotted(node.path)}:{feature}",
+                kind=FEATURE,
+                label=display[feature],
+                prefixes=tuple(prefixes_by_feature[feature]),
+                terms=(feature,),
+            )
+        )
+    if node.units:
+        out.candidates.append(_loose(node))
+    for name, layer in sorted(node.children.items()):
+        out.candidates.append(
+            Candidate(
+                key=f"{RESIDUAL}:{_dotted(layer.path)}",
+                kind=RESIDUAL,
+                label=name,
+                fallback_prefixes=(layer.path,),
+            )
+        )
+
+
+def _collect_feature_prefixes(
+    node: TrieNode,
+    features: set[str],
+    role_words: frozenset[str],
+    ubiquitous: frozenset[str],
+    prefixes_by_feature: dict[str, list[Prefix]],
+) -> None:
+    """The shallowest node under a layer whose first word is a feature keys its subtree."""
+    for name, child in sorted(node.children.items()):
+        feature = _first_stem(name)
+        if not is_role_named(name, role_words, ubiquitous) and feature in features:
+            prefixes_by_feature[feature].append(child.path)
+            continue
+        _collect_feature_prefixes(child, features, role_words, ubiquitous, prefixes_by_feature)
+
+
+def _box(node: TrieNode) -> Candidate:
+    return Candidate(
+        key=f"{BOX}:{_dotted(node.path)}", kind=BOX, label=node.path[-1] if node.path else "", prefixes=(node.path,)
+    )
+
+
+def _loose(node: TrieNode) -> Candidate:
+    return Candidate(key=f"{LOOSE}:{_dotted(node.path)}", kind=LOOSE, label="", fallback_prefixes=(node.path,))
+
+
+def _first_stem(name: str) -> str:
+    words = stems(name)
+    return words[0] if words else name.casefold()
+
+
+def _dotted(path: Prefix) -> str:
+    return ".".join(path)

--- a/static_analyzer/clustering/names/inventory.py
+++ b/static_analyzer/clustering/names/inventory.py
@@ -1,0 +1,105 @@
+"""Units and the trie of their qualified-name prefixes.
+
+A unit is one file: the set of qualified names the engine declared in it. Its *position* is
+the longest prefix its names share, read from the names alone (the engine emits no module
+node, and a file path is never parsed here). The trie over every unit's position is the
+directory tree in every language today, because every adapter derives the prefix from the
+path; a declared namespace would land in the same structure the day an adapter carried one.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+
+from static_analyzer.cfg import CallGraph
+from static_analyzer.clustering.names.tokens import segments
+
+
+@dataclass(frozen=True)
+class Unit:
+    """One file's declarations. ``unit_id`` is the engine's path, used only as an identity."""
+
+    unit_id: str
+    language: str
+    names: tuple[str, ...]
+    position: tuple[str, ...]
+
+
+def unit_position(names: Iterable[str], delimiter: str) -> tuple[str, ...]:
+    """The longest prefix the names share, less a trailing symbol.
+
+    A file declaring one class shares that class's name across every member, so the bare
+    prefix would name the class rather than the module it sits in.
+    """
+    split = [tuple(segments(name, delimiter)) for name in names]
+    if not split:
+        return ()
+    shared: list[str] = []
+    for parts in zip(*split):
+        if len(set(parts)) != 1:
+            break
+        shared.append(parts[0])
+    if tuple(shared) in split:
+        shared.pop()
+    return tuple(shared)
+
+
+def units_from_graph(graph: CallGraph, language: str) -> list[Unit]:
+    by_file: dict[str, list[str]] = {}
+    for qualified_name, node in graph.nodes.items():
+        if node.file_path:
+            by_file.setdefault(node.file_path, []).append(qualified_name)
+    return [
+        Unit(file_path, language, tuple(sorted(names)), unit_position(names, graph.delimiter))
+        for file_path, names in sorted(by_file.items())
+    ]
+
+
+def units_from_graphs(graphs: Mapping[str, CallGraph]) -> list[Unit]:
+    units: list[Unit] = []
+    for language in sorted(graphs):
+        units.extend(units_from_graph(graphs[language], language))
+    return units
+
+
+@dataclass
+class TrieNode:
+    path: tuple[str, ...]
+    children: dict[str, TrieNode] = field(default_factory=dict)
+    units: list[Unit] = field(default_factory=list)
+    count: int = 0
+    """Units in this subtree, set once the trie is built."""
+
+
+class Trie:
+    """The prefix tree of unit positions.
+
+    A node holding one unit and nothing else is usually that unit's own name (a Python
+    module, a file declaring several C# types); the walk treats such a node as a loose unit
+    of its parent rather than as a scope, but keeps it in the tree, because a one-file
+    feature directory under a layer is evidence the transposition needs.
+    """
+
+    def __init__(self, units: Iterable[Unit]):
+        self.root = TrieNode(())
+        for unit in units:
+            node = self.root
+            for depth, segment in enumerate(unit.position):
+                node = node.children.setdefault(segment, TrieNode(unit.position[: depth + 1]))
+            node.units.append(unit)
+        _count(self.root)
+
+    def node(self, path: tuple[str, ...]) -> TrieNode | None:
+        node = self.root
+        for segment in path:
+            child = node.children.get(segment)
+            if child is None:
+                return None
+            node = child
+        return node
+
+
+def _count(node: TrieNode) -> int:
+    node.count = len(node.units) + sum(_count(child) for child in node.children.values())
+    return node.count

--- a/static_analyzer/clustering/names/replay.py
+++ b/static_analyzer/clustering/names/replay.py
@@ -1,0 +1,130 @@
+"""One pure function from units and a scope's rules to a partition.
+
+A unit's box depends on its own names and the rules alone, never on a statistic over the
+collection, so a file added beside it cannot move it. Order of trial: the longest matching
+prefix, then a weighted vote over the words the rules own, then the longest matching
+fallback prefix; what is left is unplaced and reported.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+
+from static_analyzer.clustering.names.inventory import Unit
+from static_analyzer.clustering.names.spec import UNPLACED, Prefix, ScopeSpec
+from static_analyzer.clustering.names.tokens import segments, stem, tokenize
+from static_analyzer.config import ClusteringConfig
+
+PREFIX = "prefix"
+TERM = "term"
+FALLBACK = "fallback"
+
+
+@dataclass
+class Partition:
+    scope_id: str
+    assignment: dict[str, str] = field(default_factory=dict)
+    """unit_id -> component_id, for every unit some rule claimed."""
+    members: dict[str, list[Unit]] = field(default_factory=dict)
+    """component_id -> its units, in the scope's rule order; the unplaced bucket included."""
+    placed_by: dict[str, str] = field(default_factory=dict)
+    """unit_id -> how it was placed: ``prefix``, ``term``, ``fallback`` or ``unplaced``."""
+    unplaced: list[Unit] = field(default_factory=list)
+    """Units no rule claimed, whether or not the scope has a bucket to draw them in."""
+    new_scopes: dict[Prefix, list[Unit]] = field(default_factory=dict)
+    """Units no prefix or word claimed, by the prefix at which their position leaves every
+    prefix a rule owns. A group of two or more whose units are all new to the analysis is a
+    new scope; a group under a prefix some rule already falls back to is that rule's residue."""
+
+    def size(self, component_id: str) -> int:
+        return len(self.members.get(component_id, ()))
+
+
+def replay(units: Iterable[Unit], scope: ScopeSpec, role_words: frozenset[str]) -> Partition:
+    partition = Partition(scope.scope_id, members={rule.component_id: [] for rule in scope.rules})
+    components = scope.components
+    rank = {rule.component_id: index for index, rule in enumerate(components)}
+    primary = [(prefix, rule.component_id) for rule in components for prefix in rule.prefixes]
+    fallback = [(prefix, rule.component_id) for rule in components for prefix in rule.fallback_prefixes]
+    owner_by_term: dict[str, str] = {}
+    for rule in components:
+        for term in rule.terms:
+            owner_by_term.setdefault(term, rule.component_id)
+    known = {prefix for prefix, _ in primary}
+    bucket = scope.unplaced_rule
+    for unit in units:
+        component_id, how = _place(unit, primary, fallback, owner_by_term, rank, role_words)
+        if how in (FALLBACK, UNPLACED):
+            partition.new_scopes.setdefault(_divergence(unit.position, known), []).append(unit)
+        if component_id is None:
+            partition.unplaced.append(unit)
+            partition.placed_by[unit.unit_id] = UNPLACED
+            if bucket is None:
+                continue
+            component_id = bucket.component_id
+        partition.assignment[unit.unit_id] = component_id
+        partition.members[component_id].append(unit)
+        partition.placed_by[unit.unit_id] = how
+    return partition
+
+
+def term_votes(unit: Unit, owner_by_term: dict[str, str], role_words: frozenset[str]) -> Counter[str]:
+    """Weighted votes of a unit's words for the rules that own them.
+
+    Why the weighting: a noun phrase modifies rightwards, so a word nearer the head weighs
+    more; ``IncidentResolvedMetricsHandler`` is about metrics and reacts to an incident.
+    """
+    votes: Counter[str] = Counter()
+    for qualified_name in unit.names:
+        for part in segments(qualified_name, ClusteringConfig.QUALIFIED_NAME_DELIMITER):
+            words = tokenize(part)
+            for position, word in enumerate(words):
+                key = stem(word)
+                if key in role_words:
+                    continue
+                owner = owner_by_term.get(key)
+                if owner is not None:
+                    votes[owner] += 2.0 ** (position - (len(words) - 1))
+    return votes
+
+
+def _place(
+    unit: Unit,
+    primary: list[tuple[Prefix, str]],
+    fallback: list[tuple[Prefix, str]],
+    owner_by_term: dict[str, str],
+    rank: dict[str, int],
+    role_words: frozenset[str],
+) -> tuple[str | None, str]:
+    owner = _longest_match(unit.position, primary)
+    if owner is not None:
+        return owner, PREFIX
+    if owner_by_term:
+        votes = term_votes(unit, owner_by_term, role_words)
+        if votes:
+            # Ties go to the rule that comes first in the scope, never to the id's spelling.
+            return max(votes, key=lambda component_id: (votes[component_id], -rank[component_id])), TERM
+    owner = _longest_match(unit.position, fallback)
+    if owner is not None:
+        return owner, FALLBACK
+    return None, UNPLACED
+
+
+def _longest_match(position: Prefix, prefixes: list[tuple[Prefix, str]]) -> str | None:
+    best: str | None = None
+    best_length = -1
+    for prefix, component_id in prefixes:
+        if len(prefix) > best_length and position[: len(prefix)] == prefix:
+            best, best_length = component_id, len(prefix)
+    return best
+
+
+def _divergence(position: Prefix, known: set[Prefix]) -> Prefix:
+    """The first prefix of *position* that no known prefix passes through."""
+    ancestors = {prefix[:length] for prefix in known for length in range(len(prefix) + 1)}
+    for length in range(1, len(position) + 1):
+        if position[:length] not in ancestors:
+            return position[:length]
+    return position

--- a/static_analyzer/clustering/names/spec.py
+++ b/static_analyzer/clustering/names/spec.py
@@ -146,10 +146,6 @@ class TreeSpec:
             "scopes": {scope_id: self.scopes[scope_id].to_dict() for scope_id in self._tree_order()},
         }
 
-    def _tree_order(self) -> list[ScopeId]:
-        rest = CodeBoardingClusterIds.sort({scope_id for scope_id in self.scopes if not is_root(scope_id)})
-        return [ROOT_SCOPE_ID, *rest] if ROOT_SCOPE_ID in self.scopes else rest
-
     @classmethod
     def from_dict(cls, raw: Mapping[str, Any]) -> TreeSpec:
         return cls(
@@ -160,6 +156,10 @@ class TreeSpec:
             grouper=str(raw.get("grouper", "")),
             version=int(raw.get("version", SPEC_VERSION)),
         )
+
+    def _tree_order(self) -> list[ScopeId]:
+        rest = CodeBoardingClusterIds.sort({scope_id for scope_id in self.scopes if not is_root(scope_id)})
+        return [ROOT_SCOPE_ID, *rest] if ROOT_SCOPE_ID in self.scopes else rest
 
 
 def is_root(scope_id: ScopeId) -> bool:

--- a/static_analyzer/clustering/names/spec.py
+++ b/static_analyzer/clustering/names/spec.py
@@ -1,0 +1,166 @@
+"""The tree specification: the decisions a full run makes and every later run replays."""
+
+from __future__ import annotations
+
+from collections.abc import Collection, Mapping
+from dataclasses import dataclass, field
+from typing import Any
+
+from clustering_ids import ROOT_SCOPE_ID, CodeBoardingClusterIds, ScopeId
+
+Prefix = tuple[str, ...]
+
+COMPONENT = "component"
+UNPLACED = "unplaced"
+"""Kinds of rule. The unplaced bucket owns what no rule claims, so it is drawn rather than
+hidden and can never collide with a component the planner proposes."""
+
+
+@dataclass(frozen=True)
+class ComponentRule:
+    """What a component owns: prefixes of the trie, words of the names, and a last resort.
+
+    Replay tries the longest matching ``prefixes`` entry, then a weighted vote over
+    ``terms``, then the longest matching ``fallback_prefixes`` entry. ``parts`` are the
+    candidates a grouping merged into this rule; the un-merge rung splits them back out.
+    """
+
+    component_id: str
+    name: str
+    prefixes: tuple[Prefix, ...] = ()
+    terms: tuple[str, ...] = ()
+    fallback_prefixes: tuple[Prefix, ...] = ()
+    parts: tuple[ComponentRule, ...] = ()
+    origin: str = "frontier"
+    kind: str = COMPONENT
+
+    @property
+    def is_fallback_only(self) -> bool:
+        """A rule that claims units only as a last resort: loose files, a layer's residue."""
+        return not self.prefixes and not self.terms
+
+    def to_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {"id": self.component_id, "name": self.name, "origin": self.origin, "kind": self.kind}
+        if self.prefixes:
+            out["prefixes"] = [list(prefix) for prefix in self.prefixes]
+        if self.terms:
+            out["terms"] = list(self.terms)
+        if self.fallback_prefixes:
+            out["fallback_prefixes"] = [list(prefix) for prefix in self.fallback_prefixes]
+        if self.parts:
+            out["parts"] = [part.to_dict() for part in self.parts]
+        return out
+
+    @classmethod
+    def from_dict(cls, raw: Mapping[str, Any]) -> ComponentRule:
+        return cls(
+            component_id=str(raw.get("id", "")),
+            name=str(raw.get("name", "")),
+            prefixes=tuple(tuple(prefix) for prefix in raw.get("prefixes", ())),
+            terms=tuple(raw.get("terms", ())),
+            fallback_prefixes=tuple(tuple(prefix) for prefix in raw.get("fallback_prefixes", ())),
+            parts=tuple(cls.from_dict(part) for part in raw.get("parts", ())),
+            origin=str(raw.get("origin", "frontier")),
+            kind=str(raw.get("kind", COMPONENT)),
+        )
+
+
+@dataclass
+class ScopeSpec:
+    """The rules of one scope, and which rung of the ladder produced them.
+
+    No rules means the scope is a leaf: ``leaf_reason`` says why the names ran out.
+    """
+
+    scope_id: ScopeId
+    rules: list[ComponentRule] = field(default_factory=list)
+    axis: str = ""
+    rung: str = ""
+    leaf_reason: str = ""
+
+    @property
+    def is_leaf(self) -> bool:
+        return not self.rules
+
+    @property
+    def components(self) -> list[ComponentRule]:
+        return [rule for rule in self.rules if rule.kind == COMPONENT]
+
+    @property
+    def unplaced_rule(self) -> ComponentRule | None:
+        return next((rule for rule in self.rules if rule.kind == UNPLACED), None)
+
+    def rule(self, component_id: str) -> ComponentRule | None:
+        return next((rule for rule in self.rules if rule.component_id == component_id), None)
+
+    def next_id(self, taken: Collection[str] = ()) -> str:
+        """A fresh local id: above every id this scope uses or ``taken`` names, never a gap refilled."""
+        prefix = CodeBoardingClusterIds.prefix_for_scope(self.scope_id)
+        used = {rule.component_id for rule in self.rules} | set(taken)
+        local = [component_id.rpartition(".")[2] for component_id in used]
+        index = max((int(part) for part in local if part.isdigit()), default=0) + 1
+        return CodeBoardingClusterIds.qualify_local_id(str(index), prefix)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "axis": self.axis,
+            "rung": self.rung,
+            "leaf_reason": self.leaf_reason,
+            "rules": [rule.to_dict() for rule in self.rules],
+        }
+
+    @classmethod
+    def from_dict(cls, scope_id: ScopeId, raw: Mapping[str, Any]) -> ScopeSpec:
+        return cls(
+            scope_id=scope_id,
+            rules=[ComponentRule.from_dict(rule) for rule in raw.get("rules", ())],
+            axis=str(raw.get("axis", "")),
+            rung=str(raw.get("rung", "")),
+            leaf_reason=str(raw.get("leaf_reason", "")),
+        )
+
+
+SPEC_VERSION = 1
+
+
+@dataclass
+class TreeSpec:
+    """Every scope's rules plus the per-repo machinery words, written once per full run."""
+
+    scopes: dict[ScopeId, ScopeSpec] = field(default_factory=dict)
+    machinery: frozenset[str] = frozenset()
+    grouper: str = ""
+    version: int = SPEC_VERSION
+
+    def scope(self, scope_id: ScopeId) -> ScopeSpec | None:
+        return self.scopes.get(scope_id)
+
+    def set_scope(self, scope: ScopeSpec) -> None:
+        self.scopes[scope.scope_id] = scope
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "version": self.version,
+            "grouper": self.grouper,
+            "machinery": sorted(self.machinery),
+            "scopes": {scope_id: self.scopes[scope_id].to_dict() for scope_id in self._tree_order()},
+        }
+
+    def _tree_order(self) -> list[ScopeId]:
+        rest = CodeBoardingClusterIds.sort({scope_id for scope_id in self.scopes if not is_root(scope_id)})
+        return [ROOT_SCOPE_ID, *rest] if ROOT_SCOPE_ID in self.scopes else rest
+
+    @classmethod
+    def from_dict(cls, raw: Mapping[str, Any]) -> TreeSpec:
+        return cls(
+            scopes={
+                scope_id: ScopeSpec.from_dict(scope_id, scope) for scope_id, scope in raw.get("scopes", {}).items()
+            },
+            machinery=frozenset(raw.get("machinery", ())),
+            grouper=str(raw.get("grouper", "")),
+            version=int(raw.get("version", SPEC_VERSION)),
+        )
+
+
+def is_root(scope_id: ScopeId) -> bool:
+    return scope_id == ROOT_SCOPE_ID

--- a/static_analyzer/clustering/names/tokens.py
+++ b/static_analyzer/clustering/names/tokens.py
@@ -1,0 +1,132 @@
+"""Words: how a qualified name is split, stemmed and classified."""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+from collections.abc import Iterable
+
+_TOKEN = re.compile(r"[A-Z]+(?![a-z])|[A-Z][a-z0-9]*|[a-z0-9]+")
+_GENERIC_ARITY = re.compile(r"`\d+$")
+_INTERFACE_PREFIX = re.compile(r"^I(?=[A-Z][a-z])")
+
+
+def tokenize(identifier: str) -> tuple[str, ...]:
+    """Split an identifier into words: CamelCase, snake_case, runs of capitals (``HTTPServer``).
+
+    Drops a parameter list, generic arguments, a C# generic arity suffix, the ``I`` a C#/Java
+    interface name starts with, and bare numbers.
+    """
+    name = identifier.split("(", 1)[0]
+    name = _GENERIC_ARITY.sub("", name)
+    name = re.sub(r"<[^<>]*>", "", name)
+    name = _INTERFACE_PREFIX.sub("", name.strip())
+    return tuple(word for word in _TOKEN.findall(name) if not word.isdigit())
+
+
+def stem(word: str) -> str:
+    """Fold the inflections identifiers carry, so ``Ordering``, ``Orders`` and ``Order`` are one word.
+
+    Idempotent: ``Mappings`` and ``Mapping`` reach the same stem.
+    """
+    lowered = word.casefold()
+    while True:
+        stripped = _strip_one_suffix(lowered)
+        if stripped == lowered:
+            return lowered
+        lowered = stripped
+
+
+def _strip_one_suffix(lowered: str) -> str:
+    for suffix, replacement in (("ies", "y"), ("ing", ""), ("ions", "ion"), ("ed", ""), ("es", ""), ("s", "")):
+        if len(lowered) <= len(suffix) + 2 or not lowered.endswith(suffix):
+            continue
+        if suffix == "es" and lowered[-3] not in "sxzh":
+            # ``services``, ``types``, ``nodes``: the ``e`` is part of the word.
+            return lowered[:-1]
+        if suffix == "s" and lowered[-2] in "sui":
+            # ``class``, ``status``, ``analysis`` are singular.
+            return lowered
+        return lowered[: -len(suffix)] + replacement
+    return lowered
+
+
+def stems(identifier: str) -> tuple[str, ...]:
+    return tuple(stem(word) for word in tokenize(identifier))
+
+
+def segments(qualified_name: str, delimiter: str) -> list[str]:
+    """Split on *delimiter*, keeping parameter lists and generic arguments whole."""
+    out: list[str] = []
+    depth = 0
+    current: list[str] = []
+    for char in qualified_name:
+        if char in "(<":
+            depth += 1
+        elif char in ")>":
+            depth -= 1
+        if char == delimiter and depth == 0:
+            out.append("".join(current))
+            current = []
+        else:
+            current.append(char)
+    out.append("".join(current))
+    return [part for part in out if part]
+
+
+LAYOUT_WORDS = frozenset(
+    {"src", "main", "java", "kotlin", "scala", "lib", "libs", "packages", "pkg", "apps", "modules"}
+    | {"source", "sources", "python", "go", "js", "ts"}
+)
+"""Segments naming a build layout rather than a scope. The walk steps through them."""
+
+ROLE_WORDS = frozenset(
+    stem(word)
+    for word in """
+    api apis application applications domain infrastructure infra contracts contract platform core
+    common shared util utils utilities helpers helper extensions extension abstractions abstraction
+    interfaces interface impl implementation internal internals models model viewmodels viewmodel views
+    view services service controllers controller repositories repository persistence data dto dtos
+    commands command queries query handlers handler events event behaviors behaviours validations
+    validation validators validator exceptions exception config configuration configurations settings
+    options middleware middlewares filters filter mappers mapper mapping converters converter
+    resources resource assets components component pages page layouts layout hooks hook types typings
+    constants enums entities entity migrations migration seed seeds fixtures fixture mocks mock tests
+    test testing spec specs e2e docs doc examples example samples sample scripts tools tooling bin
+    build dist out generated gen proto protos client clients server servers web ui app apps lib
+    base framework frameworks integration integrations io net http grpc rest graphql
+    init index main mod module program startup
+    """.split()
+)
+"""The closed class of words that name how software is built rather than what it is about.
+
+Why fixed: it cannot be learned from identifier frequencies; a planner may add a per-repo tail.
+"""
+
+
+MIN_UBIQUITOUS = 3
+
+
+def ubiquitous_words(names: Iterable[str]) -> frozenset[str]:
+    """Words carried by at least three siblings and by at least half of them: a product namesake.
+
+    Why frequency, not intersection: one odd sibling must not keep the product name alive as
+    everyone's distinctive word. Why three: two of a few siblings sharing a word is kinship.
+    """
+    listed = list(names)
+    counts = Counter(word for name in listed for word in set(stems(name)))
+    return frozenset(word for word, count in counts.items() if count >= MIN_UBIQUITOUS and count >= len(listed) / 2)
+
+
+def is_role_named(name: str, role_words: frozenset[str], ubiquitous: frozenset[str] = frozenset()) -> bool:
+    """Whether every word of *name* (the ubiquitous ones aside) is a role word."""
+    words = [word for word in stems(name) if word not in ubiquitous]
+    return bool(words) and all(word in role_words for word in words)
+
+
+def distinctive_word(name: str, role_words: frozenset[str], ubiquitous: frozenset[str] = frozenset()) -> str:
+    """The first word of *name* that names this thing rather than every thing, else ``""``."""
+    for word in stems(name):
+        if word not in role_words and word not in ubiquitous:
+            return word
+    return ""

--- a/static_analyzer/clustering/names/tokens.py
+++ b/static_analyzer/clustering/names/tokens.py
@@ -8,6 +8,8 @@ from collections.abc import Iterable
 
 _TOKEN = re.compile(r"[A-Z]+(?![a-z])|[A-Z][a-z0-9]*|[a-z0-9]+")
 _GENERIC_ARITY = re.compile(r"`\d+$")
+_GENERIC_ARGUMENTS = re.compile(r"<[^<>]*>")
+_SUFFIXES = (("ies", "y"), ("ing", ""), ("ions", "ion"), ("ed", ""), ("es", ""), ("s", ""))
 _INTERFACE_PREFIX = re.compile(r"^I(?=[A-Z][a-z])")
 
 
@@ -19,7 +21,8 @@ def tokenize(identifier: str) -> tuple[str, ...]:
     """
     name = identifier.split("(", 1)[0]
     name = _GENERIC_ARITY.sub("", name)
-    name = re.sub(r"<[^<>]*>", "", name)
+    while (stripped := _GENERIC_ARGUMENTS.sub("", name)) != name:
+        name = stripped
     name = _INTERFACE_PREFIX.sub("", name.strip())
     return tuple(word for word in _TOKEN.findall(name) if not word.isdigit())
 
@@ -31,24 +34,20 @@ def stem(word: str) -> str:
     """
     lowered = word.casefold()
     while True:
-        stripped = _strip_one_suffix(lowered)
+        stripped = lowered
+        for suffix, replacement in _SUFFIXES:
+            if len(lowered) <= len(suffix) + 2 or not lowered.endswith(suffix):
+                continue
+            if suffix == "es" and lowered[-3] not in "sxzh":
+                # ``services``, ``types``, ``nodes``: the ``e`` is part of the word.
+                stripped = lowered[:-1]
+            elif suffix != "s" or lowered[-2] not in "sui":
+                # ``class``, ``status``, ``analysis`` are singular.
+                stripped = lowered[: -len(suffix)] + replacement
+            break
         if stripped == lowered:
             return lowered
         lowered = stripped
-
-
-def _strip_one_suffix(lowered: str) -> str:
-    for suffix, replacement in (("ies", "y"), ("ing", ""), ("ions", "ion"), ("ed", ""), ("es", ""), ("s", "")):
-        if len(lowered) <= len(suffix) + 2 or not lowered.endswith(suffix):
-            continue
-        if suffix == "es" and lowered[-3] not in "sxzh":
-            # ``services``, ``types``, ``nodes``: the ``e`` is part of the word.
-            return lowered[:-1]
-        if suffix == "s" and lowered[-2] in "sui":
-            # ``class``, ``status``, ``analysis`` are singular.
-            return lowered
-        return lowered[: -len(suffix)] + replacement
-    return lowered
 
 
 def stems(identifier: str) -> tuple[str, ...]:

--- a/tests/static_analyzer/names/conftest.py
+++ b/tests/static_analyzer/names/conftest.py
@@ -1,0 +1,43 @@
+"""Builders shared by the names tests: units straight from qualified names, no engine."""
+
+from static_analyzer.cfg import CallGraph
+from static_analyzer.clustering.names import ComponentRule, ScopeSpec, TreeSpec, Trie, Unit, unit_position
+from static_analyzer.clustering.names.inventory import TrieNode
+from static_analyzer.config import NodeType
+from static_analyzer.node import Node
+
+
+def unit(file_path: str, *names: str, language: str = "python") -> Unit:
+    return Unit(file_path, language, tuple(sorted(names)), unit_position(names, "."))
+
+
+def units_from_layout(layout: dict[str, list[str]], language: str = "python") -> list[Unit]:
+    """``{file_path: [qualified names]}`` -> units, sorted the way the inventory sorts them."""
+    return [unit(path, *names, language=language) for path, names in sorted(layout.items())]
+
+
+def graph_from_layout(layout: dict[str, list[str]], language: str = "python") -> CallGraph:
+    graph = CallGraph(language=language)
+    for path, names in layout.items():
+        for index, name in enumerate(names):
+            kind = NodeType.CLASS if name.split(".")[-1][:1].isupper() else NodeType.FUNCTION
+            graph.add_node(Node(name, kind, path, index + 1, index + 2))
+    return graph
+
+
+def scope_of(spec: TreeSpec, scope_id: str) -> ScopeSpec:
+    scope = spec.scope(scope_id)
+    assert scope is not None, f"scope {scope_id!r} was not drafted"
+    return scope
+
+
+def rule_of(scope: ScopeSpec, component_id: str) -> ComponentRule:
+    rule = scope.rule(component_id)
+    assert rule is not None, f"no rule {component_id!r} in scope {scope.scope_id!r}"
+    return rule
+
+
+def node_of(trie: Trie, path: tuple[str, ...]) -> TrieNode:
+    node = trie.node(path)
+    assert node is not None, f"no trie node at {path!r}"
+    return node

--- a/tests/static_analyzer/names/test_draft.py
+++ b/tests/static_analyzer/names/test_draft.py
@@ -1,0 +1,306 @@
+"""Drafting: the frontier grouped into components, the ladder below them, and the guard."""
+
+import pytest
+
+from clustering_ids import ROOT_SCOPE_ID
+from static_analyzer.clustering.names import (
+    CandidateGroup,
+    KinshipGrouper,
+    ROLE_WORDS,
+    draft_scope,
+    draft_tree,
+    replay,
+)
+from static_analyzer.clustering.names.draft import (
+    FRONTIER,
+    GUARD_SHARE,
+    LEAF,
+    LEAF_CAP,
+    MIN_UNITS,
+    SEGMENT,
+    UNMERGE,
+    VOCABULARY,
+)
+from static_analyzer.clustering.names.spec import UNPLACED
+from tests.static_analyzer.names.conftest import rule_of, scope_of, units_from_layout
+
+
+def project(name: str, count: int, *subdirs: str) -> dict[str, list[str]]:
+    layout: dict[str, list[str]] = {}
+    stem = name.split(".")[0]
+    for index in range(count):
+        sub = subdirs[index % len(subdirs)] if subdirs else ""
+        prefix = f"{name}.{sub}" if sub else name
+        layout[f"src/{name}/{sub}/{stem}Type{index}.cs"] = [
+            f"{prefix}.{stem}Type{index}",
+            f"{prefix}.{stem}Type{index}.Run()",
+        ]
+    return layout
+
+
+def eshop() -> dict[str, list[str]]:
+    return (
+        project("Ordering.API", 12, "Apis", "Application")
+        | project("Ordering.Domain", 4)
+        | project("OrderProcessor", 3)
+        | project("Catalog.API", 8, "Model", "Apis")
+        | project("Basket.API", 4, "Model")
+        | project("Webhooks.API", 5)
+        | project("WebhookClient", 3)
+        | project("PaymentProcessor", 3)
+    )
+
+
+def names_of(scope) -> list[str]:
+    return [rule.name for rule in scope.rules]
+
+
+class TestRootDraft:
+    def test_kinship_groups_scopes_sharing_their_word(self):
+        scope, partition = draft_scope(
+            ROOT_SCOPE_ID, units_from_layout(eshop(), "csharp"), ROLE_WORDS, KinshipGrouper()
+        )
+        assert scope.rung == FRONTIER and scope.axis == "structural"
+        assert names_of(scope) == ["Ordering", "Catalog", "Webhooks", "Basket", "PaymentProcessor"]
+        ordering = rule_of(scope, "1")
+        assert ordering.prefixes == (("OrderProcessor",), ("Ordering",))
+        assert ordering.terms == ("order",)
+        assert [part.name for part in ordering.parts] == ["OrderProcessor", "Ordering"]
+        assert partition.size("1") == 19
+        assert rule_of(scope, "5").parts == ()
+
+    def test_ids_follow_size_then_name(self):
+        scope, _ = draft_scope(ROOT_SCOPE_ID, units_from_layout(eshop(), "csharp"), ROLE_WORDS, KinshipGrouper())
+        assert [rule.component_id for rule in scope.rules] == ["1", "2", "3", "4", "5"]
+
+    def test_the_root_frontier_takes_no_guard(self):
+        """A two-file directory is a box; small boxes are the grouper's to merge, not hidden."""
+        layout = eshop() | project("Tiny.API", 2)
+        scope, _ = draft_scope(ROOT_SCOPE_ID, units_from_layout(layout, "csharp"), ROLE_WORDS, KinshipGrouper())
+        assert "Tiny" in names_of(scope)
+
+    def test_a_transposed_root_places_loose_units_by_their_words(self):
+        layout: dict[str, list[str]] = {}
+        for feature in ("Incidents", "Metrics", "Teams"):
+            for layer in ("Application", "Domain", "Infrastructure"):
+                for index in range(2):
+                    layout[f"Beacon.{layer}/{feature}/{feature}{index}.cs"] = [
+                        f"Beacon.{layer}.{feature}.{feature}Thing{index}"
+                    ]
+        layout["Beacon.Application/IncidentResolvedMetricsHandler.cs"] = [
+            "Beacon.Application.IncidentResolvedMetricsHandler",
+            "Beacon.Application.IncidentResolvedMetricsHandler.Handle()",
+        ]
+        layout["Beacon.Application/Bootstrap.cs"] = [
+            "Beacon.Application.Bootstrap",
+            "Beacon.Application.Bootstrap.Run()",
+        ]
+        scope, partition = draft_scope(ROOT_SCOPE_ID, units_from_layout(layout, "csharp"), ROLE_WORDS, KinshipGrouper())
+        assert scope.axis == "transposed"
+        by_name = {rule.name: rule.component_id for rule in scope.rules}
+        assert partition.assignment["Beacon.Application/IncidentResolvedMetricsHandler.cs"] == by_name["Metrics"]
+        assert partition.assignment["Beacon.Application/Bootstrap.cs"] == by_name["Application (residual)"]
+
+    def test_one_box_at_the_root_falls_through_to_the_words(self):
+        layout = {
+            f"converters/{fmt}_{index}.py": [
+                f"converters.{fmt}_{index}.{fmt.capitalize()}Converter",
+                f"converters.{fmt}_{index}.convert",
+            ]
+            for fmt in ("docx", "pdf", "pptx")
+            for index in range(2)
+        }
+        scope, partition = draft_scope(ROOT_SCOPE_ID, units_from_layout(layout), ROLE_WORDS, KinshipGrouper())
+        assert scope.rung == VOCABULARY
+        assert names_of(scope) == ["Docx", "Pdf", "Pptx"]
+        assert all(partition.size(rule.component_id) == 2 for rule in scope.rules)
+
+    def test_what_no_rule_claims_gets_a_bucket(self):
+        layout = {
+            f"converters/{fmt}_{role}.py": [f"converters.{fmt}_{role}.{fmt.capitalize()}{role.capitalize()}"]
+            for fmt in ("docx", "pdf")
+            for role in ("reader", "writer")
+        }
+        layout["converters/base.py"] = ["converters.base.Converter"]
+        scope, partition = draft_scope(ROOT_SCOPE_ID, units_from_layout(layout), ROLE_WORDS, KinshipGrouper())
+        bucket = scope.unplaced_rule
+        assert bucket is not None and bucket.kind == UNPLACED
+        assert partition.assignment["converters/base.py"] == bucket.component_id
+        assert [unit.unit_id for unit in partition.unplaced] == ["converters/base.py"]
+
+    def test_a_root_nothing_splits_is_one_box_never_a_refusal(self):
+        layout = {f"{d}/x.py": [f"{d}.x.run"] for d in ("alpha", "beta", "gamma")}
+        scope, partition = draft_scope(ROOT_SCOPE_ID, units_from_layout(layout), ROLE_WORDS, KinshipGrouper())
+        assert names_of(scope) == ["All files"] and scope.rung == FRONTIER
+        assert partition.size("1") == 3
+
+    def test_loose_files_stay_their_own_small_box(self):
+        """A last-resort rule is neither counted by the guard nor absorbed by a neighbour."""
+        layout = project("Ordering.API", 40) | project("Catalog.API", 40)
+        layout["src/Program.cs"] = ["Program", "Program.Main()"]
+        scope, partition = draft_scope(ROOT_SCOPE_ID, units_from_layout(layout, "csharp"), ROLE_WORDS, KinshipGrouper())
+        assert names_of(scope) == ["Catalog", "Ordering", "Loose files"]
+        assert partition.assignment["src/Program.cs"] == "3"
+
+    def test_a_root_of_one_box_plus_loose_files_reads_its_words(self):
+        layout = {
+            f"pkg/{fmt}_{role}.py": [f"pkg.{fmt}_{role}.{fmt.capitalize()}{role.capitalize()}"]
+            for fmt in ("docx", "pdf")
+            for role in ("reader", "writer")
+        }
+        layout["setup.py"] = ["setup.main"]
+        scope, _ = draft_scope(ROOT_SCOPE_ID, units_from_layout(layout), ROLE_WORDS, KinshipGrouper())
+        assert scope.rung == VOCABULARY
+
+    def test_a_machinery_word_from_the_planner_is_a_role_word(self):
+        layout = {
+            f"Beacon.{layer}/Endpoints/E{i}.cs": [f"Beacon.{layer}.Endpoints.E{i}"]
+            for layer in ("Api", "Application")
+            for i in range(2)
+        }
+        layout |= {
+            f"Beacon.{layer}/Teams/T{i}.cs": [f"Beacon.{layer}.Teams.T{i}"]
+            for layer in ("Api", "Application", "Domain")
+            for i in range(2)
+        }
+        layout |= {
+            f"Beacon.{layer}/Alerts/A{i}.cs": [f"Beacon.{layer}.Alerts.A{i}"]
+            for layer in ("Api", "Domain")
+            for i in range(2)
+        }
+        plain = draft_tree(units_from_layout(layout, "csharp"), KinshipGrouper(), 1)
+        tailed = draft_tree(units_from_layout(layout, "csharp"), KinshipGrouper(), 1, machinery=("Endpoints",))
+        assert "Endpoints" in names_of(scope_of(plain, ROOT_SCOPE_ID))
+        assert "Endpoints" not in names_of(scope_of(tailed, ROOT_SCOPE_ID))
+        assert tailed.machinery == frozenset({"Endpoints"})
+
+    def test_drafting_is_replaying(self):
+        units = units_from_layout(eshop(), "csharp")
+        scope, partition = draft_scope(ROOT_SCOPE_ID, units, ROLE_WORDS, KinshipGrouper())
+        assert replay(units, scope, ROLE_WORDS).assignment == partition.assignment
+
+
+class TestLadder:
+    def test_a_grouped_component_un_merges_into_its_parts(self):
+        spec = draft_tree(units_from_layout(eshop(), "csharp"), KinshipGrouper(), 2)
+        child = scope_of(spec, "1")
+        assert child.rung == UNMERGE
+        assert names_of(child) == ["Ordering", "OrderProcessor"]
+        assert [rule.component_id for rule in child.rules] == ["1.1", "1.2"]
+        assert rule_of(scope_of(spec, "1"), "1.1").prefixes == (("Ordering",),)
+
+    def test_a_cohesive_component_is_a_leaf_that_says_why(self):
+        spec = draft_tree(units_from_layout(eshop(), "csharp"), KinshipGrouper(), 2)
+        catalog = scope_of(spec, "2")
+        assert catalog.is_leaf and catalog.rung == LEAF
+        assert catalog.leaf_reason.startswith("cohesive: 8 units")
+
+    def test_the_guard_absorbs_a_part_too_small_to_stand(self):
+        """Two files against fifty-eight: below max(2, 5%), so the un-merge does not fire."""
+        layout = project("Ordering.API", 58) | project("OrderProcessor", 2) | project("Catalog.API", 30)
+        layout |= project("Basket.API", 20) | project("Identity.API", 20)
+        spec = draft_tree(units_from_layout(layout, "csharp"), KinshipGrouper(), 2)
+        assert [part.name for part in rule_of(scope_of(spec, ROOT_SCOPE_ID), "1").parts] == [
+            "OrderProcessor",
+            "Ordering",
+        ]
+        assert scope_of(spec, "1").is_leaf
+
+    def test_a_large_component_reads_its_own_frontier(self):
+        layout = {
+            f"pkg/kubelet/{sub}/{sub}_{index}.go": [f"pkg.kubelet.{sub}.{sub}_{index}.Run"]
+            for sub in ("images", "volumes", "network", "runtime")
+            for index in range(40)
+        }
+        for sibling in ("proxy", "scheduler", "controller", "apis", "registry"):
+            layout |= {
+                f"pkg/{sibling}/{sibling}_{index}.go": [f"pkg.{sibling}.{sibling}_{index}.Run"] for index in range(120)
+            }
+        spec = draft_tree(units_from_layout(layout, "go"), KinshipGrouper(), 2)
+        kubelet = next(scope for scope in spec.scopes.values() if scope.rung == SEGMENT)
+        assert sorted(names_of(kubelet)) == ["images", "network", "runtime", "volumes"]
+        assert rule_of(scope_of(spec, ROOT_SCOPE_ID), kubelet.scope_id).name == "kubelet"
+
+    def _flat(self, per_word: int) -> dict[str, list[str]]:
+        layout = {
+            f"pkg/big/{fmt}_{part}_{index}.py": [f"pkg.big.{fmt}_{part}_{index}.{fmt.capitalize()}Codec"]
+            for fmt in ("docx", "pdf", "pptx")
+            for part in ("reader", "writer")
+            for index in range(per_word)
+        }
+        layout |= {f"pkg/other/{index}.py": [f"pkg.other.m{index}.f"] for index in range(3)}
+        return layout
+
+    def test_a_large_flat_component_reads_its_words(self):
+        spec = draft_tree(units_from_layout(self._flat(23)), KinshipGrouper(), 2)
+        big = scope_of(spec, "1")
+        assert big.rung == VOCABULARY
+        assert names_of(big) == ["Docx", "Pdf", "Pptx"]
+
+    def test_the_leaf_cap_is_a_boundary(self):
+        """135 units is a leaf; 136 reads its words."""
+
+        def big_scope(extra: int):
+            layout = self._flat(22) | {f"pkg/big/x{i}.py": [f"pkg.big.x{i}.f"] for i in range(extra)}
+            return scope_of(draft_tree(units_from_layout(layout), KinshipGrouper(), 2), "1")
+
+        assert 3 * 2 * 22 + 3 == LEAF_CAP
+        at_cap = big_scope(3)
+        assert at_cap.is_leaf and at_cap.leaf_reason.startswith(f"cohesive: {LEAF_CAP} units")
+        assert big_scope(4).rung == VOCABULARY
+
+    def test_a_large_component_nothing_splits_is_an_exhausted_leaf(self):
+        layout = {f"pkg/big/m{i}.py": [f"pkg.big.m{i}.Thing"] for i in range(LEAF_CAP + 5)}
+        layout |= {f"pkg/other/{index}.py": [f"pkg.other.m{index}.f"] for index in range(3)}
+        big = scope_of(draft_tree(units_from_layout(layout), KinshipGrouper(), 2), "1")
+        assert big.is_leaf and big.leaf_reason.startswith("exhausted:")
+
+    def test_depth_cap_leaves_deeper_scopes_undrafted(self):
+        units = units_from_layout(eshop(), "csharp")
+        shallow = draft_tree(units, KinshipGrouper(), 1)
+        assert list(shallow.scopes) == [ROOT_SCOPE_ID]
+        deep = draft_tree(units, KinshipGrouper(), 2)
+        assert set(deep.scopes) == {ROOT_SCOPE_ID, "1", "2", "3", "4", "5"}
+
+    def test_max_depth_below_one_is_rejected(self):
+        with pytest.raises(ValueError):
+            draft_tree(units_from_layout(eshop(), "csharp"), KinshipGrouper(), 0)
+
+
+class TestGrouperContract:
+    def test_a_grouping_must_cover_every_candidate_once(self):
+        class Dropping:
+            name = "dropping"
+
+            def group(self, candidates, context):
+                return [CandidateGroup(candidate.label, (candidate.key,)) for candidate in candidates[1:]]
+
+        with pytest.raises(ValueError, match="missing"):
+            draft_scope(ROOT_SCOPE_ID, units_from_layout(eshop(), "csharp"), ROLE_WORDS, Dropping())
+
+    def test_a_grouper_may_merge_across_words(self):
+        """The planner's kind of answer: scopes sharing no word become one component."""
+
+        class Themes:
+            name = "themes"
+
+            def group(self, candidates, context):
+                keys = tuple(candidate.key for candidate in candidates)
+                return [CandidateGroup("Everything", keys, ("shop",))]
+
+        scope, partition = draft_scope(ROOT_SCOPE_ID, units_from_layout(eshop(), "csharp"), ROLE_WORDS, Themes())
+        assert names_of(scope) == ["Everything"]
+        assert partition.size("1") == len(units_from_layout(eshop(), "csharp"))
+        assert "shop" in rule_of(scope, "1").terms
+
+    def test_the_spec_records_which_grouper_drew_it(self):
+        assert draft_tree(units_from_layout(eshop(), "csharp"), KinshipGrouper(), 1).grouper == "kinship"
+
+
+class TestDeterminism:
+    def test_the_same_names_draft_the_same_tree(self):
+        units = units_from_layout(eshop(), "csharp")
+        assert (
+            draft_tree(units, KinshipGrouper(), 3).to_dict()
+            == draft_tree(list(reversed(units)), KinshipGrouper(), 3).to_dict()
+        )

--- a/tests/static_analyzer/names/test_end_to_end.py
+++ b/tests/static_analyzer/names/test_end_to_end.py
@@ -1,0 +1,60 @@
+"""The public path the pipeline will use: CallGraph -> units -> draft -> replay."""
+
+from clustering_ids import ROOT_SCOPE_ID
+from static_analyzer.cfg import CallGraph
+from static_analyzer.clustering.names import KinshipGrouper, draft_tree, replay, role_words_for, units_from_graphs
+from static_analyzer.config import NodeType
+from static_analyzer.node import Node
+from tests.static_analyzer.names.conftest import rule_of, scope_of
+
+
+def graph(language: str, files: dict[str, list[tuple[str, NodeType]]]) -> CallGraph:
+    out = CallGraph(language=language)
+    for path, symbols in files.items():
+        for index, (name, kind) in enumerate(symbols):
+            out.add_node(Node(name, kind, path, index * 3 + 1, index * 3 + 2))
+    return out
+
+
+def test_a_two_language_repo_drafts_replays_and_survives_json():
+    python = graph(
+        "python",
+        {
+            "/repo/backend/orders/models.py": [
+                ("backend.orders.models.Order", NodeType.CLASS),
+                ("backend.orders.models.Order.total", NodeType.METHOD),
+            ],
+            "/repo/backend/orders/views.py": [("backend.orders.views.list_orders", NodeType.FUNCTION)],
+            "/repo/backend/catalog/models.py": [("backend.catalog.models.Item", NodeType.CLASS)],
+            "/repo/backend/catalog/views.py": [("backend.catalog.views.list_items", NodeType.FUNCTION)],
+            "/repo/backend/main.py": [("backend.main.run", NodeType.FUNCTION)],
+        },
+    )
+    typescript = graph(
+        "typescript",
+        {
+            "/repo/frontend/orders/OrderPage.tsx": [("frontend.orders.OrderPage.OrderPage", NodeType.FUNCTION)],
+            "/repo/frontend/orders/OrderRow.tsx": [("frontend.orders.OrderRow.OrderRow", NodeType.FUNCTION)],
+            "/repo/frontend/catalog/ItemPage.tsx": [("frontend.catalog.ItemPage.ItemPage", NodeType.FUNCTION)],
+            "/repo/frontend/catalog/ItemCard.tsx": [("frontend.catalog.ItemCard.ItemCard", NodeType.FUNCTION)],
+        },
+    )
+    units = units_from_graphs({"python": python, "typescript": typescript})
+    assert [unit.language for unit in units] == ["python"] * 5 + ["typescript"] * 4
+
+    spec = draft_tree(units, KinshipGrouper(), 2)
+    root = scope_of(spec, ROOT_SCOPE_ID)
+    assert sorted(rule.name for rule in root.components if not rule.is_fallback_only) == ["catalog", "orders"]
+    orders = next(rule for rule in root.components if rule.name == "orders")
+    assert orders.prefixes == (("backend", "orders"), ("frontend", "orders"))
+
+    partition = replay(units, root, role_words_for(spec.machinery))
+    by_unit = {unit_id: rule_of(root, component_id).name for unit_id, component_id in partition.assignment.items()}
+    assert by_unit["/repo/frontend/orders/OrderRow.tsx"] == "orders"
+    assert by_unit["/repo/backend/catalog/views.py"] == "catalog"
+    assert by_unit["/repo/backend/main.py"] == "Loose files"
+
+    reloaded = spec.__class__.from_dict(spec.to_dict())
+    again = replay(units, scope_of(reloaded, ROOT_SCOPE_ID), role_words_for(reloaded.machinery))
+    assert again.assignment == partition.assignment
+    assert scope_of(reloaded, orders.component_id).rung == "unmerge"

--- a/tests/static_analyzer/names/test_frontier.py
+++ b/tests/static_analyzer/names/test_frontier.py
@@ -1,0 +1,241 @@
+"""The walk over synthetic layouts shaped like the rulers it was measured on."""
+
+from static_analyzer.clustering.names import ROLE_WORDS, Trie, walk
+from static_analyzer.clustering.names.frontier import BOX, FEATURE, LOOSE, NEARLY_ALL, RESIDUAL, ROLE_SHARE, SHARE
+from tests.static_analyzer.names.conftest import units_from_layout
+
+
+def keys(frontier) -> list[str]:
+    return [candidate.key for candidate in frontier.candidates]
+
+
+def project(name: str, count: int, *subdirs: str) -> dict[str, list[str]]:
+    """A C#-shaped project: ``count`` single-type files spread over ``subdirs``."""
+    layout: dict[str, list[str]] = {}
+    for index in range(count):
+        sub = subdirs[index % len(subdirs)] if subdirs else ""
+        prefix = f"{name}.{sub}" if sub else name
+        layout[f"src/{name}/{sub}/{name.split('.')[0]}Type{index}.cs"] = [
+            f"{prefix}.{name.split('.')[0]}Type{index}",
+            f"{prefix}.{name.split('.')[0]}Type{index}.Run()",
+        ]
+    return layout
+
+
+class TestFeatureShapedRoot:
+    def test_each_feature_directory_is_a_box(self):
+        layout = (
+            project("Catalog.API", 6, "Model", "Apis") | project("Basket.API", 4, "Model") | project("Identity.API", 5)
+        )
+        frontier = walk(Trie(units_from_layout(layout, "csharp")), ROLE_WORDS)
+        assert frontier.axis == "structural"
+        assert sorted(keys(frontier)) == ["box:Basket", "box:Catalog", "box:Identity"]
+
+    def test_a_dotted_directory_is_one_scope_with_role_children(self):
+        """``Ordering.API`` and ``Ordering.Domain`` nest under ``Ordering``, which is never split."""
+        layout = (
+            project("Ordering.API", 8, "Apis", "Application")
+            | project("Ordering.Domain", 4)
+            | project("Catalog.API", 4)
+        )
+        frontier = walk(Trie(units_from_layout(layout, "csharp")), ROLE_WORDS)
+        assert sorted(keys(frontier)) == ["box:Catalog", "box:Ordering"]
+
+    def test_a_dominant_feature_directory_is_opened(self):
+        layout = {
+            f"django/contrib/{app}/{mod}.py": [f"django.contrib.{app}.{mod}.f"]
+            for app in ("admin", "auth", "gis")
+            for mod in ("a", "b", "c")
+        }
+        layout |= {
+            f"django/{pkg}/{mod}.py": [f"django.{pkg}.{mod}.f"] for pkg in ("forms", "views") for mod in ("a", "b", "c")
+        }
+        frontier = walk(Trie(units_from_layout(layout)), ROLE_WORDS)
+        assert "opened django.contrib (9 units)" in frontier.notes
+        assert sorted(keys(frontier)) == [
+            "box:django.contrib.admin",
+            "box:django.contrib.auth",
+            "box:django.contrib.gis",
+            "box:django.forms",
+            "box:django.views",
+        ]
+
+    def test_a_layout_word_is_stepped_through(self):
+        layout = project("Catalog.API", 3) | project("Basket.API", 3)
+        layout = {f"src/{path}": [f"src.{name}" for name in names] for path, names in layout.items()}
+        frontier = walk(Trie(units_from_layout(layout, "csharp")), ROLE_WORDS)
+        assert sorted(keys(frontier)) == ["box:src.Basket", "box:src.Catalog"]
+
+    def test_a_child_holding_nearly_everything_is_stepped_through_whatever_its_name(self):
+        layout = {
+            f"app/{feature}/{mod}.py": [f"app.{feature}.{mod}.f"]
+            for feature in ("billing", "catalog", "search")
+            for mod in ("a", "b", "c")
+        }
+        layout["tools/x.py"] = ["tools.x.f"]
+        frontier = walk(Trie(units_from_layout(layout)), ROLE_WORDS)
+        assert "box:app" not in keys(frontier)
+        assert {"box:app.billing", "box:app.catalog", "box:app.search"} <= set(keys(frontier))
+
+    def test_a_role_named_child_holding_a_share_is_a_box_not_a_way_in(self):
+        """eShop's ClientApp is a box even though its children are layers with recurring features."""
+        layout = project(
+            "ClientApp", 30, "Models.Orders", "Services.Order", "Models.Basket", "Services.Basket", "Views"
+        )
+        layout |= project("Ordering.API", 20, "Apis") | project("Basket.API", 20, "Apis")
+        frontier = walk(Trie(units_from_layout(layout, "csharp")), ROLE_WORDS)
+        assert sorted(keys(frontier)) == ["box:Basket", "box:ClientApp", "box:Ordering"]
+
+    def test_one_unit_directories_and_root_files_are_loose(self):
+        layout = {
+            "pkg/a/x.py": ["pkg.a.x.f"],
+            "pkg/b/y.py": ["pkg.b.y.f", "pkg.b.y.g"],
+            "pkg/b/z.py": ["pkg.b.z.f"],
+            "setup.py": ["setup.main"],
+        }
+        frontier = walk(Trie(units_from_layout(layout)), ROLE_WORDS)
+        loose = {candidate.key for candidate in frontier.candidates if candidate.kind == LOOSE}
+        assert loose == {"loose:", "loose:pkg"}
+        assert "box:pkg.b" in keys(frontier)
+        assert "box:pkg.a" not in keys(frontier)
+
+
+class TestThresholds:
+    def test_a_feature_child_is_opened_at_the_share_and_boxed_just_below_it(self):
+        def layout(dominant: int) -> dict[str, list[str]]:
+            out = {
+                f"top/big/{sub}/{i}.py": [f"top.big.{sub}.m{i}.f"]
+                for sub in ("alpha", "beta")
+                for i in range(dominant // 2)
+            }
+            out |= {f"top/other{j}/{i}.py": [f"top.other{j}.m{i}.f"] for j in range(4) for i in range(2)}
+            return out
+
+        total = 8
+        opened = walk(Trie(units_from_layout(layout(round(SHARE * (total + 8) / (1 - SHARE)) + 1))), ROLE_WORDS)
+        assert any(note.startswith("opened top.big") for note in opened.notes)
+        boxed = walk(Trie(units_from_layout(layout(2))), ROLE_WORDS)
+        assert "box:top.big" in keys(boxed)
+
+    def test_a_node_is_layered_at_the_role_share_and_not_below_it(self):
+        def layout(role_units: int, feature_units: int) -> dict[str, list[str]]:
+            out = {
+                f"X/{layer}/Thing/{i}.cs": [f"X.{layer}.Thing.T{i}"]
+                for layer in ("Api", "Domain", "Infrastructure")
+                for i in range(role_units)
+            }
+            out |= {f"X/Billing/{i}.cs": [f"X.Billing.B{i}"] for i in range(feature_units)}
+            return out
+
+        layered = walk(Trie(units_from_layout(layout(2, 4), "csharp")), ROLE_WORDS)
+        assert any("role-named children" in note for note in layered.notes)
+        plain = walk(Trie(units_from_layout(layout(2, 5), "csharp")), ROLE_WORDS)
+        assert not any("role-named children" in note for note in plain.notes)
+        assert 6 / 10 >= ROLE_SHARE > 6 / 11
+
+    def test_a_child_is_stepped_through_at_nearly_all_and_boxed_below_it(self):
+        def layout(app_units: int) -> dict[str, list[str]]:
+            out = {f"app/{f}/{i}.py": [f"app.{f}.m{i}.f"] for f in ("billing", "search") for i in range(app_units // 2)}
+            out |= {f"tools/t{i}.py": [f"tools.t{i}.f"] for i in range(2)}
+            return out
+
+        assert "box:app" not in keys(walk(Trie(units_from_layout(layout(8))), ROLE_WORDS))
+        assert "box:app" in keys(walk(Trie(units_from_layout(layout(6))), ROLE_WORDS))
+        assert 8 / 10 >= NEARLY_ALL > 6 / 8
+
+    def test_a_nearly_all_child_is_stepped_through_before_its_role_named_siblings_can_layer_the_node(self):
+        layout = {f"app/{f}/{m}.py": [f"app.{f}.{m}.run"] for f in ("billing", "catalog", "search") for m in "abcdef"}
+        layout |= {f"tests/t{i}.py": [f"tests.t{i}.f"] for i in range(2)}
+        layout |= {f"docs/d{i}.py": [f"docs.d{i}.f"] for i in range(2)}
+        frontier = walk(Trie(units_from_layout(layout)), ROLE_WORDS)
+        assert {"box:app.billing", "box:app.catalog", "box:app.search", "box:tests", "box:docs"} <= set(keys(frontier))
+
+
+class TestLayeredRoot:
+    LAYERS = ("Application", "Domain", "Infrastructure", "Contracts")
+
+    def _beacon(self) -> dict[str, list[str]]:
+        layout: dict[str, list[str]] = {}
+        for feature in ("Incidents", "Escalation", "Teams"):
+            for layer in self.LAYERS[:3]:
+                for index in range(2):
+                    layout[f"Beacon.{layer}/{feature}/{feature}{index}.cs"] = [
+                        f"Beacon.{layer}.{feature}.{feature}Thing{index}"
+                    ]
+        layout["Beacon.Contracts/Dtos/TeamDto.cs"] = ["Beacon.Contracts.Dtos.TeamDto"]
+        layout["Beacon.Application/IncidentResolvedMetricsHandler.cs"] = [
+            "Beacon.Application.IncidentResolvedMetricsHandler",
+            "Beacon.Application.IncidentResolvedMetricsHandler.Handle()",
+        ]
+        return layout
+
+    def test_recurring_features_transpose_the_layers(self):
+        frontier = walk(Trie(units_from_layout(self._beacon(), "csharp")), ROLE_WORDS)
+        assert frontier.axis == "transposed"
+        features = {candidate.label: candidate for candidate in frontier.candidates if candidate.kind == FEATURE}
+        assert set(features) == {"Incidents", "Escalation", "Teams"}
+        assert features["Incidents"].terms == ("incident",)
+        assert ("Beacon", "Domain", "Incidents") in features["Incidents"].prefixes
+        residuals = [candidate.key for candidate in frontier.candidates if candidate.kind == RESIDUAL]
+        assert residuals == [
+            f"residual:Beacon.{layer}" for layer in ("Application", "Contracts", "Domain", "Infrastructure")
+        ]
+
+    def test_a_feature_under_one_layer_only_is_not_a_feature(self):
+        """Two same-stem directories under one layer are not a grid."""
+        layout = self._beacon()
+        layout["Beacon.Domain/Alerts/Alert.cs"] = ["Beacon.Domain.Alerts.Alert"]
+        layout["Beacon.Domain/AlertRules/AlertRule.cs"] = ["Beacon.Domain.AlertRules.AlertRule"]
+        frontier = walk(Trie(units_from_layout(layout, "csharp")), ROLE_WORDS)
+        assert not any(candidate.label == "Alerts" for candidate in frontier.candidates)
+
+    def test_two_layered_children_sharing_a_feature_word_get_distinct_candidates(self):
+        layout: dict[str, list[str]] = {}
+        for project in ("Orders", "Billing"):
+            for layer in ("Application", "Domain", "Infrastructure"):
+                for feature in ("Customers", "Payments"):
+                    for i in range(2):
+                        layout[f"{project}/{layer}/{feature}/{i}.cs"] = [f"{project}.{layer}.{feature}.T{i}"]
+        frontier = walk(Trie(units_from_layout(layout, "csharp")), ROLE_WORDS)
+        features = sorted(candidate.key for candidate in frontier.candidates if candidate.kind == FEATURE)
+        assert features == [
+            "feature:Billing:customer",
+            "feature:Billing:payment",
+            "feature:Orders:customer",
+            "feature:Orders:payment",
+        ]
+
+    def test_the_walk_does_not_depend_on_unit_order(self):
+        units = units_from_layout(self._beacon(), "csharp")
+        forward = walk(Trie(units), ROLE_WORDS)
+        backward = walk(Trie(list(reversed(units))), ROLE_WORDS)
+        assert forward.candidates == backward.candidates
+
+    def test_layers_without_a_grid_are_one_box(self):
+        layout = {
+            f"Beacon.{layer}/{layer}Thing{i}.cs": [f"Beacon.{layer}.{layer}Thing{i}"]
+            for layer in self.LAYERS
+            for i in range(3)
+        }
+        frontier = walk(Trie(units_from_layout(layout, "csharp")), ROLE_WORDS)
+        assert keys(frontier) == ["box:Beacon"]
+        assert frontier.axis == "structural"
+
+    def test_the_shallowest_feature_directory_keys_its_subtree(self):
+        layout = self._beacon()
+        layout["Beacon.Domain/Incidents/Metrics/IncidentMetric.cs"] = ["Beacon.Domain.Incidents.Metrics.IncidentMetric"]
+        layout["Beacon.Application/Metrics/MetricRollup.cs"] = ["Beacon.Application.Metrics.MetricRollup"]
+        layout["Beacon.Infrastructure/Metrics/MetricStore.cs"] = ["Beacon.Infrastructure.Metrics.MetricStore"]
+        frontier = walk(Trie(units_from_layout(layout, "csharp")), ROLE_WORDS)
+        features = {candidate.label: candidate for candidate in frontier.candidates if candidate.kind == FEATURE}
+        assert ("Beacon", "Domain", "Incidents", "Metrics") not in features["Metrics"].prefixes
+        assert ("Beacon", "Application", "Metrics") in features["Metrics"].prefixes
+
+
+class TestTheWalkEmitsRulesNotAssignments:
+    def test_every_candidate_is_a_rule_over_prefixes_or_words(self):
+        layout = project("Catalog.API", 3) | project("Basket.API", 3)
+        frontier = walk(Trie(units_from_layout(layout, "csharp")), ROLE_WORDS)
+        for candidate in frontier.candidates:
+            assert candidate.kind in (BOX, FEATURE, LOOSE, RESIDUAL)
+            assert candidate.prefixes or candidate.fallback_prefixes or candidate.terms

--- a/tests/static_analyzer/names/test_frontier.py
+++ b/tests/static_analyzer/names/test_frontier.py
@@ -181,6 +181,30 @@ class TestLayeredRoot:
             f"residual:Beacon.{layer}" for layer in ("Application", "Contracts", "Domain", "Infrastructure")
         ]
 
+    def test_features_recur_through_role_named_directories(self):
+        layout: dict[str, list[str]] = {}
+        for layer, role in (("Application", "Handlers"), ("Infrastructure", "Repositories"), ("Domain", "Entities")):
+            for feature in ("Orders", "Customers"):
+                for index in range(2):
+                    layout[f"Shop.{layer}/{role}/{feature}/{feature}{index}.cs"] = [
+                        f"Shop.{layer}.{role}.{feature}.{feature}Thing{index}"
+                    ]
+        frontier = walk(Trie(units_from_layout(layout, "csharp")), ROLE_WORDS)
+        features = {candidate.label: candidate for candidate in frontier.candidates if candidate.kind == FEATURE}
+        assert set(features) == {"Orders", "Customers"}
+        assert ("Shop", "Application", "Handlers", "Orders") in features["Orders"].prefixes
+
+    def test_a_product_name_on_every_feature_directory_is_not_the_feature(self):
+        layout: dict[str, list[str]] = {}
+        for layer in self.LAYERS[:3]:
+            for feature in ("BeaconIncidents", "BeaconEscalation", "BeaconTeams"):
+                for index in range(2):
+                    layout[f"Beacon.{layer}/{feature}/{feature}{index}.cs"] = [f"Beacon.{layer}.{feature}.Thing{index}"]
+        frontier = walk(Trie(units_from_layout(layout, "csharp")), ROLE_WORDS)
+        assert frontier.axis == "transposed"
+        features = sorted(candidate.terms[0] for candidate in frontier.candidates if candidate.kind == FEATURE)
+        assert features == ["escalation", "incident", "team"]
+
     def test_a_feature_under_one_layer_only_is_not_a_feature(self):
         """Two same-stem directories under one layer are not a grid."""
         layout = self._beacon()

--- a/tests/static_analyzer/names/test_inventory.py
+++ b/tests/static_analyzer/names/test_inventory.py
@@ -1,0 +1,81 @@
+from static_analyzer.clustering.names import Trie, unit_position, units_from_graph, units_from_graphs
+from tests.static_analyzer.names.conftest import graph_from_layout, node_of, unit
+
+
+class TestUnitPosition:
+    def test_python_module_with_several_symbols(self):
+        names = ["agents.agent.CodeBoardingAgent", "agents.agent.CodeBoardingAgent.run", "agents.agent.helper"]
+        assert unit_position(names, ".") == ("agents", "agent")
+
+    def test_a_file_declaring_one_class_sits_in_its_module_not_its_class(self):
+        names = ["agents.abstraction_agent.AbstractionAgent", "agents.abstraction_agent.AbstractionAgent.run"]
+        assert unit_position(names, ".") == ("agents", "abstraction_agent")
+
+    def test_a_file_with_one_symbol(self):
+        assert unit_position(["pkg.mod.only"], ".") == ("pkg", "mod")
+
+    def test_csharp_single_type_file_sits_in_its_directory(self):
+        """#545 collapses the stem into the type, so the position is the directory."""
+        names = ["Basket.API.Model.CustomerBasket", "Basket.API.Model.CustomerBasket.CustomerBasket()"]
+        assert unit_position(names, ".") == ("Basket", "API", "Model")
+
+    def test_csharp_file_with_sibling_types_keeps_its_stem(self):
+        names = ["Basket.API.Extensions.Extensions.Ext", "Basket.API.Extensions.Extensions.IntegrationEventContext"]
+        assert unit_position(names, ".") == ("Basket", "API", "Extensions", "Extensions")
+
+    def test_java_type_sits_in_its_package(self):
+        assert unit_position(["core.org.mockito.Fixture", "core.org.mockito.Fixture.run()"], ".") == (
+            "core",
+            "org",
+            "mockito",
+        )
+
+    def test_generic_and_parameter_delimiters_do_not_split(self):
+        names = ["A.B.Repo<T>.Add(Map<K, V.W> item)", "A.B.Repo<T>"]
+        assert unit_position(names, ".") == ("A", "B")
+
+    def test_names_sharing_nothing_sit_at_the_root(self):
+        assert unit_position(["a.x", "b.y"], ".") == ()
+
+
+class TestUnitsFromGraph:
+    def test_one_unit_per_file_keyed_by_the_engine_path(self):
+        graph = graph_from_layout(
+            {
+                "/repo/pkg/a.py": ["pkg.a.f", "pkg.a.g"],
+                "/repo/pkg/b.py": ["pkg.b.C", "pkg.b.C.m"],
+            }
+        )
+        units = units_from_graph(graph, "python")
+        assert [unit.unit_id for unit in units] == ["/repo/pkg/a.py", "/repo/pkg/b.py"]
+        assert units[0].names == ("pkg.a.f", "pkg.a.g")
+        assert units[1].position == ("pkg", "b")
+
+    def test_the_path_is_an_identity_and_never_read(self):
+        """Blanking every path segment changes no position: the names carry the structure."""
+        layout = {"/x/y/z.py": ["pkg.mod.C", "pkg.mod.C.m"]}
+        opaque = {"0": layout["/x/y/z.py"]}
+        assert units_from_graph(graph_from_layout(layout), "python")[0].position == (
+            units_from_graph(graph_from_layout(opaque), "python")[0].position
+        )
+
+    def test_languages_are_read_in_sorted_order(self):
+        graphs = {
+            "typescript": graph_from_layout({"/r/ts.ts": ["src.ts.f"]}, "typescript"),
+            "python": graph_from_layout({"/r/py.py": ["src.py.f"]}),
+        }
+        assert [unit.language for unit in units_from_graphs(graphs)] == ["python", "typescript"]
+
+
+class TestTrie:
+    def test_counts_units_per_subtree(self):
+        trie = Trie([unit("a", "p.x.A"), unit("b", "p.x.B"), unit("c", "p.y.C")])
+        assert trie.root.count == 3
+        assert node_of(trie, ("p", "x")).count == 2
+        assert node_of(trie, ("p", "y")).count == 1
+        assert trie.node(("p", "z")) is None
+
+    def test_a_unit_at_the_root_is_a_root_unit(self):
+        trie = Trie([unit("a", "A"), unit("b", "p.B")])
+        assert [u.unit_id for u in trie.root.units] == ["a"]
+        assert node_of(trie, ("p",)).count == 1

--- a/tests/static_analyzer/names/test_inventory.py
+++ b/tests/static_analyzer/names/test_inventory.py
@@ -15,7 +15,7 @@ class TestUnitPosition:
         assert unit_position(["pkg.mod.only"], ".") == ("pkg", "mod")
 
     def test_csharp_single_type_file_sits_in_its_directory(self):
-        """#545 collapses the stem into the type, so the position is the directory."""
+        """Why: the adapter folds a single-type file's stem into the type, so the directory is the position."""
         names = ["Basket.API.Model.CustomerBasket", "Basket.API.Model.CustomerBasket.CustomerBasket()"]
         assert unit_position(names, ".") == ("Basket", "API", "Model")
 

--- a/tests/static_analyzer/names/test_replay.py
+++ b/tests/static_analyzer/names/test_replay.py
@@ -1,0 +1,137 @@
+"""Replay is a pure function of a unit's names and the rules: nothing else may move a unit."""
+
+from static_analyzer.clustering.names import ROLE_WORDS, ComponentRule, ScopeSpec, replay
+from static_analyzer.clustering.names.replay import FALLBACK, PREFIX, TERM
+from static_analyzer.clustering.names.spec import UNPLACED
+from tests.static_analyzer.names.conftest import unit
+
+
+def scope(*rules: ComponentRule) -> ScopeSpec:
+    return ScopeSpec("root", list(rules))
+
+
+CATALOG = ComponentRule("1", "Catalog", prefixes=(("Catalog",),), terms=("catalog",))
+ORDER = ComponentRule("2", "Order", prefixes=(("Ordering",), ("OrderProcessor",)), terms=("order",))
+LOOSE = ComponentRule("3", "Loose files", fallback_prefixes=((),))
+
+
+class TestPrefixes:
+    def test_the_longest_matching_prefix_wins(self):
+        deep = ComponentRule("9", "Catalog items", prefixes=(("Catalog", "API", "Model"),))
+        result = replay(
+            [unit("f", "Catalog.API.Model.CatalogItem"), unit("g", "Catalog.API.Apis.CatalogApi")],
+            scope(CATALOG, deep),
+            ROLE_WORDS,
+        )
+        assert result.assignment == {"f": "9", "g": "1"}
+        assert set(result.placed_by.values()) == {PREFIX}
+
+    def test_a_prefix_never_matches_a_partial_segment(self):
+        result = replay([unit("f", "Catalogue.X")], scope(CATALOG), ROLE_WORDS)
+        assert result.unplaced[0].unit_id == "f"
+
+
+class TestTerms:
+    def test_a_unit_with_no_prefix_votes_with_its_words(self):
+        result = replay(
+            [unit("f", "Shared.OrderTotals", "Shared.OrderTotals.Sum()")], scope(CATALOG, ORDER), ROLE_WORDS
+        )
+        assert result.assignment == {"f": "2"}
+        assert result.placed_by["f"] == TERM
+
+    def test_the_head_noun_weighs_most(self):
+        """``IncidentResolvedMetricsHandler`` is about metrics and reacts to an incident."""
+        incident = ComponentRule("1", "Incidents", terms=("incident",))
+        metrics = ComponentRule("2", "Analytics", terms=("metric",))
+        result = replay([unit("f", "App.IncidentResolvedMetricsHandler")], scope(incident, metrics), ROLE_WORDS)
+        assert result.assignment == {"f": "2"}
+
+    def test_every_segment_of_every_name_votes(self):
+        catalog = ComponentRule("1", "Catalog", terms=("catalog",))
+        basket = ComponentRule("2", "Basket", terms=("basket",))
+        names = ["Web.Client", "Web.Client.GetBasket()", "Web.Client.AddToBasket()", "Web.Client.ListCatalog()"]
+        result = replay([unit("f", *names)], scope(catalog, basket), ROLE_WORDS)
+        assert result.assignment == {"f": "2"}
+
+    def test_role_words_never_vote(self):
+        service = ComponentRule("1", "Services", terms=("service",))
+        result = replay([unit("f", "X.OrderService")], scope(service, ORDER), ROLE_WORDS)
+        assert result.assignment == {"f": "2"}
+
+    def test_a_term_owned_twice_belongs_to_the_first_rule(self):
+        first = ComponentRule("1", "A", terms=("order",))
+        second = ComponentRule("2", "B", terms=("order",))
+        assert replay([unit("f", "X.Order")], scope(first, second), ROLE_WORDS).assignment == {"f": "1"}
+
+    def test_a_tied_vote_goes_to_the_rule_that_comes_first_not_the_lower_id(self):
+        zebra = ComponentRule("9", "Zebra", terms=("zebra",))
+        apple = ComponentRule("1", "Apple", terms=("apple",))
+        result = replay([unit("f", "X.AppleZebra", "X.ZebraApple")], scope(zebra, apple), ROLE_WORDS)
+        assert result.assignment == {"f": "9"}
+
+
+class TestFallbackAndUnplaced:
+    def test_fallback_comes_after_terms(self):
+        result = replay([unit("f", "Shared.OrderTotals"), unit("g", "Shared.Misc")], scope(ORDER, LOOSE), ROLE_WORDS)
+        assert result.assignment == {"f": "2", "g": "3"}
+        assert result.placed_by["g"] == FALLBACK
+
+    def test_unplaced_units_land_in_the_bucket_and_are_still_reported(self):
+        bucket = ComponentRule("4", "Unassigned", kind=UNPLACED)
+        result = replay([unit("f", "Shipping.Api.Ship")], scope(CATALOG, ORDER, bucket), ROLE_WORDS)
+        assert result.assignment == {"f": "4"}
+        assert [u.unit_id for u in result.unplaced] == ["f"]
+        assert result.placed_by["f"] == UNPLACED
+
+    def test_without_a_bucket_an_unplaced_unit_is_only_reported(self):
+        result = replay([unit("f", "Shipping.Api.Ship")], scope(CATALOG, ORDER), ROLE_WORDS)
+        assert result.assignment == {}
+        assert [u.unit_id for u in result.unplaced] == ["f"]
+
+    def test_unplaced_units_are_grouped_where_they_leave_the_known_tree(self):
+        units = [unit("f", "Shipping.Api.Ship"), unit("g", "Shipping.Domain.Parcel"), unit("h", "Loose")]
+        result = replay(units, scope(CATALOG, ORDER), ROLE_WORDS)
+        assert {key: [u.unit_id for u in members] for key, members in result.new_scopes.items()} == {
+            ("Shipping",): ["f", "g"],
+            (): ["h"],
+        }
+
+    def test_members_follow_rule_order_and_include_empty_rules(self):
+        result = replay([unit("f", "Ordering.Api.X")], scope(CATALOG, ORDER), ROLE_WORDS)
+        assert list(result.members) == ["1", "2"]
+        assert result.size("1") == 0 and result.size("2") == 1
+
+
+class TestNewScopes:
+    def test_units_a_loose_rule_catches_still_surface_where_they_diverge(self):
+        """A root with loose files must not hide a new top-level directory behind 'Loose files'."""
+        shipping = [unit(f"s{i}", f"Shipping.API.Ship{i}") for i in range(3)]
+        result = replay([unit("p", "Program"), *shipping], scope(CATALOG, ORDER, LOOSE), ROLE_WORDS)
+        assert all(result.assignment[u.unit_id] == "3" for u in shipping)
+        assert [u.unit_id for u in result.new_scopes[("Shipping",)]] == ["s0", "s1", "s2"]
+        assert [u.unit_id for u in result.new_scopes[()]] == ["p"]
+
+    def test_a_unit_a_prefix_or_word_claims_is_not_a_new_scope(self):
+        result = replay(
+            [unit("f", "Catalog.API.Item"), unit("g", "Shared.OrderTotals")], scope(CATALOG, ORDER, LOOSE), ROLE_WORDS
+        )
+        assert result.new_scopes == {}
+
+    def test_divergence_is_measured_against_owned_prefixes_only(self):
+        """A fallback prefix must not hide the directory a new unit diverges at."""
+        residual = ComponentRule("4", "Application (residual)", fallback_prefixes=(("Beacon", "Application"),))
+        feature = ComponentRule(
+            "5", "Incidents", prefixes=(("Beacon", "Application", "Incidents"),), terms=("incident",)
+        )
+        result = replay([unit("f", "Beacon.Application.Billing.Invoice")], scope(residual, feature), ROLE_WORDS)
+        assert result.assignment == {"f": "4"}
+        assert list(result.new_scopes) == [("Beacon", "Application", "Billing")]
+
+
+class TestPurity:
+    def test_a_new_sibling_moves_nothing(self):
+        before = [unit("a", "Catalog.API.Item"), unit("b", "Ordering.API.Order")]
+        old = replay(before, scope(CATALOG, ORDER), ROLE_WORDS).assignment
+        after = before + [unit("c", "Shipping.API.Ship"), unit("d", "Catalog.API.Brand")]
+        new = replay(after, scope(CATALOG, ORDER), ROLE_WORDS).assignment
+        assert {k: new[k] for k in old} == old

--- a/tests/static_analyzer/names/test_spec.py
+++ b/tests/static_analyzer/names/test_spec.py
@@ -1,0 +1,59 @@
+from clustering_ids import ROOT_SCOPE_ID
+from static_analyzer.clustering.names import ComponentRule, KinshipGrouper, ScopeSpec, TreeSpec, draft_tree
+from static_analyzer.clustering.names.spec import UNPLACED
+from tests.static_analyzer.names.conftest import units_from_layout
+
+
+def layout() -> dict[str, list[str]]:
+    return {
+        f"src/{name}/{name}{i}.cs": [f"{name}.{name}{i}", f"{name}.{name}{i}.Run()"]
+        for name in ("Ordering", "OrderProcessor", "Catalog", "Basket")
+        for i in range(3)
+    }
+
+
+class TestTreeSpecRoundTrip:
+    def test_a_drafted_tree_survives_json(self):
+        spec = draft_tree(units_from_layout(layout(), "csharp"), KinshipGrouper(), 2, machinery=("Handler",))
+        raw = spec.to_dict()
+        assert raw["version"] == 1 and raw["grouper"] == "kinship" and raw["machinery"] == ["Handler"]
+        assert TreeSpec.from_dict(raw).to_dict() == raw
+
+    def test_parts_prefixes_and_terms_are_preserved(self):
+        rule = ComponentRule(
+            "1",
+            "Ordering",
+            prefixes=(("Ordering",), ("OrderProcessor",)),
+            terms=("order",),
+            fallback_prefixes=((),),
+            parts=(ComponentRule("", "Ordering", prefixes=(("Ordering",),)), ComponentRule("", "OrderProcessor")),
+            origin="grouped",
+        )
+        assert ComponentRule.from_dict(rule.to_dict()) == rule
+
+    def test_a_leaf_scope_keeps_its_reason(self):
+        scope = ScopeSpec("3", rung="leaf", leaf_reason="cohesive: 4 units")
+        assert ScopeSpec.from_dict("3", scope.to_dict()) == scope
+        assert scope.is_leaf
+
+
+class TestScopeSpec:
+    def test_next_id_is_fresh_never_a_refilled_gap(self):
+        scope = ScopeSpec("2", [ComponentRule("2.1", "a"), ComponentRule("2.3", "b")])
+        assert scope.next_id() == "2.4"
+        assert scope.next_id(taken={"2.7"}) == "2.8"
+        assert ScopeSpec(ROOT_SCOPE_ID).next_id() == "1"
+
+    def test_scopes_serialise_in_tree_order(self):
+        spec = TreeSpec(scopes={s: ScopeSpec(s) for s in ("1.1", "10", "2", "root", "1")})
+        assert list(spec.to_dict()["scopes"]) == ["root", "1", "2", "10", "1.1"]
+
+    def test_components_exclude_the_bucket(self):
+        scope = ScopeSpec("root", [ComponentRule("1", "a"), ComponentRule("2", "Unassigned", kind=UNPLACED)])
+        assert [rule.component_id for rule in scope.components] == ["1"]
+        assert scope.unplaced_rule is not None and scope.unplaced_rule.component_id == "2"
+        assert scope.rule("9") is None
+
+    def test_a_rule_without_prefix_or_word_is_fallback_only(self):
+        assert ComponentRule("1", "Loose files", fallback_prefixes=((),)).is_fallback_only
+        assert not ComponentRule("2", "Catalog", prefixes=(("Catalog",),)).is_fallback_only

--- a/tests/static_analyzer/names/test_tokens.py
+++ b/tests/static_analyzer/names/test_tokens.py
@@ -35,6 +35,7 @@ class TestTokenize:
     def test_parameter_list_generics_and_arity_are_dropped(self):
         assert tokenize("Add(int value)") == ("Add",)
         assert tokenize("Repository<TEntity>") == ("Repository",)
+        assert tokenize("Handler<Dictionary<string, Order>>") == ("Handler",)
         assert tokenize("Repository`1") == ("Repository",)
 
 

--- a/tests/static_analyzer/names/test_tokens.py
+++ b/tests/static_analyzer/names/test_tokens.py
@@ -1,0 +1,118 @@
+from static_analyzer.clustering.names.tokens import (
+    ROLE_WORDS,
+    distinctive_word,
+    is_role_named,
+    segments,
+    stem,
+    tokenize,
+    ubiquitous_words,
+)
+
+
+class TestTokenize:
+    def test_camel_case(self):
+        assert tokenize("IncidentRepository") == ("Incident", "Repository")
+
+    def test_run_of_capitals_is_one_word(self):
+        assert tokenize("HTTPServerFactory") == ("HTTP", "Server", "Factory")
+
+    def test_snake_and_kebab_case(self):
+        assert tokenize("open_incident-handler") == ("open", "incident", "handler")
+
+    def test_interface_prefix_is_dropped(self):
+        assert tokenize("IScheduleQuery") == ("Schedule", "Query")
+
+    def test_a_word_starting_with_i_is_not_an_interface(self):
+        assert tokenize("Incident") == ("Incident",)
+        assert tokenize("IO") == ("IO",)
+        assert tokenize("IOException") == ("IO", "Exception")
+        assert tokenize("IDGenerator") == ("ID", "Generator")
+
+    def test_bare_numbers_are_not_words(self):
+        assert tokenize("docx_0") == ("docx",)
+        assert tokenize("v1alpha1") == ("v1alpha1",)
+
+    def test_parameter_list_generics_and_arity_are_dropped(self):
+        assert tokenize("Add(int value)") == ("Add",)
+        assert tokenize("Repository<TEntity>") == ("Repository",)
+        assert tokenize("Repository`1") == ("Repository",)
+
+
+class TestStem:
+    def test_folds_inflections_onto_one_word(self):
+        assert stem("Ordering") == stem("Orders") == stem("Order")
+        assert stem("Postmortems") == stem("Postmortem")
+        assert stem("Queries") == stem("Query")
+
+    def test_keeps_the_e_of_a_word_ending_in_es(self):
+        """``Services`` must meet ``Service``; stripping ``es`` blindly left ``servic``."""
+        assert stem("Services") == stem("Service")
+        assert stem("Types") == stem("Type")
+        assert stem("Classes") == stem("Class")
+
+    def test_leaves_a_short_word_alone(self):
+        assert stem("Bus") == "bus"
+
+    def test_is_idempotent(self):
+        """A plural of an -ing word must reach the same stem as the -ing word, or role words miss."""
+        assert stem("Mappings") == stem("Mapping") == stem(stem("Mappings"))
+        assert stem("Settings") == stem("Setting")
+
+
+class TestSegments:
+    def test_parameter_lists_and_generics_stay_whole(self):
+        assert segments("Basket.API.Grpc.BasketService.Get(Dictionary<string, Foo.Bar> a)", ".") == [
+            "Basket",
+            "API",
+            "Grpc",
+            "BasketService",
+            "Get(Dictionary<string, Foo.Bar> a)",
+        ]
+
+    def test_empty_parts_are_dropped(self):
+        assert segments("a..b", ".") == ["a", "b"]
+
+
+class TestRoleWords:
+    def test_layers_are_role_named(self):
+        assert is_role_named("Application", ROLE_WORDS)
+        assert is_role_named("ViewModels", ROLE_WORDS)
+        assert is_role_named("IntegrationEvents", ROLE_WORDS)
+
+    def test_a_feature_is_not(self):
+        assert not is_role_named("Ordering", ROLE_WORDS)
+        assert not is_role_named("Catalog.API", ROLE_WORDS)
+
+    def test_a_ubiquitous_word_does_not_count_against_a_role_name(self):
+        """``Beacon.Api`` is a layer once every sibling carries ``Beacon``."""
+        assert is_role_named("Beacon.Api", ROLE_WORDS, frozenset({"beacon"}))
+        assert not is_role_named("Beacon.Api", ROLE_WORDS)
+
+
+class TestUbiquitousWords:
+    def test_a_product_name_most_siblings_carry(self):
+        assert "modulify" in ubiquitous_words(["Modulify.Catalog", "Modulify.Player", "Modulify.Library"])
+
+    def test_frequency_not_intersection(self):
+        """One odd sibling must not keep the product name alive as everyone's distinctive word."""
+        assert "polly" in ubiquitous_words(["Polly.Core", "Polly.Extensions", "Polly.Testing", "Docs"])
+
+    def test_a_word_only_some_siblings_carry_is_not(self):
+        assert "catalog" not in ubiquitous_words(["Modulify.Catalog", "Modulify.Player"])
+
+    def test_two_siblings_sharing_a_word_out_of_many_is_not(self):
+        assert "app" not in ubiquitous_words(["ClientApp", "WebApp", "Catalog", "Basket", "Identity", "Ordering"])
+
+    def test_two_of_three_siblings_sharing_a_word_is_kinship_not_ubiquity(self):
+        assert "order" not in ubiquitous_words(["Ordering", "OrderProcessor", "Catalog"])
+        assert "polly" in ubiquitous_words(["Polly.Core", "Polly.Extensions", "Polly.Testing"])
+
+
+class TestDistinctiveWord:
+    def test_skips_role_and_ubiquitous_words(self):
+        assert distinctive_word("Ordering.API", ROLE_WORDS) == "order"
+        assert distinctive_word("OrderProcessor", ROLE_WORDS) == "order"
+        assert distinctive_word("Modulify.Catalog", ROLE_WORDS, frozenset({"modulify"})) == "catalog"
+
+    def test_a_name_made_of_role_words_has_none(self):
+        assert distinctive_word("WebApp", ROLE_WORDS) == ""


### PR DESCRIPTION
First of three: **this** (design + partition core) → `feat/name-tree-pipeline` (wire full, partial and incremental runs; the LLM grouper) → `feat/name-tree-cleanup` (delete Leiden, anchoring, cluster lineage and their dependencies). Replaces the clustering half of #539 and the deletion in #542; builds on the merged naming fixes #543–#545.

## What this PR is

A pure library and a design document. Nothing in the pipeline changes yet.

- `docs/design/name-tree.md` — the architecture: one tree specification drafted once per full run, one pure `replay` function that serves full, incremental and partial runs at every depth, and how a new component is identified at any depth on an incremental run.
- `static_analyzer/clustering/names/` — the partition by qualified names:
  - `inventory.py` reads units (files) and their trie position off the call graph's node keys. No path is parsed: the engine emits no module node, so a unit's position is the longest prefix its symbols share, less a trailing symbol.
  - `frontier.py` walks the trie and emits **rules** (never assignments): pass through layout words and single children, open a feature-named directory only while it holds a share of the scope, never split along role-named children, transpose a layered node onto the features that recur under at least two of its layers.
  - `draft.py` groups a rung's candidates into components through one `Grouper` interface (the deterministic `KinshipGrouper` here: `Ordering` + `OrderProcessor`; the LLM planner arrives in the next PR behind the same interface), walks the depth ladder, applies the measured guard, and writes a `TreeSpec`.
  - `replay.py` assigns every unit by the longest matching prefix, then a head-noun-weighted vote over the words the rules own, then a fallback prefix. What nothing claims is drawn in a reserved bucket and reported, never invented into a neighbour.
  - `spec.py` is the persisted form (JSON round-trip), scope by scope, with leaves recorded as decisions.

## Measured

Fed the eight rulers of the research synthesis with units synthesised the way each adapter names things (no LLM, no LSP), against the zero-model probe the design was drawn from. Pair-F1 at file granularity / boxes:

| ruler | probe frontier | this frontier | after kinship | depth 2 |
|---|---|---|---|---|
| beacon (layered C#) | 0.889 / 13 | 0.889 / 13 | 0.889 / 13 | |
| eShop depth 1 | 0.979 / 12 | 0.979 / 12 | **1.000 / 9** | |
| eShop depth 2 | 0.999 / 12 | 0.999 / 12 | 0.980 / 9 | **0.999 / 12** |
| modulify | 1.000 / 4 | 1.000 / 4 | 1.000 / 4 | |
| django (Python) | 0.714 / 28 | 0.714 / 26 | 0.714 / 26 | |
| kubernetes (Go) | 0.240 / 74 | 0.240 / 75 | 0.252 / 64 | |
| mermaid (TypeScript) | 0.670 / 33 | 0.670 / 33 | 0.624 / 30 | |
| spring-framework (Java) | 1.000 / 22 | 1.000 / 23 | 0.974 / 21 | |

Today's pipeline on the same rulers: eShop 0.667, django 0.235 and mermaid 0.083 (both below the all-in-one floor), Beacon 0.351.

## Two things I decided, and why

- **Depth is un-merge first, and only a box above 135 units reads its own sub-tree and its words.** On the one maintainer-drawn depth-2 ruler, un-merge scores 0.999 and over-splits 1 of 7 leaf parents; the next-segment and vocabulary rungs score 0.50 and 0.55 and over-split all 7. 135 is the largest box a maintainer has left unsplit. There is no graph tier.
- **The root takes no guard.** The 5% guard is measured for ladder rungs; applied at the root it turned kubernetes' 74 boxes into 5 grab bags. Small root boxes are the grouper's to merge.

- **A last-resort rule is never absorbed and never counted.** Loose files and a layer's residue stay their own small box, and a unit they catch is still reported as a new-scope candidate, so a new directory surfaces on an incremental run even in a scope that has loose files. Without this, the popularity prior the research rejected came back through the guard.

## Tests

103 unit tests over ruler-shaped layouts: the walk on feature, layered, mono and flat repos and its three thresholds pinned at their boundaries; replay order, tie-breaking, purity and new-scope detection; the ladder, the guard floor and the leaf cap at their boundaries; the grouper contract and a planner-style grouper; order independence, JSON round-trip, and one end-to-end path from a two-language `CallGraph` to a replayed partition. `pytest`, `mypy` and `black` clean; the three `test_cli_parser` failures also fail on `origin/main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added name-based repository partitioning into hierarchical components.
  * Added deterministic assignment using qualified-name prefixes and distinctive vocabulary.
  * Added support for drafting, replaying, saving, and restoring partition trees.
  * Added handling for nested scopes, fallback rules, unassigned items, and loose files.
  * Added identifier tokenization and role-aware naming analysis.

* **Documentation**
  * Added design documentation for partitioning workflows.

* **Tests**
  * Added coverage for partitioning, replay, serialization, tokenization, and multi-language analysis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->