### PR TITLE
Draw a family that talks to nobody else against the rest of a fan

### DIFF
--- a/docs/design/name-tree.md
+++ b/docs/design/name-tree.md
@@ -156,8 +156,8 @@ numbering cannot move a unit.
 |---|---|
 | root | frontier of the trie (layers transposed or drawn) → words of the units (only if the frontier gave one box) |
 | component ≤ 7 units | un-merge: the candidates the grouper folded into it → leaf ("small") |
-| component 8–135 units | un-merge → frontier of its own sub-trie, a layered grid kept whole → the same frontier with the grid drawn layer by layer → files → roles → leaf ("cohesive") |
-| component > 135 units | un-merge → frontier of its sub-trie, transposed where a grid recurs → words of its units → layers → files → roles → leaf ("exhausted") |
+| component 8–135 units | un-merge → frontier of its own sub-trie, a layered grid kept whole → the same frontier with the grid drawn layer by layer → files → roles → island → leaf ("cohesive") |
+| component > 135 units | un-merge → frontier of its sub-trie, transposed where a grid recurs → words of its units → layers → files → roles → island → leaf ("exhausted") |
 
 The two rungs below the trie read the files themselves, since below a leaf the trie is
 flat. **Files**: every file is a candidate labelled by its own name (its key: the position
@@ -167,6 +167,14 @@ bucket, a fallback-only rule on the scope's own prefix, so a one-file box is nev
 **Roles**: the same over the head word of each file's name (`Strategy`, `Options`,
 `Converter`); inside a feature the roles are the structure, so this is the one rung where a
 rule may own a role word, and replay lets a role word vote only for a rule that owns it.
