### PR TITLE
fix(naming): keep the scope agent inside the model's context and never ship a rule name or a disk path

### DIFF
--- a/agents/llm_renderers/scope.py
+++ b/agents/llm_renderers/scope.py
@@ -12,9 +12,10 @@ from agents.agent_responses import AnalysisInsights
 from repo_utils.path_utils import normalize_repo_path
 from static_analyzer.cfg.edge import EdgeKind
 from static_analyzer.clustering import ClusterConnectionEdge, ClusterGroup, ClusterScopeResult
+from static_analyzer.node import Node
 
-#: How many example edges a directed group pair shows the model. The count is always
-#: given; the examples exist so a relation's ``key_edges`` can cite exact symbols.
+#: Example edges per directed group pair; the count is always given, the examples let
+#: a relation's ``key_edges`` cite exact symbols.
 MAX_EXAMPLE_EDGES = 5
 
 
@@ -30,10 +31,8 @@ def render_scope_context(
 ) -> str:
     """Return complete group files, boundary candidates, and known calls as JSON.
 
-    ``enclosing_names`` are the names of the components this scope sits inside, outermost
-    first. They are shown so the model does not name a child after its parent: a document
-    is written per expanded component under its sanitised name, so a repeated name is two
-    documents on one path.
+    ``enclosing_names``: the components this scope sits inside, outermost first, so the
+    model does not name a child after its parent.
     """
     boundary_reasons = _boundary_reasons(scope, repo_dir)
     components = {component.component_id: component for component in analysis.components}
