### PR TITLE
Keep splitting a component below forty units

### DIFF
--- a/docs/design/name-tree.md
+++ b/docs/design/name-tree.md
@@ -155,20 +155,32 @@ numbering cannot move a unit.
 | scope | rungs, in order |
 |---|---|
 | root | frontier of the trie (layers transposed or drawn) → words of the units (only if the frontier gave one box) |
-| component < 40 units | un-merge: the candidates the grouper folded into it → leaf ("cohesive") |
-| component 40–135 units | un-merge → frontier of its own sub-trie, layered nodes with a grid kept whole → leaf ("cohesive") |
-| component > 135 units | un-merge → frontier of its sub-trie, transposed where a grid recurs → words of its units → leaf ("exhausted") |
+| component ≤ 7 units | un-merge: the candidates the grouper folded into it → leaf ("small") |
+| component 8–135 units | un-merge → frontier of its own sub-trie, a layered grid kept whole → the same frontier with the grid drawn layer by layer → files → roles → leaf ("cohesive") |
+| component > 135 units | un-merge → frontier of its sub-trie, transposed where a grid recurs → words of its units → layers → files → roles → leaf ("exhausted") |
 
-Why two thresholds: the floor (40) is the size below which a box reads whole in a listing,
-and above which a reader wants to click; the cap (135, the largest box any maintainer has
-left unsplit, eShop's client app) is where the aggressive coordinates start, because on the
-one maintainer-drawn depth-2 ruler a transposition below it over-splits every leaf parent
-(eShop depth 2: 0.974 whole, 0.59 transposed at 40 units, 0.67 at 70). The structural
-rungs below the cap cost that ruler 0.974 → 0.934 (Identity.API opens into Quickstart,
-Models, Services, Data) and buy django eight expandable components at depth 2 where there
-was one. The un-merge rung gives nesting for free: a root box folded from several
-candidates opens into them at depth 2, and each of those opens its own sub-trie at depth 3.
-There is no graph tier: Leiden is retired at every depth.
+The two rungs below the trie read the files themselves, since below a leaf the trie is
+flat. **Files**: every file is a candidate labelled by its own name (its key: the position
+plus the one class it declares), the grouper merges the ones sharing a distinctive word and
+folds the rest along the graph, and every group under the floor pools into one "Loose files"
+bucket, a fallback-only rule on the scope's own prefix, so a one-file box is never drawn.
+**Roles**: the same over the head word of each file's name (`Strategy`, `Options`,
+`Converter`); inside a feature the roles are the structure, so this is the one rung where a
+rule may own a role word, and replay lets a role word vote only for a rule that owns it.
+Measured on nine repositories with no model (study "The Leaf Ladder", Sep 2026): the files
+rung resolves every leaf the trie cannot, with cross-child call leakage of 0.35 against 0.79
+for a random partition of the same shape; name kinship without the graph fold does not
+follow the calls (0.68). What stays a leaf is a fan of parallel implementations sharing no
+word (markitdown's converters) or a feature of eight to twelve files that no name separates.
+
+Why the cap (135, the largest box any maintainer has left unsplit, eShop's client app):
+on the one maintainer-drawn depth-2 ruler a transposition below it over-splits every leaf
+parent (eShop depth 2: 0.974 whole, 0.59 transposed at 40 units, 0.67 at 70), so below the
+cap a grid is drawn layer by layer instead, and only after the plain frontier has failed.
+The leaf size (7) is the box a reader takes in at a glance; the rungs below it never run,
+the un-merge always does. The un-merge rung gives nesting for free: a root box folded from
+several candidates opens into them at depth 2, and each of those opens its own sub-trie at
+depth 3. There is no graph tier: Leiden is retired at every depth.
 
 ## 4. Full, incremental, partial: one function, three entry points
 
@@ -311,10 +323,12 @@ perfect grouping) is the planner's to reach.
 - **Only static-analysis names are partitioned.** No support-scope carve-out.
 - **Never refuse.** One box at the root falls through to the words; nothing splits it,
   one box is drawn and the structure diagnostics say so.
-- **Structure from 40 units, aggressive rungs only above the leaf cap** (§3.5): the
-  sub-trie of a component is drawn from 40 units, transposition and words only above 135,
+- **Structure above 7 units, aggressive rungs only above the leaf cap** (§3.5): the
+  sub-trie of a component is drawn from 8 units, transposition and words only above 135,
   because a transposition below the cap over-splits every maintainer-drawn leaf on the only
-  depth-2 ruler while a directory split costs it 0.04.
+  depth-2 ruler while a directory split costs it 0.04. Below the trie the files and their
+  roles draw the boxes, and the depth cap alone decides how much of that ladder a run
+  materialises: the rest is drafted when a component is expanded or the cap is raised.
 - **The guard never folds into the largest rule.** A weak rule with no neighbour in the
   graph stands; the fold, not the guard, decides where a small box goes.
 - **The graph folds, never places.** Links between candidates reach the grouper as a
@@ -351,6 +365,11 @@ perfect grouping) is the planner's to reach.
   candidates) need links the synthesised ruler harness does not carry.
 - A unit the parent placed by a word has no home among the un-merged parts and lands in
   the unplaced bucket (eShop's Basket, serilog's Core: two and three files).
+- A fan of parallel implementations sharing no word (markitdown's 23 converters, mem0's 26
+  vector stores) stays one leaf; only the planner can fold it into families, at the variance
+  the grouper study measured. Splitting a single heavy file by its declarations was measured
+  and rejected: it equals the file in class-per-file languages and groups same-named
+  functions elsewhere.
 - The stemmer is crude (`spring` → `spr`); it is consistent with the measurements and
   ubiquity absorbs most of the damage, but it should be replaced when a ruler shows it
   costing something.

--- a/static_analyzer/clustering/names/__init__.py
+++ b/static_analyzer/clustering/names/__init__.py
@@ -14,7 +14,14 @@ from static_analyzer.clustering.names.draft import (
     role_words_for,
 )
 from static_analyzer.clustering.names.frontier import Candidate, Frontier, walk
-from static_analyzer.clustering.names.inventory import Trie, Unit, unit_position, units_from_graph, units_from_graphs
+from static_analyzer.clustering.names.inventory import (
+    Trie,
+    Unit,
+    unit_key,
+    unit_position,
+    units_from_graph,
+    units_from_graphs,
+)
 from static_analyzer.clustering.names.replay import Partition, replay
 from static_analyzer.clustering.names.spec import ComponentRule, ScopeSpec, TreeSpec
 from static_analyzer.clustering.names.tokens import LAYOUT_WORDS, ROLE_WORDS, stem, tokenize
