### PR TITLE
Update project version to 0.14.0 - prepare for release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "codeboarding"
-version = "0.13.11"
+version = "0.14.0"
 description = "Interactive Diagrams for Code"
 readme = "PYPI.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -290,7 +290,7 @@ wheels = [
 
 [[package]]
 name = "codeboarding"
-version = "0.13.11"
+version = "0.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "docker" },


### PR DESCRIPTION
Version bump to `0.14.0` in preparation for release (`pyproject.toml` + `uv.lock`, one functional line each).

Merge order: land #565 (the naming fix the 0.14.0 release eval found, CodeBoarding-evals#23) before this PR so 0.14.0 ships with it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project version to 0.14.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->