### PR TITLE
feat(clustering): fold toward nine components along the graph, nest from forty units, and a planner that draws three times

### DIFF
--- a/agents/llm_config.py
+++ b/agents/llm_config.py
@@ -534,3 +534,8 @@ def supports_prompt_caching(llm: BaseChatModel) -> bool:
     today; other providers either cache transparently or not at all.
     """
     return llm.__class__.__module__.startswith("langchain_anthropic")
+
+
+def supports_json_mode(llm: BaseChatModel) -> bool:
+    """True when *llm* takes OpenAI's ``response_format={"type": "json_object"}``."""
+    return isinstance(llm, ChatOpenAI)

--- a/agents/prompts/abstract_prompt_factory.py
+++ b/agents/prompts/abstract_prompt_factory.py
@@ -6,23 +6,30 @@ Defines the abstract base class for prompt factories with all prompt methods.
 
 from abc import ABC, abstractmethod
 
-TREE_PLAN_MESSAGE = """You are grouping the scopes of a codebase into the components a maintainer would draw.
+TREE_PLAN_SYSTEM_MESSAGE = (
+    "You group the candidate groups of one scope of a codebase into the components a maintainer "
+    "would draw in an architecture diagram. Answer with JSON only."
+)
 
-Scope: {scope}
+TREE_PLAN_MESSAGE = """Scope: {scope} ({units} files in {count} candidate groups, listed largest first)
+{groups}
 
-Each candidate group below has already merged the scopes that share a name. Fold them into at most
-{budget} components where they serve one purpose together, for example the web app, the mobile app
-and the hybrid app into "Customer experiences", and leave apart what does not belong together.
+Each candidate group has already merged the scopes that share a name. Fold them into at most
+{budget} components, each for one responsibility, for example the web app, the mobile app and the
+hybrid app into "Customer experiences".
 
 Rules:
-- Never split a candidate group; a component gathers whole groups.
-- Every candidate group label must appear in exactly one component's members.
+- Every label appears in exactly one component's members. Never split a candidate group.
+- A component holds at least {floor} files. A group with fewer files joins the component whose
+  purpose it serves; it never stands alone.
+- Keep apart what does not belong together: use the budget before lumping unrelated groups.
 - Name each component for its one responsibility. Never join two things with "and" or "&".
-- `owns` is domain vocabulary a component claims beyond its groups' names: words that appear in the
-  identifiers below, never words naming how software is built (Handler, Service, Repository).
+- owns: at most 5 lowercase single words this component claims beyond its group names, taken from
+  the identifiers listed under its own groups. Never words naming how software is built (handler,
+  service, repository, converter).
 
-Candidate groups:
-{groups}
+Answer with JSON only, no prose, in this shape:
+{{"groups": [{{"name": "Customer experiences", "members": ["G1", "G4"], "owns": ["customer"]}}]}}
 """
 
 

--- a/agents/tree_planner_agent.py
+++ b/agents/tree_planner_agent.py
@@ -1,20 +1,29 @@
 """The planner: an LLM folds a scope's candidate groups into components, once per scope."""
 
+import json
 import logging
+import re
+from collections import Counter
 from collections.abc import Sequence
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import HumanMessage, SystemMessage
 from langchain_core.prompts import PromptTemplate
 
 from agents.agent import CodeBoardingAgent
-from agents.agent_responses import TreePlanInsights
-from agents.prompts import get_system_message, get_tree_plan_message
+from agents.agent_responses import PlannedGroup, TreePlanInsights
+from agents.llm_config import MONITORING_CALLBACK, supports_json_mode
+from agents.prompts import get_tree_plan_message
+from agents.prompts.abstract_prompt_factory import TREE_PLAN_SYSTEM_MESSAGE
+from agents.retry import RetryAction, RetryDecision, default_backoff, with_retries
 from monitoring import trace
 from static_analyzer.analysis_result import StaticAnalysisResults
-from static_analyzer.clustering.names import CandidateGroup, GroupingContext, KinshipGrouper
+from static_analyzer.clustering.names import CandidateGroup, GroupingContext, KinshipGrouper, stem, tokenize
+from static_analyzer.clustering.names.draft import GUARD_SHARE, MIN_UNITS
 from static_analyzer.clustering.names.frontier import Candidate
-from static_analyzer.clustering.names.tokens import stems
+from static_analyzer.clustering.names.spec import is_root
 
 logger = logging.getLogger(__name__)
 
@@ -22,9 +31,19 @@ BUDGET = 9
 """Components a scope should not exceed. A preference the planner works toward, never a cap
 the partition enforces: budgets are measured to refuse correct answers."""
 
+DRAWS = 3
+"""Answers drawn per scope; the one the others agree with most is kept. Why: the model is not
+deterministic at temperature 0 (0.5-0.7 pair agreement between two draws of one prompt), so a
+single draw makes the first run's luck the architecture."""
+
+MAX_OWNS = 5
+SAMPLE_NAMES = 5
+DRAW_TIMEOUT_SECONDS = 600
+_LABEL = re.compile(r"^G\d+$")
+
 
 class TreePlannerAgent(CodeBoardingAgent):
-    """A ``Grouper`` that lets the model merge kinship groups across words; it never sees a unit."""
+    """A ``Grouper`` that folds kinship groups across words on the medoid of several JSON draws; it never sees a unit."""
 
     name = "planner"
 
@@ -34,57 +53,218 @@ class TreePlannerAgent(CodeBoardingAgent):
         static_analysis: StaticAnalysisResults,
         agent_llm: BaseChatModel,
         parsing_llm: BaseChatModel,
+        draws: int = DRAWS,
     ):
-        super().__init__(repo_dir, static_analysis, get_system_message(), agent_llm, parsing_llm)
-        self.prompt = PromptTemplate(template=get_tree_plan_message(), input_variables=["scope", "budget", "groups"])
+        super().__init__(repo_dir, static_analysis, TREE_PLAN_SYSTEM_MESSAGE, agent_llm, parsing_llm)
+        self.prompt = PromptTemplate(
+            template=get_tree_plan_message(), input_variables=["scope", "units", "count", "budget", "floor", "groups"]
+        )
+        self.draws = draws
         self._kinship = KinshipGrouper()
+        self._model = (
+            agent_llm.bind(response_format={"type": "json_object"}) if supports_json_mode(agent_llm) else agent_llm
+        )
 
     @trace
     def group(self, candidates: Sequence[Candidate], context: GroupingContext) -> list[CandidateGroup]:
         groups = self._kinship.group(candidates, context)
         if len(groups) <= BUDGET:
             return groups
