### PR TITLE
fix(incremental): one graph per language across engine configs, new directories over word votes, retired rules leave the spec

### DIFF
--- a/diagram_analysis/scope_plan.py
+++ b/diagram_analysis/scope_plan.py
@@ -145,6 +145,8 @@ def _plan_scope_operations(
         f"[ScopePlan] {scope_id}: {len(groups)} groups, {untouched} unchanged (no operation), "
         f"{len(operations)} operation(s)"
     )
+    for operation in operations:
+        logger.info(f"[ScopePlan] {scope_id}: {operation.action.value} {operation.component_id}: {operation.rationale}")
     return ScopeUpdateDecision(operations=operations)
 
 

--- a/docs/design/name-tree.md
+++ b/docs/design/name-tree.md
@@ -188,8 +188,8 @@ clustering. Per scope, walking the tree top-down:
    membership; `previous_component_id` is the rule id, so the existing scope plan emits
    UPDATE only where members or bodies changed, and nothing else moves. Measured: 0.00%
    of unchanged files move across 27 repositories and four edit types.
-2. **New components.** Every unit that no prefix and no word claims, whether a fallback
-   rule caught it or nothing did, is reported in `Partition.new_scopes` under the prefix at
+2. **New components.** Every unit that no prefix claims, whether a word vote, a fallback
+   rule or nothing placed it, is reported in `Partition.new_scopes` under the prefix at
    which its position first leaves every prefix a rule owns: a new top-level directory
    diverges at that directory; a new file deep inside a known one is claimed by its
    ancestor's rule and never gets here. A group of ≥ 2 units whose members are all new to
@@ -201,8 +201,10 @@ clustering. Per scope, walking the tree top-down:
    unplaced bucket, which is created on demand. This is the same at every depth: a new
    sub-directory inside component `3` surfaces in scope `3` on the next run, as a new `3.k`;
    today it needed ≥ 16 files to isolate two Leiden clusters before it could appear at all.
-3. **Retired components.** A rule that claims nothing is deleted by the existing scope
-   plan (DELETE), and its child scope with it.
+3. **Retired components.** A rule that claims nothing is retired from the specification
+   with the scopes below it, and the existing scope plan emits DELETE for its component; a
+   directory that comes back is a new scope with a fresh id. (Fallback-only rules stay: they
+   are legitimately empty.)
 4. A component whose child scope was never drafted (the depth cap was raised) is drafted
    now; its membership at its own level is unchanged.
 5. Whether anything changed is read off the replayed tree against the persisted one: a

--- a/static_analyzer/__init__.py
+++ b/static_analyzer/__init__.py
@@ -824,22 +824,28 @@ class StaticAnalyzer:
         output.
         """
         results = StaticAnalysisResults()
+        # One dict per language, threaded through every engine config of that language and
+        # absorbed once. Why: each config re-LSPs only the changed files under its own root,
+        # so a config that took its own copy of the cache would hand back the nodes another
+        # config had just invalidated, and the merge would resurrect deleted files.
+        carried: dict[Language, dict] = {}
         for engine_config, engine_client in self._live_clients("warm-start"):
             adapter, project_path = engine_config.adapter, engine_config.project_path
             language = adapter.results_language
-            cached_lang_dict = self._extract_language_dict(cached_results, language)
             t_lang_start = time.monotonic()
             changed_files = self._changed_files_for_language(project_path, cached_sha, adapter.language)
 
             if changed_files is None:
                 analysis = self._run_full_analysis(engine_config, engine_client)
+                self._absorb_into_results(results, language, analysis)
             else:
                 logger.info(f"warmstart {adapter.language}: re-LSPing {len(changed_files)} changed file(s)")
+                cached_lang_dict = carried.get(language) or self._extract_language_dict(cached_results, language)
                 analysis = update_cfg_for_changed_files(
                     cached_lang_dict, changed_files, adapter, project_path, engine_client, self.ignore_manager
                 )
+                carried[language] = analysis
 
-            self._absorb_into_results(results, language, analysis)
             self._collect_diagnostics_for(adapter, engine_client, analysis)
             track_lsp_result(
                 language=adapter.language_enum.value,
@@ -849,6 +855,8 @@ class StaticAnalyzer:
                 analysis=analysis,
                 diagnostics=self.collected_diagnostics.get(adapter.results_language, {}),
             )
+        for language, analysis in carried.items():
+            self._absorb_into_results(results, language, analysis)
         results.incremental_base_results = cached_results
         return results
 

--- a/static_analyzer/clustering/names/replay.py
+++ b/static_analyzer/clustering/names/replay.py
@@ -34,9 +34,11 @@ class Partition:
     unplaced: list[Unit] = field(default_factory=list)
     """Units no rule claimed, whether or not the scope has a bucket to draw them in."""
     new_scopes: dict[Prefix, list[Unit]] = field(default_factory=dict)
-    """Units no prefix or word claimed, by the prefix at which their position leaves every
-    prefix a rule owns. A group of two or more whose units are all new to the analysis is a
-    new scope; a group under a prefix some rule already falls back to is that rule's residue."""
+    """Units no prefix claimed, whether a word, a fallback or nothing placed them, by the
+    prefix at which their position leaves every prefix a rule owns. A group of two or more
+    whose units are all new to the analysis is a new scope; a group under a prefix some rule
+    already falls back to is that rule's residue. Why words do not exempt a unit: a new
+    directory whose names happen to carry a word some rule owns is still a new directory."""
 
     def size(self, component_id: str) -> int:
         return len(self.members.get(component_id, ()))