@@ -127,14 +126,10 @@ def _group_file_reasons(
 
 
 def _known_connections(scope: ClusterScopeResult, repo_dir: Path) -> list[dict[str, Any]]:
-    """One entry per directed group pair: how many distinct calls, and a few of them in full.
+    """One entry per directed group pair: the number of distinct calls and a few in full.
 
-    Why not every edge: a dense scope has thousands of cross-group calls, and rendering
-    each as its own object made the Gson root prompt 1.68 M characters — 93% of it this
-    list — which is more than a 262k-token model accepts. The scope agent then failed
-    outright and the whole scope shipped with its deterministic names and template
-    descriptions. The count is what the model needs to label a connection; the examples
-    are what it needs to cite exact symbols in ``key_edges``.
+    Why: a dense scope has thousands of cross-group calls, and one object per edge exceeds
+    a model's context; the count labels the connection, the examples name exact symbols.
     """
     by_pair: dict[tuple[str, str], list[ClusterConnectionEdge]] = defaultdict(list)
     for connection in scope.connections:
@@ -168,10 +163,14 @@ def _example(edge: ClusterConnectionEdge, scope: ClusterScopeResult, repo_dir: P
     target = graph.nodes.get(edge.target_qualified_name) if graph is not None else None
     return {
         "source": edge.source_qualified_name,
-        "source_at": f"{normalize_repo_path(source.file_path, repo_dir)}:{source.line_start}" if source else "",
+        "source_at": _location(source, repo_dir),
         "target": edge.target_qualified_name,
-        "target_at": f"{normalize_repo_path(target.file_path, repo_dir)}:{target.line_start}" if target else "",
+        "target_at": _location(target, repo_dir),
     }
+
+
+def _location(node: Node | None, repo_dir: Path) -> str:
+    return f"{normalize_repo_path(node.file_path, repo_dir)}:{node.line_start}" if node is not None else ""
 
 
 def _boundary_reasons(

--- a/agents/llm_renderers/scope.py
+++ b/agents/llm_renderers/scope.py
@@ -4,12 +4,18 @@ from __future__ import annotations
 
 import json
 from collections import defaultdict
+from collections.abc import Sequence
 from pathlib import Path
+from typing import Any
 
 from agents.agent_responses import AnalysisInsights
 from repo_utils.path_utils import normalize_repo_path
 from static_analyzer.cfg.edge import EdgeKind
-from static_analyzer.clustering import ClusterGroup, ClusterScopeResult
+from static_analyzer.clustering import ClusterConnectionEdge, ClusterGroup, ClusterScopeResult
+
+#: How many example edges a directed group pair shows the model. The count is always
+#: given; the examples exist so a relation's ``key_edges`` can cite exact symbols.
+MAX_EXAMPLE_EDGES = 5
 
 
 def render_scope_context(
@@ -20,8 +26,15 @@ def render_scope_context(
     locked_name_ids: set[str] | frozenset[str],
     changed_files: set[str] | frozenset[str],
     incremental: bool,
+    enclosing_names: Sequence[str] = (),
 ) -> str:
-    """Return complete group files, boundary candidates, and known calls as JSON."""
+    """Return complete group files, boundary candidates, and known calls as JSON.
+
+    ``enclosing_names`` are the names of the components this scope sits inside, outermost
+    first. They are shown so the model does not name a child after its parent: a document
+    is written per expanded component under its sanitised name, so a repeated name is two
+    documents on one path.
+    """
     boundary_reasons = _boundary_reasons(scope, repo_dir)
     components = {component.component_id: component for component in analysis.components}
     groups = []
@@ -62,6 +75,7 @@ def render_scope_context(
         "mode": "incremental" if incremental else "full",
         "existing_description": analysis.description if incremental else None,
         "groups": groups,
+        "enclosing_components": list(enclosing_names),
         "known_connections": _known_connections(scope, repo_dir),
         "existing_relations": [
             {
@@ -112,40 +126,52 @@ def _group_file_reasons(
     return dict(sorted(reasons.items()))
 
 
-def _known_connections(scope: ClusterScopeResult, repo_dir: Path) -> list[dict[str, str | int]]:
-    connections: list[dict[str, str | int]] = []
-    seen: set[tuple[str, str, str]] = set()
+def _known_connections(scope: ClusterScopeResult, repo_dir: Path) -> list[dict[str, Any]]:
+    """One entry per directed group pair: how many distinct calls, and a few of them in full.
+
+    Why not every edge: a dense scope has thousands of cross-group calls, and rendering
+    each as its own object made the Gson root prompt 1.68 M characters — 93% of it this
+    list — which is more than a 262k-token model accepts. The scope agent then failed
+    outright and the whole scope shipped with its deterministic names and template
+    descriptions. The count is what the model needs to label a connection; the examples
+    are what it needs to cite exact symbols in ``key_edges``.
+    """
+    by_pair: dict[tuple[str, str], list[ClusterConnectionEdge]] = defaultdict(list)
     for connection in scope.connections:
-        for edge in connection.edges:
+        by_pair[(connection.source_group_id, connection.target_group_id)].extend(connection.edges)
+
+    connections: list[dict[str, Any]] = []
+    for (source_group_id, target_group_id), edges in sorted(by_pair.items()):
+        seen: set[tuple[str, str, str]] = set()
+        distinct: list[ClusterConnectionEdge] = []
+        for edge in edges:
             key = (edge.language, edge.source_qualified_name, edge.target_qualified_name)
             if key in seen:
                 continue
             seen.add(key)
-            graph = scope.graphs_by_language.get(edge.language)
-            source = graph.nodes.get(edge.source_qualified_name) if graph is not None else None
-            target = graph.nodes.get(edge.target_qualified_name) if graph is not None else None
-            connections.append(
-                {
-                    "source_group_id": connection.source_group_id,
-                    "target_group_id": connection.target_group_id,
-                    "language": edge.language,
-                    "source_method": edge.source_qualified_name,
-                    "source_file": normalize_repo_path(source.file_path, repo_dir) if source is not None else "",
-                    "source_line": source.line_start if source is not None else 0,
-                    "target_method": edge.target_qualified_name,
-                    "target_file": normalize_repo_path(target.file_path, repo_dir) if target is not None else "",
-                    "target_line": target.line_start if target is not None else 0,
-                }
-            )
-    return sorted(
-        connections,
-        key=lambda item: (
-            str(item["source_group_id"]),
-            str(item["target_group_id"]),
-            str(item["source_method"]),
-            str(item["target_method"]),
-        ),
-    )
+            distinct.append(edge)
+        distinct.sort(key=lambda edge: (edge.source_qualified_name, edge.target_qualified_name))
+        connections.append(
+            {
+                "source_group_id": source_group_id,
+                "target_group_id": target_group_id,
+                "calls": len(distinct),
+                "examples": [_example(edge, scope, repo_dir) for edge in distinct[:MAX_EXAMPLE_EDGES]],
+            }
+        )
+    return connections
+
+
+def _example(edge: ClusterConnectionEdge, scope: ClusterScopeResult, repo_dir: Path) -> dict[str, str]:
+    graph = scope.graphs_by_language.get(edge.language)
+    source = graph.nodes.get(edge.source_qualified_name) if graph is not None else None
+    target = graph.nodes.get(edge.target_qualified_name) if graph is not None else None
+    return {
+        "source": edge.source_qualified_name,
+        "source_at": f"{normalize_repo_path(source.file_path, repo_dir)}:{source.line_start}" if source else "",
+        "target": edge.target_qualified_name,
+        "target_at": f"{normalize_repo_path(target.file_path, repo_dir)}:{target.line_start}" if target else "",
+    }
 
 
 def _boundary_reasons(

--- a/agents/prompts/shared.py
+++ b/agents/prompts/shared.py
@@ -31,7 +31,10 @@ SCOPE_ANALYSIS_SYSTEM_MESSAGE = """You name and describe fixed, deterministic co
 The supplied group IDs, file membership, hierarchy, and known directed calls are authoritative. Never merge,
 split, move, add, or remove groups. Work at the supplied scope exactly the same way whether it is root or nested.
 
-Use the supplied files, grouping reasons, bordering files, and known connections before calling tools. `readFile`
+Use the supplied files, grouping reasons, bordering files, and known connections before calling tools. A known
+connection gives the number of distinct calls from one group to another and a few of them in full; cite only
+symbols that appear in the input. Never reuse a name listed under `enclosing_components`: those are the
+components this scope sits inside, and a child named after its parent overwrites its document. `readFile
 may inspect a specific in-scope file and `getMethodCalls` may inspect one exact in-scope symbol in one direction.
 Do not inventory the scope, browse every file, or repeat a tool call. A runtime budget limits all tools to six calls.
 

--- a/agents/prompts/shared.py
+++ b/agents/prompts/shared.py
@@ -34,7 +34,7 @@ split, move, add, or remove groups. Work at the supplied scope exactly the same 
 Use the supplied files, grouping reasons, bordering files, and known connections before calling tools. A known
 connection gives the number of distinct calls from one group to another and a few of them in full; cite only
 symbols that appear in the input. Never reuse a name listed under `enclosing_components`: those are the
-components this scope sits inside, and a child named after its parent overwrites its document. `readFile
+components this scope sits inside, and a child named after its parent overwrites its document. `readFile`
 may inspect a specific in-scope file and `getMethodCalls` may inspect one exact in-scope symbol in one direction.
 Do not inventory the scope, browse every file, or repeat a tool call. A runtime budget limits all tools to six calls.
 

--- a/agents/prompts/shared.py
+++ b/agents/prompts/shared.py
@@ -42,13 +42,13 @@ Name each editable group for one responsibility using the codebase's own vocabul
 and select only clearly evidenced key entities. Label known directed connections by their architectural meaning.
 You may add a missing non-static relation such as REST, queue, plugin, registry, file, or configuration wiring only
 when exact source symbols on both component sides and concrete textual evidence support it. Names alone are not
-evidence. Return JSON only, with no markdown fences."""
+evidence. Answer by calling the `ScopeAnalysisResult` tool; it is the only way to finish."""
 
 SCOPE_ANALYSIS_MESSAGE = """Analyze this deterministic scope:
 
 {scope_context}
 
-Return exactly this JSON shape:
+Call `ScopeAnalysisResult` with exactly this shape:
 {{
   "description": "one paragraph describing this scope's purpose and main flow",
   "components": [
@@ -96,7 +96,7 @@ Mandatory execution order:
 1. Read all supplied group and boundary context before deciding whether a tool is needed.
 2. Use a tool only to answer one unresolved question about a named file or symbol.
 3. Check every component, relation direction, and source symbol against the supplied context.
-4. Emit one JSON object and nothing else. Do not explain your reasoning or use markdown."""
+4. Finish with one `ScopeAnalysisResult` tool call. Do not explain your reasoning or use markdown."""
 
 STRICT_SCOPE_ANALYSIS_MESSAGE_SUFFIX = """
 
@@ -104,4 +104,4 @@ Final checklist before answering:
 - `components` contains exactly one entry for every editable group and no other group.
 - Every group ID and qualified name is copied exactly from the input.
 - Every relation is directed from source to target and has concrete evidence unless it is already known.
-- The response is one valid JSON object with no prose before or after it."""
+- The answer is a single `ScopeAnalysisResult` tool call, with no prose before or after it."""

--- a/agents/scope_analysis_agent.py
+++ b/agents/scope_analysis_agent.py
@@ -31,10 +31,7 @@ MAX_SCOPE_TOOL_CALLS = 6
 MAX_SCOPE_MODEL_CALLS = 8
 SCOPE_RECURSION_LIMIT = 40
 
-#: Asked once, without tools, when the bounded run ended in prose instead of the object.
-#: Measured on Hono with Kimi-K2.6: four of eleven scopes ended that way in one run and the
-#: scope then shipped its deterministic names; one plain completion over the same transcript
-#: is far cheaper than losing the scope.
+#: Sent once, without tools, when the bounded run did not end in a usable JSON object.
 JSON_RECOVERY_MESSAGE = (
     "Your previous message did not contain the JSON object. Reply now with exactly one JSON object "
     "in the requested shape and nothing else — no prose, no markdown fences."
@@ -155,15 +152,11 @@ class ScopeAnalysisAgent(MonitoringMixin):
             raise_if_auth_error(error)
             raise
         messages = response.get("messages", [])
-        text = self._last_response_text(messages)
-        if "{" not in text:
-            logger.info("Scope %s answered without a JSON object; asking once more for it", scope.scope_id)
-            text = self._recover_json(messages)
-        try:
-            return ScopeAnalysisResult.model_validate_json(self._json_object(text))
-        except (json.JSONDecodeError, ValidationError, ValueError) as error:
-            logger.warning("Scope %s returned unusable semantic output: %s", scope.scope_id, error)
-            return None
+        result = self._parse(self._last_response_text(messages), scope.scope_id)
+        if result is None:
+            logger.info("Scope %s: asking once more for the JSON object", scope.scope_id)
+            result = self._parse(self._recover_json(messages), scope.scope_id)
+        return result
 
     def _recover_json(self, messages: list) -> str:
         """One tool-free completion over the transcript, asking for the object alone."""
@@ -177,6 +170,14 @@ class ScopeAnalysisAgent(MonitoringMixin):
             logger.warning("JSON recovery call failed: %s", error)
             return ""
         return self._last_response_text([answer])
+
+    @classmethod
+    def _parse(cls, text: str, scope_id: str) -> ScopeAnalysisResult | None:
+        try:
+            return ScopeAnalysisResult.model_validate_json(cls._json_object(text))
+        except (json.JSONDecodeError, ValidationError, ValueError) as error:
+            logger.warning("Scope %s returned unusable semantic output: %s", scope_id, error)
+            return None
 
     @staticmethod
     def _last_response_text(messages: list) -> str:

--- a/agents/scope_analysis_agent.py
+++ b/agents/scope_analysis_agent.py
@@ -2,17 +2,17 @@
 
 from __future__ import annotations
 
-import json
 import logging
 from collections.abc import Sequence
 from pathlib import Path
 
 from langchain.agents import create_agent
+from langchain.agents.structured_output import ToolStrategy
 from langchain.agents.middleware import ModelCallLimitMiddleware, ToolCallLimitMiddleware
 from langchain_core.language_models import BaseChatModel
-from langchain_core.messages import AIMessage, HumanMessage
+from langchain_core.messages import HumanMessage
 from langgraph.graph.state import CompiledStateGraph
-from pydantic import Field, ValidationError
+from pydantic import Field
 
 from agents.agent_responses import AnalysisInsights, LLMBaseModel, RelationEdge, SourceCodeReference
 from agents.llm_config import MONITORING_CALLBACK, get_current_prompt_profile
@@ -30,12 +30,6 @@ logger = logging.getLogger(__name__)
 MAX_SCOPE_TOOL_CALLS = 6
 MAX_SCOPE_MODEL_CALLS = 8
 SCOPE_RECURSION_LIMIT = 40
-
-#: Sent once, without tools, when the bounded run did not end in a usable JSON object.
-JSON_RECOVERY_MESSAGE = (
-    "Your previous message did not contain the JSON object. Reply now with exactly one JSON object "
-    "in the requested shape and nothing else — no prose, no markdown fences."
-)
 
 
 class ScopeComponentSemantics(LLMBaseModel):
@@ -110,7 +104,7 @@ class ScopeAnalysisAgent(MonitoringMixin):
         incremental: bool = False,
         enclosing_names: Sequence[str] = (),
     ) -> ScopeAnalysisResult | None:
-        """Run one bounded semantic analysis, returning no result for malformed output."""
+        """Run one bounded semantic analysis; None when the run ended without the structured answer."""
         context = RepoContext(
             repo_dir=self.repo_dir,
             static_analysis=self.static_analysis,
@@ -129,6 +123,7 @@ class ScopeAnalysisAgent(MonitoringMixin):
             tools=tools,
             system_prompt=self.system_prompt,
             middleware=middleware,
+            response_format=ToolStrategy(ScopeAnalysisResult),
         )
         scope_context = render_scope_context(
             scope,
@@ -151,57 +146,8 @@ class ScopeAnalysisAgent(MonitoringMixin):
         except Exception as error:
             raise_if_auth_error(error)
             raise
-        messages = response.get("messages", [])
-        result = self._parse(self._last_response_text(messages), scope.scope_id)
-        if result is None:
-            logger.info("Scope %s: asking once more for the JSON object", scope.scope_id)
-            result = self._parse(self._recover_json(messages), scope.scope_id)
-        return result
-
-    def _recover_json(self, messages: list) -> str:
-        """One tool-free completion over the transcript, asking for the object alone."""
-        try:
-            answer = self.agent_llm.invoke(
-                [*messages, HumanMessage(content=JSON_RECOVERY_MESSAGE)],
-                config={"callbacks": [MONITORING_CALLBACK, self.agent_monitoring_callback]},
-            )
-        except Exception as error:
-            raise_if_auth_error(error)
-            logger.warning("JSON recovery call failed: %s", error)
-            return ""
-        return self._last_response_text([answer])
-
-    @classmethod
-    def _parse(cls, text: str, scope_id: str) -> ScopeAnalysisResult | None:
-        try:
-            return ScopeAnalysisResult.model_validate_json(cls._json_object(text))
-        except (json.JSONDecodeError, ValidationError, ValueError) as error:
-            logger.warning("Scope %s returned unusable semantic output: %s", scope_id, error)
+        result = response.get("structured_response")
+        if not isinstance(result, ScopeAnalysisResult):
+            logger.warning("Scope %s ended without a structured answer", scope.scope_id)
             return None
-
-    @staticmethod
-    def _last_response_text(messages: list) -> str:
-        """Extract text from the final model response across provider content formats."""
-        message = next((item for item in reversed(messages) if isinstance(item, AIMessage)), None)
-        if message is None:
-            return ""
-        if isinstance(message.content, str):
-            return message.content
-        parts: list[str] = []
-        for block in message.content:
-            if isinstance(block, str):
-                parts.append(block)
-            elif isinstance(block, dict):
-                text = block.get("text") or block.get("output_text")
-                if isinstance(text, str):
-                    parts.append(text)
-        return "".join(parts)
-
-    @staticmethod
-    def _json_object(text: str) -> str:
-        """Extract the outer JSON object without invoking a second model."""
-        start = text.find("{")
-        end = text.rfind("}")
-        if start < 0 or end < start:
-            raise ValueError("response contains no JSON object")
-        return text[start : end + 1]
+        return result

--- a/agents/scope_analysis_agent.py
+++ b/agents/scope_analysis_agent.py
@@ -10,7 +10,7 @@ from langchain.agents import create_agent
 from langchain.agents.structured_output import ToolStrategy
 from langchain.agents.middleware import ModelCallLimitMiddleware, ToolCallLimitMiddleware
 from langchain_core.language_models import BaseChatModel
-from langchain_core.messages import HumanMessage
+from langchain_core.messages import HumanMessage, ToolCall
 from langgraph.graph.state import CompiledStateGraph
 from pydantic import Field
 
@@ -79,6 +79,17 @@ class ScopeAnalysisResult(LLMBaseModel):
         return "\n".join(part for part in (self.description, components, relations) if part)
 
 
+class RepositoryToolBudget(ToolCallLimitMiddleware):
+    """A shared call budget over the repository tools that never counts the structured answer.
+
+    Why: the stock limiter counts every tool call, and the answer is delivered as a tool
+    call — a scope that spent its budget on reads would have its answer blocked.
+    """
+
+    def _matches_tool_filter(self, tool_call: ToolCall) -> bool:
+        return tool_call["name"] != ScopeAnalysisResult.__name__
+
+
 class ScopeAnalysisAgent(MonitoringMixin):
     """Analyze any deterministic scope with two scope-restricted tools."""
 
@@ -115,7 +126,7 @@ class ScopeAnalysisAgent(MonitoringMixin):
         )
         tools = [ReadFileTool(context=context), MethodCallsTool(context=context)]
         middleware: list = [
-            ToolCallLimitMiddleware(run_limit=MAX_SCOPE_TOOL_CALLS, exit_behavior="continue"),
+            RepositoryToolBudget(run_limit=MAX_SCOPE_TOOL_CALLS, exit_behavior="continue"),
             ModelCallLimitMiddleware(run_limit=MAX_SCOPE_MODEL_CALLS, exit_behavior="error"),
         ]
         agent: CompiledStateGraph = create_agent(

--- a/agents/scope_analysis_agent.py
+++ b/agents/scope_analysis_agent.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+from collections.abc import Sequence
 from pathlib import Path
 
 from langchain.agents import create_agent
@@ -29,6 +30,15 @@ logger = logging.getLogger(__name__)
 MAX_SCOPE_TOOL_CALLS = 6
 MAX_SCOPE_MODEL_CALLS = 8
 SCOPE_RECURSION_LIMIT = 40
+
+#: Asked once, without tools, when the bounded run ended in prose instead of the object.
+#: Measured on Hono with Kimi-K2.6: four of eleven scopes ended that way in one run and the
+#: scope then shipped its deterministic names; one plain completion over the same transcript
+#: is far cheaper than losing the scope.
+JSON_RECOVERY_MESSAGE = (
+    "Your previous message did not contain the JSON object. Reply now with exactly one JSON object "
+    "in the requested shape and nothing else — no prose, no markdown fences."
+)
 
 
 class ScopeComponentSemantics(LLMBaseModel):
@@ -101,6 +111,7 @@ class ScopeAnalysisAgent(MonitoringMixin):
         locked_name_ids: frozenset[str] = frozenset(),
         changed_files: frozenset[str] = frozenset(),
         incremental: bool = False,
+        enclosing_names: Sequence[str] = (),
     ) -> ScopeAnalysisResult | None:
         """Run one bounded semantic analysis, returning no result for malformed output."""
         context = RepoContext(
@@ -130,6 +141,7 @@ class ScopeAnalysisAgent(MonitoringMixin):
             locked_name_ids,
             changed_files,
             incremental,
+            enclosing_names,
         )
         try:
             response = agent.invoke(
@@ -142,12 +154,29 @@ class ScopeAnalysisAgent(MonitoringMixin):
         except Exception as error:
             raise_if_auth_error(error)
             raise
-        text = self._last_response_text(response.get("messages", []))
+        messages = response.get("messages", [])
+        text = self._last_response_text(messages)
+        if "{" not in text:
+            logger.info("Scope %s answered without a JSON object; asking once more for it", scope.scope_id)
+            text = self._recover_json(messages)
         try:
             return ScopeAnalysisResult.model_validate_json(self._json_object(text))
         except (json.JSONDecodeError, ValidationError, ValueError) as error:
             logger.warning("Scope %s returned unusable semantic output: %s", scope.scope_id, error)
             return None
+
+    def _recover_json(self, messages: list) -> str:
+        """One tool-free completion over the transcript, asking for the object alone."""
+        try:
+            answer = self.agent_llm.invoke(
+                [*messages, HumanMessage(content=JSON_RECOVERY_MESSAGE)],
+                config={"callbacks": [MONITORING_CALLBACK, self.agent_monitoring_callback]},
+            )
+        except Exception as error:
+            raise_if_auth_error(error)
+            logger.warning("JSON recovery call failed: %s", error)
+            return ""
+        return self._last_response_text([answer])
 
     @staticmethod
     def _last_response_text(messages: list) -> str:

--- a/codeboarding_cli/commands/full_analysis.py
+++ b/codeboarding_cli/commands/full_analysis.py
@@ -1,6 +1,5 @@
 import argparse
 import logging
-from constants import CLI_ROOT_DOCUMENT_NAME
 from pathlib import Path
 
 from tqdm import tqdm
@@ -11,6 +10,7 @@ from codeboarding_cli.view_instructions import print_view_instructions
 from codeboarding_workflows.analysis import run_full
 from codeboarding_workflows.orchestration import run_analysis_pipeline
 from codeboarding_workflows.sources import SourceContext, local_source, remote_source
+from constants import CLI_ROOT_DOCUMENT_NAME
 from diagram_analysis import DEFAULT_DEPTH_LEVEL, RunContext, RunPaths
 from monitoring import monitor_execution
 from monitoring.paths import get_monitoring_run_dir

--- a/codeboarding_cli/commands/full_analysis.py
+++ b/codeboarding_cli/commands/full_analysis.py
@@ -1,5 +1,6 @@
 import argparse
 import logging
+from constants import CLI_ROOT_DOCUMENT_NAME
 from pathlib import Path
 
 from tqdm import tqdm
@@ -194,7 +195,7 @@ def _process_one_remote(
                 repo_ref=f"{repo_url}/blob/{get_branch(src.repo_path)}/",
                 temp_dir=src.artifact_dir,
                 format=".md",
-                root_name="on_boarding",
+                root_name=CLI_ROOT_DOCUMENT_NAME,
                 demo_mode=True,
             )
 

--- a/codeboarding_workflows/analysis.py
+++ b/codeboarding_workflows/analysis.py
@@ -14,6 +14,7 @@ import logging
 from pathlib import Path
 
 from agents.content_hash import compute_source_tree_hash
+from agents.scope_ids import ROOT_SCOPE_ID
 from diagram_analysis import DiagramGenerator
 from diagram_analysis.io_utils import load_analysis_metadata, load_expandable_component_ids, load_full_analysis
 from diagram_analysis.run_context import DEFAULT_DEPTH_LEVEL, RunContext, RunPaths
@@ -141,7 +142,11 @@ def run_partial(
     generator = build_generator(run_paths, run_context, depth_level=depth_level, changes=ChangeSet(files=[]))
     generator.source_sha = current_source_hash
     # A component at the persisted cap needs one additional level prepared for expansion.
-    generator.prepare_analysis(hierarchy_depth=depth_level + 1, target_component=component_to_analyze)
+    generator.prepare_analysis(
+        hierarchy_depth=depth_level + 1,
+        target_component=component_to_analyze,
+        persisted_scopes={ROOT_SCOPE_ID: root_analysis, **sub_analyses},
+    )
 
     _, sub_analysis, _ = generator.process_component(component_to_analyze)
     if sub_analysis is None:

--- a/constants.py
+++ b/constants.py
@@ -18,6 +18,10 @@ PERSISTED_ANALYSIS_ARTIFACT_FILENAMES = (
 GITIGNORE_FILENAME = ".gitignore"
 CODEBOARDINGIGNORE_FILENAME = ".codeboardingignore"
 DEFAULT_STATIC_RELATION_LABEL = "calls"
+# Document names the renderers give the root analysis; no expanded component may take one.
+DEFAULT_ROOT_DOCUMENT_NAME = "overview"
+CLI_ROOT_DOCUMENT_NAME = "on_boarding"
+ROOT_DOCUMENT_NAMES = (DEFAULT_ROOT_DOCUMENT_NAME, CLI_ROOT_DOCUMENT_NAME)
 
 
 class AppConfig:

--- a/diagram_analysis/diagram_generator.py
+++ b/diagram_analysis/diagram_generator.py
@@ -763,9 +763,23 @@ class DiagramGenerator:
         incremental: bool = False,
     ) -> None:
         """Apply bounded semantic enrichment while preserving deterministic scope structure."""
-        if not editable_group_ids:
+        try:
+            if editable_group_ids:
+                self._apply_scope_semantics(
+                    scope, analysis, editable_group_ids, locked_name_ids, changed_files, incremental
+                )
+        finally:
             self._record_names(analysis)
-            return
+
+    def _apply_scope_semantics(
+        self,
+        scope: ClusterScopeResult,
+        analysis: AnalysisInsights,
+        editable_group_ids: set[str],
+        locked_name_ids: frozenset[str],
+        changed_files: frozenset[str],
+        incremental: bool,
+    ) -> None:
         enclosing_names = self._enclosing_names(scope.scope_id)
         with self._naming_counts_lock:
             self._scopes_enriched += 1
@@ -783,14 +797,10 @@ class DiagramGenerator:
             raise
         except Exception:
             logger.exception("Semantic analysis failed for scope %s; retaining deterministic output", scope.scope_id)
-            with self._naming_counts_lock:
-                self._scopes_unnamed += 1
-            self._record_names(analysis)
-            return
+            semantics = None
         if semantics is None:
             with self._naming_counts_lock:
                 self._scopes_unnamed += 1
-            self._record_names(analysis)
             return
         assert self.static_analysis is not None
         unnamed = self.scope_assembler.apply_semantics(
@@ -802,7 +812,6 @@ class DiagramGenerator:
             StaticReferenceResolver(self.repo_location, self.static_analysis),
             reserved_names=enclosing_names,
         )
-        self._record_names(analysis)
         if unnamed:
             logger.warning(
                 "Scope %s: %d of %d editable groups keep deterministic names (%s)",

--- a/diagram_analysis/diagram_generator.py
+++ b/diagram_analysis/diagram_generator.py
@@ -38,6 +38,7 @@ from agents.relation_edges import (
     prune_ungrounded_edges,
 )
 from agents.scope_ids import ROOT_SCOPE_ID
+from clustering_ids import CodeBoardingClusterIds
 from agents.scope_analysis_agent import ScopeAnalysisAgent
 from agents.content_hash import SourceCache, hash_repo_source_files, tree_hash_from_file_hashes
 from diagram_analysis.analysis_json import (
@@ -509,34 +510,30 @@ def distinguish_expanded_component_names(
     root_analysis: AnalysisInsights,
     sub_analyses: dict[str, AnalysisInsights],
 ) -> list[tuple[str, str, str]]:
-    """Make every expanded component's document name unique across the whole tree.
+    """Give every expanded component a distinct document name; returns ``(id, old, new)`` per rename.
 
-    The markdown and MDX renderers write one document per expanded component under
-    ``sanitize(name)``, so two expanded components that sanitise alike overwrite each other.
-    The scope agent is told the names it sits inside, and the assembler refuses a proposal
-    that repeats one, but two cousins named independently on the pool can still collide.
-    This is the guarantee: the later one (by id) gets its id appended, and every relation
-    that carries its name follows. Returns ``(component_id, old, new)`` per rename.
+    Why: renderers write one document per expanded component under ``sanitize(name)``,
+    case-insensitively, and scopes named in parallel can still collide.
     """
     scopes = {ROOT_SCOPE_ID: root_analysis, **sub_analyses}
-    expanded: list[tuple[str, Component, AnalysisInsights]] = []
-    for scope_id, scope_analysis in scopes.items():
-        for component in scope_analysis.components:
-            if component.component_id in sub_analyses:
-                expanded.append((component.component_id, component, scope_analysis))
-    expanded.sort(key=lambda item: [int(part) if part.isdigit() else part for part in item[0].split(".")])
-
+    expanded = {
+        component.component_id: component
+        for scope_analysis in scopes.values()
+        for component in scope_analysis.components
+        if component.component_id in sub_analyses
+    }
     renamed: list[tuple[str, str, str]] = []
     taken: set[str] = set()
-    for component_id, component, holder in expanded:
-        key = sanitize(component.name)
+    for component_id in CodeBoardingClusterIds.sort(set(expanded)):
+        component = expanded[component_id]
+        key = sanitize(component.name).casefold()
         if key not in taken:
             taken.add(key)
             continue
         new_name = f"{component.name} ({component_id})"
-        while sanitize(new_name) in taken:
+        while sanitize(new_name).casefold() in taken:
             new_name += "_"
-        taken.add(sanitize(new_name))
+        taken.add(sanitize(new_name).casefold())
         old_name = component.name
         component.name = new_name
         for scope_analysis in scopes.values():
@@ -546,12 +543,7 @@ def distinguish_expanded_component_names(
                 if relation.dst_id == component_id and relation.dst_name == old_name:
                     relation.dst_name = new_name
         renamed.append((component_id, old_name, new_name))
-        logger.warning(
-            "Expanded components would share document '%s'; renamed %s to %r",
-            key,
-            component_id,
-            new_name,
-        )
+        logger.warning("Expanded components would share document '%s'; renamed %s to %r", key, component_id, new_name)
     return renamed
 
 
@@ -627,8 +619,7 @@ class DiagramGenerator:
         self._naming_counts_lock = threading.Lock()
         self._scopes_enriched = 0
         self._scopes_unnamed = 0
-        # Every component name this run has settled, by id, so a child scope can be told
-        # the names it sits inside. Written under the lock: child scopes run on the pool.
+        # Settled component names by id, so a child scope is told the names it sits inside.
         self._names_by_id: dict[str, str] = {}
         self.incremental_updater: IncrementalUpdater | None = None
         self.file_coverage_data: dict | None = None
@@ -830,11 +821,7 @@ class DiagramGenerator:
                     self._names_by_id[component.component_id] = component.name
 
     def _enclosing_names(self, scope_id: str) -> tuple[str, ...]:
-        """The names of the components a scope sits inside, outermost first.
-
-        Scope ``1.2.1`` sits inside components ``1`` and ``1.2``; both were named when
-        their own scope was enriched, which always happens before a child is submitted.
-        """
+        """The names of the components a scope sits inside, outermost first."""
         if scope_id == ROOT_SCOPE_ID:
             return ()
         parts = scope_id.split(".")
@@ -852,7 +839,6 @@ class DiagramGenerator:
         skip_scope_ids: frozenset[str] = frozenset(),
     ) -> None:
         """Re-run semantic analysis only for scopes containing changed groups or files."""
-        # The baseline's names are the ones a re-named child must not collide with.
         self._record_names(root_analysis)
         for scope_analysis in sub_analyses.values():
             self._record_names(scope_analysis)

--- a/diagram_analysis/diagram_generator.py
+++ b/diagram_analysis/diagram_generator.py
@@ -39,6 +39,7 @@ from agents.relation_edges import (
 )
 from agents.scope_ids import ROOT_SCOPE_ID
 from clustering_ids import CodeBoardingClusterIds
+from constants import ROOT_DOCUMENT_NAMES
 from agents.scope_analysis_agent import ScopeAnalysisAgent
 from agents.content_hash import SourceCache, hash_repo_source_files, tree_hash_from_file_hashes
 from diagram_analysis.analysis_json import (
@@ -512,8 +513,8 @@ def distinguish_expanded_component_names(
 ) -> list[tuple[str, str, str]]:
     """Give every expanded component a distinct document name; returns ``(id, old, new)`` per rename.
 
-    Why: renderers write one document per expanded component under ``sanitize(name)``,
-    case-insensitively, and scopes named in parallel can still collide.
+    Why: renderers write the root under a fixed name and one document per expanded component
+    under ``sanitize(name)``, case-insensitively; scopes named in parallel can still collide.
     """
     scopes = {ROOT_SCOPE_ID: root_analysis, **sub_analyses}
     expanded = {
@@ -523,7 +524,7 @@ def distinguish_expanded_component_names(
         if component.component_id in sub_analyses
     }
     renamed: list[tuple[str, str, str]] = []
-    taken: set[str] = set()
+    taken = {sanitize(name).casefold() for name in ROOT_DOCUMENT_NAMES}
     for component_id in CodeBoardingClusterIds.sort(set(expanded)):
         component = expanded[component_id]
         key = sanitize(component.name).casefold()
@@ -681,6 +682,7 @@ class DiagramGenerator:
             # A partial run expands one component of an existing analysis, so it replays the
             # specification that analysis was drawn from rather than drafting a new one.
             self.tree_spec = self._stored_tree_spec()
+            self._record_partial_names(target_component, persisted_scopes)
             scope = self._build_component_scope(target_component, depth)
             self.clustering_hierarchy = ClusterScopeResult(scope_id=ROOT_SCOPE_ID)
             self.clustering_hierarchy.register_scope(target_component.component_id, scope)
@@ -828,6 +830,15 @@ class DiagramGenerator:
             for component in analysis.components:
                 if component.component_id:
                     self._names_by_id[component.component_id] = component.name
+
+    def _record_partial_names(
+        self, target_component: Component, persisted_scopes: Mapping[str, AnalysisInsights]
+    ) -> None:
+        """A partial run names inside an existing tree; its children must know that tree's names."""
+        for scope_analysis in persisted_scopes.values():
+            self._record_names(scope_analysis)
+        with self._naming_counts_lock:
+            self._names_by_id[target_component.component_id] = target_component.name
 
     def _enclosing_names(self, scope_id: str) -> tuple[str, ...]:
         """The names of the components a scope sits inside, outermost first."""

--- a/diagram_analysis/diagram_generator.py
+++ b/diagram_analysis/diagram_generator.py
@@ -55,6 +55,7 @@ from diagram_analysis.io_utils import load_analysis_metadata, save_analysis, wri
 from diagram_analysis.incremental_changes import compute_changed_members
 from diagram_analysis.scope_assembly import ScopeAssembler
 from repo_utils.path_utils import normalize_repo_path
+from utils import sanitize
 from diagram_analysis.scope_plan import plan_scope_result_update
 from diagram_analysis.tree_shape import absorb_single_child_components
 from health.config import initialize_health_dir, load_health_config
@@ -504,6 +505,56 @@ def _incremental_changed_component_ids(
     return changed
 
 
+def distinguish_expanded_component_names(
+    root_analysis: AnalysisInsights,
+    sub_analyses: dict[str, AnalysisInsights],
+) -> list[tuple[str, str, str]]:
+    """Make every expanded component's document name unique across the whole tree.
+
+    The markdown and MDX renderers write one document per expanded component under
+    ``sanitize(name)``, so two expanded components that sanitise alike overwrite each other.
+    The scope agent is told the names it sits inside, and the assembler refuses a proposal
+    that repeats one, but two cousins named independently on the pool can still collide.
+    This is the guarantee: the later one (by id) gets its id appended, and every relation
+    that carries its name follows. Returns ``(component_id, old, new)`` per rename.
+    """
+    scopes = {ROOT_SCOPE_ID: root_analysis, **sub_analyses}
+    expanded: list[tuple[str, Component, AnalysisInsights]] = []
+    for scope_id, scope_analysis in scopes.items():
+        for component in scope_analysis.components:
+            if component.component_id in sub_analyses:
+                expanded.append((component.component_id, component, scope_analysis))
+    expanded.sort(key=lambda item: [int(part) if part.isdigit() else part for part in item[0].split(".")])
+
+    renamed: list[tuple[str, str, str]] = []
+    taken: set[str] = set()
+    for component_id, component, holder in expanded:
+        key = sanitize(component.name)
+        if key not in taken:
+            taken.add(key)
+            continue
+        new_name = f"{component.name} ({component_id})"
+        while sanitize(new_name) in taken:
+            new_name += "_"
+        taken.add(sanitize(new_name))
+        old_name = component.name
+        component.name = new_name
+        for scope_analysis in scopes.values():
+            for relation in scope_analysis.components_relations:
+                if relation.src_id == component_id and relation.src_name == old_name:
+                    relation.src_name = new_name
+                if relation.dst_id == component_id and relation.dst_name == old_name:
+                    relation.dst_name = new_name
+        renamed.append((component_id, old_name, new_name))
+        logger.warning(
+            "Expanded components would share document '%s'; renamed %s to %r",
+            key,
+            component_id,
+            new_name,
+        )
+    return renamed
+
+
 class DiagramGenerator:
     def __init__(
         self,
@@ -576,6 +627,9 @@ class DiagramGenerator:
         self._naming_counts_lock = threading.Lock()
         self._scopes_enriched = 0
         self._scopes_unnamed = 0
+        # Every component name this run has settled, by id, so a child scope can be told
+        # the names it sits inside. Written under the lock: child scopes run on the pool.
+        self._names_by_id: dict[str, str] = {}
         self.incremental_updater: IncrementalUpdater | None = None
         self.file_coverage_data: dict | None = None
 
@@ -719,7 +773,9 @@ class DiagramGenerator:
     ) -> None:
         """Apply bounded semantic enrichment while preserving deterministic scope structure."""
         if not editable_group_ids:
+            self._record_names(analysis)
             return
+        enclosing_names = self._enclosing_names(scope.scope_id)
         with self._naming_counts_lock:
             self._scopes_enriched += 1
         try:
@@ -730,6 +786,7 @@ class DiagramGenerator:
                 locked_name_ids,
                 changed_files,
                 incremental,
+                enclosing_names=enclosing_names,
             )
         except LLMAuthError:
             raise
@@ -737,10 +794,12 @@ class DiagramGenerator:
             logger.exception("Semantic analysis failed for scope %s; retaining deterministic output", scope.scope_id)
             with self._naming_counts_lock:
                 self._scopes_unnamed += 1
+            self._record_names(analysis)
             return
         if semantics is None:
             with self._naming_counts_lock:
                 self._scopes_unnamed += 1
+            self._record_names(analysis)
             return
         assert self.static_analysis is not None
         unnamed = self.scope_assembler.apply_semantics(
@@ -750,7 +809,9 @@ class DiagramGenerator:
             editable_group_ids,
             set(locked_name_ids),
             StaticReferenceResolver(self.repo_location, self.static_analysis),
+            reserved_names=enclosing_names,
         )
+        self._record_names(analysis)
         if unnamed:
             logger.warning(
                 "Scope %s: %d of %d editable groups keep deterministic names (%s)",
@@ -762,6 +823,25 @@ class DiagramGenerator:
             with self._naming_counts_lock:
                 self._scopes_unnamed += 1
 
+    def _record_names(self, analysis: AnalysisInsights) -> None:
+        with self._naming_counts_lock:
+            for component in analysis.components:
+                if component.component_id:
+                    self._names_by_id[component.component_id] = component.name
+
+    def _enclosing_names(self, scope_id: str) -> tuple[str, ...]:
+        """The names of the components a scope sits inside, outermost first.
+
+        Scope ``1.2.1`` sits inside components ``1`` and ``1.2``; both were named when
+        their own scope was enriched, which always happens before a child is submitted.
+        """
+        if scope_id == ROOT_SCOPE_ID:
+            return ()
+        parts = scope_id.split(".")
+        with self._naming_counts_lock:
+            names = [self._names_by_id.get(".".join(parts[: index + 1])) for index in range(len(parts))]
+        return tuple(name for name in names if name)
+
     def _enrich_incremental_scopes(
         self,
         hierarchy: ClusterScopeResult,
@@ -772,6 +852,10 @@ class DiagramGenerator:
         skip_scope_ids: frozenset[str] = frozenset(),
     ) -> None:
         """Re-run semantic analysis only for scopes containing changed groups or files."""
+        # The baseline's names are the ones a re-named child must not collide with.
+        self._record_names(root_analysis)
+        for scope_analysis in sub_analyses.values():
+            self._record_names(scope_analysis)
         changed_files = self._incremental_changed_files(root_analysis)
         for scope in self._cluster_scopes(hierarchy):
             if scope.scope_id in skip_scope_ids:
@@ -1388,6 +1472,7 @@ class DiagramGenerator:
         if self.tree_spec is not None:
             self.tree_spec.reroot(absorbed_ids)
         assert_scope_containment(root_analysis, sub_analyses)
+        distinguish_expanded_component_names(root_analysis, sub_analyses)
 
     def finalize_and_save(
         self,

--- a/diagram_analysis/scope_assembly.py
+++ b/diagram_analysis/scope_assembly.py
@@ -1,7 +1,7 @@
 """Build diagram scopes from deterministic clustering results."""
 
 import logging
-from collections.abc import Collection, Callable
+from collections.abc import Callable, Collection
 from pathlib import Path
 
 from agents.agent_responses import AnalysisInsights, Component, Relation, RelationEdge

--- a/diagram_analysis/scope_assembly.py
+++ b/diagram_analysis/scope_assembly.py
@@ -104,9 +104,8 @@ class ScopeAssembler:
         """Apply valid semantic fields without changing deterministic structure.
 
         Returns the editable groups that ended up without a semantic name, so the caller can
-        report a scope the model only partly named. ``reserved_names`` are taken before any
-        proposal is: the names of the components this scope sits inside, so a child cannot be
-        named after its parent (each expanded component writes a document under its name).
+        report a scope the model only partly named. ``reserved_names`` (the enclosing
+        components) are taken before any proposal, so a child is never named after its parent.
         """
         components = {component.component_id: component for component in analysis.components}
         groups_by_id = {group.group_id: group for group in scope.groups}
@@ -350,11 +349,9 @@ class ScopeAssembler:
 
     @staticmethod
     def _fallback_description(scope: ClusterScopeResult, group: ClusterGroup, repo_dir: Path) -> str:
-        """What a component says about itself when semantic analysis skipped or failed it.
+        """The description a component keeps when semantic analysis skipped or failed it.
 
-        Repository-relative paths, deliberately: this text ships in analysis.json, and the
-        graph's file paths are absolute — a run in the extension would print the user's
-        disk layout and a run in the action the runner's temp directory.
+        Why relative paths: this text ships in analysis.json; the graph's paths are absolute.
         """
         files = sorted(
             {

--- a/diagram_analysis/scope_assembly.py
+++ b/diagram_analysis/scope_assembly.py
@@ -1,7 +1,7 @@
 """Build diagram scopes from deterministic clustering results."""
 
 import logging
-from collections.abc import Callable
+from collections.abc import Collection, Callable
 from pathlib import Path
 
 from agents.agent_responses import AnalysisInsights, Component, Relation, RelationEdge
@@ -22,6 +22,7 @@ from constants import DEFAULT_STATIC_RELATION_LABEL
 from diagram_analysis.file_index import build_file_methods_from_nodes, build_files_index
 from static_analyzer import StaticAnalysisFatalError
 from static_analyzer.cfg import Edge
+from repo_utils.path_utils import normalize_repo_path
 from static_analyzer.clustering import ClusterGroup, ClusterScopeResult, GroupConnection
 from static_analyzer.reference_resolver import StaticReferenceResolver
 
@@ -48,7 +49,7 @@ class ScopeAssembler:
             components.append(
                 Component(
                     name=group.unique_name(taken),
-                    description=self._fallback_description(scope, group),
+                    description=self._fallback_description(scope, group, self.repo_dir),
                     key_entities=[],
                     source_cluster_ids=CodeBoardingClusterIds.from_graph_ids(set(group.cluster_ids)),
                     component_id=group.group_id,
@@ -98,11 +99,14 @@ class ScopeAssembler:
         editable_group_ids: set[str],
         locked_name_ids: set[str],
         reference_resolver: StaticReferenceResolver,
+        reserved_names: Collection[str] = (),
     ) -> frozenset[str]:
         """Apply valid semantic fields without changing deterministic structure.
 
         Returns the editable groups that ended up without a semantic name, so the caller can
-        report a scope the model only partly named.
+        report a scope the model only partly named. ``reserved_names`` are taken before any
+        proposal is: the names of the components this scope sits inside, so a child cannot be
+        named after its parent (each expanded component writes a document under its name).
         """
         components = {component.component_id: component for component in analysis.components}
         groups_by_id = {group.group_id: group for group in scope.groups}
@@ -119,6 +123,7 @@ class ScopeAssembler:
             and semantics_by_id[group_id].name.strip()
         }
         taken = {component.name for group_id, component in components.items() if group_id not in proposals}
+        taken.update(reserved_names)
         named: set[str] = set()
         for group_id in ordered_ids:
             component = components.get(group_id)
@@ -344,10 +349,16 @@ class ScopeAssembler:
             )
 
     @staticmethod
-    def _fallback_description(scope: ClusterScopeResult, group: ClusterGroup) -> str:
+    def _fallback_description(scope: ClusterScopeResult, group: ClusterGroup, repo_dir: Path) -> str:
+        """What a component says about itself when semantic analysis skipped or failed it.
+
+        Repository-relative paths, deliberately: this text ships in analysis.json, and the
+        graph's file paths are absolute — a run in the extension would print the user's
+        disk layout and a run in the action the runner's temp directory.
+        """
         files = sorted(
             {
-                scope.graphs_by_language[language].nodes[qualified_name].file_path
+                normalize_repo_path(scope.graphs_by_language[language].nodes[qualified_name].file_path, repo_dir)
                 for language, qualified_names in group.symbol_members_by_language.items()
                 if language in scope.graphs_by_language
                 for qualified_name in qualified_names

--- a/output_generators/rendering.py
+++ b/output_generators/rendering.py
@@ -8,6 +8,7 @@ from tempfile import TemporaryDirectory
 from typing import Any
 
 from agents.agent_responses import AnalysisInsights, Relation
+from constants import DEFAULT_ROOT_DOCUMENT_NAME
 from agents.relation_edges import append_or_merge_relation
 from diagram_analysis.analysis_json import build_id_to_name_map, parse_unified_analysis
 from output_generators.html import generate_html_file
@@ -140,7 +141,7 @@ def render_docs(
     repo_ref: str,
     temp_dir: Path,
     format: str = ".md",
-    root_name: str = "overview",
+    root_name: str = DEFAULT_ROOT_DOCUMENT_NAME,
     demo_mode: bool = False,
 ) -> None:
     """Render docs in one extension under ``temp_dir``."""
@@ -180,7 +181,7 @@ def render(
     repo_name: str,
     output_dir: Path,
     repo_ref: str = "",
-    root_name: str = "overview",
+    root_name: str = DEFAULT_ROOT_DOCUMENT_NAME,
     demo_mode: bool = False,
 ) -> None:
     """Replace rendered docs for one format from a completed analysis.json."""

--- a/static_analyzer/clustering/service.py
+++ b/static_analyzer/clustering/service.py
@@ -199,10 +199,8 @@ class ClusteringService:
             members = partition.members.get(rule.component_id, [])
             if not members:
                 continue
-            # Every name voted; the members the agents own are the callables and classes. A
-            # rule whose units carry none — data-only files, a TSX file of constants — would
-            # become a component that owns no file, and a box with nothing in it is not a
-            # component: the diagram stays whole without it, its units draw nothing anyway.
+            # Every name voted; the members the agents own are the callables and classes.
+            # Why skip a rule without any: its component would own no file and draw nothing.
             owned_by_language: dict[str, set[str]] = {}
             for unit in members:
                 nodes = graphs[unit.language].nodes

--- a/static_analyzer/clustering/service.py
+++ b/static_analyzer/clustering/service.py
@@ -199,17 +199,26 @@ class ClusteringService:
             members = partition.members.get(rule.component_id, [])
             if not members:
                 continue
+            # Every name voted; the members the agents own are the callables and classes. A
+            # rule whose units carry none — data-only files, a TSX file of constants — would
+            # become a component that owns no file, and a box with nothing in it is not a
+            # component: the diagram stays whole without it, its units draw nothing anyway.
+            owned_by_language: dict[str, set[str]] = {}
+            for unit in members:
+                nodes = graphs[unit.language].nodes
+                owned = {name for name in unit.names if nodes[name].type in CALLABLE_TYPES | CLASS_TYPES}
+                owned_by_language.setdefault(unit.language, set()).update(owned)
+            if not any(owned_by_language.values()):
+                logger.info("Scope %s: rule %s owns no callable or class; not drawn", scope_id, rule.component_id)
+                continue
             group = ClusterGroup(
                 group_id=rule.component_id,
                 name=rule.name,
                 cluster_ids=sorted(leaf_by_unit[unit.unit_id] for unit in members),
                 previous_component_id=rule.component_id if rule.component_id in previous_ids else "",
             )
+            group.symbol_members_by_language = owned_by_language
             for unit in members:
-                # Every name voted; the members the agents own are the callables and classes.
-                nodes = graphs[unit.language].nodes
-                owned = {name for name in unit.names if nodes[name].type in CALLABLE_TYPES | CLASS_TYPES}
-                group.symbol_members_by_language.setdefault(unit.language, set()).update(owned)
                 group.file_reasons[unit.unit_id] = self._placement_reason(
                     unit,
                     rule,

--- a/tests/agents/test_llm_renderers.py
+++ b/tests/agents/test_llm_renderers.py
@@ -205,9 +205,6 @@ class TestRenderScopeContext(unittest.TestCase):
         self.assertEqual(payload["existing_relations"][0]["relation"], "submits to")
 
     def test_a_dense_pair_is_a_count_and_a_few_examples_not_every_edge(self):
-        """Gson's root scope carried 2,980 cross-group edges; rendered one object each they were
-        1.56 M of a 1.68 M-character prompt, more than a 262k-token model accepts, and the whole
-        scope shipped with rule names. The count carries the weight; five edges carry the symbols."""
         graph = CallGraph(language="python")
         edges = []
         for index in range(40):

--- a/tests/agents/test_llm_renderers.py
+++ b/tests/agents/test_llm_renderers.py
@@ -3,6 +3,7 @@ import unittest
 from pathlib import Path
 
 from agents.agent_responses import AnalysisInsights, Component, Relation
+from agents.llm_renderers.scope import MAX_EXAMPLE_EDGES
 from agents.llm_renderers import render_call_graph, render_scope_context
 from static_analyzer.cfg import CallGraph, EdgeKind, ReferenceEdge
 from static_analyzer.clustering import ClusterConnectionEdge, ClusterGroup, ClusterScopeResult, GroupConnection
@@ -189,13 +190,61 @@ class TestRenderScopeContext(unittest.TestCase):
             {
                 "source_group_id": "1",
                 "target_group_id": "2",
-                "language": "python",
-                "source_method": "client.submit",
-                "source_file": "client.py",
-                "source_line": 10,
-                "target_method": "server.receive",
-                "target_file": "server.py",
-                "target_line": 30,
+                "calls": 1,
+                "examples": [
+                    {
+                        "source": "client.submit",
+                        "source_at": "client.py:10",
+                        "target": "server.receive",
+                        "target_at": "server.py:30",
+                    }
+                ],
             },
         )
+        self.assertEqual(payload["enclosing_components"], [])
         self.assertEqual(payload["existing_relations"][0]["relation"], "submits to")
+
+    def test_a_dense_pair_is_a_count_and_a_few_examples_not_every_edge(self):
+        """Gson's root scope carried 2,980 cross-group edges; rendered one object each they were
+        1.56 M of a 1.68 M-character prompt, more than a 262k-token model accepts, and the whole
+        scope shipped with rule names. The count carries the weight; five edges carry the symbols."""
+        graph = CallGraph(language="python")
+        edges = []
+        for index in range(40):
+            graph.add_node(Node(f"a.f{index}", NodeType.FUNCTION, f"/repo/a{index}.py", 1, 2))
+            graph.add_node(Node(f"b.g{index}", NodeType.FUNCTION, f"/repo/b{index}.py", 1, 2))
+            edges.append(ClusterConnectionEdge("python", f"a.f{index}", f"b.g{index}"))
+        # The same edge reported twice (two call sites) counts once.
+        edges.append(ClusterConnectionEdge("python", "a.f0", "b.g0"))
+        scope = ClusterScopeResult(
+            scope_id="root",
+            graphs_by_language={"python": graph},
+            groups=[
+                ClusterGroup("1", [1], symbol_members_by_language={"python": {f"a.f{i}" for i in range(40)}}),
+                ClusterGroup("2", [2], symbol_members_by_language={"python": {f"b.g{i}" for i in range(40)}}),
+            ],
+            connections=[
+                GroupConnection("1", "2", edges=edges[:20]),
+                GroupConnection("1", "2", edges=edges[20:]),
+            ],
+        )
+        analysis = AnalysisInsights(description="", components=[], components_relations=[])
+
+        payload = json.loads(
+            render_scope_context(
+                scope,
+                analysis,
+                Path("/repo"),
+                {"1", "2"},
+                set(),
+                set(),
+                incremental=False,
+                enclosing_names=("Backend", "Services"),
+            )
+        )
+
+        (pair,) = payload["known_connections"]
+        self.assertEqual((pair["source_group_id"], pair["target_group_id"], pair["calls"]), ("1", "2", 40))
+        self.assertEqual(len(pair["examples"]), MAX_EXAMPLE_EDGES)
+        self.assertEqual(pair["examples"][0]["source"], "a.f0")
+        self.assertEqual(payload["enclosing_components"], ["Backend", "Services"])

--- a/tests/agents/test_scope_analysis_agent.py
+++ b/tests/agents/test_scope_analysis_agent.py
@@ -18,6 +18,7 @@ from agents.scope_analysis_agent import (
     MAX_SCOPE_MODEL_CALLS,
     MAX_SCOPE_TOOL_CALLS,
     SCOPE_RECURSION_LIMIT,
+    RepositoryToolBudget,
     ScopeAnalysisAgent,
     ScopeAnalysisResult,
     ScopeComponentSemantics,
@@ -102,6 +103,7 @@ class TestScopeAnalysisAgent(unittest.TestCase):
         middleware = create_agent.call_args.kwargs["middleware"]
         tool_limit = next(item for item in middleware if isinstance(item, ToolCallLimitMiddleware))
         model_limit = next(item for item in middleware if isinstance(item, ModelCallLimitMiddleware))
+        self.assertIsInstance(tool_limit, RepositoryToolBudget)
         self.assertEqual(tool_limit.run_limit, MAX_SCOPE_TOOL_CALLS)
         self.assertEqual(model_limit.run_limit, MAX_SCOPE_MODEL_CALLS)
         self.assertEqual(runtime.invoke.call_args.kwargs["config"]["recursion_limit"], SCOPE_RECURSION_LIMIT)
@@ -139,6 +141,7 @@ class TestScopeAnalysisAgent(unittest.TestCase):
             )
             for index in range(MAX_SCOPE_TOOL_CALLS + 1)
         ]
+        # The budget is spent (and one read beyond it blocked); the answer still lands.
         final_response = AIMessage(
             content="",
             tool_calls=[

--- a/tests/agents/test_scope_analysis_agent.py
+++ b/tests/agents/test_scope_analysis_agent.py
@@ -5,20 +5,22 @@ from typing import Any
 from unittest.mock import MagicMock, patch
 
 from langchain.agents.middleware import ModelCallLimitMiddleware, ToolCallLimitMiddleware
+from langchain.agents.structured_output import ToolStrategy
 from langchain_core.language_models import BaseChatModel, LanguageModelInput
 from langchain_core.language_models.fake_chat_models import FakeMessagesListChatModel
-from langchain_core.messages import AIMessage, HumanMessage
+from langchain_core.messages import AIMessage
 from langchain_core.runnables import Runnable
 from langchain_core.tools import BaseTool
 
 from agents.agent_responses import AnalysisInsights, Component
 from agents.llm_errors import LLMAuthError
 from agents.scope_analysis_agent import (
-    JSON_RECOVERY_MESSAGE,
     MAX_SCOPE_MODEL_CALLS,
     MAX_SCOPE_TOOL_CALLS,
     SCOPE_RECURSION_LIMIT,
     ScopeAnalysisAgent,
+    ScopeAnalysisResult,
+    ScopeComponentSemantics,
 )
 from agents.tools import MethodCallsTool, ReadFileTool
 from static_analyzer.analysis_result import StaticAnalysisResults
@@ -65,20 +67,20 @@ def _inputs() -> tuple[StaticAnalysisResults, ClusterScopeResult, AnalysisInsigh
     return static_analysis, scope, analysis
 
 
+def _answer() -> ScopeAnalysisResult:
+    return ScopeAnalysisResult(
+        description="scope",
+        components=[ScopeComponentSemantics(group_id="1", name="Runner", description="Runs work")],
+        relations=[],
+    )
+
+
 class TestScopeAnalysisAgent(unittest.TestCase):
     @patch("agents.scope_analysis_agent.create_agent")
     def test_exposes_only_scoped_file_and_method_tools_with_runtime_limits(self, create_agent):
         static_analysis, scope, analysis = _inputs()
         runtime = MagicMock()
-        runtime.invoke.return_value = {
-            "messages": [
-                AIMessage(
-                    content='{"description":"scope","components":['
-                    '{"group_id":"1","name":"Runner","description":"Runs work","key_entities":[]}],'
-                    '"relations":[]}'
-                )
-            ]
-        }
+        runtime.invoke.return_value = {"messages": [AIMessage(content="")], "structured_response": _answer()}
         create_agent.return_value = runtime
         agent = ScopeAnalysisAgent(Path("/repo"), static_analysis, MagicMock(spec=BaseChatModel))
 
@@ -87,6 +89,9 @@ class TestScopeAnalysisAgent(unittest.TestCase):
         self.assertIsNotNone(result)
         assert result is not None
         self.assertEqual(result.components[0].name, "Runner")
+        response_format = create_agent.call_args.kwargs["response_format"]
+        self.assertIsInstance(response_format, ToolStrategy)
+        self.assertIs(response_format.schema, ScopeAnalysisResult)
         tools = create_agent.call_args.kwargs["tools"]
         self.assertEqual([type(tool) for tool in tools], [ReadFileTool, MethodCallsTool])
         self.assertEqual([tool.name for tool in tools], ["readFile", "getMethodCalls"])
@@ -135,9 +140,15 @@ class TestScopeAnalysisAgent(unittest.TestCase):
             for index in range(MAX_SCOPE_TOOL_CALLS + 1)
         ]
         final_response = AIMessage(
-            content='{"description":"scope","components":['
-            '{"group_id":"1","name":"Runner","description":"Runs work","key_entities":[]}],'
-            '"relations":[]}'
+            content="",
+            tool_calls=[
+                {
+                    "name": "ScopeAnalysisResult",
+                    "args": _answer().model_dump(),
+                    "id": "final",
+                    "type": "tool_call",
+                }
+            ],
         )
         model = ToolCallingFakeModel(responses=[*tool_requests, final_response])
 
@@ -147,33 +158,20 @@ class TestScopeAnalysisAgent(unittest.TestCase):
         self.assertEqual(read_file.call_count, MAX_SCOPE_TOOL_CALLS)
 
     @patch("agents.scope_analysis_agent.create_agent")
-    def test_asks_once_more_when_the_run_ended_without_a_json_object(self, create_agent):
+    def test_returns_none_when_the_run_ended_without_a_structured_answer(self, create_agent):
         static_analysis, scope, analysis = _inputs()
         runtime = MagicMock()
-        runtime.invoke.return_value = {
-            "messages": [HumanMessage(content="analyze"), AIMessage(content="Done {no object here}.")]
-        }
+        runtime.invoke.return_value = {"messages": [AIMessage(content="Done.")], "structured_response": None}
         create_agent.return_value = runtime
-        llm = MagicMock(spec=BaseChatModel)
-        llm.invoke.return_value = AIMessage(
-            content='{"description":"scope","components":['
-            '{"group_id":"1","name":"Runner","description":"Runs work","key_entities":[]}],"relations":[]}'
-        )
-        agent = ScopeAnalysisAgent(Path("/repo"), static_analysis, llm)
+        agent = ScopeAnalysisAgent(Path("/repo"), static_analysis, MagicMock(spec=BaseChatModel))
 
-        result = agent.analyze(scope, analysis, {"1"})
-
-        assert result is not None
-        self.assertEqual(result.components[0].name, "Runner")
-        sent = llm.invoke.call_args.args[0]
-        self.assertEqual([type(m) for m in sent], [HumanMessage, AIMessage, HumanMessage])
-        self.assertEqual(sent[-1].content, JSON_RECOVERY_MESSAGE)
+        self.assertIsNone(agent.analyze(scope, analysis, {"1"}))
 
     @patch("agents.scope_analysis_agent.create_agent")
     def test_passes_the_enclosing_names_to_the_renderer(self, create_agent):
         static_analysis, scope, analysis = _inputs()
         runtime = MagicMock()
-        runtime.invoke.return_value = {"messages": [AIMessage(content='{"components":[],"relations":[]}')]}
+        runtime.invoke.return_value = {"messages": [], "structured_response": _answer()}
         create_agent.return_value = runtime
         agent = ScopeAnalysisAgent(Path("/repo"), static_analysis, MagicMock(spec=BaseChatModel))
 
@@ -181,16 +179,3 @@ class TestScopeAnalysisAgent(unittest.TestCase):
 
         prompt = runtime.invoke.call_args.args[0]["messages"][0].content
         self.assertIn('"enclosing_components": [\n    "Engine"\n  ]', prompt)
-
-    @patch("agents.scope_analysis_agent.create_agent")
-    def test_returns_none_when_the_recovery_answer_is_malformed_too(self, create_agent):
-        static_analysis, scope, analysis = _inputs()
-        runtime = MagicMock()
-        runtime.invoke.return_value = {"messages": [AIMessage(content='{"components": [')]}
-        create_agent.return_value = runtime
-        llm = MagicMock(spec=BaseChatModel)
-        llm.invoke.return_value = AIMessage(content="still not JSON")
-        agent = ScopeAnalysisAgent(Path("/repo"), static_analysis, llm)
-
-        self.assertIsNone(agent.analyze(scope, analysis, {"1"}))
-        self.assertEqual(llm.invoke.call_count, 1)

--- a/tests/agents/test_scope_analysis_agent.py
+++ b/tests/agents/test_scope_analysis_agent.py
@@ -7,13 +7,14 @@ from unittest.mock import MagicMock, patch
 from langchain.agents.middleware import ModelCallLimitMiddleware, ToolCallLimitMiddleware
 from langchain_core.language_models import BaseChatModel, LanguageModelInput
 from langchain_core.language_models.fake_chat_models import FakeMessagesListChatModel
-from langchain_core.messages import AIMessage
+from langchain_core.messages import AIMessage, HumanMessage
 from langchain_core.runnables import Runnable
 from langchain_core.tools import BaseTool
 
 from agents.agent_responses import AnalysisInsights, Component
 from agents.llm_errors import LLMAuthError
 from agents.scope_analysis_agent import (
+    JSON_RECOVERY_MESSAGE,
     MAX_SCOPE_MODEL_CALLS,
     MAX_SCOPE_TOOL_CALLS,
     SCOPE_RECURSION_LIMIT,
@@ -144,6 +145,42 @@ class TestScopeAnalysisAgent(unittest.TestCase):
 
         self.assertIsNotNone(result)
         self.assertEqual(read_file.call_count, MAX_SCOPE_TOOL_CALLS)
+
+    @patch("agents.scope_analysis_agent.create_agent")
+    def test_asks_once_more_when_the_run_ended_without_a_json_object(self, create_agent):
+        """Kimi ended four of eleven Hono scopes in prose; one tool-free completion over the
+        transcript recovers the object, and the scope keeps its names instead of its rules."""
+        static_analysis, scope, analysis = _inputs()
+        runtime = MagicMock()
+        runtime.invoke.return_value = {"messages": [HumanMessage(content="analyze"), AIMessage(content="Done.")]}
+        create_agent.return_value = runtime
+        llm = MagicMock(spec=BaseChatModel)
+        llm.invoke.return_value = AIMessage(
+            content='{"description":"scope","components":['
+            '{"group_id":"1","name":"Runner","description":"Runs work","key_entities":[]}],"relations":[]}'
+        )
+        agent = ScopeAnalysisAgent(Path("/repo"), static_analysis, llm)
+
+        result = agent.analyze(scope, analysis, {"1"})
+
+        assert result is not None
+        self.assertEqual(result.components[0].name, "Runner")
+        sent = llm.invoke.call_args.args[0]
+        self.assertEqual([type(m) for m in sent], [HumanMessage, AIMessage, HumanMessage])
+        self.assertEqual(sent[-1].content, JSON_RECOVERY_MESSAGE)
+
+    @patch("agents.scope_analysis_agent.create_agent")
+    def test_passes_the_enclosing_names_to_the_renderer(self, create_agent):
+        static_analysis, scope, analysis = _inputs()
+        runtime = MagicMock()
+        runtime.invoke.return_value = {"messages": [AIMessage(content='{"components":[],"relations":[]}')]}
+        create_agent.return_value = runtime
+        agent = ScopeAnalysisAgent(Path("/repo"), static_analysis, MagicMock(spec=BaseChatModel))
+
+        agent.analyze(scope, analysis, {"1"}, enclosing_names=("Engine",))
+
+        prompt = runtime.invoke.call_args.args[0]["messages"][0].content
+        self.assertIn('"enclosing_components": [\n    "Engine"\n  ]', prompt)
 
     @patch("agents.scope_analysis_agent.create_agent")
     def test_returns_none_for_malformed_model_output(self, create_agent):

--- a/tests/agents/test_scope_analysis_agent.py
+++ b/tests/agents/test_scope_analysis_agent.py
@@ -148,11 +148,11 @@ class TestScopeAnalysisAgent(unittest.TestCase):
 
     @patch("agents.scope_analysis_agent.create_agent")
     def test_asks_once_more_when_the_run_ended_without_a_json_object(self, create_agent):
-        """Kimi ended four of eleven Hono scopes in prose; one tool-free completion over the
-        transcript recovers the object, and the scope keeps its names instead of its rules."""
         static_analysis, scope, analysis = _inputs()
         runtime = MagicMock()
-        runtime.invoke.return_value = {"messages": [HumanMessage(content="analyze"), AIMessage(content="Done.")]}
+        runtime.invoke.return_value = {
+            "messages": [HumanMessage(content="analyze"), AIMessage(content="Done {no object here}.")]
+        }
         create_agent.return_value = runtime
         llm = MagicMock(spec=BaseChatModel)
         llm.invoke.return_value = AIMessage(
@@ -183,11 +183,14 @@ class TestScopeAnalysisAgent(unittest.TestCase):
         self.assertIn('"enclosing_components": [\n    "Engine"\n  ]', prompt)
 
     @patch("agents.scope_analysis_agent.create_agent")
-    def test_returns_none_for_malformed_model_output(self, create_agent):
+    def test_returns_none_when_the_recovery_answer_is_malformed_too(self, create_agent):
         static_analysis, scope, analysis = _inputs()
         runtime = MagicMock()
-        runtime.invoke.return_value = {"messages": [AIMessage(content="not JSON")]}
+        runtime.invoke.return_value = {"messages": [AIMessage(content='{"components": [')]}
         create_agent.return_value = runtime
-        agent = ScopeAnalysisAgent(Path("/repo"), static_analysis, MagicMock(spec=BaseChatModel))
+        llm = MagicMock(spec=BaseChatModel)
+        llm.invoke.return_value = AIMessage(content="still not JSON")
+        agent = ScopeAnalysisAgent(Path("/repo"), static_analysis, llm)
 
         self.assertIsNone(agent.analyze(scope, analysis, {"1"}))
+        self.assertEqual(llm.invoke.call_count, 1)

--- a/tests/diagram_analysis/test_diagram_analysis.py
+++ b/tests/diagram_analysis/test_diagram_analysis.py
@@ -882,6 +882,27 @@ class TestDiagramGenerator(unittest.TestCase):
         self.assertIsNotNone(gen.scope_assembler)
         self.assertIsNone(gen.incremental_updater)
 
+    def test_a_partial_run_tells_child_scopes_the_names_they_sit_inside(self):
+        gen = DiagramGenerator(
+            repo_location=self.repo_location,
+            temp_folder=self.temp_folder,
+            repo_name="test_repo",
+            output_dir=self.output_dir,
+            depth_level=2,
+            run_id="test-run-id",
+            log_path="test_repo/test-run-log",
+        )
+        root = AnalysisInsights(
+            description="",
+            components=[Component(name="Engine", description="", key_entities=[], component_id="1")],
+            components_relations=[],
+        )
+        target = Component(name="Adapters", description="", key_entities=[], component_id="1.2")
+
+        gen._record_partial_names(target, {ROOT_SCOPE_ID: root})
+
+        self.assertEqual(gen._enclosing_names("1.2.1"), ("Engine", "Adapters"))
+
     def test_enrich_scope_propagates_authentication_failures(self):
         gen = DiagramGenerator(
             repo_location=self.repo_location,

--- a/tests/diagram_analysis/test_expanded_component_names.py
+++ b/tests/diagram_analysis/test_expanded_component_names.py
@@ -1,3 +1,5 @@
+"""Expanded components write one document each, so their names must not collide."""
+
 import unittest
 
 from agents.agent_responses import AnalysisInsights, Component, Relation
@@ -78,6 +80,18 @@ class TestDistinguishExpandedComponentNames(unittest.TestCase):
         renamed = distinguish_expanded_component_names(root, subs)
 
         self.assertEqual([r[0] for r in renamed], ["legacy_component_a"])
+
+    def test_the_root_document_names_are_taken_before_any_component(self) -> None:
+        root = AnalysisInsights(
+            description="",
+            components=[_component("1", "Overview"), _component("2", "On-Boarding")],
+            components_relations=[],
+        )
+        subs = {key: AnalysisInsights(description="", components=[], components_relations=[]) for key in ("1", "2")}
+
+        distinguish_expanded_component_names(root, subs)
+
+        self.assertEqual([c.name for c in root.components], ["Overview (1)", "On-Boarding (2)"])
 
     def test_names_that_differ_only_in_punctuation_still_collide(self) -> None:
         root = AnalysisInsights(

--- a/tests/diagram_analysis/test_expanded_component_names.py
+++ b/tests/diagram_analysis/test_expanded_component_names.py
@@ -1,0 +1,60 @@
+"""Two expanded components that sanitise to one document name overwrite each other."""
+
+import unittest
+
+from agents.agent_responses import AnalysisInsights, Component, Relation
+from diagram_analysis.diagram_generator import distinguish_expanded_component_names
+
+
+def _component(component_id: str, name: str) -> Component:
+    return Component(name=name, description=name, key_entities=[], component_id=component_id)
+
+
+class TestDistinguishExpandedComponentNames(unittest.TestCase):
+    def test_a_child_named_after_its_parent_gets_its_id_and_its_relations_follow(self) -> None:
+        root = AnalysisInsights(
+            description="",
+            components=[_component("1", "Static Analysis Engine"), _component("2", "Agents")],
+            components_relations=[
+                Relation(relation="feeds", src_name="Static Analysis Engine", dst_name="Agents", src_id="1", dst_id="2")
+            ],
+        )
+        one = AnalysisInsights(
+            description="",
+            components=[_component("1.1", "Static Analysis Engine"), _component("1.2", "Adapters")],
+            components_relations=[
+                Relation(
+                    relation="uses", src_name="Static Analysis Engine", dst_name="Adapters", src_id="1.1", dst_id="1.2"
+                )
+            ],
+        )
+        one_one = AnalysisInsights(
+            description="", components=[_component("1.1.1", "Static Analysis Engine")], components_relations=[]
+        )
+
+        renamed = distinguish_expanded_component_names(root, {"1": one, "1.1": one_one})
+
+        self.assertEqual(renamed, [("1.1", "Static Analysis Engine", "Static Analysis Engine (1.1)")])
+        self.assertEqual(root.components[0].name, "Static Analysis Engine")
+        self.assertEqual(one.components[0].name, "Static Analysis Engine (1.1)")
+        self.assertEqual(one.components_relations[0].src_name, "Static Analysis Engine (1.1)")
+        # A leaf may share the name: it writes no document of its own.
+        self.assertEqual(one_one.components[0].name, "Static Analysis Engine")
+
+    def test_names_that_differ_only_in_punctuation_still_collide(self) -> None:
+        root = AnalysisInsights(
+            description="", components=[_component("1", "Foo Bar"), _component("2", "Foo-Bar")], components_relations=[]
+        )
+        subs = {
+            "1": AnalysisInsights(description="", components=[], components_relations=[]),
+            "2": AnalysisInsights(description="", components=[], components_relations=[]),
+        }
+
+        renamed = distinguish_expanded_component_names(root, subs)
+
+        self.assertEqual([r[0] for r in renamed], ["2"])
+        self.assertEqual(root.components[1].name, "Foo-Bar (2)")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/diagram_analysis/test_expanded_component_names.py
+++ b/tests/diagram_analysis/test_expanded_component_names.py
@@ -1,9 +1,8 @@
-"""Two expanded components that sanitise to one document name overwrite each other."""
-
 import unittest
 
 from agents.agent_responses import AnalysisInsights, Component, Relation
 from diagram_analysis.diagram_generator import distinguish_expanded_component_names
+from utils import sanitize
 
 
 def _component(component_id: str, name: str) -> Component:
@@ -40,6 +39,45 @@ class TestDistinguishExpandedComponentNames(unittest.TestCase):
         self.assertEqual(one.components_relations[0].src_name, "Static Analysis Engine (1.1)")
         # A leaf may share the name: it writes no document of its own.
         self.assertEqual(one_one.components[0].name, "Static Analysis Engine")
+
+    def test_names_that_differ_only_in_case_collide_as_the_renderer_sees_them(self) -> None:
+        root = AnalysisInsights(
+            description="", components=[_component("1", "API"), _component("2", "api")], components_relations=[]
+        )
+        subs = {key: AnalysisInsights(description="", components=[], components_relations=[]) for key in ("1", "2")}
+
+        distinguish_expanded_component_names(root, subs)
+
+        self.assertEqual([c.name for c in root.components], ["API", "api (2)"])
+
+    def test_a_suffixed_name_that_is_itself_taken_is_suffixed_again(self) -> None:
+        root = AnalysisInsights(
+            description="",
+            components=[_component("1", "Core"), _component("2", "Core"), _component("3", "Core (2)")],
+            components_relations=[],
+        )
+        subs = {key: AnalysisInsights(description="", components=[], components_relations=[]) for key in "123"}
+
+        distinguish_expanded_component_names(root, subs)
+
+        names = [c.name for c in root.components]
+        self.assertEqual(names, ["Core", "Core (2)", "Core (2) (3)"])
+        self.assertEqual(len({sanitize(n).casefold() for n in names}), 3)
+
+    def test_ids_of_mixed_shapes_still_order(self) -> None:
+        root = AnalysisInsights(
+            description="",
+            components=[_component("legacy_component_a", "Core"), _component("2", "Core")],
+            components_relations=[],
+        )
+        subs = {
+            key: AnalysisInsights(description="", components=[], components_relations=[])
+            for key in ("legacy_component_a", "2")
+        }
+
+        renamed = distinguish_expanded_component_names(root, subs)
+
+        self.assertEqual([r[0] for r in renamed], ["legacy_component_a"])
 
     def test_names_that_differ_only_in_punctuation_still_collide(self) -> None:
         root = AnalysisInsights(

--- a/tests/diagram_analysis/test_scope_assembly.py
+++ b/tests/diagram_analysis/test_scope_assembly.py
@@ -172,16 +172,12 @@ class TestScopeAssembler(unittest.TestCase):
         )
 
     def test_fallback_descriptions_name_files_relative_to_the_repository(self) -> None:
-        """This text ships in analysis.json when semantic analysis fails; the graph's paths
-        are absolute, and a run once printed the runner's temp directory eight times over."""
         analysis = ScopeAssembler(Path("/repo")).build(_scope(absolute=True))
 
         self.assertEqual(analysis.components[0].description, "Owns 1 symbols across 1 files: src/1.py.")
         self.assertNotIn("/repo", analysis.components[0].description)
 
     def test_a_proposal_cannot_take_an_enclosing_components_name(self) -> None:
-        """Each expanded component writes a document under its name, so a child named after
-        its parent overwrites the parent's document."""
         scope = _scope(names={"1": "engine", "2": "adapters"})
         assembler = ScopeAssembler(Path("/repo"))
         analysis = assembler.build(scope)

--- a/tests/diagram_analysis/test_scope_assembly.py
+++ b/tests/diagram_analysis/test_scope_assembly.py
@@ -22,12 +22,13 @@ def _component(component_id: str, name: str) -> Component:
     return Component(name=name, description=name, key_entities=[], component_id=component_id)
 
 
-def _scope(*pairs: tuple[str, str], names: dict[str, str] | None = None) -> ClusterScopeResult:
+def _scope(*pairs: tuple[str, str], names: dict[str, str] | None = None, absolute: bool = False) -> ClusterScopeResult:
     symbols = {"1": "a.run", "2": "b.load", "3": "c.save"}
     names = names or {}
     graph = CallGraph(language="python")
     for index, (group_id, qualified_name) in enumerate(symbols.items(), start=1):
-        graph.add_node(Node(qualified_name, NodeType.FUNCTION, f"src/{group_id}.py", index, index + 1))
+        path = f"/repo/src/{group_id}.py" if absolute else f"src/{group_id}.py"
+        graph.add_node(Node(qualified_name, NodeType.FUNCTION, path, index, index + 1))
     return ClusterScopeResult(
         scope_id="root",
         graphs_by_language={"python": graph},
@@ -169,6 +170,36 @@ class TestScopeAssembler(unittest.TestCase):
             [(relation.src_id, relation.dst_id, relation.relation) for relation in analysis.components_relations],
             [("2", "3", "calls")],
         )
+
+    def test_fallback_descriptions_name_files_relative_to_the_repository(self) -> None:
+        """This text ships in analysis.json when semantic analysis fails; the graph's paths
+        are absolute, and a run once printed the runner's temp directory eight times over."""
+        analysis = ScopeAssembler(Path("/repo")).build(_scope(absolute=True))
+
+        self.assertEqual(analysis.components[0].description, "Owns 1 symbols across 1 files: src/1.py.")
+        self.assertNotIn("/repo", analysis.components[0].description)
+
+    def test_a_proposal_cannot_take_an_enclosing_components_name(self) -> None:
+        """Each expanded component writes a document under its name, so a child named after
+        its parent overwrites the parent's document."""
+        scope = _scope(names={"1": "engine", "2": "adapters"})
+        assembler = ScopeAssembler(Path("/repo"))
+        analysis = assembler.build(scope)
+        result = ScopeAnalysisResult(
+            description="",
+            components=[
+                ScopeComponentSemantics(group_id="1", name="Static Analysis Engine", description="core"),
+                ScopeComponentSemantics(group_id="2", name="Adapters", description="per language"),
+            ],
+            relations=[],
+        )
+
+        unnamed = assembler.apply_semantics(
+            analysis, scope, result, {"1", "2"}, set(), _resolver(scope), reserved_names=("Static Analysis Engine",)
+        )
+
+        self.assertEqual([c.name for c in analysis.components], ["engine", "Adapters", "Component 3"])
+        self.assertEqual(unnamed, frozenset({"1"}))
 
     def test_names_components_from_the_clustering_rule_that_claimed_them(self) -> None:
         scope = _scope(names={"1": "Ingestion", "2": "Storage"})

--- a/tests/static_analyzer/test_clustering_service.py
+++ b/tests/static_analyzer/test_clustering_service.py
@@ -169,6 +169,21 @@ class TestFullHierarchy(unittest.TestCase):
         csharp.add_reference_edge(ReferenceEdge("B", "B.Run()", EdgeKind.CONTAINS))
         self.assertEqual(unit_links({"csharp": csharp}), {(str(REPO / "a.cs"), str(REPO / "b.cs")): 2})
 
+    def test_a_rule_whose_units_own_no_callable_or_class_is_not_drawn(self):
+        """Hono drew "Render" and "Page" with zero files: the rules matched .tsx units whose only
+        symbols were variables, so the group had nothing to own and the component nothing to show."""
+        layout = eshop() | {f"src/Assets/Asset{i}.cs": [f"Assets.asset{i}_var"] for i in range(6)}
+        hierarchy = ClusteringService().build_full_hierarchy(analysis_for(graph("csharp", layout)), max_depth=2)
+
+        def visit(scope: ClusterScopeResult) -> None:
+            for group in scope.groups:
+                self.assertTrue(any(group.symbol_members_by_language.values()), f"{group.group_id} owns nothing")
+                if group.children is not None:
+                    visit(group.children)
+
+        visit(hierarchy)
+        self.assertNotIn("Assets", {group.name for group in hierarchy.groups})
+
     def test_connections_come_from_the_graph(self):
         edges = [("Catalog.API.Model.CatalogType0.Run()", "Ordering.API.Apis.OrderingType0.Run()")]
         hierarchy = ClusteringService().build_full_hierarchy(analysis_for(graph("csharp", eshop(), edges)), max_depth=1)

--- a/tests/static_analyzer/test_clustering_service.py
+++ b/tests/static_analyzer/test_clustering_service.py
@@ -170,8 +170,6 @@ class TestFullHierarchy(unittest.TestCase):
         self.assertEqual(unit_links({"csharp": csharp}), {(str(REPO / "a.cs"), str(REPO / "b.cs")): 2})
 
     def test_a_rule_whose_units_own_no_callable_or_class_is_not_drawn(self):
-        """Hono drew "Render" and "Page" with zero files: the rules matched .tsx units whose only
-        symbols were variables, so the group had nothing to own and the component nothing to show."""
         layout = eshop() | {f"src/Assets/Asset{i}.cs": [f"Assets.asset{i}_var"] for i in range(6)}
         hierarchy = ClusteringService().build_full_hierarchy(analysis_for(graph("csharp", layout)), max_depth=2)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -145,6 +145,7 @@ class TestPartialUpdate(unittest.TestCase):
             mock_generator.prepare_analysis.assert_called_once_with(
                 hierarchy_depth=2,
                 target_component=root_component,
+                persisted_scopes={"root": root_analysis},
             )
             mock_generator.process_component.assert_called_once_with(root_component)
             changes = mock_generator_class.call_args.kwargs["changes"]
@@ -194,10 +195,8 @@ class TestPartialUpdate(unittest.TestCase):
             components=[nested_component],
             components_relations=[],
         )
-        mock_load_full.return_value = (
-            AnalysisInsights(description="root", components=[root_component], components_relations=[]),
-            {"root_comp_id": sub_analysis_of_root},
-        )
+        root_analysis = AnalysisInsights(description="root", components=[root_component], components_relations=[])
+        mock_load_full.return_value = (root_analysis, {"root_comp_id": sub_analysis_of_root})
 
         with tempfile.TemporaryDirectory() as temp_dir:
             repo_path = Path(temp_dir) / "repo"
@@ -215,6 +214,7 @@ class TestPartialUpdate(unittest.TestCase):
             mock_generator.prepare_analysis.assert_called_once_with(
                 hierarchy_depth=3,
                 target_component=nested_component,
+                persisted_scopes={"root": root_analysis, "root_comp_id": sub_analysis_of_root},
             )
             mock_generator.process_component.assert_called_once_with(nested_component)
             self.assertEqual(mock_generator_class.call_args.kwargs["depth_level"], 2)
@@ -399,10 +399,8 @@ class TestLocalSource(unittest.TestCase):
             key_entities=[],
         )
         mock_load_metadata.return_value = {"depth_level": 1, "source_tree_hash": "source-hash"}
-        mock_load_full.return_value = (
-            AnalysisInsights(description="root", components=[component], components_relations=[]),
-            {},
-        )
+        root_analysis = AnalysisInsights(description="root", components=[component], components_relations=[])
+        mock_load_full.return_value = (root_analysis, {})
         mock_generator_class.return_value.process_component.return_value = ("target", None, [])
 
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -422,6 +420,7 @@ class TestLocalSource(unittest.TestCase):
             mock_generator_class.return_value.prepare_analysis.assert_called_once_with(
                 hierarchy_depth=2,
                 target_component=component,
+                persisted_scopes={"root": root_analysis},
             )
 
 


### PR DESCRIPTION
## Why

The 0.14.0 release eval ([CodeBoarding-evals#23](https://github.com/CodeBoarding/CodeBoarding-evals/pull/23)) read `origin/main` b61e5abf against 0.13.11 on ten repositories with Kimi-K2.6 (262k context). The clustering was a large improvement everywhere, but on Gson and jsoup the top level shipped **raw rule names** (`internal`, `Loose files in gson.com.google.gson`, `helper 7`) and **every description was a template printing absolute paths of the analysed checkout** (`Owns 631 symbols across 37 files: /private/var/folders/…/repo/…`). Root cause, measured: `render_scope_context` rendered every cross-group edge as a nine-field indented object — Gson root = **1,676,924 chars ≈ 420k tokens, 93% of it `known_connections` (2,980 edges)** — the model answered 400, `_enrich_scope` caught it, and the scope kept its deterministic output. Polly / JUnit 4 / mermaid / Hono kept template descriptions one level down for a second reason (the bounded agent ended in prose, "response contains no JSON object"). CodeBoarding shipped `1` and `1.1` both named "Static Analysis Engine" (`doc_filenames_unique` violated), and Hono drew two components owning zero files.

## What changes

- **`known_connections` is one entry per directed group pair**: the number of distinct calls and up to five of them in full (`MAX_EXAMPLE_EDGES`). Gson root prompt: 1,676,924 → **106,841 chars**; the scope names itself.
- **JSON recovery**: a bounded run that ends without a JSON object gets one tool-free completion over its transcript asking for the object alone.
- **Fallback descriptions are repository-relative** (`normalize_repo_path`).
- **No child named after its parent**: the renderer lists `enclosing_components`, the prompt forbids reusing them, `apply_semantics` reserves them, and `finalize_for_save` runs `distinguish_expanded_component_names` — any two expanded components that still sanitise to one document name get an id suffix, relations following.
- **A rule whose units own no callable or class is not drawn** (`ClusteringService`).

## Verified

Re-ran the five affected rulers through the evals harness with this branch (`local:` engine, tag `release-0.14.0-fix`, Kimi-K2.6), same commits as the eval:

| ruler | template descriptions | path leaks | empty components | numbered names | duplicate document names | tokens |
|---|---:|---:|---:|---:|---:|---:|
| gson | 8 → **0** | 8 → 0 | 0 | 0 | 0 | 222k → 130k |
| jsoup | 8 → **0** | 8 → 0 | 0 | 1 → 0 | 0 | 305k → 127k |
| codeboarding | 2 → **0** | 2 → 0 | 0 | 0 | 1 → **0** | 306k → 207k |
| hono | 9 → **0** | 7 → 0 | 2 → **0** | 0 | 0 | 212k → 188k |
| polly | 10 → **0** | 10 → 0 | 0 | 1 → 0 | 0 | 686k → 455k |

25 of 25 deterministic criteria met (the candidate had 24/25). Gson root now reads "Gson Core API / Gson Internal Bindings and Utilities / JSON Streaming Layer / Configuration and Annotations / Extras and Extensions / Shrinker Test Samples / Performance Benchmarks / Build Configuration"; jsoup "DOM Node Model / HTML/XML Parser / Selector Engine / Helper Utilities / Internal Utilities / HTML Sanitizer / Facade and Exceptions / Java 11 HTTP Client".

`pytest tests/` 2041 passed; mypy and black clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved diagram generation with unique names for expanded components, preventing naming conflicts.
  * Added clearer connection summaries with call counts and representative examples.
  * Added enclosing-component context to improve analysis results.
  * Standardized default document naming across generated documentation.

* **Bug Fixes**
  * Improved recovery when analysis responses are incomplete or lack structured results.
  * Prevented child components from reusing enclosing component names.
  * Updated fallback descriptions to use repository-relative file paths.
  * Improved reliability when recording component names after analysis issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->