-        labelled = {f"G{index}": group for index, group in enumerate(groups, start=1)}
-        insights = self._parse_invoke(
-            self.prompt.format(
-                scope=context.scope_id,
-                budget=BUDGET,
-                groups="\n".join(
-                    self._describe(label, group, candidates, context) for label, group in labelled.items()
-                ),
-            ),
-            TreePlanInsights,
+        by_key = {candidate.key: candidate for candidate in candidates}
+        size = {group.keys: sum(context.sizes.get(key, 0) for key in group.keys) for group in groups}
+        shown = sorted(
+            (group for group in groups if size[group.keys]), key=lambda group: (-size[group.keys], group.name)
         )
-        folded = self._fold(labelled, insights)
-        logger.info("[Planner] %s: %d candidate groups -> %d components", context.scope_id, len(groups), len(folded))
+        labelled = {f"G{index}": group for index, group in enumerate(shown, start=1)}
+        prompt = self.prompt.format(
+            scope=context.scope_id,
+            units=context.unit_count,
+            count=len(shown),
+            budget=BUDGET,
+            floor=MIN_UNITS if is_root(context.scope_id) else max(MIN_UNITS, int(GUARD_SHARE * context.unit_count)),
+            groups="\n".join(
+                self._describe(label, group, size[group.keys], by_key, context) for label, group in labelled.items()
+            ),
+        )
+        answers = self._draw(prompt, labelled)
+        insights = answers[0] if len(answers) == 1 else self._consensus(answers, labelled)
+        folded = self._fold(labelled, insights, context)
+        folded.extend(group for group in groups if not size[group.keys])
+        logger.info(
+            "[Planner] %s: %d candidate groups -> %d components from %d draws",
+            context.scope_id,
+            len(groups),
+            len(folded),
+            len(answers),
+        )
         return folded
 
-    @staticmethod
-    def _describe(label: str, group: CandidateGroup, candidates: Sequence[Candidate], context: GroupingContext) -> str:
-        by_key = {candidate.key: candidate for candidate in candidates}
-        members = [by_key[key] for key in group.keys]
-        units = sum(context.sizes.get(key, 0) for key in group.keys)
-        names = ", ".join(candidate.label or candidate.kind for candidate in members)
-        sample = ", ".join(dict.fromkeys(name for key in group.keys for name in context.samples.get(key, ())))
-        return f"{label}: {group.name} [{names}] ({units} files) e.g. {sample}"
+    def _draw(self, prompt: str, labelled: dict[str, CandidateGroup]) -> list[TreePlanInsights]:
+        """``draws`` answers to one prompt, drawn concurrently; a draw that fails is dropped."""
+        with ThreadPoolExecutor(max_workers=self.draws) as pool:
+            futures = [pool.submit(self._ask, prompt, labelled) for _ in range(self.draws)]
+            answers = []
+            for future in futures:
+                try:
+                    answers.append(future.result(timeout=DRAW_TIMEOUT_SECONDS))
+                except Exception as exc:
+                    logger.warning("[Planner] draw failed: %s", exc)
+        if not answers:
+            raise RuntimeError("the planner got no answer from the model")
+        return answers
+
+    def _ask(self, prompt: str, labelled: dict[str, CandidateGroup]) -> TreePlanInsights:
+        def once() -> TreePlanInsights:
+            message = self._model.invoke(
+                [SystemMessage(content=self.system_message.content), HumanMessage(content=prompt)],
+                config={"callbacks": [MONITORING_CALLBACK, self.agent_monitoring_callback]},
+            )
+            text = message.content if isinstance(message.content, str) else json.dumps(message.content)
+            insights = self._read(text, labelled)
+            return insights if insights is not None else self._parse_response(prompt, text, TreePlanInsights)
+
+        def classify(_exc: Exception, attempt: int) -> RetryDecision:
+            return RetryDecision(
+                action=RetryAction.RETRY, backoff_s=default_backoff(attempt, initial_s=10.0, multiplier=2.0, max_s=60.0)
+            )
+
+        return with_retries(once, max_attempts=3, classify=classify, log_prefix="Planner draw")
 
     @staticmethod
-    def _fold(labelled: dict[str, CandidateGroup], insights: TreePlanInsights) -> list[CandidateGroup]:
-        """Every label lands in exactly one component: the first that names it, else its own."""
+    def _read(text: str, labelled: dict[str, CandidateGroup]) -> TreePlanInsights | None:
+        """The answer's JSON, members normalised to labels; None when it is not our shape.
+
+        Why: a model that names a group instead of its label ("Ordering" for "G3") would
+        otherwise leave that group out of every component.
+        """
+        start, end = text.find("{"), text.rfind("}")
+        if start < 0 or end < start:
+            return None
+        try:
+            data = json.loads(text[start : end + 1])
+        except json.JSONDecodeError:
+            return None
+        items = data.get("groups") if isinstance(data, dict) else None
+        if not isinstance(items, list):
+            return None
+        by_name = {group.name.casefold(): label for label, group in labelled.items()}
+        groups = []
+        for item in items:
+            if not isinstance(item, dict):
+                return None
+            members = [
+                member if _LABEL.match(member) else by_name.get(member.casefold(), member)
+                for member in map(str, item.get("members") or [])
+            ]
+            groups.append(
+                PlannedGroup(
+                    name=str(item.get("name") or ""),
+                    members=members,
+                    owns=[str(word) for word in item.get("owns") or []],
+                )
+            )
+        return TreePlanInsights(groups=groups)
+
+    @staticmethod
+    def _describe(
+        label: str, group: CandidateGroup, units: int, by_key: dict[str, Candidate], context: GroupingContext
+    ) -> str:
+        names = ", ".join(dict.fromkeys(by_key[key].label or by_key[key].kind for key in group.keys))
+        sample = ", ".join(_sample(group, context))
+        return f"{label}: {group.name} [{names}] ({units} files) e.g. {sample or '-'}"
+
+    @staticmethod
+    def _consensus(answers: Sequence[TreePlanInsights], labelled: dict[str, CandidateGroup]) -> TreePlanInsights:
+        """The medoid: the draw whose grouping the other draws agree with most, by pair F1.
+
+        Why a draw rather than a vote: a majority over pairs leaves every contested label on
+        its own, and names and owned words drawn from several answers do not describe one box.
+        """
+        together = [_pairs(_placement(answer, labelled)) for answer in answers]
+
+        def agreement(index: int) -> float:
+            return sum(_pair_f1(together[index], other) for other in together)
+
+        return answers[max(range(len(answers)), key=lambda index: (agreement(index), -index))]
+
+    @staticmethod
+    def _fold(
+        labelled: dict[str, CandidateGroup], insights: TreePlanInsights, context: GroupingContext
+    ) -> list[CandidateGroup]:
+        """Every label lands in exactly one component: the first that names it, else its own.
+
+        A component owns a word only when it is a lowercase stem found among its own members'
+        identifiers and nobody else's. Why: replay votes on owned words at full weight, so a
+        generic or package-wide word ("stream", the repository's name) drags every file into
+        one box.
+        """
         taken: set[str] = set()
-        folded: list[CandidateGroup] = []
+        members_of: list[tuple[PlannedGroup, list[str]]] = []
         for planned in insights.groups:
             members = [label for label in planned.members if label in labelled and label not in taken]
-            if not members:
-                continue
-            taken.update(members)
+            if members:
+                taken.update(members)
+                members_of.append((planned, members))
+        stems_of = [_stems(labelled, members, context) for _, members in members_of]
+        folded: list[CandidateGroup] = []
+        for index, (planned, members) in enumerate(members_of):
+            elsewhere = set().union(*(stems for other, stems in enumerate(stems_of) if other != index))
+            owns = [
+                word
+                for word in dict.fromkeys(word.strip().casefold() for word in planned.owns)
+                if tokenize(word) == (word,) and stem(word) == word and word in stems_of[index] - elsewhere
+            ][:MAX_OWNS]
             folded.append(
                 CandidateGroup(
                     name=planned.name.strip() or labelled[members[0]].name,
                     keys=tuple(key for label in members for key in labelled[label].keys),
                     terms=tuple(dict.fromkeys(term for label in members for term in labelled[label].terms))
-                    + tuple(stem for word in planned.owns for stem in stems(word)),
+                    + tuple(owns),
                 )
             )
         folded.extend(group for label, group in labelled.items() if label not in taken)
         return folded
+
+
+def _placement(answer: TreePlanInsights, labelled: dict[str, CandidateGroup]) -> dict[str, str]:
+    """label -> the first component naming it; a forgotten label is a component of its own."""
+    placement: dict[str, str] = {}
+    for index, group in enumerate(answer.groups):
+        for label in group.members:
+            if label in labelled:
+                placement.setdefault(label, str(index))
+    for label in labelled:
+        placement.setdefault(label, label)
+    return placement
+
+
+def _pairs(placement: dict[str, str]) -> set[frozenset[str]]:
+    """Every two labels one component holds."""
+    by_component: dict[str, list[str]] = {}
+    for label, component in placement.items():
+        by_component.setdefault(component, []).append(label)
+    return {frozenset((a, b)) for members in by_component.values() for a in members for b in members if a < b}
+
+
+def _pair_f1(left: set[frozenset[str]], right: set[frozenset[str]]) -> float:
+    if not left or not right:
+        return 1.0 if left == right else 0.0
+    precision, recall = len(left & right) / len(left), len(left & right) / len(right)
+    return 2 * precision * recall / (precision + recall) if precision + recall else 0.0
+
+
+def _sample(group: CandidateGroup, context: GroupingContext) -> list[str]:
+    """A few identifiers of the group's units, skipping dunders and names most groups share."""
+    common = Counter(name for samples in context.samples.values() for name in set(samples))
+    seen = dict.fromkeys(name for key in group.keys for name in context.samples.get(key, ()))
+    return [name for name in seen if not name.startswith("_") and common[name] < 3][:SAMPLE_NAMES]
+
+
+def _stems(labelled: dict[str, CandidateGroup], members: Sequence[str], context: GroupingContext) -> set[str]:
+    return {
+        stem(word)
+        for label in members
+        for key in labelled[label].keys
+        for name in context.samples.get(key, ())
+        for word in tokenize(name)
+    }

--- a/diagram_analysis/diagram_generator.py
+++ b/diagram_analysis/diagram_generator.py
@@ -83,7 +83,7 @@ from static_analyzer.clustering import (
     ClusterScopeResult,
 )
 from static_analyzer.clustering.exceptions import IncrementalCacheMissingError, PlannerUnavailableError
-from static_analyzer.clustering.names import Grouper, KinshipGrouper, TreeSpec
+from static_analyzer.clustering.names import AffinityGrouper, Grouper, KinshipGrouper, TreeSpec
 from static_analyzer.clustering.names.spec import SPEC_VERSION
 from static_analyzer.clustering.service import ClusteringService, hierarchy_differs
 from agents.tree_planner_agent import TreePlannerAgent
@@ -685,10 +685,12 @@ class DiagramGenerator:
         return TreeSpec.from_dict(stored)
 
     def _grouper(self) -> Grouper:
-        """The configured grouper: kinship unless the planner was asked for, which needs an LLM."""
+        """The configured grouper: affinity unless another was asked for; the planner needs an LLM."""
         choice = os.getenv(GROUPER_ENV, GROUPERS[0])
         if choice not in GROUPERS:
             raise ValueError(f"{GROUPER_ENV} must be one of {', '.join(GROUPERS)}, not {choice!r}")
+        if choice == "affinity":
+            return AffinityGrouper()
         if choice == "kinship":
             return KinshipGrouper()
         if self._llms is None or self.static_analysis is None:

--- a/docs/design/name-tree.md
+++ b/docs/design/name-tree.md
@@ -118,7 +118,16 @@ implementations behind one protocol, switchable by configuration (`CODEBOARDING_
   answer is folded deterministically (every label lands in exactly one component, the first
   to name it; a forgotten label keeps its own group) and replayed verbatim. No silent
   fallback: asking for the planner without an LLM is an error. Measured against the
-  affinity fold it is no better on the rulers and moves between draws (grouper study).
+  affinity fold it is no better on the rulers and moves between draws (grouper study): the
+  model is not deterministic at temperature 0 (its hidden reasoning is sampled; 0.5–0.7 pair
+  agreement between two draws of one prompt on markitdown and serilog). So the planner asks
+  in one JSON call with no tools, lists the groups largest first with the scope's floor, draws
+  three answers concurrently and folds the medoid (the draw the other two agree with most), and
+  keeps an `owns` word only when it is a lowercase stem found in the component's own identifiers
+  and nobody else's, because replay votes on owned words at full weight and a package-wide word
+  had pulled 35 of markitdown's 40 files into one box. Measured: markitdown draws agree at
+  0.62 instead of 0.27–0.66 with 6–7 boxes instead of 2–7, serilog 0.69–0.79; three times the
+  planner's tokens, the wall clock of one call.
 
 ### 3.4 The specification (`spec.py`)
 

--- a/docs/design/name-tree.md
+++ b/docs/design/name-tree.md
@@ -66,7 +66,7 @@ Per node, in order:
 |---|---|
 | one child, no units | pass through |
 | child is a layout word (`src`, `packages`, `pkg`, …) or holds ≥ 80% of the parent | step through, whatever it is called; this is decided before the layered test below |
-| children mostly (≥ 60%) role-named, ≥ 3 of them | **layered**: if a feature name recurs under ≥ 2 distinct layer children, **transpose** onto those features; else one box |
+| children mostly (≥ 60%) role-named, ≥ 3 of them | **layered**: if a feature name recurs under ≥ 2 distinct layer children, **transpose** onto those features (at the root and above the leaf cap; below it the node is one box, because a transposition leaves a residual per layer); else the layers are the boxes, the only structure there is |
 | child is role-named | a box, never a way in |
 | feature-named child holding ≥ 50% of the scope, with mostly feature-named children | open it: half the scope is the scope's structure, less is one of its parts |
 | feature-named child holding ≥ 50% of the scope, with ≥ 3 mostly role-named children | layered, as above |
@@ -89,22 +89,36 @@ box, and a unit it catches is still reported as a new-scope candidate (§4).
 
 ### 3.3 The grouper (`draft.py`, `Grouper`)
 
-The one judgement in the tree: turn the candidates of a rung into named components. Two
-implementations behind one protocol, switchable by configuration and kept side by side:
+The one judgement in the tree: turn the candidates of a rung into named components. Three
+implementations behind one protocol, switchable by configuration (`CODEBOARDING_GROUPER`,
+`[clustering] grouper`):
 
-- `KinshipGrouper` (deterministic, this PR): merge candidates sharing their distinctive
-  word (`Ordering` + `OrderProcessor`, `Webhooks` + `WebhookClient`, `EventBus` +
-  `EventBusRabbitMQ`). Recovers eShop's depth-1 drawing at 1.000 with no model.
+- `KinshipGrouper`: merge candidates sharing their distinctive word (`Ordering` +
+  `OrderProcessor`, `Webhooks` + `WebhookClient`, `EventBus` + `EventBusRabbitMQ`).
+  Recovers eShop's depth-1 drawing at 1.000 with no model.
+- `AffinityGrouper` (default): kinship, then fold the rung along the call graph. The
+  context hands every grouper, per candidate, its size and the graph links (call edges plus
+  `INHERITS`/`TYPEREF` reference edges, cross-file only) it exchanges with each sibling;
+  the service computes them once per run and they never reach `replay`. A candidate below
+  the scope's floor, and then the smallest candidate while the scope holds more than nine,
+  joins the sibling with the highest *observed over expected* link count
+  (`links × total / (degree × degree)`, at least two links, never past 60% of the scope).
+  Why that ratio and not the raw count: a hub (`utils`, `core`) talks to everyone, so raw
+  counts fold every small box into it; against its degree it is nobody's closest sibling.
+  Measured on django it recovers what the LLM planner folded (`http` → `views`,
+  `templatetags` → `template`, `conf`/`apps` → `core`, `urls`/`middleware` together) and
+  agrees with the planner's root grouping at 0.96 pair-F1, with no model and byte-identical
+  across runs. A candidate with no affine sibling stays its own box; the fold only ever
+  merges. The persisted rules are still prefixes and words: a fold is one rule with the
+  members' prefixes and the union of their words, so replay stays graph-free.
 - `TreePlannerAgent` (LLM): runs kinship first and, only when a scope is left with more
   than nine groups, shows the model those groups with their sizes and a few identifiers and
   lets it fold them into components toward the budget. It may merge across words
   (`apiserver` + `apimachinery`; django's docs themes), which no formula over names can. Its
   answer is folded deterministically (every label lands in exactly one component, the first
   to name it; a forgotten label keeps its own group) and replayed verbatim. No silent
-  fallback: asking for the planner without an LLM is an error. Selected with
-  `CODEBOARDING_GROUPER` or `[clustering] grouper` in `config.toml`; `kinship` is the default
-  until the planner's variance across draws has been measured on the rulers. The machinery
-  tail is not yet planner-supplied.
+  fallback: asking for the planner without an LLM is an error. Measured against the
+  affinity fold it is no better on the rulers and moves between draws (grouper study).
 
 ### 3.4 The specification (`spec.py`)
 
@@ -120,23 +134,32 @@ of an older version is redrafted by the next full run.
 ### 3.5 The ladder (`draft.py`, `draft_scope`)
 
 The first rung that yields two children wins; a rung yields children only if at least two
-rules with a prefix or a word each hold `max(2, int(5% of the parent))` units, and a smaller
-one is absorbed by the largest (the measured guard; fallback-only rules are exempt). The
-root takes no guard on its frontier: a box the names draw is a box, and small ones are the
-grouper's to merge. Ties in the word vote go to the rule that comes first in the scope,
-never to an id's spelling, so ordering and numbering cannot move a unit.
+rules with a prefix or a word each hold `max(2, int(5% of the parent))` units. A smaller
+rule the grouper found no sibling for stays its own small box: folding it into the largest
+rule was measured to turn django's `contrib` into a `gis` grab bag of twelve packages, and
+the graph fold already sends everything that has a neighbour to that neighbour. The root
+takes no guard on its frontier: a box the names draw is a box, and small ones are the
+grouper's to fold. Fallback-only rules are exempt everywhere. Ties in the word vote go to
+the rule that comes first in the scope, never to an id's spelling, so ordering and
+numbering cannot move a unit.
 
 | scope | rungs, in order |
 |---|---|
-| root | frontier of the trie → words of the units (only if the frontier gave one box) |
-| component ≤ 135 units | un-merge: the candidates the grouper merged into it → leaf ("cohesive") |
-| component > 135 units | un-merge → frontier of its own sub-trie → words of its units → leaf ("exhausted") |
+| root | frontier of the trie (layers transposed or drawn) → words of the units (only if the frontier gave one box) |
+| component < 40 units | un-merge: the candidates the grouper folded into it → leaf ("cohesive") |
+| component 40–135 units | un-merge → frontier of its own sub-trie, layered nodes with a grid kept whole → leaf ("cohesive") |
+| component > 135 units | un-merge → frontier of its sub-trie, transposed where a grid recurs → words of its units → leaf ("exhausted") |
 
-Why the cap: on the one maintainer-drawn depth-2 ruler, un-merge alone scores 0.999 and
-over-splits 1 of 7 leaf parents; the next-segment and vocabulary rungs score 0.50 and 0.55
-and over-split all 7. 135 units is the largest box any maintainer has left unsplit
-(eShop's client app). Above it a box is too large to read, so every name coordinate is
-tried before it becomes a leaf. There is no graph tier: Leiden is retired at every depth.
+Why two thresholds: the floor (40) is the size below which a box reads whole in a listing,
+and above which a reader wants to click; the cap (135, the largest box any maintainer has
+left unsplit, eShop's client app) is where the aggressive coordinates start, because on the
+one maintainer-drawn depth-2 ruler a transposition below it over-splits every leaf parent
+(eShop depth 2: 0.974 whole, 0.59 transposed at 40 units, 0.67 at 70). The structural
+rungs below the cap cost that ruler 0.974 → 0.934 (Identity.API opens into Quickstart,
+Models, Services, Data) and buy django eight expandable components at depth 2 where there
+was one. The un-merge rung gives nesting for free: a root box folded from several
+candidates opens into them at depth 2, and each of those opens its own sub-trie at depth 3.
+There is no graph tier: Leiden is retired at every depth.
 
 ## 4. Full, incremental, partial: one function, three entry points
 
@@ -227,6 +250,30 @@ zero-LLM probe the design was drawn from. Pair-F1 at file granularity / boxes.
 | mermaid (TypeScript) | 0.670 / 33 | 0.670 / 33 | 0.624 / 30 | 0.661 | |
 | spring-framework (Java) | 1.000 / 22 | 1.000 / 23 | 0.974 / 21 | 0.974 | |
 
+The fold and the nesting, on six real static analyses (pickles, zero LLM; kinship at depth 2
+is what the grouper study shipped). Expandable is per level; pair-F1 against the eShop
+README diagram and the django/mermaid docs areas, which are floors rather than truths at any
+depth but 1 for eShop.
+
+| repo (units) | root boxes | expandable L1 / L2 | largest root box | F1 depth 1 | F1 depth 2 | F1 depth 3 |
+|---|---|---|---|---|---|---|
+| eShop (475) | 14 → **9** | 2/0 → **7/1** | 28% → 28% | 0.986 → 0.985 | 0.974 → 0.934 | 0.974 → 0.861 |
+| django (635) | 18 → **9** | 1/1 → **7/8** | 46% → 47% | 0.423 → 0.410 | 0.545 → **0.709** | 0.662 → 0.434 |
+| mermaid (386) | 12 → **9** | 2/1 → **4/2** | 44% → 47% | 0.086 → 0.075 | 0.099 → 0.087 | 0.142 → **0.229** |
+| markitdown (40) | 3 → 3 | 0/0 → 0/0 | **88% → 57%** | | | |
+| serilog (109) | 7 → **9** | 1/0 → **3/1** | **69% → 43%** | | | |
+| fzf (42) | 5 → 5 | 0/0 → 0/0 | 57% → 57% | | | |
+
+eShop's nine root boxes are the maintainers' nine at 0.985: the fold merges what the ruler
+does not draw (WebAppComponents and HybridApp into WebApp, IntegrationEventLogEF into
+Catalog) and one thing it does (PaymentProcessor and the AppHost into Basket, the only
+cost). The maintainers' depth-1 boxes are recovered from the union of depth-2 boxes at 0.915.
+markitdown and serilog no longer reach the vocabulary rung: their root is layered without a
+grid, and the layers (`converters`; `Core`, `Events`, `Configuration`, `Parsing`, …) are
+what the planner had folded the words into. Agreement with the planner's root grouping:
+django 0.96, eShop 0.85, mermaid 0.83, unchanged from kinship. Every spec is byte-identical
+across two runs and across unit order.
+
 The probe opened a feature-named child at a quarter of the scope; this implementation opens
 it at half, which the probe's own sweep showed identical on seven rulers and better on
 kubernetes, and which keeps a repository with two large packages (CodeBoarding's
@@ -244,13 +291,20 @@ perfect grouping) is the planner's to reach.
   follow-up.
 - **Full qualified names vote.** Every segment of every name a unit declares (module,
   class, method) contributes to the word vote, head noun heaviest.
-- **Two groupers, one interface**, selected by configuration; both stay until one is
-  chosen on evidence. The deterministic one is the draft the planner edits.
+- **Three groupers, one interface**, selected by configuration. The affinity fold is the
+  default: it reaches the planner's root grouping without a model and without variance; the
+  planner stays as the escape hatch for what no formula over names and links can group.
 - **Only static-analysis names are partitioned.** No support-scope carve-out.
 - **Never refuse.** One box at the root falls through to the words; nothing splits it,
   one box is drawn and the structure diagnostics say so.
-- **Aggressive rungs only above the leaf cap** (§3.5), because both over-split every
-  maintainer-drawn leaf on the only depth-2 ruler.
+- **Structure from 40 units, aggressive rungs only above the leaf cap** (§3.5): the
+  sub-trie of a component is drawn from 40 units, transposition and words only above 135,
+  because a transposition below the cap over-splits every maintainer-drawn leaf on the only
+  depth-2 ruler while a directory split costs it 0.04.
+- **The guard never folds into the largest rule.** A weak rule with no neighbour in the
+  graph stands; the fold, not the guard, decides where a small box goes.
+- **The graph folds, never places.** Links between candidates reach the grouper as a
+  context; the persisted rules stay prefixes and words, and replay never sees an edge.
 
 ## 9. The stack
 
@@ -274,8 +328,15 @@ perfect grouping) is the planner's to reach.
 
 - Kubernetes-scale repos over-produce root boxes (44–53 against 16 sigs); grouping them
   is the planner's job and its variance must be measured across draws before it ships.
-- The vocabulary rung without a model over-splits; a planner-owned vocabulary (as in the
-  measurements) would make it usable below the leaf cap. Not attempted here.
+- The vocabulary rung without a model collapses onto the commonest word (markitdown 88%,
+  serilog 69% in the grouper study). After the layered root draws its layers no repository
+  in the set reaches the rung, so the co-occurrence grouping of its words the study proposed
+  is unmeasured and not attempted; the affinity fold applies to word candidates as to any
+  other, which is all the rung has today.
+- The fold is measured on repositories of at most 635 units; kubernetes-scale roots (44–53
+  candidates) need links the synthesised ruler harness does not carry.
+- A unit the parent placed by a word has no home among the un-merged parts and lands in
+  the unplaced bucket (eShop's Basket, serilog's Core: two and three files).
 - The stemmer is crude (`spring` → `spr`); it is consistent with the measurements and
   ubiquity absorbs most of the damage, but it should be replaced when a ruler shows it
   costing something.

--- a/static_analyzer/clustering/names/__init__.py
+++ b/static_analyzer/clustering/names/__init__.py
@@ -4,6 +4,7 @@ See ``docs/design/name-tree.md``.
 """
 
 from static_analyzer.clustering.names.draft import (
+    AffinityGrouper,
     CandidateGroup,
     Grouper,
     GroupingContext,
@@ -21,6 +22,7 @@ from static_analyzer.clustering.names.tokens import LAYOUT_WORDS, ROLE_WORDS, st
 __all__ = [
     "LAYOUT_WORDS",
     "ROLE_WORDS",
+    "AffinityGrouper",
     "Candidate",
     "CandidateGroup",
     "ComponentRule",

--- a/static_analyzer/clustering/names/draft.py
+++ b/static_analyzer/clustering/names/draft.py
@@ -1,17 +1,18 @@
 """The ladder: how a scope's rules are drafted one rung at a time, and where it stops.
 
 The root reads the frontier of its trie, then its units' words if that gave one box. A
-component splits back into the candidates that were grouped into it; only a component above
-``LEAF_CAP`` goes on to the frontier of its own sub-trie and then to its units' words. A rung
-counts when at least two children each clear the guard; a scope no rung can split is a leaf
-that says why. Every rung is candidates in, rules out: ``replay`` places the units, at draft
-time as on every later run.
+component splits back into the candidates that were grouped into it; from ``NEST_FLOOR``
+units it goes on to the frontier of its own sub-trie, and above ``LEAF_CAP`` it also draws a
+layered sub-tree layer by layer and then reads its units' words. A rung counts when at least
+two children each clear the guard; a scope no rung can split is a leaf that says why. Every
+rung is candidates in, rules out: ``replay`` places the units, at draft time as on every
+later run.
 """
 
 from __future__ import annotations
 
 from collections import Counter
-from collections.abc import Callable, Iterable, Sequence
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass, field, replace
 from typing import Protocol
 
@@ -38,9 +39,20 @@ from static_analyzer.config import ClusteringConfig
 
 MIN_UNITS = 2
 GUARD_SHARE = 0.05
+NEST_FLOOR = 40
+"""Units from which a component reads the frontier of its own sub-tree."""
 LEAF_CAP = 135
-"""Units a component may hold and still be a leaf without reading its sub-tree or its words."""
+"""Units above which a component draws a layered sub-tree layer by layer and reads its words."""
+BUDGET = 9
+"""Components a rung is folded toward; the guard, not the budget, is what a rung must clear."""
+MIN_LINKS = 2
+"""Graph links two candidates must exchange before they count as affine: one is noise."""
+CAP_SHARE = 0.6
+"""No fold may grow a component past this share of its scope."""
 UNPLACED_NAME = "Unassigned"
+
+Links = Mapping[tuple[str, str], int]
+"""Weight of the graph edges between two units, keyed by the unit ids in sorted order."""
 
 UNMERGE = "unmerge"
 FRONTIER = "frontier"
@@ -51,8 +63,9 @@ LEAF = "leaf"
 
 @dataclass(frozen=True)
 class GroupingContext:
-    """What a grouper may know beyond the candidates: the scope, and per candidate its size
-    and a few identifiers, so a planner can judge without ever seeing a unit."""
+    """What a grouper may know beyond the candidates: the scope, and per candidate its size,
+    a few identifiers and the graph links it exchanges with each sibling, so a grouper can
+    judge without ever seeing a unit."""
 
     scope_id: ScopeId
     role_words: frozenset[str]
@@ -60,6 +73,10 @@ class GroupingContext:
     rung: str
     sizes: dict[str, int] = field(default_factory=dict)
     samples: dict[str, tuple[str, ...]] = field(default_factory=dict)
+    links: dict[tuple[str, str], int] = field(default_factory=dict)
+    """Graph edges between two candidates' units, keyed by their keys in sorted order."""
+    floor: int = MIN_UNITS
+    """Units a candidate must hold to stand on its own in this scope."""
 
 
 @dataclass(frozen=True)
@@ -106,6 +123,79 @@ class KinshipGrouper:
         return groups
 
 
+class AffinityGrouper:
+    """Kinship, then fold the rung along the graph: a candidate below the floor, and the
+    smallest candidate while the rung is over budget, joins the sibling it exchanges the most
+    links with against what their sizes predict.
+
+    Why observed over expected: a hub (``utils``, ``core``) talks to everyone, so raw counts
+    would fold every small box into it; against its degree it is nobody's closest sibling.
+    """
+
+    name = "affinity"
+
+    def group(self, candidates: Sequence[Candidate], context: GroupingContext) -> list[CandidateGroup]:
+        groups = KinshipGrouper().group(candidates, context)
+        members = [list(group.keys) for group in groups]
+        terms = [group.terms for group in groups]
+        sizes = [sum(context.sizes.get(key, 0) for key in group.keys) for group in groups]
+        links = [
+            [sum(context.links.get((min(a, b), max(a, b)), 0) for a in left for b in right) for right in members]
+            for left in members
+        ]
+        for index in range(len(members)):
+            links[index][index] = 0
+        while True:
+            live = sorted((index for index in range(len(members)) if sizes[index]), key=lambda i: (sizes[i], i))
+            sources = [index for index in live if sizes[index] < context.floor]
+            if len(live) > BUDGET:
+                sources = live
+            chosen = self._fold(sources, live, sizes, links, context)
+            if chosen is None:
+                break
+            source, target = chosen
+            members[target].extend(members[source])
+            terms[target] = _dedupe(terms[target] + terms[source])
+            sizes[target] += sizes[source]
+            sizes[source] = 0
+            for other in range(len(members)):
+                links[target][other] += links[source][other]
+                links[other][target] += links[other][source]
+            links[target][target] = 0
+            members[source] = []
+        by_key = {candidate.key: candidate for candidate in candidates}
+        groups = []
+        for index, keys in enumerate(members):
+            if not keys:
+                continue
+            # The biggest member names a fold: the box a reader already recognises.
+            biggest = max(context.sizes.get(key, 0) for key in keys)
+            name = _plainest([by_key[key] for key in keys if context.sizes.get(key, 0) == biggest])
+            groups.append(CandidateGroup(name, tuple(keys), terms[index]))
+        return groups
+
+    @staticmethod
+    def _fold(
+        sources: list[int], live: list[int], sizes: list[int], links: list[list[int]], context: GroupingContext
+    ) -> tuple[int, int] | None:
+        """The smallest source with an affine sibling, and that sibling: ``(source, target)``."""
+        degree = [sum(row) for row in links]
+        total = sum(degree) / 2 or 1.0
+        cap = CAP_SHARE * context.unit_count
+        for source in sources:
+            best: tuple[float, int, int] | None = None
+            for target in live:
+                count = links[source][target]
+                if target == source or count < MIN_LINKS or sizes[source] + sizes[target] > cap:
+                    continue
+                affinity = count * total / (degree[source] * degree[target])
+                if best is None or (affinity, -sizes[target], -target) > best:
+                    best = (affinity, -sizes[target], -target)
+            if best is not None:
+                return source, -best[2]
+        return None
+
+
 def candidate_name(candidate: Candidate) -> str:
     if candidate.kind == LOOSE:
         where = ".".join(candidate.fallback_prefixes[0]) if candidate.fallback_prefixes else ""
@@ -130,8 +220,13 @@ def draft_tree(
     *,
     machinery: Iterable[str] = (),
     share: float = SHARE,
+    links: Links | None = None,
 ) -> TreeSpec:
-    """Draft the root and every scope below it down to ``max_depth``."""
+    """Draft the root and every scope below it down to ``max_depth``.
+
+    ``links`` are the graph's edges between units; they reach the grouper as affinities
+    between candidates and never place a unit.
+    """
     if max_depth < 1:
         raise ValueError("max_depth must be at least 1")
     machinery = frozenset(machinery)
@@ -139,7 +234,9 @@ def draft_tree(
     role_words = role_words_for(machinery)
 
     def build(scope_id: ScopeId, scope_units: list[Unit], parts: tuple[ComponentRule, ...], depth: int) -> None:
-        scope, partition = draft_scope(scope_id, scope_units, role_words, grouper, parts=parts, share=share)
+        scope, partition = draft_scope(
+            scope_id, scope_units, role_words, grouper, parts=parts, share=share, links=links
+        )
         spec.set_scope(scope)
         if depth >= max_depth:
             return
@@ -158,18 +255,28 @@ def draft_scope(
     *,
     parts: tuple[ComponentRule, ...] = (),
     share: float = SHARE,
+    links: Links | None = None,
 ) -> tuple[ScopeSpec, Partition]:
     """Draft one scope's rules from its units: the first rung that splits it wins."""
     scope_units = list(units)
+    links = links or {}
     rungs: list[tuple[str, Callable[[], tuple[list[ComponentRule], str]]]] = []
+
+    def frontier(rung: str, transpose: bool) -> tuple[list[ComponentRule], str]:
+        return _frontier_rules(scope_id, scope_units, role_words, grouper, share, rung, links, transpose)
+
+    def vocabulary() -> tuple[list[ComponentRule], str]:
+        return _vocabulary_rules(scope_id, scope_units, role_words, grouper, links)
+
     if len(parts) >= 2:
         rungs.append((UNMERGE, lambda: (list(parts), "structural")))
     if is_root(scope_id):
-        rungs.append((FRONTIER, lambda: _frontier_rules(scope_id, scope_units, role_words, grouper, share, FRONTIER)))
-        rungs.append((VOCABULARY, lambda: _vocabulary_rules(scope_id, scope_units, role_words, grouper)))
-    elif len(scope_units) > LEAF_CAP:
-        rungs.append((SEGMENT, lambda: _frontier_rules(scope_id, scope_units, role_words, grouper, share, SEGMENT)))
-        rungs.append((VOCABULARY, lambda: _vocabulary_rules(scope_id, scope_units, role_words, grouper)))
+        rungs.append((FRONTIER, lambda: frontier(FRONTIER, True)))
+        rungs.append((VOCABULARY, vocabulary))
+    elif len(scope_units) >= NEST_FLOOR:
+        rungs.append((SEGMENT, lambda: frontier(SEGMENT, len(scope_units) > LEAF_CAP)))
+        if len(scope_units) > LEAF_CAP:
+            rungs.append((VOCABULARY, vocabulary))
     produced: dict[str, tuple[list[ComponentRule], str]] = {}
     for rung, produce in rungs:
         produced[rung] = rules, axis = produce()
@@ -200,8 +307,10 @@ def _leaf_reason(
     if is_root(scope_id):
         return f"no rung ({', '.join(rung for rung, _ in rungs)}) yields two children of {unit_count} units"
     unmerge = "un-merge failed the guard" if len(parts) >= 2 else "nothing to un-merge"
+    if unit_count < NEST_FLOOR:
+        return f"cohesive: {unit_count} units, under {NEST_FLOOR}; {unmerge}"
     if unit_count <= LEAF_CAP:
-        return f"cohesive: {unit_count} units, at most {LEAF_CAP}; {unmerge}"
+        return f"cohesive: {unit_count} units, at most {LEAF_CAP}; {unmerge}; the sub-tree yields no two children"
     return f"exhausted: {unmerge}; neither the sub-tree nor the words yield two children of {unit_count} units"
 
 
@@ -212,12 +321,14 @@ def _frontier_rules(
     grouper: Grouper,
     share: float,
     rung: str,
+    links: Links,
+    transpose: bool,
 ) -> tuple[list[ComponentRule], str]:
-    frontier = walk(Trie(units), role_words, share=share)
+    frontier = walk(Trie(units), role_words, share=share, transpose=transpose)
     candidates = sorted(frontier.candidates, key=lambda candidate: candidate.key)
     if not candidates:
         return [], frontier.axis
-    context = _context(scope_id, units, candidates, role_words, rung)
+    context = _context(scope_id, units, candidates, role_words, rung, links)
     return _rules_from_groups(grouper.group(candidates, context), candidates), frontier.axis
 
 
@@ -226,6 +337,7 @@ def _vocabulary_rules(
     units: list[Unit],
     role_words: frozenset[str],
     grouper: Grouper,
+    links: Links,
 ) -> tuple[list[ComponentRule], str]:
     """One candidate per word the units' own names elect, head noun weighing most."""
     counts: Counter[str] = Counter()
@@ -236,7 +348,7 @@ def _vocabulary_rules(
     candidates = [Candidate(f"{WORD}:{key}", WORD, key, terms=(key,)) for key in keys]
     if len(candidates) < 2:
         return [], VOCABULARY
-    context = _context(scope_id, units, candidates, role_words, VOCABULARY)
+    context = _context(scope_id, units, candidates, role_words, VOCABULARY, links)
     return _rules_from_groups(grouper.group(candidates, context), candidates), VOCABULARY
 
 
@@ -249,12 +361,18 @@ def _context(
     candidates: Sequence[Candidate],
     role_words: frozenset[str],
     rung: str,
+    links: Links,
 ) -> GroupingContext:
-    """Size and a few identifiers per candidate, from a replay of the candidates as rules."""
+    """Size, a few identifiers and links per candidate, from a replay of the candidates as rules."""
     provisional = ScopeSpec(
         scope_id, [replace(_candidate_rule(candidate), component_id=candidate.key) for candidate in candidates]
     )
     partition = replay(units, provisional, role_words)
+    between: Counter[tuple[str, str]] = Counter()
+    for (left, right), weight in links.items():
+        left_owner, right_owner = partition.assignment.get(left), partition.assignment.get(right)
+        if left_owner and right_owner and left_owner != right_owner:
+            between[(min(left_owner, right_owner), max(left_owner, right_owner))] += weight
     samples: dict[str, tuple[str, ...]] = {}
     for candidate in candidates:
         seen: dict[str, None] = {}
@@ -267,7 +385,8 @@ def _context(
                 break
         samples[candidate.key] = tuple(seen)
     sizes = {candidate.key: partition.size(candidate.key) for candidate in candidates}
-    return GroupingContext(scope_id, role_words, len(units), rung, sizes, samples)
+    floor = MIN_UNITS if rung == FRONTIER else _floor(len(units))
+    return GroupingContext(scope_id, role_words, len(units), rung, sizes, samples, dict(between), floor)
 
 
 def _unit_stems(unit: Unit) -> set[str]:
@@ -346,9 +465,11 @@ def _settle(
     """Replay the rules, apply the guard, number the survivors, and bucket what is left.
 
     The guard: at least ``min_rules`` rules with a prefix or a word must each hold
-    ``max(MIN_UNITS, int(GUARD_SHARE * parent))`` units; a smaller one is absorbed by the
-    largest. A fallback-only rule (loose files, a layer's residue) is neither counted nor
-    absorbed: it is the scope's last resort and stays its own box however small.
+    ``max(MIN_UNITS, int(GUARD_SHARE * parent))`` units, else the rung does not count. A
+    smaller rule the grouper found no sibling for stays its own small box: the names drew
+    it, and folding it into the largest rule was measured to make a grab bag of that rule.
+    A fallback-only rule (loose files, a layer's residue) is not counted: it is the scope's
+    last resort and stays its own box however small.
     """
     if len(rules) < min_rules:
         return None
@@ -356,16 +477,11 @@ def _settle(
     partition = replay(units, ScopeSpec(scope_id, provisional), role_words)
     sizes = {rule.component_id: partition.size(rule.component_id) for rule in provisional}
     floor = _floor(len(units)) if guard else 1
-    claimants = [rule for rule in provisional if not rule.is_fallback_only]
-    strong = [rule for rule in claimants if sizes[rule.component_id] >= floor]
+    strong = [rule for rule in provisional if not rule.is_fallback_only and sizes[rule.component_id] >= floor]
     if len(strong) < min_rules:
         return None
-    kept = {rule.component_id: rule for rule in provisional if rule in strong or rule.is_fallback_only}
-    largest = max(strong, key=lambda rule: sizes[rule.component_id]).component_id
-    for weak in (rule for rule in claimants if rule not in strong and sizes[rule.component_id]):
-        kept[largest] = _merge_rules(kept[largest], weak)
-        sizes[largest] += sizes[weak.component_id]
-    ordered = sorted(kept.values(), key=lambda rule: (-sizes[rule.component_id], rule.name))
+    kept = [rule for rule in provisional if sizes[rule.component_id] or rule.is_fallback_only]
+    ordered = sorted(kept, key=lambda rule: (-sizes[rule.component_id], rule.name))
     scope = ScopeSpec(scope_id)
     for rule in ordered:
         scope.rules.append(replace(rule, component_id=scope.next_id()))
@@ -378,20 +494,6 @@ def _settle(
 
 def _floor(unit_count: int) -> int:
     return max(MIN_UNITS, int(GUARD_SHARE * unit_count))
-
-
-def _merge_rules(target: ComponentRule, weak: ComponentRule) -> ComponentRule:
-    return replace(
-        target,
-        prefixes=target.prefixes + weak.prefixes,
-        terms=_dedupe(target.terms + weak.terms),
-        fallback_prefixes=target.fallback_prefixes + weak.fallback_prefixes,
-        parts=(target.parts or (_as_part(target),)) + (weak.parts or (_as_part(weak),)),
-    )
-
-
-def _as_part(rule: ComponentRule) -> ComponentRule:
-    return replace(rule, component_id="", parts=())
 
 
 def _dedupe(terms: tuple[str, ...]) -> tuple[str, ...]:

--- a/static_analyzer/clustering/names/frontier.py
+++ b/static_analyzer/clustering/names/frontier.py
@@ -63,27 +63,41 @@ class Frontier:
     notes: list[str] = field(default_factory=list)
 
 
-def walk(trie: Trie, role_words: frozenset[str], *, share: float = SHARE) -> Frontier:
+def walk(trie: Trie, role_words: frozenset[str], *, share: float = SHARE, transpose: bool = True) -> Frontier:
+    """The candidates of a trie.
+
+    A layered node whose features recur is transposed onto them only with ``transpose``, else
+    kept as one box; one whose features do not recur is drawn layer by layer. Why the switch:
+    below the leaf cap a transposition leaves a residual per layer, which reads as a grab bag;
+    layers are directories a reader can name.
+    """
     frontier = Frontier()
     top = trie.root
     while len(top.children) == 1 and not top.units:
         top = next(iter(top.children.values()))
-    _visit(top, top.count, role_words, share, frontier, top=True)
+    _visit(top, top.count, role_words, share, frontier, transpose, top=True)
     return frontier
 
 
 def _visit(
-    node: TrieNode, total: int, role_words: frozenset[str], share: float, out: Frontier, *, top: bool = False
+    node: TrieNode,
+    total: int,
+    role_words: frozenset[str],
+    share: float,
+    out: Frontier,
+    transpose: bool,
+    *,
+    top: bool = False,
 ) -> None:
     children = sorted(node.children.items())
     if len(children) == 1 and not node.units:
-        _visit(children[0][1], total, role_words, share, out, top=top)
+        _visit(children[0][1], total, role_words, share, out, transpose, top=top)
         return
     ubiquitous = ubiquitous_words(name for name, _ in children)
     stepped = {name for name, child in children if _stepped_through(name, child, node)}
     role_units = sum(child.count for name, child in children if is_role_named(name, role_words, ubiquitous))
     if not stepped and len(children) >= MIN_LAYERS and node.count and role_units / node.count >= ROLE_SHARE:
-        _layered(node, ubiquitous, role_words, out, top=top)
+        _layered(node, ubiquitous, role_words, out, transpose, top=top)
         return
     if top:
         out.axis = "structural"
@@ -95,7 +109,7 @@ def _visit(
             continue
         scopes += 1
         if name in stepped:
-            _visit(child, total, role_words, share, out)
+            _visit(child, total, role_words, share, out, transpose)
             continue
         if is_role_named(name, role_words, ubiquitous):
             out.candidates.append(_box(child))
@@ -111,9 +125,9 @@ def _visit(
         dominant = total > 0 and child.count / total >= share
         if dominant and child_names and child_role_share < ROLE_SHARE:
             out.notes.append(f"opened {_dotted(child.path)} ({child.count} units)")
-            _visit(child, total, role_words, share, out)
+            _visit(child, total, role_words, share, out, transpose)
         elif dominant and len(child_names) >= MIN_LAYERS and child_role_share >= ROLE_SHARE:
-            _layered(child, child_ubiquitous, role_words, out)
+            _layered(child, child_ubiquitous, role_words, out, transpose)
         else:
             out.candidates.append(_box(child))
     if not scopes:
@@ -132,10 +146,12 @@ def _layered(
     ubiquitous: frozenset[str],
     role_words: frozenset[str],
     out: Frontier,
+    transpose: bool,
     *,
     top: bool = False,
 ) -> None:
-    """A node whose children are layers: transpose onto the features recurring under two of them."""
+    """A node whose children are layers: transpose onto the features recurring under two of
+    them, else draw the layers, the only structure there is."""
     layers = sorted(node.children.items())
     ubiquitous = ubiquitous | ubiquitous_words(name for _, layer in layers for name in layer.children)
     layers_by_feature: dict[str, set[str]] = {}
@@ -146,11 +162,21 @@ def _layered(
             layers_by_feature.setdefault(feature, set()).add(layer_name)
             display.setdefault(feature, name)
     features = sorted(feature for feature, feature_layers in layers_by_feature.items() if len(feature_layers) >= 2)
+    if len(features) >= 2 and not transpose:
+        out.notes.append(f"{_dotted(node.path) or '<root>'}: layered, kept as one box")
+        out.candidates.append(_box(node))
+        return
     if len(features) < 2:
-        out.notes.append(f"{_dotted(node.path) or '<root>'}: role-named children, no recurring features; one box")
         if top:
             out.axis = "structural"
-        out.candidates.append(_box(node))
+        out.notes.append(
+            f"{_dotted(node.path) or '<root>'}: role-named children, no recurring features; layers as boxes"
+        )
+        for _, layer in sorted(node.children.items()):
+            if layer.count > 1:
+                out.candidates.append(_box(layer))
+        if node.units or any(layer.count == 1 for layer in node.children.values()):
+            out.candidates.append(_loose(node))
         return
     if top:
         out.axis = "transposed"

--- a/static_analyzer/clustering/service.py
+++ b/static_analyzer/clustering/service.py
@@ -11,6 +11,7 @@ from clustering_ids import ROOT_SCOPE_ID, ClusterId, ComponentId, ScopeId
 from repo_utils.path_utils import normalize_repo_path
 from static_analyzer.analysis_result import StaticAnalysisResults
 from static_analyzer.cfg import CallGraph
+from static_analyzer.cfg.edge import EdgeKind
 from static_analyzer.clustering.exceptions import IncrementalCacheMissingError
 from static_analyzer.clustering.models import (
     ClusterConnectionEdge,
@@ -20,9 +21,9 @@ from static_analyzer.clustering.models import (
     GroupConnection,
 )
 from static_analyzer.clustering.names import (
+    AffinityGrouper,
     ComponentRule,
     Grouper,
-    KinshipGrouper,
     Partition,
     ScopeSpec,
     TreeSpec,
@@ -33,9 +34,13 @@ from static_analyzer.clustering.names import (
     role_words_for,
     units_from_graphs,
 )
-from static_analyzer.clustering.names.draft import UNPLACED_NAME
+from static_analyzer.clustering.names.draft import UNPLACED_NAME, Links
 from static_analyzer.clustering.names.spec import UNPLACED
 from static_analyzer.config import CALLABLE_TYPES, CLASS_TYPES
+
+AFFINE_REFERENCE_KINDS = frozenset({EdgeKind.INHERITS, EdgeKind.TYPEREF})
+"""Reference edges that count as links between files, with the call edges. CONTAINS never
+crosses a file; IMPORT is not emitted yet and would be too dense to weigh."""
 
 FILE_STRATEGY = "file_leaves"
 """Recorded on a ``ClusterResult`` whose leaves are files: the unit the names partition."""
@@ -66,6 +71,22 @@ def file_leaf_clusters(graph: CallGraph) -> ClusterResult:
     )
 
 
+def unit_links(graphs: Mapping[str, CallGraph]) -> Links:
+    """Edges between files: call edges plus the reference kinds that cross a file."""
+    links: dict[tuple[str, str], int] = {}
+    for graph in graphs.values():
+        pairs = [(edge.get_source(), edge.get_destination()) for edge in graph.edges]
+        pairs.extend((ref.src, ref.dst) for ref in graph.reference_edges if ref.kind in AFFINE_REFERENCE_KINDS)
+        for source, target in pairs:
+            left, right = graph.nodes.get(source), graph.nodes.get(target)
+            if left is None or right is None or not left.file_path or not right.file_path:
+                continue
+            if left.file_path != right.file_path:
+                key = (min(left.file_path, right.file_path), max(left.file_path, right.file_path))
+                links[key] = links.get(key, 0) + 1
+    return links
+
+
 class ClusteringService:
     """Build the component hierarchy from what the qualified names say.
 
@@ -77,14 +98,16 @@ class ClusteringService:
     """
 
     def __init__(self, grouper: Grouper | None = None) -> None:
-        self.grouper: Grouper = grouper if grouper is not None else KinshipGrouper()
+        self.grouper: Grouper = grouper if grouper is not None else AffinityGrouper()
         self.spec = TreeSpec(grouper=self.grouper.name)
+        self._links: Links = {}
 
     def build_full_hierarchy(self, static_analysis: StaticAnalysisResults, max_depth: int) -> ClusterScopeResult:
         """Draft the specification from every language's names and materialize the tree."""
         graphs = static_analysis.available_cfgs()
         units = units_from_graphs(graphs)
-        self.spec = draft_tree(units, self.grouper, max_depth + 1)
+        self._links = unit_links(graphs)
+        self.spec = draft_tree(units, self.grouper, max_depth + 1, links=self._links)
         hierarchy = self._materialize(graphs, units, ROOT_SCOPE_ID, 1, max_depth)
         hierarchy.index_hierarchy()
         return hierarchy
@@ -107,6 +130,7 @@ class ClusteringService:
         self.spec = spec
         graphs = static_analysis.available_cfgs()
         units = units_from_graphs(graphs)
+        self._links = unit_links(graphs)
         baseline = _Baseline(
             persisted_scopes, repo_dir, [unit.unit_id for unit in units_from_graphs(base.available_cfgs())]
         )
@@ -130,6 +154,7 @@ class ClusteringService:
             raise ValueError("max_depth must be at least 1")
         self.spec = spec
         units = units_from_graphs(graphs)
+        self._links = unit_links(graphs)
         hierarchy = self._materialize(graphs, units, root_scope_id, 1, max_depth)
         hierarchy.index_hierarchy()
         return hierarchy
@@ -201,7 +226,9 @@ class ClusteringService:
         if parent is not None:
             rule = parent.rule(scope_id)
             parts = rule.parts if rule is not None else ()
-        scope, _ = draft_scope(scope_id, units, role_words_for(self.spec.machinery), self.grouper, parts=parts)
+        scope, _ = draft_scope(
+            scope_id, units, role_words_for(self.spec.machinery), self.grouper, parts=parts, links=self._links
+        )
         self.spec.set_scope(scope)
         return scope
 

--- a/tests/agents/test_tree_planner_agent.py
+++ b/tests/agents/test_tree_planner_agent.py
@@ -15,15 +15,41 @@ def candidates(count: int) -> list[Candidate]:
     return [Candidate(f"box:Feature{i}", BOX, f"Feature{i}", prefixes=((f"Feature{i}",),)) for i in range(count)]
 
 
-def context(items: list[Candidate]) -> GroupingContext:
+WORDS = (
+    "apple",
+    "banana",
+    "cherry",
+    "date",
+    "elder",
+    "fig",
+    "grape",
+    "honey",
+    "iris",
+    "jade",
+    "kiwi",
+    "lemon",
+    "mango",
+)
+
+
+def context(items: list[Candidate], sizes: dict[str, int] | None = None) -> GroupingContext:
+    """Sizes fall with the index, so G1 is Feature0; each candidate has one word of its own."""
+    sizes = sizes or {c.key: 30 - i for i, c in enumerate(items)}
     return GroupingContext(
         "root",
         ROLE_WORDS,
-        len(items) * 3,
+        sum(sizes.values()),
         "frontier",
-        sizes={c.key: 3 for c in items},
-        samples={c.key: (f"{c.label}Service", f"{c.label}Repository") for c in items},
+        sizes=sizes,
+        samples={
+            c.key: (f"{c.label}Service", f"{WORDS[i].title()}Client", "__init__", "accepts")
+            for i, c in enumerate(items)
+        },
     )
+
+
+def answer(*groups: tuple[str, list[str]]) -> TreePlanInsights:
+    return TreePlanInsights(groups=[PlannedGroup(name=name, members=members) for name, members in groups])
 
 
 class TestTreePlannerAgent(unittest.TestCase):
@@ -33,43 +59,65 @@ class TestTreePlannerAgent(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self.repo_dir, ignore_errors=True)
 
-    def _agent(self) -> TreePlannerAgent:
+    def _agent(self, draws: int = 1) -> TreePlannerAgent:
         llm = MagicMock()
         llm.model_name = "test-model"
-        return TreePlannerAgent(self.repo_dir, StaticAnalysisResults(), llm, llm)
+        return TreePlannerAgent(self.repo_dir, StaticAnalysisResults(), llm, llm, draws=draws)
 
     def test_a_scope_within_the_budget_never_reaches_the_model(self):
         items = candidates(BUDGET)
-        with patch.object(TreePlannerAgent, "_parse_invoke") as parse:
+        with patch.object(TreePlannerAgent, "_ask") as ask:
             groups = self._agent().group(items, context(items))
         self.assertEqual(len(groups), BUDGET)
-        parse.assert_not_called()
+        ask.assert_not_called()
 
     def test_the_model_folds_kinship_groups_into_themes(self):
         items = candidates(BUDGET + 3)
-        answer = TreePlanInsights(
+        planned = TreePlanInsights(
             groups=[
-                PlannedGroup(name="Customer experiences", members=["G1", "G2", "G3"], owns=["Customers", "Loyalty"]),
+                PlannedGroup(name="Customer experiences", members=["G1", "G2", "G3"], owns=["apple"]),
                 PlannedGroup(name="Everything else", members=[f"G{i}" for i in range(4, BUDGET + 4)]),
             ]
         )
-        with patch.object(TreePlannerAgent, "_parse_invoke", return_value=answer) as parse:
+        with patch.object(TreePlannerAgent, "_ask", return_value=planned) as ask:
             groups = self._agent().group(items, context(items))
         self.assertEqual([group.name for group in groups], ["Customer experiences", "Everything else"])
         self.assertEqual(groups[0].keys, ("box:Feature0", "box:Feature1", "box:Feature2"))
-        self.assertEqual(groups[0].terms[-2:], ("customer", "loyalty"), "owned words vote as the stems replay looks up")
-        prompt = parse.call_args.args[0]
-        self.assertIn("G1: Feature0 [Feature0] (3 files) e.g. Feature0Service, Feature0Repository", prompt)
+        self.assertIn("apple", groups[0].terms)
+        prompt = ask.call_args.args[0]
+        self.assertIn("G1: Feature0 [Feature0] (30 files) e.g. Feature0Service, AppleClient", prompt)
+        self.assertNotIn("__init__", prompt)
+        self.assertNotIn("accepts", prompt)
+
+    def test_labels_run_largest_first_and_an_empty_group_is_kept_out_of_the_prompt(self):
+        items = candidates(BUDGET + 2)
+        sizes = {c.key: 1 for c in items}
+        sizes["box:Feature5"] = 9
+        sizes["box:Feature7"] = 0
+        with patch.object(TreePlannerAgent, "_ask", return_value=answer(("Big", ["G1"]))) as ask:
+            groups = self._agent().group(items, context(items, sizes))
+        prompt = ask.call_args.args[0]
+        self.assertIn("G1: Feature5 [Feature5] (9 files)", prompt)
+        self.assertNotIn("Feature7", prompt)
+        self.assertEqual(groups[0].keys, ("box:Feature5",))
+        self.assertIn(("box:Feature7",), [group.keys for group in groups])
+        self.assertEqual(sum(len(group.keys) for group in groups), BUDGET + 2)
+
+    def test_the_floor_mirrors_the_partition_guard_none_at_the_root_five_percent_below(self):
+        items = candidates(BUDGET + 1)
+        sizes = {c.key: 100 for c in items}
+        planned = answer(("All", [f"G{i}" for i in range(1, BUDGET + 2)]))
+        with patch.object(TreePlannerAgent, "_ask", return_value=planned) as ask:
+            self._agent().group(items, context(items, sizes))
+            self.assertIn("at least 2 files", ask.call_args.args[0])
+            below = GroupingContext("1", ROLE_WORDS, 1000, "segment", sizes=sizes, samples={})
+            self._agent().group(items, below)
+            self.assertIn("at least 50 files", ask.call_args.args[0])
 
     def test_a_label_the_model_forgot_keeps_its_own_group_and_a_repeat_goes_to_the_first(self):
         items = candidates(BUDGET + 1)
-        answer = TreePlanInsights(
-            groups=[
-                PlannedGroup(name="A", members=["G1", "G2"]),
-                PlannedGroup(name="B", members=["G2", "G3", "G99"]),
-            ]
-        )
-        with patch.object(TreePlannerAgent, "_parse_invoke", return_value=answer):
+        planned = answer(("A", ["G1", "G2"]), ("B", ["G2", "G3", "G99"]))
+        with patch.object(TreePlannerAgent, "_ask", return_value=planned):
             groups = self._agent().group(items, context(items))
         self.assertEqual([group.name for group in groups][:2], ["A", "B"])
         self.assertEqual(groups[0].keys, ("box:Feature0", "box:Feature1"))
@@ -78,8 +126,66 @@ class TestTreePlannerAgent(unittest.TestCase):
 
     def test_a_component_with_no_known_member_is_dropped(self):
         items = candidates(BUDGET + 1)
-        answer = TreePlanInsights(groups=[PlannedGroup(name="Ghost", members=["G77"])])
-        with patch.object(TreePlannerAgent, "_parse_invoke", return_value=answer):
+        with patch.object(TreePlannerAgent, "_ask", return_value=answer(("Ghost", ["G77"]))):
             groups = self._agent().group(items, context(items))
         self.assertNotIn("Ghost", [group.name for group in groups])
         self.assertEqual(len(groups), BUDGET + 1)
+
+    def test_owned_words_must_be_stems_of_the_members_own_identifiers_and_nobody_elses(self):
+        items = candidates(BUDGET + 1)
+        planned = TreePlanInsights(
+            groups=[
+                PlannedGroup(name="A", members=["G1"], owns=["apple", "Apple", "service", "feature", "stream", "a b"]),
+                PlannedGroup(name="B", members=["G2"], owns=["banana", "apple", "client"]),
+            ]
+        )
+        with patch.object(TreePlannerAgent, "_ask", return_value=planned):
+            groups = self._agent().group(items, context(items))
+        self.assertEqual(groups[0].terms[-1:], ("apple",))
+        self.assertEqual(groups[1].terms[-1:], ("banana",))
+        for word in ("Apple", "service", "feature", "stream", "a b", "client"):
+            self.assertNotIn(word, groups[0].terms + groups[1].terms)
+
+    def test_the_answer_is_read_from_json_with_names_as_labels(self):
+        items = candidates(BUDGET + 1)
+        labelled = {f"G{i + 1}": MagicMock(name=c.label) for i, c in enumerate(items)}
+        for label, group in labelled.items():
+            group.name = items[int(label[1:]) - 1].label
+        text = 'Sure:\n{"groups": [{"name": "A", "members": ["G1", "feature1", "G3"], "owns": ["x"]}], "notes": ""}'
+        insights = TreePlannerAgent._read(text, labelled)
+        self.assertIsNotNone(insights)
+        self.assertEqual(insights.groups[0].members, ["G1", "G2", "G3"])
+        self.assertIsNone(TreePlannerAgent._read("no json here", labelled))
+        self.assertIsNone(TreePlannerAgent._read('{"components": []}', labelled))
+
+    def test_three_draws_fold_to_the_one_the_others_agree_with(self):
+        items = candidates(BUDGET + 3)
+        draws = iter(
+            [
+                answer(("Pair", ["G1", "G2"]), ("Trio", ["G3", "G4", "G5"]), ("Rest", [f"G{i}" for i in range(6, 13)])),
+                answer(("Pair", ["G1", "G2"]), ("Trio", ["G3", "G4", "G5"]), ("Rest", [f"G{i}" for i in range(6, 13)])),
+                answer(("Odd", ["G1", "G3"]), ("Two", ["G2", "G4", "G5"]), ("Rest", [f"G{i}" for i in range(6, 13)])),
+            ]
+        )
+        with patch.object(TreePlannerAgent, "_ask", side_effect=lambda *_: next(draws)):
+            groups = self._agent(draws=3).group(items, context(items))
+        self.assertEqual([group.name for group in groups], ["Pair", "Trio", "Rest"])
+        self.assertEqual(groups[0].keys, ("box:Feature0", "box:Feature1"))
+        self.assertEqual(groups[1].keys, ("box:Feature2", "box:Feature3", "box:Feature4"))
+
+    def test_a_failed_draw_is_dropped_and_no_answer_at_all_raises(self):
+        items = candidates(BUDGET + 1)
+        draws = iter([RuntimeError("boom"), answer(("All", [f"G{i}" for i in range(1, BUDGET + 2)]))])
+
+        def ask(*_):
+            item = next(draws)
+            if isinstance(item, Exception):
+                raise item
+            return item
+
+        with patch.object(TreePlannerAgent, "_ask", side_effect=ask):
+            groups = self._agent(draws=2).group(items, context(items))
+        self.assertEqual([group.name for group in groups], ["All"])
+        with patch.object(TreePlannerAgent, "_ask", side_effect=RuntimeError("boom")):
+            with self.assertRaises(RuntimeError):
+                self._agent(draws=2).group(items, context(items))

--- a/tests/static_analyzer/names/test_draft.py
+++ b/tests/static_analyzer/names/test_draft.py
@@ -4,6 +4,8 @@ import pytest
 
 from clustering_ids import ROOT_SCOPE_ID
 from static_analyzer.clustering.names import (
+    AffinityGrouper,
+    Candidate,
     CandidateGroup,
     KinshipGrouper,
     ROLE_WORDS,
@@ -12,15 +14,21 @@ from static_analyzer.clustering.names import (
     replay,
 )
 from static_analyzer.clustering.names.draft import (
+    BUDGET,
+    CAP_SHARE,
     FRONTIER,
     GUARD_SHARE,
     LEAF,
     LEAF_CAP,
+    MIN_LINKS,
     MIN_UNITS,
+    NEST_FLOOR,
     SEGMENT,
     UNMERGE,
     VOCABULARY,
+    GroupingContext,
 )
+from static_analyzer.clustering.names.frontier import BOX
 from static_analyzer.clustering.names.spec import UNPLACED
 from tests.static_analyzer.names.conftest import rule_of, scope_of, units_from_layout
 
@@ -128,6 +136,13 @@ class TestRootDraft:
         assert partition.assignment["converters/base.py"] == bucket.component_id
         assert [unit.unit_id for unit in partition.unplaced] == ["converters/base.py"]
 
+    def test_a_layered_root_without_a_grid_draws_its_layers_before_reading_words(self):
+        """serilog's shape: every top-level directory is role-named and no feature recurs."""
+        layout = project("Serilog", 40, "Core", "Events", "Configuration", "Parsing")
+        scope, _ = draft_scope(ROOT_SCOPE_ID, units_from_layout(layout, "csharp"), ROLE_WORDS, AffinityGrouper())
+        assert scope.rung == FRONTIER
+        assert sorted(names_of(scope)) == ["Configuration", "Core", "Events", "Parsing"]
+
     def test_a_root_nothing_splits_is_one_box_never_a_refusal(self):
         layout = {f"{d}/x.py": [f"{d}.x.run"] for d in ("alpha", "beta", "gamma")}
         scope, partition = draft_scope(ROOT_SCOPE_ID, units_from_layout(layout), ROLE_WORDS, KinshipGrouper())
@@ -205,6 +220,47 @@ class TestLadder:
             "Ordering",
         ]
         assert scope_of(spec, "1").is_leaf
+
+    def test_a_weak_rule_with_no_sibling_stands_as_its_own_box(self):
+        """Two files under a floor of three, linked to nothing: drawn, not folded into the largest."""
+        layout = project("Big", 60, "One", "Two") | project("Mid", 6) | project("Tiny", 2)
+        layout |= project("Beta", 100) | project("Gamma", 100)
+        spec = draft_tree(units_from_layout(layout, "csharp"), AffinityGrouper(), 2)
+        assert names_of(scope_of(spec, ROOT_SCOPE_ID)) == ["Beta", "Gamma", "Big", "Mid", "Tiny"]
+        big = scope_of(spec, "3")
+        assert big.rung == SEGMENT and names_of(big) == ["One", "Two"]
+
+    def test_nesting_starts_at_the_floor(self):
+        def component(count: int):
+            layout = project("Alpha", count, "One", "Two") | project("Beta", 30) | project("Gamma", 30)
+            return scope_of(draft_tree(units_from_layout(layout, "csharp"), AffinityGrouper(), 2), "1")
+
+        nested = component(NEST_FLOOR)
+        assert nested.rung == SEGMENT and names_of(nested) == ["One", "Two"]
+        leaf = component(NEST_FLOOR - 1)
+        assert leaf.is_leaf and leaf.leaf_reason.startswith(f"cohesive: {NEST_FLOOR - 1} units, under {NEST_FLOOR}")
+
+    def test_a_layered_component_without_a_grid_draws_its_layers(self):
+        layout = project("Ordering", 60, "API", "Domain", "Infrastructure") | project("Beta", 40) | project("Gamma", 40)
+        ordering = scope_of(draft_tree(units_from_layout(layout, "csharp"), AffinityGrouper(), 2), "1")
+        assert ordering.rung == SEGMENT
+        assert names_of(ordering) == ["API", "Domain", "Infrastructure"]
+
+    def test_a_layered_component_with_a_grid_transposes_only_above_the_cap(self):
+        """A client app organised by layers over features: one box while it can be read whole."""
+
+        def client_app(count: int):
+            layout = project(
+                "ClientApp", count, "Models.Orders", "Services.Order", "Models.Basket", "Services.Basket", "Views"
+            )
+            layout |= project("Beta", 40) | project("Gamma", 40)
+            return scope_of(draft_tree(units_from_layout(layout, "csharp"), AffinityGrouper(), 2), "1")
+
+        whole = client_app(LEAF_CAP)
+        assert whole.is_leaf and whole.leaf_reason.startswith(f"cohesive: {LEAF_CAP} units, at most {LEAF_CAP}")
+        transposed = client_app(LEAF_CAP + 1)
+        assert transposed.rung == SEGMENT and transposed.axis == "transposed"
+        assert {"Orders", "Basket"} <= set(names_of(transposed))
 
     def test_a_large_component_reads_its_own_frontier(self):
         layout = {
@@ -295,6 +351,73 @@ class TestGrouperContract:
 
     def test_the_spec_records_which_grouper_drew_it(self):
         assert draft_tree(units_from_layout(eshop(), "csharp"), KinshipGrouper(), 1).grouper == "kinship"
+        assert draft_tree(units_from_layout(eshop(), "csharp"), AffinityGrouper(), 1).grouper == "affinity"
+
+
+def boxes(*names: str) -> list[Candidate]:
+    return [Candidate(f"box:{name}", BOX, name, prefixes=((name,),)) for name in names]
+
+
+def context(
+    sizes: dict[str, int], links: dict[tuple[str, str], int], *, floor: int = MIN_UNITS, unit_count: int = 0
+) -> GroupingContext:
+    return GroupingContext(
+        ROOT_SCOPE_ID,
+        ROLE_WORDS,
+        unit_count or sum(sizes.values()),
+        FRONTIER,
+        sizes={f"box:{name}": size for name, size in sizes.items()},
+        links={tuple(sorted((f"box:{a}", f"box:{b}"))): count for (a, b), count in links.items()},  # type: ignore[misc]
+        floor=floor,
+    )
+
+
+def members_of(groups: list[CandidateGroup]) -> dict[str, tuple[str, ...]]:
+    return {group.name: tuple(key.removeprefix("box:") for key in group.keys) for group in groups}
+
+
+class TestAffinityGrouper:
+    BIG = tuple(f"box{index}" for index in range(10))
+
+    def test_over_budget_the_smallest_joins_its_closest_sibling_until_nothing_affine_is_left(self):
+        sizes = dict.fromkeys(self.BIG, 5) | {"tiny": 2, "small": 3}
+        links = {("tiny", "box0"): 3, ("small", "box1"): 3}
+        groups = AffinityGrouper().group(boxes(*sizes), context(sizes, links))
+        assert len(groups) == BUDGET + 1, "ten big boxes share no link: the fold stops short of the budget"
+        assert members_of(groups)["box0"] == ("box0", "tiny")
+        assert members_of(groups)["box1"] == ("box1", "small")
+
+    def test_within_budget_only_a_candidate_below_the_floor_folds(self):
+        sizes = {"alpha": 5, "beta": 5, "tiny": 2}
+        links = {("tiny", "alpha"): 2, ("alpha", "beta"): 9}
+        assert len(AffinityGrouper().group(boxes(*sizes), context(sizes, links))) == 3
+        folded = AffinityGrouper().group(boxes(*sizes), context(sizes, links, floor=3))
+        assert members_of(folded) == {"alpha": ("alpha", "tiny"), "beta": ("beta",)}
+
+    def test_a_hub_is_nobody_s_closest_sibling(self):
+        sizes = {"utils": 9, "billing": 5, "tiny": 2} | dict.fromkeys(self.BIG, 5)
+        links = {("tiny", "utils"): 3, ("tiny", "billing"): 3} | {("utils", name): 10 for name in self.BIG}
+        folded = AffinityGrouper().group(boxes(*sizes), context(sizes, links, floor=3))
+        assert members_of(folded)["billing"] == ("billing", "tiny")
+
+    def test_one_link_is_noise(self):
+        sizes = {"alpha": 5, "tiny": 2}
+        links = {("tiny", "alpha"): MIN_LINKS - 1}
+        assert len(AffinityGrouper().group(boxes(*sizes), context(sizes, links, floor=3))) == 2
+
+    def test_the_cap_sends_a_fold_to_the_next_sibling(self):
+        sizes = {"big": 6, "mid": 3, "tiny": 2}
+        links = {("tiny", "big"): 3, ("tiny", "mid"): 2}
+        assert 6 + 2 > CAP_SHARE * 11 >= 3 + 2
+        folded = AffinityGrouper().group(boxes(*sizes), context(sizes, links, floor=3))
+        assert members_of(folded) == {"big": ("big",), "mid": ("mid", "tiny")}
+
+    def test_kinship_comes_first_and_a_fold_keeps_every_word(self):
+        sizes = {"Ordering": 8, "OrderProcessor": 2, "Basket": 5, "tiny": 2}
+        links = {("tiny", "Basket"): 2}
+        folded = AffinityGrouper().group(boxes(*sizes), context(sizes, links, floor=3))
+        assert members_of(folded) == {"Ordering": ("Ordering", "OrderProcessor"), "Basket": ("Basket", "tiny")}
+        assert next(group.terms for group in folded if group.name == "Ordering") == ("order",)
 
 
 class TestDeterminism:
@@ -304,3 +427,12 @@ class TestDeterminism:
             draft_tree(units, KinshipGrouper(), 3).to_dict()
             == draft_tree(list(reversed(units)), KinshipGrouper(), 3).to_dict()
         )
+
+    def test_the_same_names_and_links_fold_the_same_tree(self):
+        layout = eshop() | project("Tiny.API", 2)
+        units = units_from_layout(layout, "csharp")
+        paths = sorted(layout)
+        links = {(paths[index], paths[-1 - index]): 2 + index % 3 for index in range(len(paths) // 2)}
+        forward = draft_tree(units, AffinityGrouper(), 3, links=links).to_dict()
+        backward = draft_tree(list(reversed(units)), AffinityGrouper(), 3, links=dict(reversed(links.items())))
+        assert forward == backward.to_dict()

--- a/tests/static_analyzer/names/test_frontier.py
+++ b/tests/static_analyzer/names/test_frontier.py
@@ -235,15 +235,20 @@ class TestLayeredRoot:
         backward = walk(Trie(list(reversed(units))), ROLE_WORDS)
         assert forward.candidates == backward.candidates
 
-    def test_layers_without_a_grid_are_one_box(self):
+    def test_layers_without_a_grid_are_the_boxes(self):
         layout = {
             f"Beacon.{layer}/{layer}Thing{i}.cs": [f"Beacon.{layer}.{layer}Thing{i}"]
             for layer in self.LAYERS
             for i in range(3)
         }
         frontier = walk(Trie(units_from_layout(layout, "csharp")), ROLE_WORDS)
-        assert keys(frontier) == ["box:Beacon"]
+        assert keys(frontier) == [f"box:Beacon.{layer}" for layer in sorted(self.LAYERS)]
         assert frontier.axis == "structural"
+
+    def test_a_grid_is_one_box_when_the_walk_may_not_transpose(self):
+        frontier = walk(Trie(units_from_layout(self._beacon(), "csharp")), ROLE_WORDS, transpose=False)
+        assert keys(frontier) == ["box:Beacon"]
+        assert any(note.endswith("kept as one box") for note in frontier.notes)
 
     def test_the_shallowest_feature_directory_keys_its_subtree(self):
         layout = self._beacon()

--- a/tests/static_analyzer/test_clustering_service.py
+++ b/tests/static_analyzer/test_clustering_service.py
@@ -8,10 +8,11 @@ from agents.file_index_models import FileMethodGroup, MethodEntry
 from clustering_ids import ROOT_SCOPE_ID
 from static_analyzer.analysis_result import StaticAnalysisResults
 from static_analyzer.cfg import CallGraph
+from static_analyzer.cfg.edge import EdgeKind, ReferenceEdge
 from static_analyzer.clustering import ClusterGroup, ClusterScopeResult
 from static_analyzer.clustering.exceptions import IncrementalCacheMissingError
 from static_analyzer.clustering.names import TreeSpec
-from static_analyzer.clustering.service import NEW_SCOPE, ClusteringService, hierarchy_differs
+from static_analyzer.clustering.service import NEW_SCOPE, ClusteringService, hierarchy_differs, unit_links
 from static_analyzer.config import Language, NodeType
 from static_analyzer.node import Node
 from tests.static_analyzer.names.conftest import rule_of, scope_of
@@ -137,6 +138,26 @@ class TestFullHierarchy(unittest.TestCase):
         self.assertIsNone(catalog.children)
         self.assertIn("1.1", self.service.spec.scopes, "the spec is drafted one level deeper than the tree")
         self.assertTrue(scope_of(self.service.spec, "1.1").is_leaf)
+
+    def test_the_default_grouper_folds_along_the_graph(self):
+        """Fifteen root boxes, Tiny.API calling Ordering: the smallest box joins the one it calls."""
+        self.assertEqual(self.service.spec.grouper, "affinity")
+        layout = eshop() | project("Tiny.API", 2)
+        for name in ("Alpha", "Beta", "Gamma", "Delta", "Epsilon", "Zeta", "Eta", "Theta", "Iota"):
+            layout |= project(name, 3)
+        edges = [(f"Tiny.API.TinyType{i}.Run()", "Ordering.API.Apis.OrderingType0.Run()") for i in range(2)]
+        service = ClusteringService()
+        service.build_full_hierarchy(analysis_for(graph("csharp", layout, edges)), max_depth=1)
+        ordering = rule_of(scope_of(service.spec, ROOT_SCOPE_ID), "1")
+        self.assertIn(("Tiny",), ordering.prefixes)
+        self.assertEqual([part.name for part in ordering.parts], ["OrderProcessor", "Ordering", "Tiny"])
+
+    def test_unit_links_count_calls_and_reference_edges_between_files(self):
+        csharp = graph("csharp", {"a.cs": ["A", "A.Run()"], "b.cs": ["B", "B.Run()"]}, [("A.Run()", "B.Run()")])
+        csharp.add_edge("A.Run()", "A", call_sites=[{"file": "a.cs", "line": 2}])
+        csharp.add_reference_edge(ReferenceEdge("A", "B", EdgeKind.INHERITS))
+        csharp.add_reference_edge(ReferenceEdge("B", "B.Run()", EdgeKind.CONTAINS))
+        self.assertEqual(unit_links({"csharp": csharp}), {(str(REPO / "a.cs"), str(REPO / "b.cs")): 2})
 
     def test_connections_come_from_the_graph(self):
         edges = [("Catalog.API.Model.CatalogType0.Run()", "Ordering.API.Apis.OrderingType0.Run()")]

--- a/user_config.py
+++ b/user_config.py
@@ -56,9 +56,10 @@ _PROVIDER_ENDPOINT_OVERRIDES: dict[str, str] = {
 _PROVIDER_KEY_TO_ENV: dict[str, str] = _PROVIDER_SECRETS | _PROVIDER_ENDPOINTS | _PROVIDER_ENDPOINT_OVERRIDES
 
 GROUPER_ENV = "CODEBOARDING_GROUPER"
-GROUPERS = ("kinship", "planner")
-"""How frontier candidates become components: ``kinship`` merges scopes sharing a word with no
-model; ``planner`` lets an LLM group across words toward a 5-9 preference."""
+GROUPERS = ("affinity", "kinship", "planner")
+"""How frontier candidates become components: ``affinity`` merges scopes sharing a word, then
+folds a scope toward nine components along the call graph, with no model; ``kinship`` stops
+after the shared words; ``planner`` lets an LLM group across words toward a 5-9 preference."""
 
 # Template written to ~/.codeboarding/config.toml on first install.
 CONFIG_TEMPLATE = """\
@@ -96,10 +97,11 @@ CONFIG_TEMPLATE = """\
 # context_window = 272000   # override if needed
 
 # Optional: how top-level components are grouped from the repository's names.
-# "kinship" (default) merges scopes that share a word, with no model call;
+# "affinity" (default) merges scopes that share a word, then folds toward 9 components
+# along the call graph, with no model call; "kinship" stops after the shared words;
 # "planner" asks the LLM to group across words toward 5-9 components.
 [clustering]
-# grouper = "kinship"
+# grouper = "affinity"
 """
 
 


### PR DESCRIPTION
Follow-up to #552, kept separate so the stack's original shape and this one can be compared side by side.

> **Read this first.** Three groupers exist: `kinship` (deterministic, the #552 default: directory boxes merged by a shared word), `affinity` (deterministic, **the new default here**: kinship plus a fold along the call graph) and `planner` (the opt-in LLM grouper). **Every real run in this PR and in CodeBoarding-tests#33 is deterministic; the planner was not used in any of them.** Part 2 below stabilises the planner, measured partition-only (60 model calls), so the escape hatch is sane if it is kept. On the evidence, affinity is the one to ship: better on the only maintainer-drawn ruler, agrees with the planner's own grouping at 0.96 on django, bit-identical across runs, no model call. No measured repository needs the planner; it remains for a case no formula over names and links can group (kubernetes-scale roots, 44–53 candidates, are the only unmeasured ones). Deleting it would remove ~230 lines and the run's only LLM dependency before description time; that is a product call this PR leaves open.

Two changes, each measured with no LLM on the six static analyses of the grouper study (CodeBoarding-tests#32) plus real depth-3 runs.

## 1. Fewer root boxes, real nesting, no grab bags (deterministic)

The study's kinship arm drew 14/18/12 root boxes on eShop/django/mermaid with 1–2 expandable components, and nothing below depth 2. Three causes, three fixes in `draft.py`/`frontier.py`:

- **`AffinityGrouper`, the new default.** Kinship first, then fold along the call graph: a candidate below the scope's floor, and the smallest candidate while the scope holds more than nine, joins the sibling with the highest *observed over expected* link count (call + `INHERITS`/`TYPEREF` edges, cross-file; `links × total / (degree × degree)`, at least two links, never past 60% of the scope). The ratio is what defeats the `utils`/`core` hub. The links reach the grouper as context only; the persisted rules are still prefixes and words and `replay` never sees an edge. On django it recovers the planner's own merges (`http` → `views`, `templatetags` → `template`, `conf`/`apps` → `core`) at 0.96 agreement with the LLM planner's root grouping, byte-identical across runs and unit order.
- **Nesting from 40 units.** A component of ≥ 40 units reads the frontier of its own sub-trie; transposition and the vocabulary rung stay above 135, because a transposition below the cap over-splits every maintainer-drawn leaf on the eShop depth-2 ruler (0.59–0.67) while a directory split costs it 0.04. The un-merge rung gives nesting for free: a folded root box opens into its candidates at depth 2, each of which opens its sub-trie at depth 3.
- **The guard no longer absorbs into the largest rule** (django's `contrib` had become a `gis` grab bag of twelve packages), and **a layered node without a grid draws its layers** instead of one box, which is what sent markitdown and serilog to the vocabulary rung (88% / 69% in one box).

| repo (units) | root boxes | expandable components at depth 1 / at depth 2 | largest root box | F1 d1 | F1 d2 |
|---|---|---|---|---|---|
| eShop (475) | 14 → **9** | 2/0 → **7/1** | 28% → 28% | 0.986 → 0.985 | 0.974 → 0.934 |
| django (635) | 18 → **9** | 1/1 → **7/8** | 46% → 47% | 0.423 → 0.410 | 0.545 → **0.709** |
| mermaid (386) | 12 → **9** | 2/1 → **4/2** | 44% → 47% | 0.086 → 0.075 | 0.099 → 0.087 |
| markitdown (40) | 3 → 3 | 0/0 | **88% → 57%** | | |
| serilog (109) | 7 → **9** | 1/0 → **3/1** | **69% → 43%** | | |
| fzf (42) | 5 → 5 | 0/0 | 57% | | |

eShop's nine root boxes are the maintainers' nine at 0.985; the one cost is `PaymentProcessor` + AppHost folded into Basket, and depth 2 drops to 0.934 because `Identity.API` now opens into its layers. Depth-1 F1 is unchanged on all eight synthesised rulers of the design doc.

## 2. The LLM planner, close to deterministic

The study's variance is the model itself: Kimi-K2.6 at temperature 0 gives three different answers to a byte-identical prompt (its hidden reasoning is sampled; `seed` is ignored, thinking cannot be disabled through the proxy), and markitdown's 2-box draw was entirely an `owns` word (`markitdown`) that replay's vote turned into 35 of 40 files. So `TreePlannerAgent` now asks in one JSON call with no tools, lists groups largest first with the scope's floor, draws three answers concurrently and folds the medoid, and keeps an `owns` word only when it is a lowercase stem in the component's own identifiers and nobody else's.

| repo | before (study, single draw) | after (3 draws, medoid) |
|---|---|---|
| markitdown root agreement, boxes | 0.27–0.66, 2–7 | 0.62, 6–7 |
| serilog root agreement | 0.53–0.95 | 0.69–0.79 |
| django scope 1 (label level) | 0.67 | 1.00 |

Three times the planner's tokens, the wall clock of one call. The planner stays opt-in (`CODEBOARDING_GROUPER=planner`); the default is the affinity fold.

## Real runs at depth 3 (affinity grouper, no planner; Kimi-K2.6 names and describes)

| repo | root | expandable components at depth 1 / at depth 2 | boxes at depth 2 / depth 3 | calls | tokens |
|---|---|---|---|---|---|
| mem0 (499 files, Python + TypeScript) | 7 | 3 / 5 | 14 / 25 | 72 | 708k |
| serilog (109, C#) | 9 | 3 / 1 | 8 / 4 | 54 | 531k |

The runs, their nested diagrams and a renderer are in CodeBoarding-tests (`shape-study/`, branch `study/name-tree-shape`).

## Incremental behaviour

Measured in CodeBoarding-tests#33 (`shape-study/incremental/`): one add+delete+modify change set per repository on both arms. Collateral was 0 in all six runs and unchanged components were byte-identical. Three defects found there (a deleted project resurrected by a second engine config, a new directory lost to a word vote, dead rules left in the spec) are fixed in #555 on top of this PR.

## Known limits

- Every expanded scope has at least two real children (the guard requires it), but three splits in the real runs are lopsided, one child holding 85–89% (eShop's Catalog, mem0's ingestion layer, serilog's Core). A share cap on the split is the obvious next rule.

- Small root boxes with no neighbour in the graph stay (eShop's two TypeScript files, mermaid's `scripts`/`cypress`); the budget cannot fold what nothing links.
- A unit the parent placed by a word has no home among the un-merged parts and lands in "Unassigned" (two or three files on eShop, serilog, mermaid).
- The fold is measured up to 635 units; kubernetes-scale roots need links the synthesised ruler harness does not carry.
- k=3 draws leave the model's ambiguity over one-file groups; more draws buy it down at linear cost.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added affinity-based clustering that groups related components using call and reference relationships.
  * Added configurable multi-draw planning with JSON responses, retries, timeouts, and consensus selection.
  * Added support for choosing among affinity, kinship, and planner-based grouping strategies.

* **Improvements**
  * Improved diagram organization with clearer component size limits and nesting behavior.
  * Refined ownership labels to use concise, component-specific terms.
  * Updated layered diagrams to preserve meaningful boxes instead of over-collapsing them.

* **Documentation**
  * Updated design documentation to describe the new grouping strategies, layout rules, and measurements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->