@@ -56,8 +58,8 @@ def replay(units: Iterable[Unit], scope: ScopeSpec, role_words: frozenset[str]) 
     bucket = scope.unplaced_rule
     for unit in units:
         component_id, how = _place(unit, primary, fallback, owner_by_term, rank, role_words)
-        if how in (FALLBACK, UNPLACED):
-            partition.new_scopes.setdefault(_divergence(unit.position, known), []).append(unit)
+        if how != PREFIX:
+            partition.new_scopes.setdefault(divergence(unit.position, known), []).append(unit)
         if component_id is None:
             partition.unplaced.append(unit)
             partition.placed_by[unit.unit_id] = UNPLACED
@@ -121,7 +123,7 @@ def _longest_match(position: Prefix, prefixes: list[tuple[Prefix, str]]) -> str 
     return best
 
 
-def _divergence(position: Prefix, known: set[Prefix]) -> Prefix:
+def divergence(position: Prefix, known: set[Prefix]) -> Prefix:
     """The first prefix of *position* that no known prefix passes through."""
     ancestors = {prefix[:length] for prefix in known for length in range(len(prefix) + 1)}
     for length in range(1, len(position) + 1):

--- a/static_analyzer/clustering/service.py
+++ b/static_analyzer/clustering/service.py
@@ -35,6 +35,8 @@ from static_analyzer.clustering.names import (
     units_from_graphs,
 )
 from static_analyzer.clustering.names.draft import UNPLACED_NAME, Links
+from static_analyzer.clustering.names.replay import divergence
+from static_analyzer.clustering.names.spec import Prefix
 from static_analyzer.clustering.names.spec import UNPLACED
 from static_analyzer.config import CALLABLE_TYPES, CLASS_TYPES
 
@@ -177,6 +179,7 @@ class ClusteringService:
         partition = replay(units, scope, role_words)
         if baseline is not None:
             partition = self._admit_new_scopes(scope, units, partition, role_words, baseline)
+            self._retire_empty_rules(scope, partition)
         result.leaf_clusters_by_language = self._leaf_clusters(graphs)
         leaf_by_unit = {
             file_path: cluster_id
@@ -240,16 +243,22 @@ class ClusteringService:
         role_words: frozenset[str],
         baseline: _Baseline,
     ) -> Partition:
-        """Append a rule for every group of new units that diverges under a prefix no rule owns.
+        """Append a rule for every group of new units that leaves the tree of the units before it.
 