+**Island**: the last resort, for a fan of parallel implementations. The files rung wants two
+families; a fan usually has one at most, the siblings that route through a shared sibling
+(markitdown's nine HTML-based converters), beside siblings that share nothing. That family is
+drawn against "Other converters" only when it holds a third of the scope and no link crosses to
+the rest. Why the link test: without it the fold cuts a hub's neighbours in two by how many
+links each exchanges with the hub, and every such cut measured (CodeBoarding's adapters, mem0's
+loaders, Polly's benchmarks) was arbitrary; with it the rung fires on two leaves in nine
+repositories and both are right.
 Measured on nine repositories with no model (study "The Leaf Ladder", Sep 2026): the files
 rung resolves every leaf the trie cannot, with cross-child call leakage of 0.35 against 0.79
 for a random partition of the same shape; name kinship without the graph fold does not

--- a/static_analyzer/clustering/names/draft.py
+++ b/static_analyzer/clustering/names/draft.py
@@ -14,6 +14,7 @@ from static_analyzer.clustering.names.replay import Partition, replay
 from static_analyzer.clustering.names.spec import (
     FILES,
     FRONTIER,
+    ISLAND,
     LAYERS,
     LEAF,
     ROLE,
@@ -52,6 +53,10 @@ CAP_SHARE = 0.6
 """No fold may grow a component past this share of its scope."""
 UNPLACED_NAME = "Unassigned"
 LOOSE_NAME = "Loose files"
+ISLAND_SHARE = 1 / 3
+"""Share of a scope one family must hold to be drawn on its own against the rest."""
+ISLAND_STRAYS = 1
+"""Links a family may exchange with the rest and still count as an island: one is noise."""
 
 Links = Mapping[tuple[str, str], int]
 """Weight of the graph edges between two units, keyed by the unit ids in sorted order."""
@@ -285,6 +290,7 @@ def draft_scope(
         rungs.append((LAYERS, lambda: frontier(LAYERS, False, layers=True)))
         rungs.append((FILES, lambda: _file_rules(scope_id, scope_units, role_words, grouper, links)))
         rungs.append((ROLE, lambda: _role_rules(scope_id, scope_units, role_words, grouper, links)))
+        rungs.append((ISLAND, lambda: _island_rules(scope_id, scope_units, role_words, grouper, links)))
     produced: dict[str, tuple[list[ComponentRule], str]] = {}
     for rung, produce in rungs:
         produced[rung] = rules, axis = produce()
@@ -402,6 +408,73 @@ def _role_rules(
         for word, members in sorted(by_head.items())
     ]
     return _grouped_rules(scope_id, units, candidates, role_words, grouper, ROLE, links), ROLE
+
+
+def _island_rules(
+    scope_id: ScopeId,
+    units: list[Unit],
+    role_words: frozenset[str],
+    grouper: Grouper,
+    links: Links,
+) -> tuple[list[ComponentRule], str]:
+    """One family that talks to itself and to nobody else, against the rest of a fan.
+
+    The files rung wants two families; a fan of parallel implementations usually has one at
+    most, the files that route through a shared sibling, beside siblings that share nothing.
+    That family is a box only when no link crosses to the rest: a family the rest calls is
+    the fold cutting a hub's neighbours in two, which is arbitrary, and stays whole.
+    """
+    by_key: dict[Prefix, list[Unit]] = {}
+    for unit in units:
+        by_key.setdefault(unit.key, []).append(unit)
+    candidates = [Candidate(f"{FILE}:{'.'.join(key)}", FILE, _label(key), prefixes=(key,)) for key in sorted(by_key)]
+    if len(candidates) < 2:
+        return [], ISLAND
+    context = _context(scope_id, units, candidates, role_words, ISLAND, links)
+    groups = grouper.group(candidates, context)
+    strong = [group for group in groups if sum(context.sizes.get(key, 0) for key in group.keys) >= context.floor]
+    if len(strong) != 1:
+        return [], ISLAND
+    family_keys = set(strong[0].keys)
+    family = [unit for unit in units if f"{FILE}:{'.'.join(unit.key)}" in family_keys]
+    rest = [unit for unit in units if f"{FILE}:{'.'.join(unit.key)}" not in family_keys]
+    if len(family) < ISLAND_SHARE * len(units) or len(rest) < context.floor:
+        return [], ISLAND
+    family_ids = {unit.unit_id for unit in family}
+    rest_ids = {unit.unit_id for unit in rest}
+    crossing = sum(
+        weight
+        for (left, right), weight in links.items()
+        if (left in family_ids and right in rest_ids) or (left in rest_ids and right in family_ids)
+    )
+    if crossing > ISLAND_STRAYS:
+        return [], ISLAND
+    rules = _rules_from_groups(strong, [candidate for candidate in candidates if candidate.key in family_keys])
+    rules.append(
+        ComponentRule(
+            "",
+            _rest_name(rest),
+            prefixes=tuple(dict.fromkeys(unit.key for unit in rest)),
+            fallback_prefixes=(_common_prefix(units),),
+            origin=ISLAND,
+        )
+    )
+    return rules, ISLAND
+
+
+def _rest_name(units: list[Unit]) -> str:
+    """``Other converters``: the word most of the fan's names end in, else ``Other files``."""
+    heads: Counter[str] = Counter()
+    for unit in units:
+        words = tokenize(_label(unit.key))
+        if words:
+            heads[words[-1].casefold()] += 1
+    if not heads:
+        return "Other files"
+    word, count = heads.most_common(1)[0]
+    if count < len(units) / 2:
+        return "Other files"
+    return f"Other {word}" if word.endswith("s") else f"Other {word}s"
 
 
 def _grouped_rules(

--- a/static_analyzer/clustering/names/spec.py
+++ b/static_analyzer/clustering/names/spec.py
@@ -22,10 +22,11 @@ SEGMENT = "segment"
 LAYERS = "layers"
 FILES = "files"
 ROLE = "role"
+ISLAND = "island"
 LEAF = "leaf"
 """The rungs of the ladder, recorded on the scope they drew."""
 
-KEYED_RUNGS = frozenset({FILES, ROLE})
+KEYED_RUNGS = frozenset({FILES, ROLE, ISLAND})
 """Rungs whose rules own files by their key rather than directories by their position: replay
 matches the key only there, so a class named like a sibling directory moves nothing above."""
 

--- a/tests/static_analyzer/names/test_draft.py
+++ b/tests/static_analyzer/names/test_draft.py
@@ -19,6 +19,7 @@ from static_analyzer.clustering.names.draft import (
     FILES,
     FRONTIER,
     GUARD_SHARE,
+    ISLAND,
     LAYERS,
     LEAF,
     LEAF_CAP,
@@ -331,6 +332,75 @@ class TestLadder:
         assert rule_of(feature, "1.2").terms == ("strategy",)
         added = units_from_layout({"pkg/feat/kappa_strategy.py": ["pkg.feat.kappa_strategy.KappaStrategy"]})
         assert replay(added, feature, ROLE_WORDS).assignment == {"pkg/feat/kappa_strategy.py": "1.2"}
+
+    def _fan(self, *members: str) -> tuple[list, dict]:
+        """A fan of converters: the HTML-based ones call the HTML converter, the rest call nobody."""
+        layout = self._flat_feature(*members)
+        html = {
+            name for name in members if name in ("HtmlConverter", "DocxConverter", "EpubConverter", "PptxConverter")
+        }
+        links = {
+            (f"pkg/feat/{a.lower()}.py", f"pkg/feat/{b.lower()}.py"): 2
+            for a in sorted(html)
+            for b in sorted(html)
+            if a < b
+        }
+        return units_from_layout(layout), links
+
+    def test_a_family_that_talks_to_nobody_else_is_an_island_against_the_rest(self):
+        units, links = self._fan(
+            "HtmlConverter",
+            "DocxConverter",
+            "EpubConverter",
+            "PptxConverter",
+            "PdfConverter",
+            "AudioConverter",
+            "ImageConverter",
+            "ZipConverter",
+            "CsvConverter",
+        )
+        feature = scope_of(draft_tree(units, AffinityGrouper(), 3, links=links), "1")
+        assert feature.rung == ISLAND
+        assert names_of(feature) == ["Other converters", "DocxConverter"]
+        rest, family = feature.rules
+        assert len(rest.prefixes) == 5 and rest.fallback_prefixes == (("pkg", "feat"),)
+        assert len(family.prefixes) == 4
+        placed = replay(units, feature, ROLE_WORDS)
+        assert placed.size("1.1") == 5 and placed.size("1.2") == 4
+        assert scope_of(draft_tree(units, AffinityGrouper(), 3, links=links), "1.1").is_leaf
+
+    def test_a_family_the_rest_calls_is_a_hub_cut_and_stays_whole(self):
+        units, links = self._fan(
+            "HtmlConverter",
+            "DocxConverter",
+            "EpubConverter",
+            "PptxConverter",
+            "PdfConverter",
+            "AudioConverter",
+            "ImageConverter",
+            "ZipConverter",
+            "CsvConverter",
+        )
+        for name in ("pdfconverter", "audioconverter", "imageconverter"):
+            links[("pkg/feat/htmlconverter.py", f"pkg/feat/{name}.py")] = 1
+        feature = scope_of(draft_tree(units, AffinityGrouper(), 2, links=links), "1")
+        assert feature.is_leaf and "island" in feature.leaf_reason
+
+    def test_a_family_too_small_for_its_scope_is_not_an_island(self):
+        units, links = self._fan(
+            "HtmlConverter",
+            "DocxConverter",
+            "PdfConverter",
+            "AudioConverter",
+            "ImageConverter",
+            "ZipConverter",
+            "CsvConverter",
+            "TextConverter",
+            "RtfConverter",
+            "XmlConverter",
+        )
+        feature = scope_of(draft_tree(units, AffinityGrouper(), 2, links=links), "1")
+        assert feature.is_leaf
 
     def test_the_ladder_stops_at_the_leaf_units(self):
         layout = self._flat_feature("AlphaStrategy", "BetaStrategy", "GammaStrategy", "DeltaOptions", "EpsOptions")


### PR DESCRIPTION
On top of #561. One more rung at the very bottom of the ladder, for the case #561 leaves whole: a fan of parallel implementations of one interface.

## The gap

markitdown's 23 converters stayed one box. The files rung had found the one real structure inside it, the nine converters that route through the HTML converter, but the guard needs **two** solid groups and the other fourteen share nothing, so the rung reported nothing.

## The rule

After every other rung has failed, take the files rung's grouping once more. If it holds exactly one solid group, that group is at least a third of the scope, and **no call or reference link crosses** between it and the rest (one stray allowed), draw two boxes: the family, and the rest named after the word most of its files end in, "Other converters".

The link test is the whole point. Without it, the same rule splits fifteen more leaves across nine repositories, and I printed every one: CodeBoarding's adapters into csharp/go/php versus java/python/typescript, mem0's LLM providers into anthropic through jina versus llama2 through vllm, Polly's benchmarks into two halves. That is the fold cutting a hub's neighbours in two by how many links each exchanges with the hub. In every such case the links crossing the cut are comparable to the links inside the family; in the two real cases they are 1 and 0.

## Impact, nine repositories, zero LLM

Fires on two leaves. Everything else, including every scope #561 drafts, comes back identical.

- **markitdown** `Built-in Format Converters` (23) → `HTML-based converters` (9) + `Other converters` (14). The nine then split by the files rung into the five office formats that render through HTML (docx, epub, pptx, xlsx, html) and the four web-page converters (bing, rss, wikipedia, markdownify). Files in leaves of 7 or fewer: 42% → 65%.
- **eShop** eight shared extension classes → the four OpenAPI/auth/configuration extensions that call each other + `Other extensions` (4). 93% → 95%.

## Tests

Three new: an island splits, a hub cut stays whole with the reason naming the rung, a family below a third of the scope is not an island. Full suite 2299 passed, the same three pre-existing `test_cli_parser` failures as `main`; `mypy .` and `black` clean.

Depth-3 runs of both leaves with this engine are in the CodeBoarding-tests study PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved component grouping for converter layouts by identifying sufficiently large, self-contained families as separate “island” components.
  - Unrelated converters are grouped into an “Other converters” remainder, while interconnected hub families remain together.
  - Small or externally connected families continue to be handled by existing grouping behavior.

- **Documentation**
  - Updated the design guidance to describe the new island grouping criteria and placement in the grouping hierarchy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->