### PR TITLE
Name scopes deterministically and stop the silent naming fallbacks

### DIFF
--- a/agents/constants.py
+++ b/agents/constants.py
@@ -4,6 +4,9 @@
 class LLMDefaults:
     DEFAULT_AGENT_TEMPERATURE = 0
     AWS_MAX_TOKENS = 4096
+    # Why: the provider configs below pass this straight to the client. ``None`` there disables the
+    # SDK's own default, so a stalled socket hangs the whole analysis with nothing to interrupt it.
+    REQUEST_TIMEOUT_SECONDS = 300.0
 
 
 class ModelCapabilities:

--- a/agents/llm_config.py
+++ b/agents/llm_config.py
@@ -149,7 +149,7 @@ LLM_PROVIDERS = {
         base_url_env="OPENAI_BASE_URL",
         extra_args={
             "max_tokens": None,
-            "timeout": None,
+            "timeout": LLMDefaults.REQUEST_TIMEOUT_SECONDS,
             "max_retries": 0,
         },
     ),
@@ -162,7 +162,7 @@ LLM_PROVIDERS = {
         default_base_url="https://ai-gateway.vercel.sh/v1",
         extra_args={
             "max_tokens": None,
-            "timeout": None,
+            "timeout": LLMDefaults.REQUEST_TIMEOUT_SECONDS,
             "max_retries": 0,
         },
     ),
@@ -175,7 +175,7 @@ LLM_PROVIDERS = {
         extra_args={
             "thinking": {"type": "disabled"},
             "max_tokens": 8192,
-            "timeout": None,
+            "timeout": LLMDefaults.REQUEST_TIMEOUT_SECONDS,
             "max_retries": 0,
         },
     ),
@@ -186,7 +186,7 @@ LLM_PROVIDERS = {
         agent_model="gemini-3.8-flash",
         extra_args={
             "max_tokens": None,
-            "timeout": None,
+            "timeout": LLMDefaults.REQUEST_TIMEOUT_SECONDS,
             "max_retries": 0,
         },
     ),
@@ -208,7 +208,7 @@ LLM_PROVIDERS = {
         agent_model="zai-glm-4.7",
         extra_args={
             "max_tokens": None,
-            "timeout": None,
+            "timeout": LLMDefaults.REQUEST_TIMEOUT_SECONDS,
             "max_retries": 0,
         },
     ),
@@ -232,7 +232,7 @@ LLM_PROVIDERS = {
         default_base_url="https://api.deepseek.com/v1",
         extra_args={
             "max_tokens": None,
-            "timeout": None,
+            "timeout": LLMDefaults.REQUEST_TIMEOUT_SECONDS,
             "max_retries": 0,
         },
     ),
@@ -245,7 +245,7 @@ LLM_PROVIDERS = {
         default_base_url="https://open.bigmodel.cn/api/paas/v4",
         extra_args={
             "max_tokens": None,
-            "timeout": None,
+            "timeout": LLMDefaults.REQUEST_TIMEOUT_SECONDS,
             "max_retries": 0,
         },
     ),
@@ -258,7 +258,7 @@ LLM_PROVIDERS = {
         default_base_url="https://api.moonshot.cn/v1",
         extra_args={
             "max_tokens": None,
-            "timeout": None,
+            "timeout": LLMDefaults.REQUEST_TIMEOUT_SECONDS,
             "max_retries": 0,
         },
     ),
@@ -271,7 +271,7 @@ LLM_PROVIDERS = {
         default_base_url="https://openrouter.ai/api/v1",
         extra_args={
             "max_tokens": None,
-            "timeout": None,
+            "timeout": LLMDefaults.REQUEST_TIMEOUT_SECONDS,
             "max_retries": 0,
         },
     ),
@@ -284,7 +284,7 @@ LLM_PROVIDERS = {
         default_base_url="https://api.orcarouter.ai/v1",
         extra_args={
             "max_tokens": None,
-            "timeout": None,
+            "timeout": LLMDefaults.REQUEST_TIMEOUT_SECONDS,
             "max_retries": 0,
         },
     ),
@@ -299,7 +299,7 @@ LLM_PROVIDERS = {
         base_url_env="LITELLM_BASE_URL",
         extra_args={
             "max_tokens": None,
-            "timeout": None,
+            "timeout": LLMDefaults.REQUEST_TIMEOUT_SECONDS,
             "max_retries": 0,
         },
     ),

--- a/agents/llm_config.py
+++ b/agents/llm_config.py
@@ -3,6 +3,7 @@ import os
 from dataclasses import dataclass, field
 from typing import Any
 
+from botocore.config import Config as BotoConfig
 from langchain_anthropic import ChatAnthropic
 from langchain_aws import ChatBedrockConverse
 from langchain_cerebras import ChatCerebras
