### PR TITLE
fix(clustering): the review round over the shape, planner and incremental PRs

### DIFF
--- a/agents/tree_planner_agent.py
+++ b/agents/tree_planner_agent.py
@@ -6,13 +6,15 @@ import re
 from collections import Counter
 from collections.abc import Sequence
 from concurrent.futures import ThreadPoolExecutor
+from contextvars import copy_context
 from pathlib import Path
 
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import HumanMessage, SystemMessage
 from langchain_core.prompts import PromptTemplate
 
-from agents.agent import CodeBoardingAgent
+from agents.agent import CodeBoardingAgent, _raise_if_auth_error
+from agents.llm_errors import LLMAuthError
 from agents.agent_responses import PlannedGroup, TreePlanInsights
 from agents.llm_config import MONITORING_CALLBACK, supports_json_mode
 from agents.prompts import get_tree_plan_message
@@ -101,16 +103,25 @@ class TreePlannerAgent(CodeBoardingAgent):
 
     def _draw(self, prompt: str, labelled: dict[str, CandidateGroup]) -> list[TreePlanInsights]:
         """``draws`` answers to one prompt, drawn concurrently; a draw that fails is dropped."""
-        with ThreadPoolExecutor(max_workers=self.draws) as pool:
-            futures = [pool.submit(self._ask, prompt, labelled) for _ in range(self.draws)]
-            answers = []
+        # Not ``with``: its ``__exit__`` waits for a stalled draw; a copied context carries the
+        # monitoring step into each worker.
+        pool = ThreadPoolExecutor(max_workers=self.draws)
+        answers: list[TreePlanInsights] = []
+        failures: list[Exception] = []
+        try:
+            futures = [pool.submit(copy_context().run, self._ask, prompt, labelled) for _ in range(self.draws)]
             for future in futures:
                 try:
                     answers.append(future.result(timeout=DRAW_TIMEOUT_SECONDS))
+                except LLMAuthError:
+                    raise
                 except Exception as exc:
+                    failures.append(exc)
                     logger.warning("[Planner] draw failed: %s", exc)
+        finally:
+            pool.shutdown(wait=False, cancel_futures=True)
         if not answers:
-            raise RuntimeError("the planner got no answer from the model")
+            raise RuntimeError("the planner got no answer from the model") from failures[-1]
         return answers
 
     def _ask(self, prompt: str, labelled: dict[str, CandidateGroup]) -> TreePlanInsights:
@@ -123,7 +134,8 @@ class TreePlannerAgent(CodeBoardingAgent):
             insights = self._read(text, labelled)
             return insights if insights is not None else self._parse_response(prompt, text, TreePlanInsights)
 
-        def classify(_exc: Exception, attempt: int) -> RetryDecision:
+        def classify(exc: Exception, attempt: int) -> RetryDecision:
+            _raise_if_auth_error(exc)
             return RetryDecision(
                 action=RetryAction.RETRY, backoff_s=default_backoff(attempt, initial_s=10.0, multiplier=2.0, max_s=60.0)
             )
@@ -205,14 +217,17 @@ class TreePlannerAgent(CodeBoardingAgent):
             if members:
                 taken.update(members)
                 members_of.append((planned, members))
-        stems_of = [_stems(labelled, members, context) for _, members in members_of]
+        stems_of = {label: _stems(labelled, [label], context) for label in labelled}
         folded: list[CandidateGroup] = []