@@ -41,6 +48,7 @@ __all__ = [
     "role_words_for",
     "stem",
     "tokenize",
+    "unit_key",
     "unit_position",
     "units_from_graph",
     "units_from_graphs",

--- a/static_analyzer/clustering/names/draft.py
+++ b/static_analyzer/clustering/names/draft.py
@@ -8,12 +8,21 @@ from dataclasses import dataclass, field, replace
 from typing import Protocol
 
 from clustering_ids import ROOT_SCOPE_ID, ScopeId
-from static_analyzer.clustering.names.frontier import BOX, LOOSE, RESIDUAL, SHARE, WORD, Candidate, walk
+from static_analyzer.clustering.names.frontier import BOX, FILE, HEAD, LOOSE, RESIDUAL, SHARE, WORD, Candidate, walk
 from static_analyzer.clustering.names.inventory import Trie, Unit
 from static_analyzer.clustering.names.replay import Partition, replay
 from static_analyzer.clustering.names.spec import (
+    FILES,
+    FRONTIER,
+    LAYERS,
+    LEAF,
+    ROLE,
+    SEGMENT,
+    UNMERGE,
     UNPLACED,
+    VOCABULARY,
     ComponentRule,
+    Prefix,
     ScopeSpec,
     TreeSpec,
     is_root,
@@ -23,6 +32,7 @@ from static_analyzer.clustering.names.tokens import (
     distinctive_word,
     segments,
     stem,
+    stems,
     tokenize,
     ubiquitous_words,
 )
@@ -30,10 +40,10 @@ from static_analyzer.config import ClusteringConfig
 
 MIN_UNITS = 2
 GUARD_SHARE = 0.05
-NEST_FLOOR = 40
-"""Units from which a component reads the frontier of its own sub-tree."""
+LEAF_UNITS = 7
+"""Units at or under which a component is a leaf: a box a reader takes in at a glance."""
 LEAF_CAP = 135
-"""Units above which a component draws a layered sub-tree layer by layer and reads its words."""
+"""Units above which a component transposes a layered sub-tree and reads its words."""
 BUDGET = 9
 """Components a rung is folded toward; the guard, not the budget, is what a rung must clear."""
 MIN_LINKS = 2
@@ -41,15 +51,10 @@ MIN_LINKS = 2
 CAP_SHARE = 0.6
 """No fold may grow a component past this share of its scope."""
 UNPLACED_NAME = "Unassigned"
+LOOSE_NAME = "Loose files"
 
 Links = Mapping[tuple[str, str], int]
 """Weight of the graph edges between two units, keyed by the unit ids in sorted order."""
-
-UNMERGE = "unmerge"
-FRONTIER = "frontier"
-VOCABULARY = "vocabulary"
-SEGMENT = "segment"
-LEAF = "leaf"
 
 
 @dataclass(frozen=True)
@@ -201,7 +206,7 @@ def candidate_name(candidate: Candidate) -> str:
         return f"Loose files in {where}" if where else "Loose files"
     if candidate.kind == RESIDUAL:
         return f"{candidate.label} (residual)"
-    if candidate.kind == WORD:
+    if candidate.kind in (WORD, HEAD):
         return candidate.label.capitalize()
     if candidate.kind == BOX and not candidate.label:
         return "All files"
@@ -261,8 +266,8 @@ def draft_scope(
     links = links or {}
     rungs: list[tuple[str, Callable[[], tuple[list[ComponentRule], str]]]] = []
 
-    def frontier(rung: str, transpose: bool) -> tuple[list[ComponentRule], str]:
-        return _frontier_rules(scope_id, scope_units, role_words, grouper, share, rung, links, transpose)
+    def frontier(rung: str, transpose: bool, layers: bool = False) -> tuple[list[ComponentRule], str]:
+        return _frontier_rules(scope_id, scope_units, role_words, grouper, share, rung, links, transpose, layers)
 
     def vocabulary() -> tuple[list[ComponentRule], str]:
         return _vocabulary_rules(scope_id, scope_units, role_words, grouper, links)
@@ -272,28 +277,30 @@ def draft_scope(
     if is_root(scope_id):
         rungs.append((FRONTIER, lambda: frontier(FRONTIER, True)))
         rungs.append((VOCABULARY, vocabulary))
-    elif len(scope_units) >= NEST_FLOOR:
-        rungs.append((SEGMENT, lambda: frontier(SEGMENT, len(scope_units) > LEAF_CAP)))
-        if len(scope_units) > LEAF_CAP:
+    elif len(scope_units) > LEAF_UNITS:
+        transpose = len(scope_units) > LEAF_CAP
+        rungs.append((SEGMENT, lambda: frontier(SEGMENT, transpose)))
+        if transpose:
             rungs.append((VOCABULARY, vocabulary))
+        rungs.append((LAYERS, lambda: frontier(LAYERS, False, layers=True)))
+        rungs.append((FILES, lambda: _file_rules(scope_id, scope_units, role_words, grouper, links)))
+        rungs.append((ROLE, lambda: _role_rules(scope_id, scope_units, role_words, grouper, links)))
     produced: dict[str, tuple[list[ComponentRule], str]] = {}
     for rung, produce in rungs:
         produced[rung] = rules, axis = produce()
-        settled = _settle(scope_id, scope_units, rules, role_words, guard=rung != FRONTIER)
+        settled = _settle(scope_id, scope_units, rules, role_words, rung, guard=rung != FRONTIER)
         if settled is None:
             continue
         scope, partition = settled
         scope.axis = axis
-        scope.rung = rung
         return scope, partition
     if is_root(scope_id) and scope_units:
         # Never refuse: a root nothing splits is drawn as the one box the frontier gave it.
         rules, axis = produced[FRONTIER]
-        settled = _settle(scope_id, scope_units, rules, role_words, guard=False, min_rules=1)
+        settled = _settle(scope_id, scope_units, rules, role_words, FRONTIER, guard=False, min_rules=1)
         if settled is not None:
             scope, partition = settled
             scope.axis = axis
-            scope.rung = FRONTIER
             return scope, partition
     return ScopeSpec(
         scope_id, rung=LEAF, leaf_reason=_leaf_reason(scope_id, len(scope_units), parts, rungs)
@@ -306,11 +313,11 @@ def _leaf_reason(
     if is_root(scope_id):
         return f"no rung ({', '.join(rung for rung, _ in rungs)}) yields two children of {unit_count} units"
     unmerge = "un-merge failed the guard" if len(parts) >= 2 else "nothing to un-merge"
-    if unit_count < NEST_FLOOR:
-        return f"cohesive: {unit_count} units, under {NEST_FLOOR}; {unmerge}"
-    if unit_count <= LEAF_CAP:
-        return f"cohesive: {unit_count} units, at most {LEAF_CAP}; {unmerge}; the sub-tree yields no two children"
-    return f"exhausted: {unmerge}; neither the sub-tree nor the words yield two children of {unit_count} units"
+    if unit_count <= LEAF_UNITS:
+        return f"small: {unit_count} units, at most {LEAF_UNITS}; {unmerge}"
+    tried = ", ".join(rung for rung, _ in rungs if rung != UNMERGE)
+    kind = "cohesive" if unit_count <= LEAF_CAP else "exhausted"
+    return f"{kind}: {unit_count} units; {unmerge}; no rung ({tried}) yields two children"
 
 
 def _frontier_rules(
@@ -322,8 +329,9 @@ def _frontier_rules(
     rung: str,
     links: Links,
     transpose: bool,
+    layers: bool = False,
 ) -> tuple[list[ComponentRule], str]:
-    frontier = walk(Trie(units), role_words, share=share, transpose=transpose)
+    frontier = walk(Trie(units), role_words, share=share, transpose=transpose, layers=layers)
     candidates = sorted(frontier.candidates, key=lambda candidate: candidate.key)
     if not candidates:
         return [], frontier.axis
@@ -351,6 +359,88 @@ def _vocabulary_rules(
     return _rules_from_groups(grouper.group(candidates, context), candidates), VOCABULARY
 
 
+def _file_rules(
+    scope_id: ScopeId,
+    units: list[Unit],
+    role_words: frozenset[str],
+    grouper: Grouper,
+    links: Links,
+) -> tuple[list[ComponentRule], str]:
+    """One candidate per file, labelled by its own name: kinship on the names, then the fold along the graph."""
+    by_key: dict[Prefix, list[Unit]] = {}
+    for unit in units:
+        by_key.setdefault(unit.key, []).append(unit)
+    candidates = [Candidate(f"{FILE}:{'.'.join(key)}", FILE, _label(key), prefixes=(key,)) for key in sorted(by_key)]
+    return _grouped_rules(scope_id, units, candidates, role_words, grouper, FILES, links), FILES
+
+
+def _role_rules(
+    scope_id: ScopeId,
+    units: list[Unit],
+    role_words: frozenset[str],
+    grouper: Grouper,
+    links: Links,
+) -> tuple[list[ComponentRule], str]:
+    """One candidate per head word of the files' names (``Strategy``, ``Options``, ``Converter``).
+
+    Why here and nowhere else: a role word never defines a box above a leaf, but inside a
+    feature the roles are the structure there is.
+    """
+    by_head: dict[str, list[Unit]] = {}
+    for unit in units:
+        words = stems(_label(unit.key))
+        if words:
+            by_head.setdefault(words[-1], []).append(unit)
+    candidates = [
+        Candidate(
+            f"{HEAD}:{word}",
+            HEAD,
+            word,
+            prefixes=tuple(dict.fromkeys(unit.key for unit in members)),
+            terms=(word,),
+        )
+        for word, members in sorted(by_head.items())
+    ]
+    return _grouped_rules(scope_id, units, candidates, role_words, grouper, ROLE, links), ROLE
+
+
+def _grouped_rules(
+    scope_id: ScopeId,
+    units: list[Unit],
+    candidates: list[Candidate],
+    role_words: frozenset[str],
+    grouper: Grouper,
+    rung: str,
+    links: Links,
+) -> list[ComponentRule]:
+    """Group the candidates; a group under the floor pools into one loose bucket, never a one-file box."""
+    if len(candidates) < 2:
+        return []
+    context = _context(scope_id, units, candidates, role_words, rung, links)
+    groups = grouper.group(candidates, context)
+    strong = [group for group in groups if sum(context.sizes.get(key, 0) for key in group.keys) >= context.floor]
+    if len(strong) < 2:
+        return []
+    kept = {key for group in strong for key in group.keys}
+    rules = _rules_from_groups(strong, [candidate for candidate in candidates if candidate.key in kept])
+    if len(strong) < len(groups):
+        rules.append(ComponentRule("", LOOSE_NAME, fallback_prefixes=(_common_prefix(units),), origin=LOOSE))
+    return rules
+
+
+def _label(key: Prefix) -> str:
+    return key[-1] if key else ""
+
+
+def _common_prefix(units: list[Unit]) -> Prefix:
+    shared: list[str] = []
+    for parts in zip(*(unit.position for unit in units)):
+        if len(set(parts)) != 1:
+            break
+        shared.append(parts[0])
+    return tuple(shared)
+
+
 SAMPLE_IDENTIFIERS = 6
 
 
@@ -364,7 +454,9 @@ def _context(
 ) -> GroupingContext:
     """Size, a few identifiers and links per candidate, from a replay of the candidates as rules."""
     provisional = ScopeSpec(
-        scope_id, [replace(_candidate_rule(candidate), component_id=candidate.key) for candidate in candidates]
+        scope_id,
+        [replace(_candidate_rule(candidate), component_id=candidate.key) for candidate in candidates],
+        rung=rung,
     )
     partition = replay(units, provisional, role_words)
     between: Counter[tuple[str, str]] = Counter()
@@ -459,6 +551,7 @@ def _settle(
     units: list[Unit],
     rules: list[ComponentRule],
     role_words: frozenset[str],
+    rung: str,
     *,
     guard: bool,
     min_rules: int = 2,
@@ -475,7 +568,7 @@ def _settle(
     if len(rules) < min_rules:
         return None
     provisional = [replace(rule, component_id=f"?{index}") for index, rule in enumerate(rules)]
-    partition = replay(units, ScopeSpec(scope_id, provisional), role_words)
+    partition = replay(units, ScopeSpec(scope_id, provisional, rung=rung), role_words)
     sizes = {rule.component_id: partition.size(rule.component_id) for rule in provisional}
     floor = _floor(len(units)) if guard else 1
     strong = [rule for rule in provisional if not rule.is_fallback_only and sizes[rule.component_id] >= floor]
@@ -483,7 +576,7 @@ def _settle(
         return None
     kept = [rule for rule in provisional if sizes[rule.component_id] or rule.is_fallback_only]
     ordered = sorted(kept, key=lambda rule: (-sizes[rule.component_id], rule.name))
-    scope = ScopeSpec(scope_id)
+    scope = ScopeSpec(scope_id, rung=rung)
     for rule in ordered:
         scope.rules.append(replace(rule, component_id=scope.next_id()))
     partition = replay(units, scope, role_words)

--- a/static_analyzer/clustering/names/frontier.py
+++ b/static_analyzer/clustering/names/frontier.py
@@ -42,6 +42,10 @@ FEATURE = "feature"
 LOOSE = "loose"
 RESIDUAL = "residual"
 WORD = "word"
+FILE = "file"
+HEAD = "head"
+"""Kinds of candidate. The walk emits the first four; the ladder's word, file and role rungs
+draw the rest from the units themselves."""
 
 
 @dataclass(frozen=True)
@@ -63,19 +67,21 @@ class Frontier:
     notes: list[str] = field(default_factory=list)
 
 
-def walk(trie: Trie, role_words: frozenset[str], *, share: float = SHARE, transpose: bool = True) -> Frontier:
+def walk(
+    trie: Trie, role_words: frozenset[str], *, share: float = SHARE, transpose: bool = True, layers: bool = False
+) -> Frontier:
     """The candidates of a trie.
 
     A layered node whose features recur is transposed onto them only with ``transpose``, else
-    kept as one box; one whose features do not recur is drawn layer by layer. Why the switch:
-    below the leaf cap a transposition leaves a residual per layer, which reads as a grab bag;
-    layers are directories a reader can name.
+    drawn layer by layer with ``layers``, else kept as one box; one whose features do not recur
+    is always drawn layer by layer. Why the switch: below the leaf cap a transposition leaves a
+    residual per layer, which reads as a grab bag; layers are directories a reader can name.
     """
     frontier = Frontier()
     top = trie.root
     while len(top.children) == 1 and not top.units:
         top = next(iter(top.children.values()))
-    _visit(top, top.count, role_words, share, frontier, transpose, top=True)
+    _visit(top, top.count, role_words, share, frontier, transpose, layers, top=True)
     return frontier
 
 
@@ -86,19 +92,20 @@ def _visit(
     share: float,
     out: Frontier,
     transpose: bool,
+    layers: bool,
     *,
     top: bool = False,
 ) -> None:
     children = sorted(node.children.items())
     if len(children) == 1 and not node.units:
-        _visit(children[0][1], total, role_words, share, out, transpose, top=top)
+        _visit(children[0][1], total, role_words, share, out, transpose, layers, top=top)
         return
     ubiquitous = ubiquitous_words(name for name, _ in children)
     stepped = {name for name, child in children if _stepped_through(name, child, node)}
-    layers = [child for name, child in children if is_role_named(name, role_words, ubiquitous)]
-    role_units = sum(layer.count for layer in layers)
-    if not stepped and len(layers) >= MIN_LAYERS and node.count and role_units / node.count >= ROLE_SHARE:
-        _layered(node, ubiquitous, role_words, out, transpose, top=top)
+    role_children = [child for name, child in children if is_role_named(name, role_words, ubiquitous)]
+    role_units = sum(child.count for child in role_children)
+    if not stepped and len(role_children) >= MIN_LAYERS and node.count and role_units / node.count >= ROLE_SHARE:
+        _layered(node, ubiquitous, role_words, out, transpose, layers, top=top)
         return
     if top:
         out.axis = "structural"
@@ -110,7 +117,7 @@ def _visit(
             continue
         scopes += 1
         if name in stepped:
-            _visit(child, total, role_words, share, out, transpose)
+            _visit(child, total, role_words, share, out, transpose, layers)
             continue
         if is_role_named(name, role_words, ubiquitous):
             out.candidates.append(_box(child))
@@ -126,9 +133,9 @@ def _visit(
         dominant = total > 0 and child.count / total >= share
         if dominant and child_names and child_role_share < ROLE_SHARE:
             out.notes.append(f"opened {_dotted(child.path)} ({child.count} units)")
-            _visit(child, total, role_words, share, out, transpose)
+            _visit(child, total, role_words, share, out, transpose, layers)
         elif dominant and len(child_layers) >= MIN_LAYERS and child_role_share >= ROLE_SHARE:
-            _layered(child, child_ubiquitous, role_words, out, transpose)
+            _layered(child, child_ubiquitous, role_words, out, transpose, layers)
         else:
             out.candidates.append(_box(child))
     if not scopes:
@@ -148,39 +155,40 @@ def _layered(
     role_words: frozenset[str],
     out: Frontier,
     transpose: bool,
+    layers: bool,
     *,
     top: bool = False,
 ) -> None:
     """A node whose children are layers: transpose onto the features recurring under two of
     them, else draw the layers, the only structure there is."""
-    layers = sorted(node.children.items())
+    by_name = sorted(node.children.items())
     while True:
         # The product's name may sit on the feature directories themselves, behind the layers'
         # role-named containers; widen until no more of them read as ubiquitous.
-        found = [name for _, layer in layers for name, _ in _feature_directories(layer, role_words, ubiquitous)]
+        found = [name for _, layer in by_name for name, _ in _feature_directories(layer, role_words, ubiquitous)]
         widened = ubiquitous | ubiquitous_words(found)
         if widened == ubiquitous:
             break
         ubiquitous = widened
     layers_by_feature: dict[str, set[str]] = {}
     display: dict[str, str] = {}
-    for layer_name, layer in layers:
+    for layer_name, layer in by_name:
         for name, _ in _feature_directories(layer, role_words, ubiquitous):
             feature = _feature_stem(name, role_words, ubiquitous)
             layers_by_feature.setdefault(feature, set()).add(layer_name)
             display.setdefault(feature, name)
     features = sorted(feature for feature, feature_layers in layers_by_feature.items() if len(feature_layers) >= 2)
-    if len(features) >= 2 and not transpose:
+    grid = len(features) >= 2
+    if grid and not transpose and not layers:
         out.notes.append(f"{_dotted(node.path) or '<root>'}: layered, kept as one box")
         out.candidates.append(_box(node))
         return
-    if len(features) < 2:
+    if not grid or not transpose:
         if top:
             out.axis = "structural"
-        out.notes.append(
-            f"{_dotted(node.path) or '<root>'}: role-named children, no recurring features; layers as boxes"
-        )
-        for _, layer in sorted(node.children.items()):
+        why = "a grid drawn layer by layer" if grid else "no recurring features"
+        out.notes.append(f"{_dotted(node.path) or '<root>'}: role-named children, {why}; layers as boxes")
+        for _, layer in by_name:
             if layer.count > 1:
                 out.candidates.append(_box(layer))
         if node.units or any(layer.count == 1 for layer in node.children.values()):
@@ -190,7 +198,7 @@ def _layered(
         out.axis = "transposed"
     out.notes.append(f"transposed {_dotted(node.path) or '<root>'} onto {', '.join(features)}")
     prefixes_by_feature: dict[str, list[Prefix]] = {feature: [] for feature in features}
-    for _, layer in layers:
+    for _, layer in by_name:
         for name, child in _feature_directories(layer, role_words, ubiquitous):
             feature = _feature_stem(name, role_words, ubiquitous)
             if feature in prefixes_by_feature:
@@ -207,7 +215,7 @@ def _layered(
         )
     if node.units:
         out.candidates.append(_loose(node))
-    for name, layer in layers:
+    for name, layer in by_name:
         out.candidates.append(
             Candidate(
                 key=f"{RESIDUAL}:{_dotted(layer.path)}",

--- a/static_analyzer/clustering/names/inventory.py
+++ b/static_analyzer/clustering/names/inventory.py
@@ -24,25 +24,30 @@ class Unit:
     language: str
     names: tuple[str, ...]
     position: tuple[str, ...]
+    key: tuple[str, ...]
+    """``position`` plus the one symbol the file declares, when it declares one: what a rule owns
+    to claim this file and not a sibling declared in the same module."""
+
+
+def unit_key(names: Iterable[str], delimiter: str) -> tuple[str, ...]:
+    """The longest prefix the names share."""
+    shared: list[str] = []
+    for parts in zip(*(tuple(segments(name, delimiter)) for name in names)):
+        if len(set(parts)) != 1:
+            break
+        shared.append(parts[0])
+    return tuple(shared)
 
 
 def unit_position(names: Iterable[str], delimiter: str) -> tuple[str, ...]:
-    """The longest prefix the names share, less a trailing symbol.
+    """The unit key less a trailing symbol.
 
     A file declaring one class shares that class's name across every member, so the bare
     prefix would name the class rather than the module it sits in.
     """
-    split = [tuple(segments(name, delimiter)) for name in names]
-    if not split:
-        return ()
-    shared: list[str] = []
-    for parts in zip(*split):
-        if len(set(parts)) != 1:
-            break
-        shared.append(parts[0])
-    if tuple(shared) in split:
-        shared.pop()
-    return tuple(shared)
+    listed = list(names)
+    key = unit_key(listed, delimiter)
+    return key[:-1] if any(tuple(segments(name, delimiter)) == key for name in listed) else key
 
 
 def units_from_graph(graph: CallGraph, language: str) -> list[Unit]:
@@ -51,7 +56,13 @@ def units_from_graph(graph: CallGraph, language: str) -> list[Unit]:
         if node.file_path:
             by_file.setdefault(node.file_path, []).append(qualified_name)
     return [
-        Unit(file_path, language, tuple(sorted(names)), unit_position(names, graph.delimiter))
+        Unit(
+            file_path,
+            language,
+            tuple(sorted(names)),
+            unit_position(names, graph.delimiter),
+            unit_key(names, graph.delimiter),
+        )
         for file_path, names in sorted(by_file.items())
     ]
 

--- a/static_analyzer/clustering/names/replay.py
+++ b/static_analyzer/clustering/names/replay.py
@@ -1,9 +1,10 @@
 """One pure function from units and a scope's rules to a partition.
 
 A unit's box depends on its own names and the rules alone, never on a statistic over the
-collection, so a file added beside it cannot move it. Order of trial: the longest matching
-prefix, then a weighted vote over the words the rules own, then the longest matching
-fallback prefix; what is left is unplaced and reported.
+collection, so a file added beside it cannot move it. Order of trial: the longest prefix
+matching the unit's position (its key, in a scope the files or role rung drew), then a
+weighted vote over the words the rules own, then the longest matching fallback prefix; what
+is left is unplaced and reported.
 """
 
 from __future__ import annotations
@@ -13,7 +14,7 @@ from collections.abc import Iterable
 from dataclasses import dataclass, field
 
 from static_analyzer.clustering.names.inventory import Unit
-from static_analyzer.clustering.names.spec import UNPLACED, Prefix, ScopeSpec
+from static_analyzer.clustering.names.spec import KEYED_RUNGS, UNPLACED, Prefix, ScopeSpec
 from static_analyzer.clustering.names.tokens import segments, stem, tokenize
 from static_analyzer.config import ClusteringConfig
 
@@ -59,9 +60,11 @@ def replay(units: Iterable[Unit], scope: ScopeSpec, role_words: frozenset[str]) 
     named = [(prefix, component_id) for prefix, component_id in primary if prefix]
     known = {prefix for prefix, _ in named}
     bucket = scope.unplaced_rule
+    keyed = scope.rung in KEYED_RUNGS
     for unit in units:
-        component_id, how = _place(unit, primary, fallback, owner_by_term, rank, role_words)
-        if how != PREFIX or _longest_match(unit.position, named) is None:
+        where = unit.key if keyed else unit.position
+        component_id, how = _place(unit, where, primary, fallback, owner_by_term, rank, role_words)
+        if how != PREFIX or _longest_match(where, named) is None:
             partition.new_scopes.setdefault(divergence(unit.position, known), []).append(unit)
         if component_id is None:
             partition.unplaced.append(unit)
@@ -79,7 +82,9 @@ def term_votes(unit: Unit, owner_by_term: dict[str, str], role_words: frozenset[
     """Weighted votes of a unit's words for the rules that own them.
 
     Why the weighting: a noun phrase modifies rightwards, so a word nearer the head weighs
-    more; ``IncidentResolvedMetricsHandler`` is about metrics and reacts to an incident.
+    more; ``IncidentResolvedMetricsHandler`` is about metrics and reacts to an incident. A
+    role word votes only for a rule that owns it: the role rung draws boxes by role inside a
+    feature, and no rule above a leaf ever owns one.
     """
     votes: Counter[str] = Counter()
     for qualified_name in unit.names:
@@ -87,8 +92,6 @@ def term_votes(unit: Unit, owner_by_term: dict[str, str], role_words: frozenset[
             words = tokenize(part)
             for position, word in enumerate(words):
                 key = stem(word)
-                if key in role_words:
-                    continue
                 owner = owner_by_term.get(key)
                 if owner is not None:
                     votes[owner] += 2.0 ** (position - (len(words) - 1))
@@ -97,13 +100,14 @@ def term_votes(unit: Unit, owner_by_term: dict[str, str], role_words: frozenset[
 
 def _place(
     unit: Unit,
+    where: Prefix,
     primary: list[tuple[Prefix, str]],
     fallback: list[tuple[Prefix, str]],
     owner_by_term: dict[str, str],
     rank: dict[str, int],
     role_words: frozenset[str],
 ) -> tuple[str | None, str]:
-    owner = _longest_match(unit.position, primary)
+    owner = _longest_match(where, primary)
     if owner is not None:
         return owner, PREFIX
     if owner_by_term:

--- a/static_analyzer/clustering/names/spec.py
+++ b/static_analyzer/clustering/names/spec.py
@@ -15,6 +15,20 @@ UNPLACED = "unplaced"
 """Kinds of rule. The unplaced bucket owns what no rule claims, so it is drawn rather than
 hidden and can never collide with a component the planner proposes."""
 
+UNMERGE = "unmerge"
+FRONTIER = "frontier"
+VOCABULARY = "vocabulary"
+SEGMENT = "segment"
+LAYERS = "layers"
+FILES = "files"
+ROLE = "role"
+LEAF = "leaf"
+"""The rungs of the ladder, recorded on the scope they drew."""
+
+KEYED_RUNGS = frozenset({FILES, ROLE})
+"""Rungs whose rules own files by their key rather than directories by their position: replay
+matches the key only there, so a class named like a sibling directory moves nothing above."""
+
 
 @dataclass(frozen=True)
 class ComponentRule:
@@ -124,8 +138,9 @@ class ScopeSpec:
         )
 
 
-SPEC_VERSION = 2
-"""2: ``last_id`` per scope; a spec without it cannot keep a retired id from being reissued."""
+SPEC_VERSION = 3
+"""3: the files and role rungs below the old floor of forty units, whose rules claim a unit by its
+key and may own a role word. 2: ``last_id`` per scope."""
 
 
 @dataclass

--- a/tests/static_analyzer/names/conftest.py
+++ b/tests/static_analyzer/names/conftest.py
@@ -1,14 +1,14 @@
 """Builders shared by the names tests: units straight from qualified names, no engine."""
 
 from static_analyzer.cfg import CallGraph
-from static_analyzer.clustering.names import ComponentRule, ScopeSpec, TreeSpec, Trie, Unit, unit_position
+from static_analyzer.clustering.names import ComponentRule, ScopeSpec, TreeSpec, Trie, Unit, unit_key, unit_position
 from static_analyzer.clustering.names.inventory import TrieNode
 from static_analyzer.config import NodeType
 from static_analyzer.node import Node
 
 
 def unit(file_path: str, *names: str, language: str = "python") -> Unit:
-    return Unit(file_path, language, tuple(sorted(names)), unit_position(names, "."))
+    return Unit(file_path, language, tuple(sorted(names)), unit_position(names, "."), unit_key(names, "."))
 
 
 def units_from_layout(layout: dict[str, list[str]], language: str = "python") -> list[Unit]:

--- a/tests/static_analyzer/names/test_draft.py
+++ b/tests/static_analyzer/names/test_draft.py
@@ -16,13 +16,17 @@ from static_analyzer.clustering.names import (
 from static_analyzer.clustering.names.draft import (
     BUDGET,
     CAP_SHARE,
+    FILES,
     FRONTIER,
     GUARD_SHARE,
+    LAYERS,
     LEAF,
     LEAF_CAP,
+    LEAF_UNITS,
+    LOOSE_NAME,
     MIN_LINKS,
     MIN_UNITS,
-    NEST_FLOOR,
+    ROLE,
     SEGMENT,
     UNMERGE,
     VOCABULARY,
@@ -204,11 +208,15 @@ class TestLadder:
         assert [rule.component_id for rule in child.rules] == ["1.1", "1.2"]
         assert rule_of(scope_of(spec, "1"), "1.1").prefixes == (("Ordering",),)
 
-    def test_a_cohesive_component_is_a_leaf_that_says_why(self):
+    def test_a_small_component_is_a_leaf_that_says_why(self):
         spec = draft_tree(units_from_layout(eshop(), "csharp"), KinshipGrouper(), 2)
-        catalog = scope_of(spec, "2")
-        assert catalog.is_leaf and catalog.rung == LEAF
-        assert catalog.leaf_reason.startswith("cohesive: 8 units")
+        basket = scope_of(spec, "4")
+        assert basket.is_leaf and basket.rung == LEAF
+        assert basket.leaf_reason.startswith(f"small: 4 units, at most {LEAF_UNITS}")
+
+    def test_a_component_above_the_leaf_units_reads_its_own_sub_tree(self):
+        catalog = scope_of(draft_tree(units_from_layout(eshop(), "csharp"), KinshipGrouper(), 2), "2")
+        assert catalog.rung == SEGMENT and names_of(catalog) == ["Apis", "Model"]
 
     def test_the_guard_absorbs_a_part_too_small_to_stand(self):
         """Two files against fifty-eight: below max(2, 5%), so the un-merge does not fire."""
@@ -230,15 +238,17 @@ class TestLadder:
         big = scope_of(spec, "3")
         assert big.rung == SEGMENT and names_of(big) == ["One", "Two"]
 
-    def test_nesting_starts_at_the_floor(self):
+    def test_nesting_starts_above_the_leaf_units(self):
         def component(count: int):
             layout = project("Alpha", count, "One", "Two") | project("Beta", 30) | project("Gamma", 30)
-            return scope_of(draft_tree(units_from_layout(layout, "csharp"), AffinityGrouper(), 2), "1")
+            spec = draft_tree(units_from_layout(layout, "csharp"), AffinityGrouper(), 2)
+            alpha = next(rule for rule in scope_of(spec, ROOT_SCOPE_ID).rules if rule.name == "Alpha")
+            return scope_of(spec, alpha.component_id)
 
-        nested = component(NEST_FLOOR)
+        nested = component(LEAF_UNITS + 1)
         assert nested.rung == SEGMENT and names_of(nested) == ["One", "Two"]
-        leaf = component(NEST_FLOOR - 1)
-        assert leaf.is_leaf and leaf.leaf_reason.startswith(f"cohesive: {NEST_FLOOR - 1} units, under {NEST_FLOOR}")
+        leaf = component(LEAF_UNITS)
+        assert leaf.is_leaf and leaf.leaf_reason.startswith(f"small: {LEAF_UNITS} units, at most {LEAF_UNITS}")
 
     def test_a_layered_component_without_a_grid_draws_its_layers(self):
         layout = project("Ordering", 60, "API", "Domain", "Infrastructure") | project("Beta", 40) | project("Gamma", 40)
@@ -246,8 +256,8 @@ class TestLadder:
         assert ordering.rung == SEGMENT
         assert names_of(ordering) == ["API", "Domain", "Infrastructure"]
 
-    def test_a_layered_component_with_a_grid_transposes_only_above_the_cap(self):
-        """A client app organised by layers over features: one box while it can be read whole."""
+    def test_a_layered_component_with_a_grid_draws_its_layers_below_the_cap_and_transposes_above_it(self):
+        """A client app organised by layers over features: the layers are its boxes while it reads whole."""
 
         def client_app(count: int):
             layout = project(
@@ -256,11 +266,77 @@ class TestLadder:
             layout |= project("Beta", 40) | project("Gamma", 40)
             return scope_of(draft_tree(units_from_layout(layout, "csharp"), AffinityGrouper(), 2), "1")
 
-        whole = client_app(LEAF_CAP)
-        assert whole.is_leaf and whole.leaf_reason.startswith(f"cohesive: {LEAF_CAP} units, at most {LEAF_CAP}")
+        layered = client_app(LEAF_CAP)
+        assert layered.rung == LAYERS and names_of(layered) == ["Models", "Services", "Views"]
         transposed = client_app(LEAF_CAP + 1)
         assert transposed.rung == SEGMENT and transposed.axis == "transposed"
         assert {"Orders", "Basket"} <= set(names_of(transposed))
+
+    def _flat_feature(self, *class_names: str) -> dict[str, list[str]]:
+        layout = {f"pkg/feat/{name.lower()}.py": [f"pkg.feat.{name.lower()}.{name}"] for name in class_names}
+        return layout | {f"pkg/other/{index}.py": [f"pkg.other.m{index}.f"] for index in range(3)}
+
+    def test_a_flat_component_groups_its_files_by_their_words(self):
+        """What no directory separates, the file names do; what shares no word is loose, never a one-file box."""
+        layout = self._flat_feature(
+            "RetryPolicy",
+            "RetryBuilder",
+            "RetryOptions",
+            "TimeoutPolicy",
+            "TimeoutBuilder",
+            "TimeoutOptions",
+            "Hedging",
+            "Fallback",
+            "Misc",
+            "Other",
+        )
+        units = units_from_layout(layout)
+        feature = scope_of(draft_tree(units, KinshipGrouper(), 2), "1")
+        assert feature.rung == FILES
+        assert names_of(feature) == [LOOSE_NAME, "RetryBuilder", "TimeoutBuilder"]
+        retry = rule_of(feature, "1.2")
+        assert retry.terms == ("retry",) and len(retry.prefixes) == 3
+        assert ("pkg", "feat", "retrypolicy", "RetryPolicy") in retry.prefixes
+        loose = rule_of(feature, "1.1")
+        assert loose.is_fallback_only and loose.fallback_prefixes == (("pkg", "feat"),)
+        placed = replay(units, feature, ROLE_WORDS)
+        assert placed.size("1.1") == 4 and placed.size("1.2") == 3 and placed.size("1.3") == 3
+
+    def test_a_file_added_to_a_flat_component_follows_its_word(self):
+        layout = self._flat_feature("RetryPolicy", "RetryBuilder", "RetryOptions", "TimeoutPolicy", "TimeoutBuilder")
+        layout |= self._flat_feature("TimeoutOptions", "Hedging", "Fallback", "Misc", "Other")
+        feature = scope_of(draft_tree(units_from_layout(layout), KinshipGrouper(), 2), "1")
+        added = units_from_layout({"pkg/feat/retry_extra.py": ["pkg.feat.retry_extra.RetryExtra"]})
+        placed = replay(added, feature, ROLE_WORDS)
+        assert placed.assignment == {"pkg/feat/retry_extra.py": "1.2"} and placed.placed_by == {
+            "pkg/feat/retry_extra.py": "term"
+        }
+
+    def test_inside_a_feature_the_roles_are_the_boxes(self):
+        """Nine files sharing no word: their head words, a role word each, draw the boxes; one owns its word."""
+        layout = self._flat_feature(
+            "AlphaStrategy",
+            "BetaStrategy",
+            "GammaStrategy",
+            "DeltaOptions",
+            "EpsOptions",
+            "ZetaOptions",
+            "EtaHandler",
+            "ThetaHandler",
+            "Iota",
+        )
+        feature = scope_of(draft_tree(units_from_layout(layout), KinshipGrouper(), 2), "1")
+        assert feature.rung == ROLE
+        assert names_of(feature) == ["Option", "Strategy", "Handler", LOOSE_NAME]
+        assert rule_of(feature, "1.2").terms == ("strategy",)
+        added = units_from_layout({"pkg/feat/kappa_strategy.py": ["pkg.feat.kappa_strategy.KappaStrategy"]})
+        assert replay(added, feature, ROLE_WORDS).assignment == {"pkg/feat/kappa_strategy.py": "1.2"}
+
+    def test_the_ladder_stops_at_the_leaf_units(self):
+        layout = self._flat_feature("AlphaStrategy", "BetaStrategy", "GammaStrategy", "DeltaOptions", "EpsOptions")
+        layout |= self._flat_feature("ZetaOptions", "EtaHandler")
+        feature = scope_of(draft_tree(units_from_layout(layout), KinshipGrouper(), 2), "1")
+        assert feature.is_leaf and feature.leaf_reason.startswith(f"small: {LEAF_UNITS} units")
 
     def test_a_large_component_reads_its_own_frontier(self):
         layout = {
@@ -302,7 +378,7 @@ class TestLadder:
 
         assert 3 * 2 * 22 + 3 == LEAF_CAP
         at_cap = big_scope(3)
-        assert at_cap.is_leaf and at_cap.leaf_reason.startswith(f"cohesive: {LEAF_CAP} units")
+        assert at_cap.rung == FILES and names_of(at_cap) == ["DocxCodec", "PdfCodec", "PptxCodec", LOOSE_NAME]
         assert big_scope(4).rung == VOCABULARY
 
     def test_a_large_component_nothing_splits_is_an_exhausted_leaf(self):

--- a/tests/static_analyzer/names/test_frontier.py
+++ b/tests/static_analyzer/names/test_frontier.py
@@ -283,6 +283,11 @@ class TestLayeredRoot:
         assert keys(frontier) == ["box:Beacon"]
         assert any(note.endswith("kept as one box") for note in frontier.notes)
 
+    def test_a_grid_is_drawn_layer_by_layer_when_asked(self):
+        frontier = walk(Trie(units_from_layout(self._beacon(), "csharp")), ROLE_WORDS, transpose=False, layers=True)
+        assert keys(frontier) == [f"box:Beacon.{layer}" for layer in sorted(self.LAYERS[:3])] + ["loose:Beacon"]
+        assert any("a grid drawn layer by layer" in note for note in frontier.notes)
+
     def test_the_shallowest_feature_directory_keys_its_subtree(self):
         layout = self._beacon()
         layout["Beacon.Domain/Incidents/Metrics/IncidentMetric.cs"] = ["Beacon.Domain.Incidents.Metrics.IncidentMetric"]

--- a/tests/static_analyzer/names/test_inventory.py
+++ b/tests/static_analyzer/names/test_inventory.py
@@ -1,4 +1,4 @@
-from static_analyzer.clustering.names import Trie, unit_position, units_from_graph, units_from_graphs
+from static_analyzer.clustering.names import Trie, unit_key, unit_position, units_from_graph, units_from_graphs
 from tests.static_analyzer.names.conftest import graph_from_layout, node_of, unit
 
 
@@ -6,6 +6,10 @@ class TestUnitPosition:
     def test_python_module_with_several_symbols(self):
         names = ["agents.agent.CodeBoardingAgent", "agents.agent.CodeBoardingAgent.run", "agents.agent.helper"]
         assert unit_position(names, ".") == ("agents", "agent")
+
+    def test_the_key_keeps_the_one_class_a_file_declares(self):
+        assert unit_key(["pkg.mod.Thing", "pkg.mod.Thing.run"], ".") == ("pkg", "mod", "Thing")
+        assert unit_key(["pkg.mod.a", "pkg.mod.b"], ".") == ("pkg", "mod")
 
     def test_a_file_declaring_one_class_sits_in_its_module_not_its_class(self):
         names = ["agents.abstraction_agent.AbstractionAgent", "agents.abstraction_agent.AbstractionAgent.run"]

--- a/tests/static_analyzer/names/test_replay.py
+++ b/tests/static_analyzer/names/test_replay.py
@@ -53,9 +53,14 @@ class TestTerms:
         result = replay([unit("f", *names)], scope(catalog, basket), ROLE_WORDS)
         assert result.assignment == {"f": "2"}
 
-    def test_role_words_never_vote(self):
+    def test_a_role_word_votes_only_for_a_rule_that_owns_it(self):
+        """The role rung draws boxes by role inside a feature; nowhere else does a rule own one."""
         service = ComponentRule("1", "Services", terms=("service",))
         result = replay([unit("f", "X.OrderService")], scope(service, ORDER), ROLE_WORDS)
+        assert result.assignment == {"f": "1"}
+        result = replay(
+            [unit("f", "X.OrderService")], scope(ComponentRule("1", "A", terms=("zzz",)), ORDER), ROLE_WORDS
+        )
         assert result.assignment == {"f": "2"}
 
     def test_a_term_owned_twice_belongs_to_the_first_rule(self):

--- a/tests/static_analyzer/test_clustering_service.py
+++ b/tests/static_analyzer/test_clustering_service.py
@@ -140,14 +140,14 @@ class TestFullHierarchy(unittest.TestCase):
         self.assertIn(consts, [cluster_id for group in ordering.children.groups for cluster_id in group.cluster_ids])
 
     def test_children_follow_the_ladder_and_expandable_is_a_decision(self):
-        ordering, catalog = self.hierarchy.groups[0], self.hierarchy.groups[1]
+        ordering, basket = self.hierarchy.groups[0], self.hierarchy.groups[3]
         self.assertTrue(ordering.expandable)
         assert ordering.children is not None
         self.assertEqual([group.group_id for group in ordering.children.groups], ["1.1", "1.2"])
-        self.assertFalse(catalog.expandable)
-        self.assertIsNone(catalog.children)
+        self.assertFalse(basket.expandable)
+        self.assertIsNone(basket.children)
         self.assertIn("1.1", self.service.spec.scopes, "the spec is drafted one level deeper than the tree")
-        self.assertTrue(scope_of(self.service.spec, "1.1").is_leaf)
+        self.assertTrue(scope_of(self.service.spec, "4").is_leaf)
 
     def test_the_default_grouper_folds_along_the_graph(self):
         """Fifteen root boxes, Tiny.API calling Ordering: the smallest box joins the one it calls."""
@@ -349,8 +349,8 @@ class TestScopeHierarchy(unittest.TestCase):
         with self.assertRaisesRegex(PlannerUnavailableError, "never drafted"):
             ClusteringService().build_scope_hierarchy({"csharp": self.graph}, 2, "1", spec)
 
-    def test_a_cohesive_component_comes_back_without_groups(self):
-        self.assertEqual(self._scope("2").groups, [])
+    def test_a_small_component_comes_back_without_groups(self):
+        self.assertEqual(self._scope("4").groups, [])
 
 
 class TestRerootIndexes(unittest.TestCase):


### PR DESCRIPTION
## What this fixes

A component with fewer than 40 files was a leaf whatever it looked like, so a lot of a diagram ended in boxes you cannot open: on nine repositories, **50-95% of files sat in a leaf of more than 7 files**, some of them 100+ files. markitdown was 95%, eShop 84%, junit4 88%.

## What it does

The ladder keeps going until a component holds **7 files or fewer**. Three new rungs run only after the ones we already have find nothing:

| rung | what it does |
|---|---|
| **layers** | a layered sub-tree (Models, Services, Views) is drawn layer by layer instead of kept whole |
| **files** | every file is a candidate named by itself: the grouper merges the ones sharing a word (`RetryPolicy` + `RetryOptions`) and folds the rest along the call graph. Anything under the floor pools into one "Loose files" box, so a one-file box is never drawn |
| **role** | the same over the head word of each name (`*Strategy`, `*Options`, `*Converter`). Inside a feature the roles are the structure |

Two small mechanics support them. A unit carries its **key** (its position plus the one class the file declares), matched only in scopes those two rungs drew, so a class named like a sibling directory cannot move a file anywhere else. And a **role word may be a term** only for a rule that owns one.

Depth is unchanged as a concept: `--depth-level` still decides what a run materialises, the spec is drafted a level deeper, and everything below is drawn when a component is expanded or the cap is raised.

## No regression above the old leaves

Both engines replayed over the same static analyses of markitdown, CodeBoarding, serilog, mermaid, eShop, mem0, Polly, junit4 and fzf, with no LLM: **every scope `main` drafted comes back with identical rules and identical members**. The only change at existing levels is that leaves now say they can be expanded.

Files in leaves of 7 or fewer, and the depth the tree reaches on its own:

| repo | before | after | depth before → after |
|---|---|---|---|
| junit4 | 12% | 100% | 2 → 4 |
| eShop | 16% | 93% | 4 → 5 |
| serilog | 45% | 93% | 3 → 5 |
| Polly | 11% | 91% | 4 → 6 |
| CodeBoarding | 25% | 90% | 3 → 5 |
| mermaid | 50% | 89% | 4 → 6 |
| fzf | 24% | 62% | 1 → 2 |
| mem0 | 20% | 52% | 4 → 6 |
| markitdown | 5% | 42% | 1 → 3 |

What stays whole is what should: a fan of parallel implementations that share no word (markitdown's 23 converters, mem0's vector stores) and cohesive 8-11 file features. Each records its reason.

## Cost and rollout

Roughly **3x the components** at a deep cap, so a full run at depth 3+ costs proportionally more description calls. `SPEC_VERSION` goes to 3, so the first sync after merge does one full analysis.

## Tests

New coverage for the three rungs, the leaf boundary, the loose bucket and the key matching. `mypy .` and `black` clean. Full suite: 2296 passed, 3 pre-existing `test_cli_parser` failures that fail identically on `main`.

Example runs at depth 3, both engines, in CodeBoarding-tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved name clustering with finer-grained grouping for small components, files, and role-based structures.
  * Added layered views for components, allowing recurring structures to be displayed by layer.
  * Improved handling of similarly named files and symbols within the same module.
  * Role-based naming and placement now provide more accurate clustering results.

* **Documentation**
  * Updated design documentation to reflect revised clustering thresholds and layered grouping behavior.

* **Tests**
  * Added coverage for file grouping, role-based boxes, layered views, and updated leaf classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->