@@ -197,6 +198,10 @@ LLM_PROVIDERS = {
         agent_model="anthropic.claude-sonnet-4-6",
         extra_args={
             "max_tokens": 4096,
+            "config": lambda: BotoConfig(
+                read_timeout=LLMDefaults.REQUEST_TIMEOUT_SECONDS,
+                connect_timeout=LLMDefaults.REQUEST_TIMEOUT_SECONDS,
+            ),
             "region_name": lambda: os.getenv("AWS_DEFAULT_REGION", "us-east-1"),
             "credentials_profile_name": None,
         },
@@ -221,6 +226,7 @@ LLM_PROVIDERS = {
         keyless_capable=True,
         agent_model="qwen3:30b",
         agent_temperature=LLMDefaults.DEFAULT_AGENT_TEMPERATURE,
+        extra_args={"client_kwargs": {"timeout": LLMDefaults.REQUEST_TIMEOUT_SECONDS}},
         base_url_env="OLLAMA_BASE_URL",
     ),
     "deepseek": LLMConfig(

--- a/agents/llm_renderers/scope.py
+++ b/agents/llm_renderers/scope.py
@@ -28,8 +28,6 @@ def render_scope_context(
     for group in scope.groups:
         component = components.get(group.group_id)
         file_reasons = _group_file_reasons(group, scope, repo_dir)
-        for file_path in file_reasons.keys() & changed_files:
-            boundary_reasons[group.group_id][file_path].add("changed in incremental analysis")
         groups.append(
             {
                 "group_id": group.group_id,

--- a/diagram_analysis/diagram_generator.py
+++ b/diagram_analysis/diagram_generator.py
@@ -742,19 +742,8 @@ class DiagramGenerator:
             with self._naming_counts_lock:
                 self._scopes_unnamed += 1
             return
-        missing = editable_group_ids - {component.group_id for component in semantics.components}
-        if missing:
-            logger.warning(
-                "Scope %s: semantic analysis skipped %d of %d editable groups (%s); they keep deterministic names",
-                scope.scope_id,
-                len(missing),
-                len(editable_group_ids),
-                ", ".join(sorted(missing)),
-            )
-            with self._naming_counts_lock:
-                self._scopes_unnamed += 1
         assert self.static_analysis is not None
-        self.scope_assembler.apply_semantics(
+        unnamed = self.scope_assembler.apply_semantics(
             analysis,
             scope,
             semantics,
@@ -762,6 +751,16 @@ class DiagramGenerator:
             set(locked_name_ids),
             StaticReferenceResolver(self.repo_location, self.static_analysis),
         )
+        if unnamed:
+            logger.warning(
+                "Scope %s: %d of %d editable groups keep deterministic names (%s)",
+                scope.scope_id,
+                len(unnamed),
+                len(editable_group_ids),
+                ", ".join(sorted(unnamed)),
+            )
+            with self._naming_counts_lock:
+                self._scopes_unnamed += 1
 
     def _enrich_incremental_scopes(
         self,
@@ -1217,49 +1216,49 @@ class DiagramGenerator:
             while future_to_task:
                 completed_futures, _ = wait(future_to_task.keys(), return_when=FIRST_COMPLETED)
 
+                # Read every outcome in the batch before acting on any of it: a rejected key
+                # must abort the run before a sibling's success is saved or expanded.
+                outcomes: list[tuple[Component, int, tuple[str | None, AnalysisInsights | None, list[Component]]]] = []
                 for future in completed_futures:
                     component, level = future_to_task.pop(future)
                     stats["completed"] += 1
-
                     try:
-                        comp_name, sub_analysis, new_components = future.result()
-
-                        if comp_name and sub_analysis:
-                            sub_analyses[comp_name] = sub_analysis
-                            expanded_components.append(component)
-                            stats["saves"] += 1
-
-                            logger.debug("Saving intermediate analysis for '%s'", comp_name)
-                            self._strip_ignored(analysis, sub_analyses)
-                            expandable_ids, sub_expandable_ids = self._expandable_ids_for_tree(analysis, sub_analyses)
-                            save_analysis(
-                                analysis=analysis,
-                                output_dir=Path(self.output_dir),
-                                sub_analyses=sub_analyses,
-                                repo_name=self.repo_name,
-                                repo_dir=self.repo_location,
-                                source_tree_hash=self._source_tree_hash(),
-                                expandable_component_ids=expandable_ids,
-                                sub_expandable_ids=sub_expandable_ids,
-                                depth_cap=self.depth_level,
-                                tree_spec=self._tree_spec_dict(),
-                            )
-
-                        if new_components and level + 1 < self.depth_level:
-                            for child in new_components:
-                                submit_component(child, level + 1)
-
-                            logger.info("Expanded '%s' with %d new children.", comp_name, len(new_components))
-
+                        outcomes.append((component, level, future.result()))
                     except LLMAuthError:
-                        # A rejected key fails every remaining component identically; stop
-                        # scheduling more instead of saving a tree with silent holes.
                         for pending in future_to_task:
                             pending.cancel()
                         raise
                     except Exception:
                         stats["errors"] += 1
                         logger.exception("Component '%s' generated an exception", component.name)
+
+                for component, level, (comp_name, sub_analysis, new_components) in outcomes:
+                    if comp_name and sub_analysis:
+                        sub_analyses[comp_name] = sub_analysis
+                        expanded_components.append(component)
+                        stats["saves"] += 1
+
+                        logger.debug("Saving intermediate analysis for '%s'", comp_name)
+                        self._strip_ignored(analysis, sub_analyses)
+                        expandable_ids, sub_expandable_ids = self._expandable_ids_for_tree(analysis, sub_analyses)
+                        save_analysis(
+                            analysis=analysis,
+                            output_dir=Path(self.output_dir),
+                            sub_analyses=sub_analyses,
+                            repo_name=self.repo_name,
+                            repo_dir=self.repo_location,
+                            source_tree_hash=self._source_tree_hash(),
+                            expandable_component_ids=expandable_ids,
+                            sub_expandable_ids=sub_expandable_ids,
+                            depth_cap=self.depth_level,
+                            tree_spec=self._tree_spec_dict(),
+                        )
+
+                    if new_components and level + 1 < self.depth_level:
+                        for child in new_components:
+                            submit_component(child, level + 1)
+
+                        logger.info("Expanded '%s' with %d new children.", comp_name, len(new_components))
 
                 logger.info(
                     "Progress: %d completed, %d in flight, %d errors",

--- a/diagram_analysis/diagram_generator.py
+++ b/diagram_analysis/diagram_generator.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import threading
 import time
 from collections import Counter, defaultdict
 from collections.abc import Collection, Iterable, Iterator, Mapping
@@ -569,6 +570,12 @@ class DiagramGenerator:
         self._incremental_preparation: _IncrementalPreparation | None = None
         self.scope_assembler = ScopeAssembler(repo_location)
         self.scope_analysis_agent: ScopeAnalysisAgent | None = None
+        # Semantic analysis degrades to the deterministic names rather than failing the run, so
+        # count the scopes that took that path: nothing else in the output says it happened.
+        # Child scopes are enriched on the expansion pool, hence the lock.
+        self._naming_counts_lock = threading.Lock()
+        self._scopes_enriched = 0
+        self._scopes_unnamed = 0
         self.incremental_updater: IncrementalUpdater | None = None
         self.file_coverage_data: dict | None = None
 
@@ -713,6 +720,8 @@ class DiagramGenerator:
         """Apply bounded semantic enrichment while preserving deterministic scope structure."""
         if not editable_group_ids:
             return
+        with self._naming_counts_lock:
+            self._scopes_enriched += 1
         try:
             semantics = self._scope_agent().analyze(
                 scope,
@@ -726,8 +735,12 @@ class DiagramGenerator:
             raise
         except Exception:
             logger.exception("Semantic analysis failed for scope %s; retaining deterministic output", scope.scope_id)
+            with self._naming_counts_lock:
+                self._scopes_unnamed += 1
             return
         if semantics is None:
+            with self._naming_counts_lock:
+                self._scopes_unnamed += 1
             return
         assert self.static_analysis is not None
         self.scope_assembler.apply_semantics(
@@ -985,6 +998,10 @@ class DiagramGenerator:
             new_components = [child for child in analysis.components if child.component_id in preclustered_scopes]
 
             return component.component_id, analysis, new_components
+        except LLMAuthError:
+            # A rejected key fails every component identically; don't swallow it
+            # per-component and grind through the rest - abort the whole run.
+            raise
         except Exception as e:
             logging.error(f"Error processing component {component.name}: {e}")
             return None, None, []
@@ -1373,6 +1390,12 @@ class DiagramGenerator:
         unchanged and persists its updated lineage after this save.
         """
         self.finalize_for_save(root_analysis, sub_analyses)
+        if self._scopes_unnamed:
+            logger.warning(
+                "Semantic naming fell back to deterministic names for %d of %d scopes",
+                self._scopes_unnamed,
+                self._scopes_enriched,
+            )
         if persist_side_artifacts:
             source_tree_hash = self._source_tree_hash()
         else:

--- a/diagram_analysis/diagram_generator.py
+++ b/diagram_analysis/diagram_generator.py
@@ -742,6 +742,17 @@ class DiagramGenerator:
             with self._naming_counts_lock:
                 self._scopes_unnamed += 1
             return
+        missing = editable_group_ids - {component.group_id for component in semantics.components}
+        if missing:
+            logger.warning(
+                "Scope %s: semantic analysis skipped %d of %d editable groups (%s); they keep deterministic names",
+                scope.scope_id,
+                len(missing),
+                len(editable_group_ids),
+                ", ".join(sorted(missing)),
+            )
+            with self._naming_counts_lock:
+                self._scopes_unnamed += 1
         assert self.static_analysis is not None
         self.scope_assembler.apply_semantics(
             analysis,
@@ -1240,6 +1251,12 @@ class DiagramGenerator:
 
                             logger.info("Expanded '%s' with %d new children.", comp_name, len(new_components))
 
+                    except LLMAuthError:
+                        # A rejected key fails every remaining component identically; stop
+                        # scheduling more instead of saving a tree with silent holes.
+                        for pending in future_to_task:
+                            pending.cancel()
+                        raise
                     except Exception:
                         stats["errors"] += 1
                         logger.exception("Component '%s' generated an exception", component.name)

--- a/diagram_analysis/scope_assembly.py
+++ b/diagram_analysis/scope_assembly.py
@@ -17,6 +17,7 @@ from agents.relation_edges import (
 )
 from agents.scope_analysis_agent import ScopeAnalysisResult
 from agents.scope_ids import ROOT_SCOPE_ID
+from diagram_analysis.scope_plan import deterministic_component_name
 from clustering_ids import CodeBoardingClusterIds
 from constants import DEFAULT_STATIC_RELATION_LABEL
 from diagram_analysis.file_index import build_file_methods_from_nodes, build_files_index
@@ -47,7 +48,7 @@ class ScopeAssembler:
         for group in scope.groups:
             components.append(
                 Component(
-                    name=self._deterministic_name(group, taken),
+                    name=deterministic_component_name(group, taken),
                     description=self._fallback_description(scope, group),
                     key_entities=[],
                     source_cluster_ids=CodeBoardingClusterIds.from_graph_ids(set(group.cluster_ids)),
@@ -320,19 +321,6 @@ class ScopeAssembler:
                 component.source_cluster_ids,
                 CodeBoardingClusterIds.prefix_for_scope(scope_id),
             )
-
-    @staticmethod
-    def _deterministic_name(group: ClusterGroup, taken: set[str]) -> str:
-        """Name a group from the clustering rule that claimed it.
-
-        Why: the rule name is the only name a scope has before semantic analysis runs, and the
-        one it keeps when that analysis fails.
-        """
-        name = group.name.strip() or f"Component {group.group_id}"
-        if name in taken:
-            name = f"{name} {group.group_id}"
-        taken.add(name)
-        return name
 
     @staticmethod
     def _fallback_description(scope: ClusterScopeResult, group: ClusterGroup) -> str:

--- a/diagram_analysis/scope_assembly.py
+++ b/diagram_analysis/scope_assembly.py
@@ -43,10 +43,11 @@ class ScopeAssembler:
             )
 
         components: list[Component] = []
+        taken: set[str] = set()
         for group in scope.groups:
             components.append(
                 Component(
-                    name=f"Component {group.group_id}",
+                    name=self._deterministic_name(group, taken),
                     description=self._fallback_description(scope, group),
                     key_entities=[],
                     source_cluster_ids=CodeBoardingClusterIds.from_graph_ids(set(group.cluster_ids)),
@@ -103,7 +104,9 @@ class ScopeAssembler:
         semantics_by_id = {item.group_id: item for item in result.components if item.group_id in components}
         used_names = {component.name for component in analysis.components}
         updated_ids: set[str] = set()
-        for group_id in editable_group_ids:
+        # Scope order, not set order: a duplicate name proposed for two groups must resolve the
+        # same way on every run.
+        for group_id in (group.group_id for group in scope.groups if group.group_id in editable_group_ids):
             component = components.get(group_id)
             component_semantics = semantics_by_id.get(group_id)
             if component is None or component_semantics is None:
@@ -119,8 +122,11 @@ class ScopeAssembler:
                 used_names.add(proposed_name)
             if component_semantics.description.strip():
                 component.description = component_semantics.description.strip()
-            component.key_entities = [reference.model_copy(deep=True) for reference in component_semantics.key_entities]
-            updated_ids.add(group_id)
+            if component_semantics.key_entities:
+                component.key_entities = [
+                    reference.model_copy(deep=True) for reference in component_semantics.key_entities
+                ]
+                updated_ids.add(group_id)
 
         if updated_ids:
             reference_resolver.fix_key_entities_refs(analysis, updated_ids)
@@ -133,6 +139,8 @@ class ScopeAssembler:
             for relation in analysis.components_relations
             if relation.src_id not in editable_group_ids and relation.dst_id not in editable_group_ids
         ]
+        preserved_pairs = {(relation.src_id, relation.dst_id) for relation in preserved}
+        existing_by_pair = {(relation.src_id, relation.dst_id): relation for relation in analysis.components_relations}
         for relation in preserved:
             source = components.get(relation.src_id)
             target = components.get(relation.dst_id)
@@ -182,7 +190,27 @@ class ScopeAssembler:
                 )
             )
 
-        analysis.components_relations = [*preserved, *semantic_relations]
+        # A group the model was asked about drops every relation it touches. Where the model did
+        # not label one back, keep the label the previous run gave it rather than resetting a
+        # still-connected edge to the generic default.
+        carried = [
+            relation.model_copy(deep=True)
+            for pair, relation in existing_by_pair.items()
+            if pair not in seen_pairs
+            and pair not in preserved_pairs
+            and relation.relation.strip()
+            and relation.relation != DEFAULT_STATIC_RELATION_LABEL
+            and scope.connection_between(*pair) is not None
+        ]
+        for relation in carried:
+            source = components.get(relation.src_id)
+            target = components.get(relation.dst_id)
+            if source is not None:
+                relation.src_name = source.name
+            if target is not None:
+                relation.dst_name = target.name
+
+        analysis.components_relations = [*preserved, *carried, *semantic_relations]
         self.merge_scope_relations(analysis, scope)
 
     @staticmethod
@@ -292,6 +320,19 @@ class ScopeAssembler:
                 component.source_cluster_ids,
                 CodeBoardingClusterIds.prefix_for_scope(scope_id),
             )
+
+    @staticmethod
+    def _deterministic_name(group: ClusterGroup, taken: set[str]) -> str:
+        """Name a group from the clustering rule that claimed it.
+
+        Why: the rule name is the only name a scope has before semantic analysis runs, and the
+        one it keeps when that analysis fails.
+        """
+        name = group.name.strip() or f"Component {group.group_id}"
+        if name in taken:
+            name = f"{name} {group.group_id}"
+        taken.add(name)
+        return name
 
     @staticmethod
     def _fallback_description(scope: ClusterScopeResult, group: ClusterGroup) -> str:

--- a/diagram_analysis/scope_assembly.py
+++ b/diagram_analysis/scope_assembly.py
@@ -17,7 +17,6 @@ from agents.relation_edges import (
 )
 from agents.scope_analysis_agent import ScopeAnalysisResult
 from agents.scope_ids import ROOT_SCOPE_ID
-from diagram_analysis.scope_plan import deterministic_component_name
 from clustering_ids import CodeBoardingClusterIds
 from constants import DEFAULT_STATIC_RELATION_LABEL
 from diagram_analysis.file_index import build_file_methods_from_nodes, build_files_index
@@ -48,7 +47,7 @@ class ScopeAssembler:
         for group in scope.groups:
             components.append(
                 Component(
-                    name=deterministic_component_name(group, taken),
+                    name=group.unique_name(taken),
                     description=self._fallback_description(scope, group),
                     key_entities=[],
                     source_cluster_ids=CodeBoardingClusterIds.from_graph_ids(set(group.cluster_ids)),
@@ -99,31 +98,52 @@ class ScopeAssembler:
         editable_group_ids: set[str],
         locked_name_ids: set[str],
         reference_resolver: StaticReferenceResolver,
-    ) -> None:
-        """Apply valid semantic fields without changing deterministic structure."""
+    ) -> frozenset[str]:
+        """Apply valid semantic fields without changing deterministic structure.
+
+        Returns the editable groups that ended up without a semantic name, so the caller can
+        report a scope the model only partly named.
+        """
         components = {component.component_id: component for component in analysis.components}
+        groups_by_id = {group.group_id: group for group in scope.groups}
         semantics_by_id = {item.group_id: item for item in result.components if item.group_id in components}
-        used_names = {component.name for component in analysis.components}
+        ordered_ids = [group.group_id for group in scope.groups if group.group_id in editable_group_ids]
+
+        # Names are allocated against the final set, not the current one: a swap between two
+        # siblings is valid, while a name already held by a component that cannot move is not.
+        proposals = {
+            group_id: semantics_by_id[group_id].name.strip()
+            for group_id in ordered_ids
+            if group_id in semantics_by_id
+            and group_id not in locked_name_ids
+            and semantics_by_id[group_id].name.strip()
+        }
+        taken = {component.name for group_id, component in components.items() if group_id not in proposals}
+        named: set[str] = set()
+        for group_id in ordered_ids:
+            component = components.get(group_id)
+            proposed = proposals.get(group_id)
+            if component is None or proposed is None:
+                continue
+            if proposed not in taken:
+                component.name = proposed
+                named.add(group_id)
+            elif component.name in taken:
+                # Its previous name went to an accepted proposal; fall back to the rule name.
+                component.name = groups_by_id[group_id].unique_name(taken)
+                continue
+            taken.add(component.name)
+
         updated_ids: set[str] = set()
-        # Scope order, not set order: a duplicate name proposed for two groups must resolve the
-        # same way on every run.
-        for group_id in (group.group_id for group in scope.groups if group.group_id in editable_group_ids):
+        for group_id in ordered_ids:
             component = components.get(group_id)
             component_semantics = semantics_by_id.get(group_id)
             if component is None or component_semantics is None:
                 continue
-            proposed_name = component_semantics.name.strip()
-            if (
-                group_id not in locked_name_ids
-                and proposed_name
-                and (proposed_name == component.name or proposed_name not in used_names)
-            ):
-                used_names.discard(component.name)
-                component.name = proposed_name
-                used_names.add(proposed_name)
             if component_semantics.description.strip():
                 component.description = component_semantics.description.strip()
-            if component_semantics.key_entities:
+            # An explicit empty list clears the entities; an absent key keeps them.
+            if "key_entities" in component_semantics.model_fields_set:
                 component.key_entities = [
                     reference.model_copy(deep=True) for reference in component_semantics.key_entities
                 ]
@@ -213,6 +233,7 @@ class ScopeAssembler:
 
         analysis.components_relations = [*preserved, *carried, *semantic_relations]
         self.merge_scope_relations(analysis, scope)
+        return frozenset(editable_group_ids - named - locked_name_ids)
 
     @staticmethod
     def merge_scope_relations(analysis: AnalysisInsights, scope: ClusterScopeResult) -> None:

--- a/diagram_analysis/scope_plan.py
+++ b/diagram_analysis/scope_plan.py
@@ -20,6 +20,22 @@ from static_analyzer.clustering import ClusterGroup, ClusterResult, ClusterScope
 logger = logging.getLogger(__name__)
 
 
+def deterministic_component_name(group: ClusterGroup, taken: set[str]) -> str:
+    """Name a group from the clustering rule that claimed it, unique among ``taken``.
+
+    Why: the rule name is the only name a scope has before semantic analysis runs, and the
+    one it keeps when that analysis fails or skips the group.
+    """
+    base = group.name.strip() or f"Component {group.group_id}"
+    name = base
+    suffix = 1
+    while name in taken:
+        suffix += 1
+        name = f"{base} {group.group_id}" if suffix == 2 else f"{base} {group.group_id} {suffix - 1}"
+    taken.add(name)
+    return name
+
+
 def plan_scope_result_update(
     scope: AnalysisInsights,
     clustering: ClusterScopeResult,
@@ -83,6 +99,7 @@ def _plan_scope_operations(
     operations: list[ScopeOperation] = []
     kept: set[str] = set()
     untouched = 0
+    sibling_names = {component.name for component in scope.components if component.component_id}
     for cluster_group in groups:
         group = set(cluster_group.cluster_ids)
         owner = cluster_group.previous_component_id
@@ -124,7 +141,7 @@ def _plan_scope_operations(
                     # The specification allocated this id; the component must keep it or the
                     # next replay would not recognise its own rule.
                     component_id=cluster_group.group_id,
-                    name=f"Component {cluster_group.group_id}",
+                    name=deterministic_component_name(cluster_group, sibling_names),
                     description=_provisional_description(group, combined),
                     rationale="clusters with no predecessor in this scope",
                 )

--- a/diagram_analysis/scope_plan.py
+++ b/diagram_analysis/scope_plan.py
@@ -20,22 +20,6 @@ from static_analyzer.clustering import ClusterGroup, ClusterResult, ClusterScope
 logger = logging.getLogger(__name__)
 
 
-def deterministic_component_name(group: ClusterGroup, taken: set[str]) -> str:
-    """Name a group from the clustering rule that claimed it, unique among ``taken``.
-
-    Why: the rule name is the only name a scope has before semantic analysis runs, and the
-    one it keeps when that analysis fails or skips the group.
-    """
-    base = group.name.strip() or f"Component {group.group_id}"
-    name = base
-    suffix = 1
-    while name in taken:
-        suffix += 1
-        name = f"{base} {group.group_id}" if suffix == 2 else f"{base} {group.group_id} {suffix - 1}"
-    taken.add(name)
-    return name
-
-
 def plan_scope_result_update(
     scope: AnalysisInsights,
     clustering: ClusterScopeResult,
@@ -99,7 +83,8 @@ def _plan_scope_operations(
     operations: list[ScopeOperation] = []
     kept: set[str] = set()
     untouched = 0
-    sibling_names = {component.name for component in scope.components if component.component_id}
+    surviving = {group.previous_component_id for group in groups if group.previous_component_id}
+    sibling_names = {component.name for component in scope.components if component.component_id in surviving}
     for cluster_group in groups:
         group = set(cluster_group.cluster_ids)
         owner = cluster_group.previous_component_id
@@ -141,7 +126,7 @@ def _plan_scope_operations(
                     # The specification allocated this id; the component must keep it or the
                     # next replay would not recognise its own rule.
                     component_id=cluster_group.group_id,
-                    name=deterministic_component_name(cluster_group, sibling_names),
+                    name=cluster_group.unique_name(sibling_names),
                     description=_provisional_description(group, combined),
                     rationale="clusters with no predecessor in this scope",
                 )

--- a/static_analyzer/clustering/models.py
+++ b/static_analyzer/clustering/models.py
@@ -53,6 +53,7 @@ class ClusterGroup:
 
     group_id: GroupId
     cluster_ids: list[ClusterId]
+    name: str = ""
     symbol_members_by_language: dict[str, set[str]] = field(default_factory=dict)
     file_reasons: dict[str, str] = field(default_factory=dict)
     previous_component_id: ComponentId = ""

--- a/static_analyzer/clustering/models.py
+++ b/static_analyzer/clustering/models.py
@@ -68,6 +68,21 @@ class ClusterGroup:
             for qualified_name in language_qualified_names
         }
 
+    def unique_name(self, taken: set[str]) -> str:
+        """The rule name that claimed this group, made unique among ``taken`` and reserved there.
+
+        Why: it is the only name a scope has before semantic analysis runs, and the one a
+        group keeps when that analysis fails or skips it.
+        """
+        base = self.name.strip() or f"Component {self.group_id}"
+        name = base
+        suffix = 1
+        while name in taken:
+            suffix += 1
+            name = f"{base} {self.group_id}" if suffix == 2 else f"{base} {self.group_id} {suffix - 1}"
+        taken.add(name)
+        return name
+
 
 @dataclass
 class ClusterScopeResult:

--- a/static_analyzer/clustering/service.py
+++ b/static_analyzer/clustering/service.py
@@ -201,6 +201,7 @@ class ClusteringService:
                 continue
             group = ClusterGroup(
                 group_id=rule.component_id,
+                name=rule.name,
                 cluster_ids=sorted(leaf_by_unit[unit.unit_id] for unit in members),
                 previous_component_id=rule.component_id if rule.component_id in previous_ids else "",
             )

--- a/tests/agents/test_llm_config.py
+++ b/tests/agents/test_llm_config.py
@@ -137,6 +137,14 @@ class TestProviderSelection:
         with patch.dict(os.environ, {env_var: "https://custom.example/v1"}, clear=True):
             assert config.get_resolved_extra_args()["base_url"] == "https://custom.example/v1"
 
+    def test_every_provider_declaring_a_timeout_gives_its_client_a_real_one(self):
+        """A ``None`` here disables the SDK default, so a stalled request hangs the whole run."""
+        assert [
+            name
+            for name, config in LLM_PROVIDERS.items()
+            if "timeout" in config.extra_args and not config.extra_args["timeout"]
+        ] == []
+
     def test_anthropic_defaults_to_sonnet_5(self):
         anthropic = LLM_PROVIDERS["anthropic"]
 

--- a/tests/agents/test_llm_config.py
+++ b/tests/agents/test_llm_config.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from agents.constants import LLMDefaults
 from agents.llm_config import (
     LLM_ENV_VARS,
     LLM_PROVIDERS,
@@ -137,13 +138,22 @@ class TestProviderSelection:
         with patch.dict(os.environ, {env_var: "https://custom.example/v1"}, clear=True):
             assert config.get_resolved_extra_args()["base_url"] == "https://custom.example/v1"
 
-    def test_every_provider_declaring_a_timeout_gives_its_client_a_real_one(self):
-        """A ``None`` here disables the SDK default, so a stalled request hangs the whole run."""
-        assert [
-            name
-            for name, config in LLM_PROVIDERS.items()
-            if "timeout" in config.extra_args and not config.extra_args["timeout"]
-        ] == []
+    def test_every_provider_bounds_its_requests(self):
+        """A stalled request must time out on every provider, whichever knob its client exposes."""
+
+        def bound(config):
+            args = config.get_resolved_extra_args()
+            if "timeout" in args:
+                return args["timeout"]
+            if "client_kwargs" in args:
+                return args["client_kwargs"].get("timeout")
+            if "config" in args:
+                return args["config"].read_timeout
+            return None
+
+        assert {name: bound(config) for name, config in LLM_PROVIDERS.items()} == {
+            name: LLMDefaults.REQUEST_TIMEOUT_SECONDS for name in LLM_PROVIDERS
+        }
 
     def test_anthropic_defaults_to_sonnet_5(self):
         anthropic = LLM_PROVIDERS["anthropic"]

--- a/tests/diagram_analysis/test_diagram_analysis.py
+++ b/tests/diagram_analysis/test_diagram_analysis.py
@@ -1059,6 +1059,35 @@ class TestDiagramGenerator(unittest.TestCase):
         self.assertIsNone(result_analysis)
         self.assertEqual(new_components, [])
 
+    def test_process_component_propagates_authentication_failures(self):
+        gen = DiagramGenerator(
+            repo_location=self.repo_location,
+            temp_folder=self.temp_folder,
+            repo_name="test_repo",
+            output_dir=self.output_dir,
+            depth_level=2,
+            run_id="test-run-id",
+            log_path="test_repo/test-run-log",
+        )
+        gen._enrich_scope = Mock(
+            side_effect=LLMAuthError(
+                "key rejected",
+                provider="openai",
+                key_tail="1234",
+                telemetry_properties={"error_type": "auth"},
+            )
+        )
+        component = Component(name="TestComponent", description="Test", key_entities=[], component_id="1")
+        scope = ClusterScopeResult(scope_id="1")
+        gen.clustering_hierarchy = ClusterScopeResult(
+            scope_id="root",
+            groups=[ClusterGroup(group_id="1", cluster_ids=[1], children=scope)],
+        )
+        gen.clustering_hierarchy.index_hierarchy()
+
+        with self.assertRaises(LLMAuthError):
+            gen.process_component(component)
+
     def test_process_component_propagates_missing_scope(self):
         gen = DiagramGenerator(
             repo_location=self.repo_location,

--- a/tests/diagram_analysis/test_diagram_analysis.py
+++ b/tests/diagram_analysis/test_diagram_analysis.py
@@ -4,6 +4,7 @@ import shutil
 import tempfile
 import time
 import unittest
+from concurrent.futures import ALL_COMPLETED, wait
 from pathlib import Path
 from unittest.mock import MagicMock, Mock, patch
 
@@ -909,7 +910,7 @@ class TestDiagramGenerator(unittest.TestCase):
 
         self.assertIs(caught.exception, error)
 
-    def test_enrich_scope_counts_a_response_that_skips_editable_groups_as_a_fallback(self):
+    def test_enrich_scope_counts_a_partly_named_scope_as_a_fallback(self):
         gen = DiagramGenerator(
             repo_location=self.repo_location,
             temp_folder=self.temp_folder,
@@ -921,10 +922,8 @@ class TestDiagramGenerator(unittest.TestCase):
         )
         gen.static_analysis = StaticAnalysisResults()
         gen.scope_analysis_agent = MagicMock()
-        gen.scope_analysis_agent.analyze.return_value = ScopeAnalysisResult(
-            components=[ScopeComponentSemantics(group_id="1", name="Runner", description="Runs.")]
-        )
-        gen.scope_assembler.apply_semantics = Mock()
+        gen.scope_analysis_agent.analyze.return_value = ScopeAnalysisResult()
+        gen.scope_assembler.apply_semantics = Mock(return_value=frozenset({"2"}))
 
         gen._enrich_scope(
             ClusterScopeResult(scope_id="root"),
@@ -933,35 +932,47 @@ class TestDiagramGenerator(unittest.TestCase):
         )
 
         self.assertEqual((gen._scopes_enriched, gen._scopes_unnamed), (1, 1))
-        gen.scope_assembler.apply_semantics.assert_called_once()
 
     @patch("diagram_analysis.diagram_generator.save_analysis")
-    def test_generate_subcomponents_aborts_on_authentication_failure(self, mock_save_analysis):
+    def test_generate_subcomponents_aborts_before_acting_on_a_batch_with_an_auth_failure(self, mock_save_analysis):
+        """A sibling's success that completes alongside a rejected key is neither saved nor expanded."""
         gen = DiagramGenerator(
             repo_location=self.repo_location,
             temp_folder=self.temp_folder,
             repo_name="test_repo",
             output_dir=self.output_dir,
-            depth_level=2,
+            depth_level=3,
             run_id="test-run-id",
             log_path="test_repo/test-run-log",
         )
-        root = Component(name="A", description="", key_entities=[], component_id="1")
-        gen._process_component = Mock(
-            side_effect=LLMAuthError(
+        good = Component(name="A", description="", key_entities=[], component_id="1")
+        bad = Component(name="B", description="", key_entities=[], component_id="2")
+        child = Component(name="A-child", description="", key_entities=[], component_id="1.1")
+        sub = AnalysisInsights(description="", components=[child], components_relations=[])
+
+        def process(component: Component):
+            if component.name == "A":
+                return "A", sub, [child]
+            raise LLMAuthError(
                 "key rejected",
                 provider="openai",
                 key_tail="1234",
                 telemetry_properties={"error_type": "auth"},
             )
-        )
 
-        with self.assertRaises(LLMAuthError):
-            gen._generate_subcomponents(
-                AnalysisInsights(description="", components=[root], components_relations=[]), [root]
-            )
+        gen._process_component = Mock(side_effect=process)
+        root = AnalysisInsights(description="", components=[good, bad], components_relations=[])
+
+        # Deliver both outcomes in one batch, whichever finished first.
+        with patch(
+            "diagram_analysis.diagram_generator.wait",
+            side_effect=lambda futures, **_: wait(futures, return_when=ALL_COMPLETED),
+        ):
+            with self.assertRaises(LLMAuthError):
+                gen._generate_subcomponents(root, [good, bad])
 
         mock_save_analysis.assert_not_called()
+        self.assertEqual([call.args[0].name for call in gen._process_component.call_args_list], ["A", "B"])
 
     @patch("diagram_analysis.diagram_generator.get_static_analysis")
     def test_new_analyzer_honors_cache_reuse_override(self, mock_get_static_analysis):

--- a/tests/diagram_analysis/test_diagram_analysis.py
+++ b/tests/diagram_analysis/test_diagram_analysis.py
@@ -20,6 +20,7 @@ from agents.agent_responses import (
 from agents.file_index_models import FileEntry, FileMethodGroup, MethodEntry
 from agents.incremental_results import RecursiveScopeUpdateResult, ScopeRelationContext, ScopeUpdateResult
 from agents.llm_errors import LLMAuthError
+from agents.scope_analysis_agent import ScopeAnalysisResult, ScopeComponentSemantics
 from agents.relation_edges import index_relation_endpoints
 from agents.scope_ids import ROOT_SCOPE_ID
 from diagram_analysis.analysis_json import (
@@ -907,6 +908,60 @@ class TestDiagramGenerator(unittest.TestCase):
             )
 
         self.assertIs(caught.exception, error)
+
+    def test_enrich_scope_counts_a_response_that_skips_editable_groups_as_a_fallback(self):
+        gen = DiagramGenerator(
+            repo_location=self.repo_location,
+            temp_folder=self.temp_folder,
+            repo_name="test_repo",
+            output_dir=self.output_dir,
+            depth_level=2,
+            run_id="test-run-id",
+            log_path="test_repo/test-run-log",
+        )
+        gen.static_analysis = StaticAnalysisResults()
+        gen.scope_analysis_agent = MagicMock()
+        gen.scope_analysis_agent.analyze.return_value = ScopeAnalysisResult(
+            components=[ScopeComponentSemantics(group_id="1", name="Runner", description="Runs.")]
+        )
+        gen.scope_assembler.apply_semantics = Mock()
+
+        gen._enrich_scope(
+            ClusterScopeResult(scope_id="root"),
+            AnalysisInsights(description="", components=[], components_relations=[]),
+            {"1", "2"},
+        )
+
+        self.assertEqual((gen._scopes_enriched, gen._scopes_unnamed), (1, 1))
+        gen.scope_assembler.apply_semantics.assert_called_once()
+
+    @patch("diagram_analysis.diagram_generator.save_analysis")
+    def test_generate_subcomponents_aborts_on_authentication_failure(self, mock_save_analysis):
+        gen = DiagramGenerator(
+            repo_location=self.repo_location,
+            temp_folder=self.temp_folder,
+            repo_name="test_repo",
+            output_dir=self.output_dir,
+            depth_level=2,
+            run_id="test-run-id",
+            log_path="test_repo/test-run-log",
+        )
+        root = Component(name="A", description="", key_entities=[], component_id="1")
+        gen._process_component = Mock(
+            side_effect=LLMAuthError(
+                "key rejected",
+                provider="openai",
+                key_tail="1234",
+                telemetry_properties={"error_type": "auth"},
+            )
+        )
+
+        with self.assertRaises(LLMAuthError):
+            gen._generate_subcomponents(
+                AnalysisInsights(description="", components=[root], components_relations=[]), [root]
+            )
+
+        mock_save_analysis.assert_not_called()
 
     @patch("diagram_analysis.diagram_generator.get_static_analysis")
     def test_new_analyzer_honors_cache_reuse_override(self, mock_get_static_analysis):

--- a/tests/diagram_analysis/test_scope_assembly.py
+++ b/tests/diagram_analysis/test_scope_assembly.py
@@ -190,6 +190,16 @@ class TestScopeAssembler(unittest.TestCase):
             ["Storage", "Storage 2", "Component 3"],
         )
 
+    def test_keeps_suffixing_until_the_name_is_free(self) -> None:
+        scope = _scope(names={"1": "Storage", "2": "Storage 3", "3": "Storage"})
+
+        analysis = ScopeAssembler(Path("/repo")).build(scope)
+
+        self.assertEqual(
+            [component.name for component in analysis.components],
+            ["Storage", "Storage 3", "Storage 3 2"],
+        )
+
     def test_keeps_existing_key_entities_when_semantics_omit_them(self) -> None:
         scope = _scope()
         assembler = ScopeAssembler(Path("/repo"))

--- a/tests/diagram_analysis/test_scope_assembly.py
+++ b/tests/diagram_analysis/test_scope_assembly.py
@@ -206,12 +206,71 @@ class TestScopeAssembler(unittest.TestCase):
         analysis = assembler.build(scope)
         analysis.components[0].key_entities = [SourceCodeReference(qualified_name="a.run")]
         result = ScopeAnalysisResult(
-            components=[ScopeComponentSemantics(group_id="1", name="Runner", description="Runs.", key_entities=[])],
+            components=[ScopeComponentSemantics(group_id="1", name="Runner", description="Runs.")],
         )
 
         assembler.apply_semantics(analysis, scope, result, {"1"}, set(), _resolver(scope))
 
         self.assertEqual([entity.qualified_name for entity in analysis.components[0].key_entities], ["a.run"])
+
+    def test_an_explicit_empty_key_entity_list_clears_them(self) -> None:
+        scope = _scope()
+        assembler = ScopeAssembler(Path("/repo"))
+        analysis = assembler.build(scope)
+        analysis.components[0].key_entities = [SourceCodeReference(qualified_name="a.run")]
+        result = ScopeAnalysisResult.model_validate_json(
+            '{"components": [{"group_id": "1", "name": "Runner", "description": "Runs.", "key_entities": []}]}'
+        )
+
+        assembler.apply_semantics(analysis, scope, result, {"1"}, set(), _resolver(scope))
+
+        self.assertEqual(analysis.components[0].key_entities, [])
+
+    def test_names_are_allocated_against_final_siblings_so_a_swap_is_valid(self) -> None:
+        scope = _scope(names={"1": "API", "2": "Storage"})
+        assembler = ScopeAssembler(Path("/repo"))
+        analysis = assembler.build(scope)
+        result = ScopeAnalysisResult(
+            components=[
+                ScopeComponentSemantics(group_id="1", name="Storage", description="Stores."),
+                ScopeComponentSemantics(group_id="2", name="Persistence", description="Persists."),
+            ],
+        )
+
+        unnamed = assembler.apply_semantics(analysis, scope, result, {"1", "2"}, set(), _resolver(scope))
+
+        self.assertEqual([component.name for component in analysis.components[:2]], ["Storage", "Persistence"])
+        self.assertEqual(unnamed, frozenset())
+
+    def test_a_losing_duplicate_proposal_falls_back_to_its_rule_name_and_is_reported(self) -> None:
+        scope = _scope(names={"1": "API", "2": "Storage", "3": "Cache"})
+        assembler = ScopeAssembler(Path("/repo"))
+        analysis = assembler.build(scope)
+        result = ScopeAnalysisResult(
+            components=[
+                ScopeComponentSemantics(group_id="1", name="Storage", description="Stores."),
+                ScopeComponentSemantics(group_id="2", name="Storage", description="Also stores."),
+                ScopeComponentSemantics(group_id="3", name="", description="Blank name."),
+            ],
+        )
+
+        unnamed = assembler.apply_semantics(analysis, scope, result, {"1", "2", "3"}, set(), _resolver(scope))
+
+        self.assertEqual([component.name for component in analysis.components], ["Storage", "Storage 2", "Cache"])
+        self.assertEqual(unnamed, frozenset({"2", "3"}))
+
+    def test_a_proposal_cannot_take_a_name_held_by_a_group_that_cannot_move(self) -> None:
+        scope = _scope(names={"1": "API", "2": "Storage"})
+        assembler = ScopeAssembler(Path("/repo"))
+        analysis = assembler.build(scope)
+        result = ScopeAnalysisResult(
+            components=[ScopeComponentSemantics(group_id="1", name="Storage", description="Stores.")],
+        )
+
+        unnamed = assembler.apply_semantics(analysis, scope, result, {"1"}, set(), _resolver(scope))
+
+        self.assertEqual([component.name for component in analysis.components[:2]], ["API", "Storage"])
+        self.assertEqual(unnamed, frozenset({"1"}))
 
     def test_keeps_the_previous_label_when_semantics_omit_a_still_connected_pair(self) -> None:
         scope = _scope(("1", "2"))

--- a/tests/diagram_analysis/test_scope_assembly.py
+++ b/tests/diagram_analysis/test_scope_assembly.py
@@ -22,8 +22,9 @@ def _component(component_id: str, name: str) -> Component:
     return Component(name=name, description=name, key_entities=[], component_id=component_id)
 
 
-def _scope(*pairs: tuple[str, str]) -> ClusterScopeResult:
+def _scope(*pairs: tuple[str, str], names: dict[str, str] | None = None) -> ClusterScopeResult:
     symbols = {"1": "a.run", "2": "b.load", "3": "c.save"}
+    names = names or {}
     graph = CallGraph(language="python")
     for index, (group_id, qualified_name) in enumerate(symbols.items(), start=1):
         graph.add_node(Node(qualified_name, NodeType.FUNCTION, f"src/{group_id}.py", index, index + 1))
@@ -33,6 +34,7 @@ def _scope(*pairs: tuple[str, str]) -> ClusterScopeResult:
         groups=[
             ClusterGroup(
                 group_id=group_id,
+                name=names.get(group_id, ""),
                 cluster_ids=[int(group_id)],
                 symbol_members_by_language={"python": {qualified_name}},
             )
@@ -53,6 +55,13 @@ def _scope(*pairs: tuple[str, str]) -> ClusterScopeResult:
             for source_id, target_id in pairs
         ],
     )
+
+
+def _resolver(scope: ClusterScopeResult) -> StaticReferenceResolver:
+    static_analysis = StaticAnalysisResults()
+    static_analysis.add_cfg(Language.PYTHON, scope.graphs_by_language["python"])
+    static_analysis.add_references(Language.PYTHON, list(scope.graphs_by_language["python"].nodes.values()))
+    return StaticReferenceResolver(Path("/repo"), static_analysis)
 
 
 class TestScopeAssembler(unittest.TestCase):
@@ -159,6 +168,64 @@ class TestScopeAssembler(unittest.TestCase):
         self.assertEqual(
             [(relation.src_id, relation.dst_id, relation.relation) for relation in analysis.components_relations],
             [("2", "3", "calls")],
+        )
+
+    def test_names_components_from_the_clustering_rule_that_claimed_them(self) -> None:
+        scope = _scope(names={"1": "Ingestion", "2": "Storage"})
+
+        analysis = ScopeAssembler(Path("/repo")).build(scope)
+
+        self.assertEqual(
+            [component.name for component in analysis.components],
+            ["Ingestion", "Storage", "Component 3"],
+        )
+
+    def test_disambiguates_two_groups_claiming_the_same_rule_name(self) -> None:
+        scope = _scope(names={"1": "Storage", "2": "Storage"})
+
+        analysis = ScopeAssembler(Path("/repo")).build(scope)
+
+        self.assertEqual(
+            [component.name for component in analysis.components],
+            ["Storage", "Storage 2", "Component 3"],
+        )
+
+    def test_keeps_existing_key_entities_when_semantics_omit_them(self) -> None:
+        scope = _scope()
+        assembler = ScopeAssembler(Path("/repo"))
+        analysis = assembler.build(scope)
+        analysis.components[0].key_entities = [SourceCodeReference(qualified_name="a.run")]
+        result = ScopeAnalysisResult(
+            components=[ScopeComponentSemantics(group_id="1", name="Runner", description="Runs.", key_entities=[])],
+        )
+
+        assembler.apply_semantics(analysis, scope, result, {"1"}, set(), _resolver(scope))
+
+        self.assertEqual([entity.qualified_name for entity in analysis.components[0].key_entities], ["a.run"])
+
+    def test_keeps_the_previous_label_when_semantics_omit_a_still_connected_pair(self) -> None:
+        scope = _scope(("1", "2"))
+        assembler = ScopeAssembler(Path("/repo"))
+        analysis = assembler.build(scope)
+        analysis.components_relations = [
+            Relation(
+                relation="dispatches to",
+                src_name=analysis.components[0].name,
+                dst_name=analysis.components[1].name,
+                src_id="1",
+                dst_id="2",
+                is_static=True,
+            )
+        ]
+        result = ScopeAnalysisResult(
+            components=[ScopeComponentSemantics(group_id="1", name="Runner", description="Runs.", key_entities=[])],
+        )
+
+        assembler.apply_semantics(analysis, scope, result, {"1"}, set(), _resolver(scope))
+
+        self.assertEqual(
+            [(relation.src_id, relation.dst_id, relation.relation) for relation in analysis.components_relations],
+            [("1", "2", "dispatches to")],
         )
 
     def test_semantics_cannot_change_fixed_ids_membership_or_a_locked_name(self) -> None:

--- a/tests/diagram_analysis/test_scope_plan.py
+++ b/tests/diagram_analysis/test_scope_plan.py
@@ -142,6 +142,23 @@ class TestPlanScopeResultUpdate(unittest.TestCase):
             },
         )
 
+    def test_a_new_group_is_created_under_its_rule_name_unique_among_siblings(self):
+        existing = component("1", ["a.one"], ["1"])
+        existing.name = "Ingestion"
+        scope = AnalysisInsights(description="", components=[existing], components_relations=[])
+        groups = [
+            ClusterGroup(group_id="1", cluster_ids=[1], previous_component_id="1"),
+            ClusterGroup(group_id="2", name="Ingestion", cluster_ids=[2]),
+            ClusterGroup(group_id="3", cluster_ids=[3]),
+        ]
+
+        decision = plan_result(scope, {1: {"a.one"}, 2: {"b.two"}, 3: {"c.three"}}, groups=groups)
+
+        created = {
+            op.component_id: op.name for op in decision.operations if op.action == ScopeOperationAction.CREATE_COMPONENT
+        }
+        self.assertEqual(created, {"2": "Ingestion 2", "3": "Component 3"})
+
     def test_an_untouched_scope_plans_nothing_at_all(self):
         # An operation is not free: update_scope puts its target in refresh_ids, which
         # reruns the LLM relation analysis for the entire scope. A scope that did not

--- a/tests/diagram_analysis/test_scope_plan.py
+++ b/tests/diagram_analysis/test_scope_plan.py
@@ -17,6 +17,7 @@ from static_analyzer.clustering import ClusterGroup, ClusterResult, ClusterScope
 
 FILE = "pkg/mod.py"
 DELETE = ScopeOperationAction.DELETE_COMPONENT
+CREATE = ScopeOperationAction.CREATE_COMPONENT
 REPO = Path("/repo")
 
 
@@ -158,6 +159,18 @@ class TestPlanScopeResultUpdate(unittest.TestCase):
             op.component_id: op.name for op in decision.operations if op.action == ScopeOperationAction.CREATE_COMPONENT
         }
         self.assertEqual(created, {"2": "Ingestion 2", "3": "Component 3"})
+
+    def test_a_retired_sibling_releases_its_name_to_a_new_group(self):
+        retired = component("1", ["a.one"], ["1"])
+        retired.name = "Storage"
+        scope = AnalysisInsights(description="", components=[retired], components_relations=[])
+        groups = [ClusterGroup(group_id="2", name="Storage", cluster_ids=[2])]
+
+        decision = plan_result(scope, {2: {"b.two"}}, groups=groups)
+
+        created = {op.component_id: op.name for op in decision.operations if op.action == CREATE}
+        self.assertEqual(created, {"2": "Storage"})
+        self.assertEqual(actions(decision)["1"], DELETE)
 
     def test_an_untouched_scope_plans_nothing_at_all(self):
         # An operation is not free: update_scope puts its target in refresh_ids, which


### PR DESCRIPTION
Review follow-ups for #559. Stacked on top of it (base is `feat/scope-analysis-agent`), so it merges after #558 and #559.

## The main one

`ComponentRule.name` is computed by the name tree and then dropped on the floor in `ClusteringService._materialize`. Every scope therefore starts life as `Component <id>` and stays that way whenever semantic analysis fails, is truncated, or omits a group.

This carries `rule.name` onto `ClusterGroup` and uses it as the component's deterministic name. Two things follow:

- #558 becomes safe to sit on main on its own, rather than shipping `Component 1` through `Component 8` if a release lands between the two stack steps.
- Every failure path in #559 degrades to a real name instead of a placeholder.

Names are de-duplicated within a scope, so two rules claiming the same name stay distinguishable.

## The rest

| Fix | Why |
|---|---|
| Keep existing `key_entities` when a response omits them | The assignment was unconditional while `name` and `description` were both `.strip()`-guarded, so a valid response that skipped the field wiped a changed group's entities. |
| Keep the previous relation label when the model does not label a still-connected pair back | `preserved` only keeps relations where neither side is editable, so one changed group dropped its neighbours' labels back to `DEFAULT_STATIC_RELATION_LABEL`. Only carries pairs that still have a live static connection and a non-default label. |
| Iterate editable groups in scope order | `editable_group_ids` is a set, so a duplicate proposed name was awarded by string-hash iteration order and could change between identical runs. |
| Re-raise `LLMAuthError` from `_process_component` | `_enrich_scope` rethrows it deliberately, and the blanket `except Exception` immediately swallowed it again, so a rejected key silently dropped a whole subtree. `main` had this guard; #558 removed it correctly because there was no LLM left in that path, and #559 put the call back without it. |
| Give every provider client a real request timeout | Eleven provider configs passed `"timeout": None`, which disables the SDK's own default. Nothing bounded a stalled socket once the old 300/600s agent wrapper went away. `LLMDefaults.REQUEST_TIMEOUT_SECONDS = 300`. |
| Count and log the scopes that fell back | Semantic analysis degrading to deterministic names is invisible in the output. One warning line at save time says how many of how many. |
| Drop changed files from `bordering_files` | They already carry a `changed` flag in `files`, and the system prompt tells the model bordering files are boundary candidates. |

## Verification

- `uv run black .`
- `uv run mypy .` (302 source files, no issues)
- `uv run pytest --cov=. --cov-report=term --cov-fail-under=80` (2039 passed, coverage 84.62%)
- 3 `tests/test_cli_parser.py` failures are pre-existing on the #559 head, a macOS `/tmp` to `/private/tmp` symlink mismatch, unrelated to this change

New tests cover the deterministic naming, the duplicate-name case, the `key_entities` guard, the label carry-forward, the auth propagation, and a regression guard on the provider timeouts.

## Review follow-ups

The bot findings pointed at one underlying problem: naming policy was spread over four places (the assembler, the incremental planner, `apply_semantics`, and the caller guessing coverage), so each pass found a gap in one of them. The follow-up commits consolidate it instead of patching each site.

- **`ClusterGroup.unique_name`** is the single source of a group's deterministic name. The full-run assembler and the incremental create path both call it. The planner reserves only the names of components that survive the plan, so a retired sibling no longer forces a suffix onto a new group, and suffixing continues until the name is free.
- **`apply_semantics` owns semantic naming** and allocates proposals against the *final* sibling set in scope order: a swap between two groups is accepted, a name held by a group that cannot move is not, and a group whose proposal loses and whose previous name was taken falls back to its rule name. It returns the editable groups left without a semantic name; `_enrich_scope` reports and counts from that rather than inspecting the raw response, so blank names and omitted groups are covered by construction.
- An explicit empty `key_entities` list clears the entities; an absent key keeps them (`model_fields_set`).
- `_generate_subcomponents` reads every outcome in a completed batch before acting on any of it, so a rejected key aborts before a sibling's success is saved or expanded; pending futures are cancelled.
- Ollama (`client_kwargs`) and Bedrock (botocore `Config`) are bounded like the other providers; the test asserts the same timeout resolves for every provider through `get_resolved_extra_args`.

Each point has a regression test. One honest limit: `ThreadPoolExecutor.__exit__` still waits for workers already mid-request before the auth error propagates, so abort is prompt, not instant; each such request is now bounded by the provider timeout.

## Not addressed here

The remaining review items are not code changes and are left for #559 to answer: the strict prompt profile is still unvalidated (evals only ran gemini flash, which resolves to standard), the eval judge was disabled so there is still no naming quality evidence, and `llms.txt` still embeds the deleted modules.

Codex also raised the data-only file selection, the polyglot qualified-name ambiguity, and bounding the scope context by the model's context window. Those are Ivan's calls on #559 rather than mine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Reliability**
  - AI provider requests now use a 5-minute timeout to prevent analyses from hanging indefinitely.
  - Authentication failures during diagram analysis now stop processing and surface clearly without saving partial results.
- **Bug Fixes**
  - Diagram components now receive rule-based names with consistent disambiguation for duplicates.
  - Existing key entities and relationship labels are preserved when semantic results are incomplete.
  - Scope boundary descriptions no longer include an unnecessary incremental-analysis marker.
- **Tests**
  - Added coverage for timeouts, authentication errors, naming, and semantic preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