-        for index, (planned, members) in enumerate(members_of):
-            elsewhere = set().union(*(stems for other, stems in enumerate(stems_of) if other != index))
+        for planned, members in members_of:
+            # Exclusive against every label, the forgotten ones included: a word shared with a
+            # box the model left alone would still move that box's files.
+            own = set().union(*(stems_of[label] for label in members))
+            elsewhere = set().union(*(stems_of[label] for label in labelled if label not in members))
             owns = [
                 word
                 for word in dict.fromkeys(word.strip().casefold() for word in planned.owns)
-                if tokenize(word) == (word,) and stem(word) == word and word in stems_of[index] - elsewhere
+                if tokenize(word) == (word,) and stem(word) == word and word in own - elsewhere
             ][:MAX_OWNS]
             folded.append(
                 CandidateGroup(

--- a/agents/tree_planner_agent.py
+++ b/agents/tree_planner_agent.py
@@ -63,8 +63,12 @@ class TreePlannerAgent(CodeBoardingAgent):
         )
         self.draws = draws
         self._kinship = KinshipGrouper()
+        # The request itself is bounded, not only the wait for it: an abandoned draw thread must
+        # not hold a connection open past the scope's deadline.
         self._model = (
-            agent_llm.bind(response_format={"type": "json_object"}) if supports_json_mode(agent_llm) else agent_llm
+            agent_llm.bind(response_format={"type": "json_object"}, timeout=DRAW_TIMEOUT_SECONDS)
+            if supports_json_mode(agent_llm)
+            else agent_llm
         )
 
     @trace

--- a/diagram_analysis/diagram_generator.py
+++ b/diagram_analysis/diagram_generator.py
@@ -1112,28 +1112,14 @@ class DiagramGenerator:
     def _build_component_scope(self, component: Component, hierarchy_depth: int) -> ClusterScopeResult:
         """Precompute an exact hierarchy rooted at one persisted component ID."""
         assert self.static_analysis is not None
-        member_keys = {
-            (normalize_repo_path(file_path, self.repo_location), qualified_name)
-            for file_path, qualified_name in _member_keys(component)
-        }
-        graphs: dict[str, CallGraph] = {}
-        for language, graph in self.static_analysis.available_cfgs().items():
-            owned_names = {
-                qualified_name
-                for qualified_name, node in graph.nodes.items()
-                if (normalize_repo_path(node.file_path, self.repo_location), qualified_name) in member_keys
-            }
-            if not owned_names:
-                continue
-            scoped_graph = graph.filter_by_nodes(owned_names)
-            if scoped_graph.nodes:
-                graphs[language] = scoped_graph
+        graphs = self.static_analysis.available_cfgs()
         if not graphs:
             raise ClusteringScopeUnavailableError(component.component_id, "no owned CFG nodes")
-
         remaining_depth = max(1, hierarchy_depth - _component_depth(component.component_id))
         assert self.tree_spec is not None
         service = ClusteringService(self._grouper())
+        # The service replays the specification from the root down to this component, so the
+        # scope holds the units a full run placed in it, data-only files included.
         scope = service.build_scope_hierarchy(graphs, remaining_depth, component.component_id, self.tree_spec)
         self.tree_spec = service.spec
         if not scope.groups:

--- a/docs/design/name-tree.md
+++ b/docs/design/name-tree.md
@@ -189,11 +189,14 @@ clustering. Per scope, walking the tree top-down:
    UPDATE only where members or bodies changed, and nothing else moves. Measured: 0.00%
    of unchanged files move across 27 repositories and four edit types.
 2. **New components.** Every unit that no prefix claims, whether a word vote, a fallback
-   rule or nothing placed it, is reported in `Partition.new_scopes` under the prefix at
+   rule or nothing placed it (an empty catch-all prefix does not count), is reported in
+   `Partition.new_scopes` under the prefix at
    which its position first leaves every prefix a rule owns: a new top-level directory
    diverges at that directory; a new file deep inside a known one is claimed by its
-   ancestor's rule and never gets here. A group of ≥ 2 units whose members are all new to
-   the analysis (absent from the baseline membership) becomes a new rule appended to the
+   ancestor's rule and never gets here. A group of ≥ 2 new units (absent from the
+   baseline's graph), keyed by the prefix at which they leave the tree of the baseline's
+   units (a scope drawn from words owns no prefix, and a directory whose every file was
+   replaced is not new), becomes a new rule appended to the
    scope, prefix only and without words so no existing unit can be re-voted, with a fresh id
    above every id the scope has ever used; the scope plan then emits CREATE and the
    incremental agent names it. A group that also holds units the baseline knew is a rule's

--- a/static_analyzer/clustering/names/draft.py
+++ b/static_analyzer/clustering/names/draft.py
@@ -1,13 +1,4 @@
-"""The ladder: how a scope's rules are drafted one rung at a time, and where it stops.
-
-The root reads the frontier of its trie, then its units' words if that gave one box. A
-component splits back into the candidates that were grouped into it; from ``NEST_FLOOR``
-units it goes on to the frontier of its own sub-trie, and above ``LEAF_CAP`` it also draws a
-layered sub-tree layer by layer and then reads its units' words. A rung counts when at least
-two children each clear the guard; a scope no rung can split is a leaf that says why. Every
-rung is candidates in, rules out: ``replay`` places the units, at draft time as on every
-later run.
-"""
+"""The ladder: a scope's rules drafted one rung at a time, the grouper its one judgement."""
 
 from __future__ import annotations
 
@@ -161,6 +152,7 @@ class AffinityGrouper:
             for other in range(len(members)):
                 links[target][other] += links[source][other]
                 links[other][target] += links[other][source]
+                links[source][other] = links[other][source] = 0
             links[target][target] = 0
             members[source] = []
         by_key = {candidate.key: candidate for candidate in candidates}
@@ -194,6 +186,13 @@ class AffinityGrouper:
             if best is not None:
                 return source, -best[2]
         return None
+
+
+DETERMINISTIC_GROUPERS: dict[str, type[Grouper]] = {
+    KinshipGrouper.name: KinshipGrouper,
+    AffinityGrouper.name: AffinityGrouper,
+}
+"""The groupers a run can construct without a model, by the name a specification records."""
 
 
 def candidate_name(candidate: Candidate) -> str:
@@ -421,9 +420,11 @@ def _rules_from_groups(groups: list[CandidateGroup], candidates: Sequence[Candid
     missing = sorted(set(by_key) - set(seen))
     unknown = sorted(set(seen) - set(by_key))
     repeated = sorted(key for key, count in seen.items() if count > 1)
-    if missing or unknown or repeated:
+    empty = [group.name for group in groups if not group.keys]
+    if missing or unknown or repeated or empty:
         raise ValueError(
-            f"grouping must cover every candidate once: missing={missing} unknown={unknown} repeated={repeated}"
+            "grouping must cover every candidate once and name no empty group: "
+            f"missing={missing} unknown={unknown} repeated={repeated} empty={empty}"
         )
     rules: list[ComponentRule] = []
     for group in groups:

--- a/static_analyzer/clustering/names/frontier.py
+++ b/static_analyzer/clustering/names/frontier.py
@@ -95,8 +95,9 @@ def _visit(
         return
     ubiquitous = ubiquitous_words(name for name, _ in children)
     stepped = {name for name, child in children if _stepped_through(name, child, node)}
-    role_units = sum(child.count for name, child in children if is_role_named(name, role_words, ubiquitous))
-    if not stepped and len(children) >= MIN_LAYERS and node.count and role_units / node.count >= ROLE_SHARE:
+    layers = [child for name, child in children if is_role_named(name, role_words, ubiquitous)]
+    role_units = sum(layer.count for layer in layers)
+    if not stepped and len(layers) >= MIN_LAYERS and node.count and role_units / node.count >= ROLE_SHARE:
         _layered(node, ubiquitous, role_words, out, transpose, top=top)
         return
     if top:
@@ -116,17 +117,17 @@ def _visit(
             continue
         child_names = sorted(child.children)
         child_ubiquitous = ubiquitous_words(child_names)
-        child_role_units = sum(
-            grandchild.count
+        child_layers = [
+            grandchild
             for grandchild_name, grandchild in child.children.items()
             if is_role_named(grandchild_name, role_words, child_ubiquitous)
-        )
-        child_role_share = child_role_units / child.count if child.count else 1.0
+        ]
+        child_role_share = sum(layer.count for layer in child_layers) / child.count if child.count else 1.0
         dominant = total > 0 and child.count / total >= share
         if dominant and child_names and child_role_share < ROLE_SHARE:
             out.notes.append(f"opened {_dotted(child.path)} ({child.count} units)")
             _visit(child, total, role_words, share, out, transpose)
-        elif dominant and len(child_names) >= MIN_LAYERS and child_role_share >= ROLE_SHARE:
+        elif dominant and len(child_layers) >= MIN_LAYERS and child_role_share >= ROLE_SHARE:
             _layered(child, child_ubiquitous, role_words, out, transpose)
         else:
             out.candidates.append(_box(child))
@@ -153,7 +154,14 @@ def _layered(
     """A node whose children are layers: transpose onto the features recurring under two of
     them, else draw the layers, the only structure there is."""
     layers = sorted(node.children.items())
-    ubiquitous = ubiquitous | ubiquitous_words(name for _, layer in layers for name in layer.children)
+    while True:
+        # The product's name may sit on the feature directories themselves, behind the layers'
+        # role-named containers; widen until no more of them read as ubiquitous.
+        found = [name for _, layer in layers for name, _ in _feature_directories(layer, role_words, ubiquitous)]
+        widened = ubiquitous | ubiquitous_words(found)
+        if widened == ubiquitous:
+            break
+        ubiquitous = widened
     layers_by_feature: dict[str, set[str]] = {}
     display: dict[str, str] = {}
     for layer_name, layer in layers:
@@ -183,7 +191,10 @@ def _layered(
     out.notes.append(f"transposed {_dotted(node.path) or '<root>'} onto {', '.join(features)}")
     prefixes_by_feature: dict[str, list[Prefix]] = {feature: [] for feature in features}
     for _, layer in layers:
-        _collect_feature_prefixes(layer, set(features), role_words, ubiquitous, prefixes_by_feature)
+        for name, child in _feature_directories(layer, role_words, ubiquitous):
+            feature = _feature_stem(name, role_words, ubiquitous)
+            if feature in prefixes_by_feature:
+                prefixes_by_feature[feature].append(child.path)
     for feature in features:
         out.candidates.append(
             Candidate(
@@ -210,7 +221,11 @@ def _layered(
 def _feature_directories(
     node: TrieNode, role_words: frozenset[str], ubiquitous: frozenset[str]
 ) -> list[tuple[str, TrieNode]]:
-    """The shallowest feature-named directories under a layer, looking through its role-named ones."""
+    """The shallowest feature-named directories under a layer, looking through its role-named ones.
+
+    Why the walk stops there: a feature nested inside another (``Billing.Orders``) belongs to the
+    outer one, whatever the inner name recurs with elsewhere.
+    """
     found: list[tuple[str, TrieNode]] = []
     for name, child in sorted(node.children.items()):
         if is_role_named(name, role_words, ubiquitous):
@@ -218,22 +233,6 @@ def _feature_directories(
         else:
             found.append((name, child))
     return found
-
-
-def _collect_feature_prefixes(
-    node: TrieNode,
-    features: set[str],
-    role_words: frozenset[str],
-    ubiquitous: frozenset[str],
-    prefixes_by_feature: dict[str, list[Prefix]],
-) -> None:
-    """The shallowest node under a layer whose first word is a feature keys its subtree."""
-    for name, child in sorted(node.children.items()):
-        feature = _feature_stem(name, role_words, ubiquitous)
-        if not is_role_named(name, role_words, ubiquitous) and feature in features:
-            prefixes_by_feature[feature].append(child.path)
-            continue
-        _collect_feature_prefixes(child, features, role_words, ubiquitous, prefixes_by_feature)
 
 
 def _box(node: TrieNode) -> Candidate:

--- a/static_analyzer/clustering/names/replay.py
+++ b/static_analyzer/clustering/names/replay.py
@@ -34,7 +34,7 @@ class Partition:
     unplaced: list[Unit] = field(default_factory=list)
     """Units no rule claimed, whether or not the scope has a bucket to draw them in."""
     new_scopes: dict[Prefix, list[Unit]] = field(default_factory=dict)
-    """Units no prefix claimed, whether a word, a fallback or nothing placed them, by the
+    """Units no named prefix claimed, whether a word, a fallback or nothing placed them, by the
     prefix at which their position leaves every prefix a rule owns. A group of two or more
     whose units are all new to the analysis is a new scope; a group under a prefix some rule
     already falls back to is that rule's residue. Why words do not exempt a unit: a new
@@ -54,11 +54,14 @@ def replay(units: Iterable[Unit], scope: ScopeSpec, role_words: frozenset[str]) 
     for rule in components:
         for term in rule.terms:
             owner_by_term.setdefault(term, rule.component_id)
-    known = {prefix for prefix, _ in primary}
+    # An empty prefix (a root drawn as one box) claims every position; it must not hide the
+    # directories added after it, so only a named prefix settles a unit.
+    named = [(prefix, component_id) for prefix, component_id in primary if prefix]
+    known = {prefix for prefix, _ in named}
     bucket = scope.unplaced_rule
     for unit in units:
         component_id, how = _place(unit, primary, fallback, owner_by_term, rank, role_words)
-        if how != PREFIX:
+        if how != PREFIX or _longest_match(unit.position, named) is None:
             partition.new_scopes.setdefault(divergence(unit.position, known), []).append(unit)
         if component_id is None:
             partition.unplaced.append(unit)

--- a/static_analyzer/clustering/names/spec.py
+++ b/static_analyzer/clustering/names/spec.py
@@ -124,7 +124,8 @@ class ScopeSpec:
         )
 
 
-SPEC_VERSION = 1
+SPEC_VERSION = 2
+"""2: ``last_id`` per scope; a spec without it cannot keep a retired id from being reissued."""
 
 
 @dataclass

--- a/static_analyzer/clustering/names/spec.py
+++ b/static_analyzer/clustering/names/spec.py
@@ -77,6 +77,8 @@ class ScopeSpec:
     axis: str = ""
     rung: str = ""
     leaf_reason: str = ""
+    last_id: int = 0
+    """The highest local id this scope ever allocated, so a retired component's id is never reissued."""
 
     @property
     def is_leaf(self) -> bool:
@@ -98,14 +100,15 @@ class ScopeSpec:
         prefix = CodeBoardingClusterIds.prefix_for_scope(self.scope_id)
         used = {rule.component_id for rule in self.rules} | set(taken)
         local = [component_id.rpartition(".")[2] for component_id in used]
-        index = max((int(part) for part in local if part.isdigit()), default=0) + 1
-        return CodeBoardingClusterIds.qualify_local_id(str(index), prefix)
+        self.last_id = max(self.last_id, max((int(part) for part in local if part.isdigit()), default=0)) + 1
+        return CodeBoardingClusterIds.qualify_local_id(str(self.last_id), prefix)
 
     def to_dict(self) -> dict[str, Any]:
         return {
             "axis": self.axis,
             "rung": self.rung,
             "leaf_reason": self.leaf_reason,
+            "last_id": self.last_id,
             "rules": [rule.to_dict() for rule in self.rules],
         }
 
@@ -117,6 +120,7 @@ class ScopeSpec:
             axis=str(raw.get("axis", "")),
             rung=str(raw.get("rung", "")),
             leaf_reason=str(raw.get("leaf_reason", "")),
+            last_id=int(raw.get("last_id", 0)),
         )
 
 
@@ -155,6 +159,10 @@ class TreeSpec:
 
             scopes: dict[ScopeId, ScopeSpec] = {}
             for scope_id, scope in self.scopes.items():
+                under_parent = scope_id.startswith(f"{parent_id}.") if parent_id else scope_id != ROOT_SCOPE_ID
+                if under_parent and not scope_id.startswith(prefix):
+                    # A retired sibling of the absorbed child: its id may be reissued, so its scope must go.
+                    continue
                 scope.scope_id = moved(scope_id)
                 scope.rules = [replace(rule, component_id=moved(rule.component_id)) for rule in scope.rules]
                 scopes[scope.scope_id] = scope
@@ -165,6 +173,7 @@ class TreeSpec:
                 child.axis,
                 child.rung,
                 child.leaf_reason,
+                child.last_id,
             )
             self.scopes = scopes
 

--- a/static_analyzer/clustering/service.py
+++ b/static_analyzer/clustering/service.py
@@ -12,7 +12,7 @@ from repo_utils.path_utils import normalize_repo_path
 from static_analyzer.analysis_result import StaticAnalysisResults
 from static_analyzer.cfg import CallGraph
 from static_analyzer.cfg.edge import EdgeKind
-from static_analyzer.clustering.exceptions import IncrementalCacheMissingError
+from static_analyzer.clustering.exceptions import IncrementalCacheMissingError, PlannerUnavailableError
 from static_analyzer.clustering.models import (
     ClusterConnectionEdge,
     ClusterGroup,
@@ -36,7 +36,7 @@ from static_analyzer.clustering.names import (
 )
 from static_analyzer.clustering.names.draft import DETERMINISTIC_GROUPERS, UNPLACED_NAME, Links
 from static_analyzer.clustering.names.replay import divergence
-from static_analyzer.clustering.names.spec import Prefix
+from static_analyzer.clustering.names.spec import Prefix, is_root
 from static_analyzer.clustering.names.spec import UNPLACED
 from static_analyzer.config import CALLABLE_TYPES, CLASS_TYPES
 
@@ -103,6 +103,7 @@ class ClusteringService:
         self.grouper: Grouper = grouper if grouper is not None else AffinityGrouper()
         self.spec = TreeSpec(grouper=self.grouper.name)
         self._links: Links = {}
+        self._baseline: _Baseline | None = None
 
     def build_full_hierarchy(self, static_analysis: StaticAnalysisResults, max_depth: int) -> ClusterScopeResult:
         """Draft the specification from every language's names and materialize the tree."""
@@ -132,19 +133,11 @@ class ClusteringService:
             raise IncrementalCacheMissingError(artifact_dir, "the baseline carries no tree specification")
         if graphs and not base.available_cfgs():
             raise IncrementalCacheMissingError(artifact_dir, "the baseline static analysis carries no call graph")
-        self.spec = spec
-        if spec.grouper in DETERMINISTIC_GROUPERS:
-            self.grouper = DETERMINISTIC_GROUPERS[spec.grouper]()
-        elif spec.grouper:
-            logger.warning(
-                "[Names] the baseline was drawn by the %s grouper, which needs a model; a scope it never reached "
-                "is drafted by %s on this run",
-                spec.grouper,
-                self.grouper.name,
-            )
+        self._adopt(spec)
         units = units_from_graphs(graphs)
         self._links = unit_links(graphs)
         baseline = _Baseline(persisted_scopes, repo_dir, units_from_graphs(base.available_cfgs()))
+        self._baseline = baseline
         hierarchy = self._materialize(graphs, units, ROOT_SCOPE_ID, 1, max_depth, baseline=baseline)
         hierarchy.index_hierarchy()
         return hierarchy
@@ -163,8 +156,13 @@ class ClusteringService:
         """
         if max_depth < 1:
             raise ValueError("max_depth must be at least 1")
-        self.spec = spec
-        units = units_from_graphs(graphs)
+        self._adopt(spec)
+        role_words = role_words_for(spec.machinery)
+        units = self._scope_units(units_from_graphs(graphs), root_scope_id, role_words)
+        if not is_root(root_scope_id):
+            # The scope's own graphs, induced by the files its ancestors' replay placed in it, so a
+            # partial run sees the units a full run would have handed it, data-only files included.
+            graphs = self._induced_graphs(units, graphs)
         self._links = unit_links(graphs)
         hierarchy = self._materialize(graphs, units, root_scope_id, 1, max_depth)
         hierarchy.index_hierarchy()
@@ -225,11 +223,33 @@ class ClusteringService:
             )
         return result
 
+    def _adopt(self, spec: TreeSpec) -> None:
+        """Replay ``spec`` with the grouper that drew it, so a scope it never reached is drafted the same way."""
+        self.spec = spec
+        if spec.grouper in DETERMINISTIC_GROUPERS:
+            self.grouper = DETERMINISTIC_GROUPERS[spec.grouper]()
+
+    def _scope_units(self, units: list[Unit], scope_id: ScopeId, role_words: frozenset[str]) -> list[Unit]:
+        """The units a scope holds: every unit at the root, else its rule's members in the parent's replay."""
+        if is_root(scope_id):
+            return units
+        parent_id = scope_id.rpartition(".")[0] or ROOT_SCOPE_ID
+        parent = self.spec.scope(parent_id)
+        if parent is None:
+            return []
+        return replay(self._scope_units(units, parent_id, role_words), parent, role_words).members.get(scope_id, [])
+
     def _scope_rules(self, scope_id: ScopeId, units: list[Unit]) -> ScopeSpec:
         """The scope's rules from the specification, drafted now if it was never reached."""
         scope = self.spec.scope(scope_id)
         if scope is not None:
             return scope
+        if self.spec.grouper and self.spec.grouper != self.grouper.name:
+            # No silent fallback: a scope the planner never drew must not be drawn by another grouper.
+            raise PlannerUnavailableError(
+                f"scope {scope_id} was never drafted and the baseline was drawn by the {self.spec.grouper} grouper; "
+                "run a full analysis"
+            )
         parts: tuple[ComponentRule, ...] = ()
         parent_id = scope_id.rpartition(".")[0] or ROOT_SCOPE_ID
         parent = self.spec.scope(parent_id) if scope_id != ROOT_SCOPE_ID else None
@@ -250,18 +270,20 @@ class ClusteringService:
         role_words: frozenset[str],
         baseline: _Baseline,
     ) -> Partition:
-        """Append a rule for every group of new units that leaves the tree of the baseline's units.
+        """Append a rule for every group of new units that leaves the tree of the baseline's units in this scope.
 
-        Why the baseline's tree and not the owned prefixes or the live units: a scope drawn from
-        words owns no prefix at all, and a directory whose every file was replaced in one update
-        is not a new directory. Why new units only: a unit the baseline already placed is a rule's
-        residue. Why prefix only: a new rule with words could re-vote an existing unit.
+        Why the baseline's tree, of this scope only: a scope drawn from words owns no prefix at
+        all; a directory whose every file was replaced in one update is not a new directory; and
+        a sibling's directories must not decide where this scope's new files diverge. Why new
+        units only: a unit the baseline already placed is a rule's residue. Why prefix only: a
+        new rule with words could re-vote an existing unit.
         """
         taken = baseline.component_ids(scope.scope_id)
         owned = {prefix for rule in scope.rules for prefix in rule.prefixes + rule.fallback_prefixes}
+        settled = {unit.position for unit in self._scope_units(baseline.units, scope.scope_id, role_words)}
         fresh: dict[Prefix, list[Unit]] = {}
         for unit in (unit for members in partition.new_scopes.values() for unit in members if baseline.is_new(unit)):
-            fresh.setdefault(divergence(unit.position, baseline.positions), []).append(unit)
+            fresh.setdefault(divergence(unit.position, settled), []).append(unit)
         added = False
         for key, members in sorted(fresh.items()):
             if len(members) < 2 or key in owned:
@@ -375,10 +397,9 @@ class _Baseline:
             scope_id: frozenset(component.component_id for component in scope.components if component.component_id)
             for scope_id, scope in persisted_scopes.items()
         }
-        units = list(units)
-        self._files = {normalize_repo_path(unit.unit_id, repo_dir) for unit in units}
-        self.positions = {unit.position for unit in units}
-        """Where the baseline's units sat: the tree a new directory must leave to be one."""
+        self.units = list(units)
+        """The baseline's units, for the tree a new directory must leave to be one."""
+        self._files = {normalize_repo_path(unit.unit_id, repo_dir) for unit in self.units}
 
     def component_ids(self, scope_id: ScopeId) -> frozenset[ComponentId]:
         return self._ids_by_scope.get(scope_id, frozenset())

--- a/static_analyzer/clustering/service.py
+++ b/static_analyzer/clustering/service.py
@@ -34,7 +34,7 @@ from static_analyzer.clustering.names import (
     role_words_for,
     units_from_graphs,
 )
-from static_analyzer.clustering.names.draft import UNPLACED_NAME, Links
+from static_analyzer.clustering.names.draft import DETERMINISTIC_GROUPERS, UNPLACED_NAME, Links
 from static_analyzer.clustering.names.replay import divergence
 from static_analyzer.clustering.names.spec import Prefix
 from static_analyzer.clustering.names.spec import UNPLACED
@@ -125,17 +125,26 @@ class ClusteringService:
     ) -> ClusterScopeResult:
         """Replay ``spec`` over the live names; a new scope becomes a new rule, nothing else moves."""
         base = static_analysis.incremental_base_results
+        graphs = static_analysis.available_cfgs()
         if base is None:
             raise IncrementalCacheMissingError(artifact_dir)
         if spec.scope(ROOT_SCOPE_ID) is None:
             raise IncrementalCacheMissingError(artifact_dir, "the baseline carries no tree specification")
+        if graphs and not base.available_cfgs():
+            raise IncrementalCacheMissingError(artifact_dir, "the baseline static analysis carries no call graph")
         self.spec = spec
-        graphs = static_analysis.available_cfgs()
+        if spec.grouper in DETERMINISTIC_GROUPERS:
+            self.grouper = DETERMINISTIC_GROUPERS[spec.grouper]()
+        elif spec.grouper:
+            logger.warning(
+                "[Names] the baseline was drawn by the %s grouper, which needs a model; a scope it never reached "
+                "is drafted by %s on this run",
+                spec.grouper,
+                self.grouper.name,
+            )
         units = units_from_graphs(graphs)
         self._links = unit_links(graphs)
-        baseline = _Baseline(
-            persisted_scopes, repo_dir, [unit.unit_id for unit in units_from_graphs(base.available_cfgs())]
-        )
+        baseline = _Baseline(persisted_scopes, repo_dir, units_from_graphs(base.available_cfgs()))
         hierarchy = self._materialize(graphs, units, ROOT_SCOPE_ID, 1, max_depth, baseline=baseline)
         hierarchy.index_hierarchy()
         return hierarchy
@@ -205,9 +214,7 @@ class ClusteringService:
             result.groups.append(group)
         result.connections = self._build_connections(graphs, result.groups)
         for group in result.groups:
-            # The child scope reads its own graphs: the members' files, so a file that only
-            # declares data voted above but is nobody's member below.
-            child_graphs = self._induced_graphs(group, graphs)
+            child_graphs = self._induced_graphs(partition.members.get(group.group_id, []), graphs)
             child_units = units_from_graphs(child_graphs)
             child = self._scope_rules(group.group_id, child_units)
             group.expandable = not child.is_leaf and bool(child_units)
@@ -243,19 +250,18 @@ class ClusteringService:
         role_words: frozenset[str],
         baseline: _Baseline,
     ) -> Partition:
-        """Append a rule for every group of new units that leaves the tree of the units before it.
+        """Append a rule for every group of new units that leaves the tree of the baseline's units.
 
-        Why the tree of units and not of owned prefixes: a scope drawn from words owns no prefix
-        at all, and every unit would diverge at the first segment. Why new units only: a unit the
-        baseline already placed is a rule's residue, not a new directory. Why prefix only: a new
-        rule with words could re-vote an existing unit.
+        Why the baseline's tree and not the owned prefixes or the live units: a scope drawn from
+        words owns no prefix at all, and a directory whose every file was replaced in one update
+        is not a new directory. Why new units only: a unit the baseline already placed is a rule's
+        residue. Why prefix only: a new rule with words could re-vote an existing unit.
         """
         taken = baseline.component_ids(scope.scope_id)
         owned = {prefix for rule in scope.rules for prefix in rule.prefixes + rule.fallback_prefixes}
-        settled = {unit.position for unit in units if not baseline.is_new(unit)}
         fresh: dict[Prefix, list[Unit]] = {}
         for unit in (unit for members in partition.new_scopes.values() for unit in members if baseline.is_new(unit)):
-            fresh.setdefault(divergence(unit.position, settled), []).append(unit)
+            fresh.setdefault(divergence(unit.position, baseline.positions), []).append(unit)
         added = False
         for key, members in sorted(fresh.items()):
             if len(members) < 2 or key in owned:
@@ -309,16 +315,18 @@ class ClusteringService:
         return leaves
 
     @staticmethod
-    def _induced_graphs(group: ClusterGroup, graphs: Mapping[str, CallGraph]) -> dict[str, CallGraph]:
-        """The exact per-language subgraphs owned by ``group``."""
+    def _induced_graphs(members: Iterable[Unit], graphs: Mapping[str, CallGraph]) -> dict[str, CallGraph]:
+        """The per-language subgraphs of the members' files, every declaration included.
+
+        Why files and not the agents' symbol members: the child scope was drafted over the units
+        its parent placed, data-only files among them, and must replay over the same.
+        """
+        files = {(unit.language, unit.unit_id) for unit in members}
         child_graphs: dict[str, CallGraph] = {}
         for language, graph in graphs.items():
-            members = group.symbol_members_by_language.get(language, set())
-            if not members:
-                continue
-            child = graph.filter_by_nodes(members)
-            if child.nodes:
-                child_graphs[language] = child
+            names = {name for name, node in graph.nodes.items() if (language, node.file_path) in files}
+            if names:
+                child_graphs[language] = graph.filter_by_nodes(names)
         return child_graphs
 
     @staticmethod
@@ -361,13 +369,16 @@ class _Baseline:
     ``file_methods`` and would look new on every run.
     """
 
-    def __init__(self, persisted_scopes: Mapping[ScopeId, Any], repo_dir: Path, files: Iterable[str]) -> None:
+    def __init__(self, persisted_scopes: Mapping[ScopeId, Any], repo_dir: Path, units: Iterable[Unit]) -> None:
         self._repo_dir = repo_dir
         self._ids_by_scope = {
             scope_id: frozenset(component.component_id for component in scope.components if component.component_id)
             for scope_id, scope in persisted_scopes.items()
         }
-        self._files = {normalize_repo_path(path, repo_dir) for path in files}
+        units = list(units)
+        self._files = {normalize_repo_path(unit.unit_id, repo_dir) for unit in units}
+        self.positions = {unit.position for unit in units}
+        """Where the baseline's units sat: the tree a new directory must leave to be one."""
 
     def component_ids(self, scope_id: ScopeId) -> frozenset[ComponentId]:
         return self._ids_by_scope.get(scope_id, frozenset())

--- a/tests/agents/test_tree_planner_agent.py
+++ b/tests/agents/test_tree_planner_agent.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 from agents.agent_responses import PlannedGroup, TreePlanInsights
 from agents.tree_planner_agent import BUDGET, TreePlannerAgent
 from static_analyzer.analysis_result import StaticAnalysisResults
-from static_analyzer.clustering.names import ROLE_WORDS, GroupingContext
+from static_analyzer.clustering.names import ROLE_WORDS, CandidateGroup, GroupingContext
 from static_analyzer.clustering.names.frontier import BOX, Candidate
 
 
@@ -164,12 +164,10 @@ class TestTreePlannerAgent(unittest.TestCase):
 
     def test_the_answer_is_read_from_json_with_names_as_labels(self):
         items = candidates(BUDGET + 1)
-        labelled = {f"G{i + 1}": MagicMock(name=c.label) for i, c in enumerate(items)}
-        for label, group in labelled.items():
-            group.name = items[int(label[1:]) - 1].label
+        labelled = {f"G{i + 1}": CandidateGroup(c.label, (c.key,)) for i, c in enumerate(items)}
         text = 'Sure:\n{"groups": [{"name": "A", "members": ["G1", "feature1", "G3"], "owns": ["x"]}], "notes": ""}'
         insights = TreePlannerAgent._read(text, labelled)
-        self.assertIsNotNone(insights)
+        assert insights is not None
         self.assertEqual(insights.groups[0].members, ["G1", "G2", "G3"])
         self.assertIsNone(TreePlannerAgent._read("no json here", labelled))
         self.assertIsNone(TreePlannerAgent._read('{"components": []}', labelled))

--- a/tests/agents/test_tree_planner_agent.py
+++ b/tests/agents/test_tree_planner_agent.py
@@ -146,6 +146,22 @@ class TestTreePlannerAgent(unittest.TestCase):
         for word in ("Apple", "service", "feature", "stream", "a b", "client"):
             self.assertNotIn(word, groups[0].terms + groups[1].terms)
 
+    def test_a_word_shared_with_a_forgotten_label_is_not_owned(self):
+        items = candidates(BUDGET + 2)
+        ctx = context(items)
+        shared = {key: samples + ("SharedThing",) for key, samples in ctx.samples.items()}
+        ctx = GroupingContext(ctx.scope_id, ctx.role_words, ctx.unit_count, ctx.rung, ctx.sizes, shared)
+        planned = TreePlanInsights(
+            groups=[
+                PlannedGroup(name="Most", members=[f"G{i}" for i in range(1, BUDGET + 2)], owns=["shared", "apple"])
+            ]
+        )
+        with patch.object(TreePlannerAgent, "_ask", return_value=planned):
+            groups = self._agent().group(items, ctx)
+        most = next(group for group in groups if group.name == "Most")
+        self.assertNotIn("shared", most.terms, "the forgotten last label carries the word too")
+        self.assertIn("apple", most.terms)
+
     def test_the_answer_is_read_from_json_with_names_as_labels(self):
         items = candidates(BUDGET + 1)
         labelled = {f"G{i + 1}": MagicMock(name=c.label) for i, c in enumerate(items)}

--- a/tests/diagram_analysis/test_diagram_analysis.py
+++ b/tests/diagram_analysis/test_diagram_analysis.py
@@ -1197,8 +1197,14 @@ class TestDiagramGenerator(unittest.TestCase):
         graph.add_node(Node("pkg.other.run", NodeType.FUNCTION, str(self.repo_location / "other.py"), 1, 4))
         gen.static_analysis = StaticAnalysisResults()
         gen.static_analysis.add_cfg(Language.PYTHON, graph)
+        # The service replays from the root down, so the spec carries the root that places pkg.persisted in 2.
         gen.tree_spec = TreeSpec(
-            scopes={"2": ScopeSpec("2", [ComponentRule("2.1", "Persisted", prefixes=(("pkg", "persisted"),))])}
+            scopes={
+                ROOT_SCOPE_ID: ScopeSpec(
+                    ROOT_SCOPE_ID, [ComponentRule("2", "Persisted", prefixes=(("pkg", "persisted"),))]
+                ),
+                "2": ScopeSpec("2", [ComponentRule("2.1", "Persisted", prefixes=(("pkg", "persisted"),))]),
+            }
         )
         component = Component(
             name="Persisted child",

--- a/tests/diagram_analysis/test_tree_spec_persistence.py
+++ b/tests/diagram_analysis/test_tree_spec_persistence.py
@@ -10,6 +10,7 @@ from agents.agent_responses import AnalysisInsights, Component
 from diagram_analysis.diagram_generator import DiagramGenerator
 from diagram_analysis.io_utils import load_analysis_metadata, save_analysis
 from static_analyzer.clustering.exceptions import IncrementalCacheMissingError
+from static_analyzer.clustering.names.spec import SPEC_VERSION
 
 
 class TestTreeSpecPersistence(unittest.TestCase):
@@ -20,7 +21,7 @@ class TestTreeSpecPersistence(unittest.TestCase):
             components=[Component(name="A", description="", key_entities=[], component_id="1")],
             components_relations=[],
         )
-        self.spec = {"version": 1, "grouper": "kinship", "machinery": [], "scopes": {"root": {"rules": []}}}
+        self.spec = {"version": SPEC_VERSION, "grouper": "kinship", "machinery": [], "scopes": {"root": {"rules": []}}}
 
     def tearDown(self):
         shutil.rmtree(self.temp_dir, ignore_errors=True)
@@ -54,7 +55,7 @@ class TestTreeSpecPersistence(unittest.TestCase):
 
     def test_a_specification_of_another_version_is_not_replayed(self):
         """Why: the tokenizer, stemmer and role words behind a version would move units silently."""
-        self._save(self.spec | {"version": self.spec["version"] + 1})
+        self._save(self.spec | {"version": SPEC_VERSION + 1})
         generator = DiagramGenerator(
             repo_location=self.temp_dir,
             temp_folder=self.temp_dir,

--- a/tests/static_analyzer/names/test_draft.py
+++ b/tests/static_analyzer/names/test_draft.py
@@ -420,6 +420,18 @@ class TestAffinityGrouper:
         assert next(group.terms for group in folded if group.name == "Ordering") == ("order",)
 
 
+class TestGroupingContractErrors:
+    def test_an_empty_group_is_refused_like_a_missing_key(self):
+        class Empty:
+            name = "empty"
+
+            def group(self, candidates, context):
+                return [CandidateGroup("all", tuple(c.key for c in candidates)), CandidateGroup("none", ())]
+
+        with pytest.raises(ValueError, match="empty=\\['none'\\]"):
+            draft_tree(units_from_layout(eshop(), "csharp"), Empty(), 1)
+
+
 class TestDeterminism:
     def test_the_same_names_draft_the_same_tree(self):
         units = units_from_layout(eshop(), "csharp")

--- a/tests/static_analyzer/names/test_frontier.py
+++ b/tests/static_analyzer/names/test_frontier.py
@@ -205,6 +205,39 @@ class TestLayeredRoot:
         features = sorted(candidate.terms[0] for candidate in frontier.candidates if candidate.kind == FEATURE)
         assert features == ["escalation", "incident", "team"]
 
+    def test_two_layers_and_a_feature_are_not_a_layered_node(self):
+        layout = {
+            f"Beacon.{layer}/{layer}Thing{i}.cs": [f"Beacon.{layer}.{layer}Thing{i}"]
+            for layer in ("Domain", "Infrastructure")
+            for i in range(3)
+        }
+        layout |= {f"Beacon.Billing/Invoice{i}.cs": [f"Beacon.Billing.Invoice{i}"] for i in range(2)}
+        frontier = walk(Trie(units_from_layout(layout, "csharp")), ROLE_WORDS)
+        assert not any("role-named children" in note for note in frontier.notes)
+        assert {"box:Beacon.Domain", "box:Beacon.Infrastructure", "box:Beacon.Billing"} <= set(keys(frontier))
+
+    def test_a_product_name_behind_the_layers_role_containers_is_not_the_feature(self):
+        layout: dict[str, list[str]] = {}
+        for layer, role in (("Application", "Handlers"), ("Infrastructure", "Repositories"), ("Domain", "Entities")):
+            for feature in ("BeaconOrders", "BeaconCustomers", "BeaconPayments"):
+                for index in range(2):
+                    layout[f"Shop.{layer}/{role}/{feature}/{feature}{index}.cs"] = [
+                        f"Shop.{layer}.{role}.{feature}.Thing{index}"
+                    ]
+        frontier = walk(Trie(units_from_layout(layout, "csharp")), ROLE_WORDS)
+        features = sorted(candidate.terms[0] for candidate in frontier.candidates if candidate.kind == FEATURE)
+        assert features == ["customer", "order", "payment"]
+
+    def test_a_feature_nested_in_another_stays_with_the_outer_one(self):
+        layout = self._beacon()
+        layout["Beacon.Application/Billing/Incidents/BilledIncident.cs"] = [
+            "Beacon.Application.Billing.Incidents.BilledIncident"
+        ]
+        layout["Beacon.Application/Billing/Bill.cs"] = ["Beacon.Application.Billing.Bill"]
+        frontier = walk(Trie(units_from_layout(layout, "csharp")), ROLE_WORDS)
+        incidents = next(candidate for candidate in frontier.candidates if candidate.label == "Incidents")
+        assert ("Beacon", "Application", "Billing", "Incidents") not in incidents.prefixes
+
     def test_a_feature_under_one_layer_only_is_not_a_feature(self):
         """Two same-stem directories under one layer are not a grid."""
         layout = self._beacon()

--- a/tests/static_analyzer/names/test_replay.py
+++ b/tests/static_analyzer/names/test_replay.py
@@ -117,6 +117,14 @@ class TestNewScopes:
         assert result.assignment["s0"] == "2"
         assert [u.unit_id for u in result.new_scopes[("Shipping",)]] == ["s0"]
 
+    def test_a_root_drawn_as_one_box_does_not_hide_the_directories_added_after_it(self):
+        everything = ComponentRule("1", "All files", prefixes=((),))
+        result = replay(
+            [unit("s0", "Shipping.Ship.Run()"), unit("s1", "Shipping.Dock.Run()")], scope(everything), ROLE_WORDS
+        )
+        assert result.assignment == {"s0": "1", "s1": "1"}
+        assert [u.unit_id for u in result.new_scopes[("Shipping",)]] == ["s0", "s1"]
+
     def test_a_unit_a_prefix_claims_is_not_a_new_scope(self):
         result = replay(
             [unit("f", "Catalog.API.Item"), unit("g", "OrderProcessor.Totals")],

--- a/tests/static_analyzer/names/test_spec.py
+++ b/tests/static_analyzer/names/test_spec.py
@@ -1,6 +1,6 @@
 from clustering_ids import ROOT_SCOPE_ID
 from static_analyzer.clustering.names import ComponentRule, KinshipGrouper, ScopeSpec, TreeSpec, draft_tree
-from static_analyzer.clustering.names.spec import UNPLACED
+from static_analyzer.clustering.names.spec import SPEC_VERSION, UNPLACED
 from tests.static_analyzer.names.conftest import units_from_layout
 
 
@@ -16,7 +16,7 @@ class TestTreeSpecRoundTrip:
     def test_a_drafted_tree_survives_json(self):
         spec = draft_tree(units_from_layout(layout(), "csharp"), KinshipGrouper(), 2, machinery=("Handler",))
         raw = spec.to_dict()
-        assert raw["version"] == 1 and raw["grouper"] == "kinship" and raw["machinery"] == ["Handler"]
+        assert raw["version"] == SPEC_VERSION and raw["grouper"] == "kinship" and raw["machinery"] == ["Handler"]
         assert TreeSpec.from_dict(raw).to_dict() == raw
 
     def test_parts_prefixes_and_terms_are_preserved(self):

--- a/tests/static_analyzer/names/test_spec.py
+++ b/tests/static_analyzer/names/test_spec.py
@@ -56,6 +56,20 @@ class TestTreeSpecReroot:
         assert [rule.component_id for rule in spec.scopes["1"].rules] == ["1.1", "1.2"]
         assert spec.scopes["2"].is_leaf
 
+    def test_a_retired_sibling_of_the_absorbed_child_is_dropped(self):
+        spec = TreeSpec(
+            scopes={
+                ROOT_SCOPE_ID: ScopeSpec(ROOT_SCOPE_ID, [ComponentRule("1", "Only")]),
+                "1": ScopeSpec("1", [ComponentRule("1.1", "A")], last_id=2),
+                "1.1": ScopeSpec("1.1", [ComponentRule("1.1.1", "AA"), ComponentRule("1.1.2", "AB")]),
+                "1.2": ScopeSpec("1.2", rung="leaf", leaf_reason="retired"),
+                "2": ScopeSpec("2", rung="leaf"),
+            }
+        )
+        spec.reroot(["1.1"])
+        assert set(spec.scopes) == {ROOT_SCOPE_ID, "1", "2"}
+        assert [rule.component_id for rule in spec.scopes["1"].rules] == ["1.1", "1.2"]
+
     def test_a_child_never_drafted_changes_nothing(self):
         spec = TreeSpec(scopes={ROOT_SCOPE_ID: ScopeSpec(ROOT_SCOPE_ID, [ComponentRule("1", "Only")])})
         spec.reroot(["1"])
@@ -63,6 +77,13 @@ class TestTreeSpecReroot:
 
 
 class TestScopeSpec:
+    def test_a_retired_id_is_never_reissued_even_after_a_round_trip(self):
+        scope = ScopeSpec("root", [ComponentRule("1", "A"), ComponentRule("2", "B"), ComponentRule("3", "C")])
+        assert scope.next_id() == "4"
+        scope.rules = scope.rules[:2]
+        scope = ScopeSpec.from_dict("root", scope.to_dict())
+        assert scope.next_id() == "5"
+
     def test_next_id_is_fresh_never_a_refilled_gap(self):
         scope = ScopeSpec("2", [ComponentRule("2.1", "a"), ComponentRule("2.3", "b")])
         assert scope.next_id() == "2.4"

--- a/tests/static_analyzer/test_clustering_service.py
+++ b/tests/static_analyzer/test_clustering_service.py
@@ -129,6 +129,16 @@ class TestFullHierarchy(unittest.TestCase):
             len({node.file_path for name, node in self.graph.nodes.items() if name.startswith("Order")}),
         )
 
+    def test_a_child_scope_replays_over_the_units_its_parent_placed_data_only_files_included(self):
+        ordering = self.hierarchy.groups[0]
+        assert ordering.children is not None
+        consts = next(
+            cluster_id
+            for cluster_id, files in ordering.children.leaf_clusters_by_language["csharp"].cluster_to_files.items()
+            if any(path.endswith("consts.cs") for path in files)
+        )
+        self.assertIn(consts, [cluster_id for group in ordering.children.groups for cluster_id in group.cluster_ids])
+
     def test_children_follow_the_ladder_and_expandable_is_a_decision(self):
         ordering, catalog = self.hierarchy.groups[0], self.hierarchy.groups[1]
         self.assertTrue(ordering.expandable)
@@ -247,6 +257,20 @@ class TestIncrementalHierarchy(unittest.TestCase):
         self.assertTrue(hierarchy_differs(hierarchy, self.persisted))
         self.assertIsNone(scope_of(service.spec, ROOT_SCOPE_ID).rule("5"))
         self.assertNotIn("5", service.spec.scopes)
+
+    def test_the_scopes_the_baseline_never_reached_are_drafted_by_the_grouper_that_drew_it(self):
+        spec = TreeSpec.from_dict(self.spec.to_dict() | {"grouper": "kinship"})
+        analysis = analysis_for(graph("csharp", self.layout))
+        analysis.incremental_base_results = analysis_for(graph("csharp", self.layout))
+        service = ClusteringService()
+        service.build_incremental_hierarchy(analysis, 2, spec, self.persisted, REPO, REPO)
+        self.assertEqual(service.grouper.name, "kinship")
+
+    def test_a_baseline_without_a_call_graph_cannot_be_built_on(self):
+        analysis = analysis_for(graph("csharp", self.layout))
+        analysis.incremental_base_results = StaticAnalysisResults()
+        with self.assertRaisesRegex(IncrementalCacheMissingError, "call graph"):
+            ClusteringService().build_incremental_hierarchy(analysis, 2, self.spec, self.persisted, REPO, REPO)
 
     def test_a_new_directory_in_a_scope_drawn_from_words_is_still_a_new_component(self):
         """No rule owns a prefix here, so the new files must be keyed by where they leave the old units."""

--- a/tests/static_analyzer/test_clustering_service.py
+++ b/tests/static_analyzer/test_clustering_service.py
@@ -10,7 +10,7 @@ from static_analyzer.analysis_result import StaticAnalysisResults
 from static_analyzer.cfg import CallGraph
 from static_analyzer.cfg.edge import EdgeKind, ReferenceEdge
 from static_analyzer.clustering import ClusterGroup, ClusterScopeResult
-from static_analyzer.clustering.exceptions import IncrementalCacheMissingError
+from static_analyzer.clustering.exceptions import IncrementalCacheMissingError, PlannerUnavailableError
 from static_analyzer.clustering.names import ComponentRule, ScopeSpec, TreeSpec
 from static_analyzer.clustering.service import NEW_SCOPE, ClusteringService, hierarchy_differs, unit_links
 from static_analyzer.config import Language, NodeType
@@ -325,13 +325,29 @@ class TestScopeHierarchy(unittest.TestCase):
         self.spec = first.spec
 
     def _scope(self, component_id: str) -> ClusterScopeResult:
-        members = next(group for group in self.hierarchy.groups if group.group_id == component_id).qualified_names
-        graphs = {"csharp": self.graph.filter_by_nodes(members)}
-        return ClusteringService().build_scope_hierarchy(graphs, 1, component_id, self.spec)
+        return ClusteringService().build_scope_hierarchy({"csharp": self.graph}, 1, component_id, self.spec)
 
     def test_a_grouped_component_replays_its_parts(self):
         scope = self._scope("1")
         self.assertEqual([group.group_id for group in scope.groups], ["1.1", "1.2"])
+
+    def test_a_partial_run_holds_the_units_a_full_run_placed_data_only_files_included(self):
+        graph_with_consts = graph(
+            "csharp", eshop() | {"src/Ordering.API/Apis/consts.cs": ["Ordering.API.Apis.limits_var"]}
+        )
+        first = ClusteringService()
+        full = first.build_full_hierarchy(analysis_for(graph_with_consts), max_depth=2)
+        partial = ClusteringService().build_scope_hierarchy({"csharp": graph_with_consts}, 1, "1", first.spec)
+        assert full.groups[0].children is not None
+        self.assertEqual(
+            [(g.group_id, sorted(g.cluster_ids)) for g in partial.groups],
+            [(g.group_id, sorted(g.cluster_ids)) for g in full.groups[0].children.groups],
+        )
+
+    def test_a_scope_the_planner_never_drew_is_not_drawn_by_another_grouper(self):
+        spec = TreeSpec.from_dict(self.spec.to_dict() | {"grouper": "planner"})
+        with self.assertRaisesRegex(PlannerUnavailableError, "never drafted"):
+            ClusteringService().build_scope_hierarchy({"csharp": self.graph}, 2, "1", spec)
 
     def test_a_cohesive_component_comes_back_without_groups(self):
         self.assertEqual(self._scope("2").groups, [])


### PR DESCRIPTION
The open review threads of #550, #551, #553 and #555, fixed on one branch on top of #555 so the tested behaviour of those PRs stays as measured and this one can be iterated on. Each thread, and what changed:

| PR | thread | fix |
|---|---|---|
| #550 | `replay.py`: an `All files` rule with the empty prefix hides every later directory | only a named prefix settles a unit; a unit the empty prefix claims is still a new-scope candidate |
| #550 | `frontier.py`: ubiquity computed from the layers' direct children only | widened to a fixpoint over the feature directories found behind the role-named containers |
| #550 | `frontier.py`: prefix search descends through unrelated feature directories (`Billing.Orders`) | prefixes come from the same first-feature-directory walk as recurrence detection; `_collect_feature_prefixes` is gone |
| #550 | `frontier.py`: `MIN_LAYERS` counts every child | counts role-named children, at the node and at a dominant child |
| #550 | `draft.py`: nine-line module docstring | one line |
| #550 | `draft.py`: an empty group passes validation and raises `IndexError` | refused with the contract `ValueError` |
| #551 | `diagram_generator.py`: incremental drafting ignores the spec's grouper | the service drafts unreached scopes with the deterministic grouper the spec records; a planner-drawn spec logs a warning and uses the configured default (the planner needs a model that is not up before clustering) |
| #551 | `service.py`: child scopes drafted over all units but materialised over callables and classes | child graphs are induced by the members' files, every declaration included; test with a data-only file |
| #551 | `service.py`: a warm-start object with no graph makes every file new | refused with `IncrementalCacheMissingError` when the live analysis has graphs |
| #551 | `spec.py`: `reroot` keeps the retired siblings' scopes | dropped, so a reissued id cannot replay a stale scope |
| #553 | `tree_planner_agent.py`: the executor waits for a stalled draw | `shutdown(wait=False, cancel_futures=True)` |
| #553 | `draft.py`: the affinity fold leaves the dead row in the matrix | source row and column cleared after the transfer |
| #553 | `tree_planner_agent.py`: a 401 is retried and then masked | `_raise_if_auth_error` in the classifier; `LLMAuthError` propagates out of `_draw` |
| #553 | `service.py`: incremental drafting on the new default rather than the baseline's grouper | as above |
| #553 | `tree_planner_agent.py`: `owns` exclusivity ignores the labels the model forgot | exclusive against every label |
| #553 | `tree_planner_agent.py`: draw threads lose the monitoring step | each draw runs under a copied context |
| #555 | `service.py`: new-scope key from the live units loses a directory whose files were all replaced | keyed by the baseline units' positions |
| #555 | `service.py`: a retired rule's id can be reissued | `ScopeSpec.last_id` high-water mark, persisted |

Second round (same branch):

| thread | fix |
|---|---|
| a planner-drawn spec drafted by another grouper | `PlannerUnavailableError` when a scope the planner never reached must be drafted; the deterministic grouper the spec records is adopted otherwise |
| draw threads outlive the deadline | per-request `timeout` bound on the model where the client takes one |
| a version-1 spec has no high-water mark | `SPEC_VERSION = 2`; older baselines need a full run |
| a partial run rebuilds the scope from callable members only | the service replays from the root to the scope over the whole analysis; partial and full runs hold the same units |
| repository-wide baseline positions decide a scope's divergence | the baseline units of that scope, by the same descent |

CI's `mypy .` (which covers tests) now passes; the earlier failure was two test files.

Not changed: the candidate-key "collision" thread on #550 (`segments()` keeps generics whole, so a dot inside a segment cannot be mistaken for a boundary). One test per fix; full suite green except the three `test_cli_parser` failures that also fail on `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved diagram and component analysis, including more complete coverage of data-only files.
  * Improved incremental analysis so newly added directories and units are identified more accurately.
  * Preserved component identity more reliably across reorganizations and saved analysis data.
  * Improved handling of model timeouts and authentication failures.

* **Bug Fixes**
  * Corrected grouping and ownership results for overlooked labels, nested features, and shared words.
  * Added validation for invalid empty groups with clearer error reporting.

* **Documentation**
  * Clarified incremental-run behavior and new-scope detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->