-        Why all-new: a group with a unit the baseline already placed is a rule's residue, not a
-        new directory. Why prefix only: a new rule with words could re-vote an existing unit.
+        Why the tree of units and not of owned prefixes: a scope drawn from words owns no prefix
+        at all, and every unit would diverge at the first segment. Why new units only: a unit the
+        baseline already placed is a rule's residue, not a new directory. Why prefix only: a new
+        rule with words could re-vote an existing unit.
         """
         taken = baseline.component_ids(scope.scope_id)
         owned = {prefix for rule in scope.rules for prefix in rule.prefixes + rule.fallback_prefixes}
+        settled = {unit.position for unit in units if not baseline.is_new(unit)}
+        fresh: dict[Prefix, list[Unit]] = {}
+        for unit in (unit for members in partition.new_scopes.values() for unit in members if baseline.is_new(unit)):
+            fresh.setdefault(divergence(unit.position, settled), []).append(unit)
         added = False
-        for key, members in sorted(partition.new_scopes.items()):
-            if len(members) < 2 or key in owned or not all(baseline.is_new(unit) for unit in members):
+        for key, members in sorted(fresh.items()):
+            if len(members) < 2 or key in owned:
                 continue
             scope.rules.append(
                 ComponentRule(scope.next_id(taken), key[-1] if key else "New scope", prefixes=(key,), origin=NEW_SCOPE)
@@ -262,6 +271,21 @@ class ClusteringService:
             scope.rules.append(ComponentRule(scope.next_id(taken), UNPLACED_NAME, origin=UNPLACED, kind=UNPLACED))
             partition = replay(units, scope, role_words)
         return partition
+
+    def _retire_empty_rules(self, scope: ScopeSpec, partition: Partition) -> None:
+        """Drop a rule that claims nothing, and the scopes below it, so the spec matches the tree.
+
+        A fallback-only rule stays: it is the scope's last resort and legitimately empty.
+        """
+        for rule in list(scope.rules):
+            if rule.is_fallback_only or rule.kind == UNPLACED or partition.size(rule.component_id):
+                continue
+            scope.rules.remove(rule)
+            for scope_id in [
+                s for s in self.spec.scopes if s == rule.component_id or s.startswith(f"{rule.component_id}.")
+            ]:
+                del self.spec.scopes[scope_id]
+            logger.info("[Names] %s: retired %s (%s), it claims nothing", scope.scope_id, rule.component_id, rule.name)
 
     @staticmethod
     def _leaf_clusters(graphs: Mapping[str, CallGraph]) -> dict[str, ClusterResult]:

--- a/tests/static_analyzer/names/test_replay.py
+++ b/tests/static_analyzer/names/test_replay.py
@@ -111,9 +111,17 @@ class TestNewScopes:
         assert [u.unit_id for u in result.new_scopes[("Shipping",)]] == ["s0", "s1", "s2"]
         assert [u.unit_id for u in result.new_scopes[()]] == ["p"]
 
-    def test_a_unit_a_prefix_or_word_claims_is_not_a_new_scope(self):
+    def test_a_unit_a_word_claims_outside_every_prefix_is_still_a_new_scope_candidate(self):
+        """A new directory is a new directory, whatever its names happen to say."""
+        result = replay([unit("s0", "Shipping.OrderShipment.Run()")], scope(ORDER), ROLE_WORDS)
+        assert result.assignment["s0"] == "2"
+        assert [u.unit_id for u in result.new_scopes[("Shipping",)]] == ["s0"]
+
+    def test_a_unit_a_prefix_claims_is_not_a_new_scope(self):
         result = replay(
-            [unit("f", "Catalog.API.Item"), unit("g", "Shared.OrderTotals")], scope(CATALOG, ORDER, LOOSE), ROLE_WORDS
+            [unit("f", "Catalog.API.Item"), unit("g", "OrderProcessor.Totals")],
+            scope(CATALOG, ORDER, LOOSE),
+            ROLE_WORDS,
         )
         assert result.new_scopes == {}
 

--- a/tests/static_analyzer/test_clustering_service.py
+++ b/tests/static_analyzer/test_clustering_service.py
@@ -11,7 +11,7 @@ from static_analyzer.cfg import CallGraph
 from static_analyzer.cfg.edge import EdgeKind, ReferenceEdge
 from static_analyzer.clustering import ClusterGroup, ClusterScopeResult
 from static_analyzer.clustering.exceptions import IncrementalCacheMissingError
-from static_analyzer.clustering.names import TreeSpec
+from static_analyzer.clustering.names import ComponentRule, ScopeSpec, TreeSpec
 from static_analyzer.clustering.service import NEW_SCOPE, ClusteringService, hierarchy_differs, unit_links
 from static_analyzer.config import Language, NodeType
 from static_analyzer.node import Node
@@ -239,11 +239,46 @@ class TestIncrementalHierarchy(unittest.TestCase):
         self.assertEqual(bucket.qualified_names, {"Shipping.Ship"})
         self.assertEqual([rule.origin for rule in root.rules if rule.origin == NEW_SCOPE], [])
 
-    def test_a_retired_directory_leaves_no_group(self):
+    def test_a_retired_directory_leaves_no_group_and_no_rule(self):
         layout = {path: names for path, names in self.layout.items() if "Payment" not in path}
-        _, hierarchy = self._incremental(layout)
+        self.assertIn("5", self.spec.scopes, "the baseline drafted the retired component's scope")
+        service, hierarchy = self._incremental(layout)
         self.assertEqual([group.group_id for group in hierarchy.groups], ["1", "2", "3", "4"])
         self.assertTrue(hierarchy_differs(hierarchy, self.persisted))
+        self.assertIsNone(scope_of(service.spec, ROOT_SCOPE_ID).rule("5"))
+        self.assertNotIn("5", service.spec.scopes)
+
+    def test_a_new_directory_in_a_scope_drawn_from_words_is_still_a_new_component(self):
+        """No rule owns a prefix here, so the new files must be keyed by where they leave the old units."""
+        rules = [ComponentRule("1", "Sink", terms=("sink",)), ComponentRule("2", "Logger", terms=("logger",))]
+        spec = TreeSpec(scopes={ROOT_SCOPE_ID: ScopeSpec(ROOT_SCOPE_ID, rules, rung="vocabulary")})
+        old = {
+            f"src/Serilog/Core/{name}.cs": [f"Serilog.Core.{name}", f"Serilog.Core.{name}.Emit()"]
+            for name in ("FileSink", "ConsoleSink", "Logger", "LoggerConfiguration")
+        }
+        new = old | {
+            f"src/Serilog/Sampling/{name}.cs": [f"Serilog.Sampling.{name}", f"Serilog.Sampling.{name}.IsEnabled()"]
+            for name in ("LevelSampler", "SinkSampler", "LoggerSampler")
+        }
+        analysis = analysis_for(graph("csharp", new))
+        analysis.incremental_base_results = analysis_for(graph("csharp", old))
+        service = ClusteringService()
+        hierarchy = service.build_incremental_hierarchy(analysis, 1, spec, {}, REPO, REPO)
+        sampling = rule_of(scope_of(service.spec, ROOT_SCOPE_ID), "3")
+        self.assertEqual((sampling.origin, sampling.prefixes), (NEW_SCOPE, (("Serilog", "Sampling"),)))
+        self.assertEqual(len(next(group for group in hierarchy.groups if group.group_id == "3").qualified_names), 6)
+
+    def test_a_new_directory_whose_names_vote_elsewhere_is_still_a_new_component(self):
+        """Its names carry ``Order``, which the Ordering rule owns; the directory still wins."""
+        layout = self.layout | {
+            f"src/Shipping/OrderShipment{i}.cs": [f"Shipping.OrderShipment{i}", f"Shipping.OrderShipment{i}.Run()"]
+            for i in range(3)
+        }
+        service, hierarchy = self._incremental(layout)
+        shipping = next(group for group in hierarchy.groups if group.previous_component_id == "")
+        self.assertEqual(len(shipping.qualified_names), 6)
+        rule = rule_of(scope_of(service.spec, ROOT_SCOPE_ID), shipping.group_id)
+        self.assertEqual((rule.origin, rule.prefixes), (NEW_SCOPE, (("Shipping",),)))
 
     def test_a_baseline_without_a_specification_cannot_be_built_on(self):
         analysis = analysis_for(graph("csharp", self.layout))

--- a/tests/static_analyzer/test_warmstart_changed_files.py
+++ b/tests/static_analyzer/test_warmstart_changed_files.py
@@ -77,6 +77,29 @@ class TestWarmStartChangedFiles(unittest.TestCase):
         )
         self.assertEqual(passed, {inside})
 
+    @patch("static_analyzer.get_changed_files_since")
+    def test_engine_configs_of_one_language_thread_one_dict_and_absorb_once(self, mock_git) -> None:
+        """Why: a config that copies the cache hands back the nodes another config invalidated."""
+        analyzer = _analyzer_with_one_engine(self.project, changed_files={self.project / "a.py"})
+        ((config, client),) = analyzer._engine_clients
+        analyzer._engine_clients.append(
+            (EngineConfig(adapter=config.adapter, project_path=self.project / "sub"), client)
+        )
+        first, second = {"call_graph": "first"}, {"call_graph": "second"}
+        with (
+            patch("static_analyzer.update_cfg_for_changed_files", side_effect=[first, second]) as mock_update,
+            patch.object(analyzer, "_extract_language_dict", return_value={"call_graph": "cached"}) as extract,
+            patch.object(analyzer, "_absorb_into_results") as absorb,
+            patch.object(analyzer, "_collect_diagnostics_for"),
+            patch("static_analyzer.track_lsp_result"),
+        ):
+            analyzer._update_cached_results(self.cached, cached_sha="deadbeef")
+        mock_git.assert_not_called()
+        extract.assert_called_once()
+        self.assertIs(mock_update.call_args_list[1].args[0], first)
+        absorb.assert_called_once()
+        self.assertIs(absorb.call_args.args[2], second)
+
     @patch("static_analyzer.update_cfg_for_changed_files", return_value={})
     @patch("static_analyzer.get_changed_files_since", return_value={Path("/proj/x.py")})
     def test_none_falls_back_to_git(self, mock_git, mock_update) -> None:


### PR DESCRIPTION
Follow-up to #553, from the incremental study in CodeBoarding-tests#33 (`shape-study/incremental/`): one change set per repository with an addition, a deletion and a modification at once (eShop: a new `ShippingProcessor` project, `WebhookClient` deleted, Basket publishing to the event bus; serilog: a new `Sampling` directory, `Settings` deleted, the logger calling into formatting; mem0: a new plugin cloned from `openclaw`, `vercel-ai-sdk` deleted, a new helper called from `memory/main.py`), run on both engine arms (**both deterministic**: kinship = #552, affinity = #553; the LLM planner was not used) and diffed component by component. Collateral (components touched without holding a changed file) was **0 in all six runs**; unchanged components were byte-identical. Three defects were found and are fixed here.

## 1. Deleted and modified files survived when a language has more than one engine config

eShop's C# has two engine configs (the solution and `src/ClientApp`). `_update_cached_results` handed each config its own copy of the language's cached graph, invalidated only the changed files under that config's root, and merged the results: the second config's untouched copy put every node the first had deleted or re-analysed back. On eShop the deleted `WebhookClient` project reappeared in `analysis.json` with all 11 files while `fingerprint.json` no longer listed them, and DELETE, single-child absorption and the spec reroot never ran. Now one dict per language is threaded through its configs and absorbed once. Re-run on the same change set: 11 deleted files dropped, `WebhookClient` retired, scope 6 absorbs its remaining child, the spec is rerooted, and the diff shows exactly the expected set.

## 2. A new directory whose names carried a word an existing rule owned was never a new scope

Replay tries prefixes, then a weighted word vote, then fallbacks; only fallback-caught and unplaced units were reported as new-scope candidates. serilog's kinship root is drawn from words (`Sink`, `Logger`, …), so three of the four new `Sampling` files were voted into `Core` by `IsEnabled(LogEvent)` and the fourth stayed unplaced: no component. eShop was one unit from the same failure (4 of 5 ShippingProcessor units vote `order`). Now every unit no prefix claims is a candidate, and the service keys the new units by where they leave the tree of the units the baseline knew rather than the tree of owned prefixes (a scope drawn from words owns no prefix at all, so everything diverged at `Serilog`). A new directory of two or more new files is a new component whatever its names say.

## 3. A rule that claimed nothing stayed in the spec after its component was deleted

serilog deleted component `6 Pair` (its files went with `Settings`) and `8 Settings`, but the rules stayed in `tree_spec`, ready to re-claim units later while the tree no longer had the component. A rule with no members is now retired from the spec with the scopes below it; fallback-only rules stay, they are legitimately empty; a directory that comes back is a new scope with a fresh id.

Also: `[ScopePlan]` now logs every operation it emits (action, id, rationale); the study could not attribute the extra root operations from the count alone.

## Re-run of the two failing cases on this branch (`shape-study/incremental/runs-fixed/`)

| repo × arm | result | collateral |
|---|---|---|
| eShop × affinity | 11 deleted files dropped; `ShippingProcessor` created with 6 units; `WebhookClient` retired, scope 6 absorbs its remaining child, spec rerooted; 35 of 40 components unchanged | 0 |
| serilog × kinship | `Sampling` created with all 4 files; `Settings` deleted and `Pair` retired from the spec; 10 of 13 unchanged | 0 |

## Not fixed, recorded in the study

- A modification can move a word-placed file (serilog: dropping the `KeyValuePairs` overloads moved `LoggerSettingsConfiguration` from `Pair` to `Logger`). Correct by the rules; membership of word-placed files depends on method naming.
- The intended Basket → EventBus edge was not extracted (interface-member call, C# adapter), so the kinship arm's LLM dropped the baseline Basket → EventBus relation. Relation quality after a modification is bounded by edge extraction.
- The affinity root stores the global relation list and re-resolves it by name on every incremental run (~48 "Dropping relation" lines, harmless).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved incremental analysis when multiple configurations share a language, preventing outdated or deleted results from being restored.
  - New directories are now correctly recognized as new components, including when names match existing terms.
  - Empty component rules are retired while fallback-only rules remain available.
  - Scope planning now records operation actions, affected components, and rationales.

- **Documentation**
  - Clarified incremental-run behavior for new and retired components, including fallback-only rules.

- **Tests**
  - Added coverage for new-component detection, retired components, and multi-configuration warm starts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->