### PR TITLE
feat(cfg): type-reference edges from source, drawn as relations; fix the callable-usage walk; two save-path quadratics

### DIFF
--- a/agents/agent_responses.py
+++ b/agents/agent_responses.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel, Field
 from clustering_ids import ComponentId
 from agents.file_index_models import FileEntry, FileMethodGroup, MethodIndexEntry
 from agents.scope_ids import ROOT_SCOPE_ID
+from static_analyzer.cfg.edge import EdgeKind
 
 logger = logging.getLogger(__name__)
 
@@ -77,6 +78,13 @@ class RelationCallSite(BaseModel):
     column: int = Field(description="One-based column number of the call site in the source file.")
 
 
+# What a static reference edge says about itself; ``static_relation_label`` reads it back.
+REFERENCE_EDGE_DESCRIPTIONS: dict[EdgeKind, str] = {
+    EdgeKind.INHERITS: "inherits from",
+    EdgeKind.TYPEREF: "references type",
+}
+
+
 class RelationEdge(LLMBaseModel):
     """A source-to-target code reference that supports a component relation."""
 
@@ -119,6 +127,25 @@ class RelationEdge(LLMBaseModel):
                 reference_end_line=edge.dst_node.line_end,
             ),
             call_sites=[RelationCallSite.model_validate(call_site) for call_site in edge.call_sites],
+        )
+
+    @classmethod
+    def from_reference(cls, source, target, kind: EdgeKind) -> RelationEdge:
+        """An edge backed by a reference (inheritance, a type mention) rather than a call site."""
+        return cls(
+            source=SourceCodeReference(
+                qualified_name=source.fully_qualified_name,
+                reference_file=source.file_path,
+                reference_start_line=source.line_start,
+                reference_end_line=source.line_end,
+            ),
+            target=SourceCodeReference(
+                qualified_name=target.fully_qualified_name,
+                reference_file=target.file_path,
+                reference_start_line=target.line_start,
+                reference_end_line=target.line_end,
+            ),
+            description=REFERENCE_EDGE_DESCRIPTIONS[kind],
         )
 
     def llm_str(self) -> str:

--- a/agents/agent_responses.py
+++ b/agents/agent_responses.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import abc
 import logging
 from abc import abstractmethod
-from collections.abc import Hashable
+from collections.abc import Hashable, Sequence
 from enum import StrEnum
 
 from pydantic import BaseModel, Field
@@ -11,7 +11,8 @@ from pydantic import BaseModel, Field
 from clustering_ids import ComponentId
 from agents.file_index_models import FileEntry, FileMethodGroup, MethodIndexEntry
 from agents.scope_ids import ROOT_SCOPE_ID
-from static_analyzer.cfg.edge import EdgeKind
+from static_analyzer.cfg.edge import CallSiteLocation, EdgeKind
+from static_analyzer.node import Node
 
 logger = logging.getLogger(__name__)
 
@@ -78,13 +79,6 @@ class RelationCallSite(BaseModel):
     column: int = Field(description="One-based column number of the call site in the source file.")
 
 
-# What a static reference edge says about itself; ``static_relation_label`` reads it back.
-REFERENCE_EDGE_DESCRIPTIONS: dict[EdgeKind, str] = {
-    EdgeKind.INHERITS: "inherits from",
-    EdgeKind.TYPEREF: "references type",
-}
-
-
 class RelationEdge(LLMBaseModel):
     """A source-to-target code reference that supports a component relation."""
 
@@ -93,7 +87,12 @@ class RelationEdge(LLMBaseModel):
     description: str = Field(default="", description="Short explanation of how source reaches or configures target.")
     call_sites: list[RelationCallSite] = Field(
         default_factory=list,
-        description="Call-site line and column pairs for this edge.",
+        description="Line and column pairs where this edge occurs.",
+        exclude=True,
+    )
+    kind: EdgeKind = Field(
+        default=EdgeKind.CALL,
+        description="The static edge behind this one: a call unless it came from a reference edge.",
         exclude=True,
     )
 
@@ -130,8 +129,10 @@ class RelationEdge(LLMBaseModel):
         )
 
     @classmethod
-    def from_reference(cls, source, target, kind: EdgeKind) -> RelationEdge:
-        """An edge backed by a reference (inheritance, a type mention) rather than a call site."""
+    def from_reference(
+        cls, source: Node, target: Node, kind: EdgeKind, sites: Sequence[CallSiteLocation] = ()
+    ) -> RelationEdge:
+        """An edge backed by a reference (inheritance, a type mention) rather than a call."""
         return cls(
             source=SourceCodeReference(
                 qualified_name=source.fully_qualified_name,
@@ -145,7 +146,9 @@ class RelationEdge(LLMBaseModel):
                 reference_start_line=target.line_start,
                 reference_end_line=target.line_end,
             ),
-            description=REFERENCE_EDGE_DESCRIPTIONS[kind],
+            description=kind.relation_label,
+            call_sites=[RelationCallSite.model_validate(site) for site in sites],
+            kind=kind,
         )
 
     def llm_str(self) -> str:
@@ -187,6 +190,20 @@ def _relation_endpoint_from_key(
     )
 
 
+def static_relation_label(edges: Sequence[RelationEdge]) -> str:
+    """The label a relation gets from its static edges alone.
+
+    A single call outranks any reference; one kind of reference reads as that kind; mixed
+    references read as the umbrella ``uses``.
+    """
+    kinds = {edge.kind for edge in edges}
+    if not kinds or EdgeKind.CALL in kinds:
+        return EdgeKind.CALL.relation_label
+    if len(kinds) == 1:
+        return next(iter(kinds)).relation_label
+    return EdgeKind.TYPEREF.relation_label
+
+
 class Relation(LLMBaseModel):
     """A relationship between two components."""
 
@@ -210,6 +227,11 @@ class Relation(LLMBaseModel):
     src_id: str = Field(default="", description="Component ID of the source.", exclude=True)
     dst_id: str = Field(default="", description="Component ID of the destination.", exclude=True)
     is_static: bool = Field(default=False, description="True if derived from static CFG analysis.", exclude=True)
+    default_label: bool = Field(
+        default=False,
+        description="True when the label is what the static edges give the pair, not a description someone wrote.",
+        exclude=True,
+    )
     all_edges: list[RelationEdge] = Field(
         default_factory=list,
         description="All known source-to-target edges for this relation, populated deterministically when available.",
@@ -217,26 +239,17 @@ class Relation(LLMBaseModel):
     )
 
     @classmethod
-    def from_edges(
-        cls,
-        relation: str,
-        src_name: str,
-        dst_name: str,
-        src_id: str,
-        dst_id: str,
-        edges: list[RelationEdge],
-        is_static: bool,
-        evidence: str = "",
-    ) -> Relation:
+    def from_edges(cls, src_name: str, dst_name: str, src_id: str, dst_id: str, edges: list[RelationEdge]) -> Relation:
+        """The relation the static edges alone make between two components, labelled by their kinds."""
         return cls(
-            relation=relation,
+            relation=static_relation_label(edges),
             src_name=src_name,
             dst_name=dst_name,
-            evidence=evidence,
             key_edges=[],
             src_id=src_id,
             dst_id=dst_id,
-            is_static=is_static,
+            is_static=True,
+            default_label=True,
             all_edges=cls.unique_edges(edges),
         )
 
@@ -261,6 +274,7 @@ class Relation(LLMBaseModel):
             src_id=self.src_id,
             dst_id=self.dst_id,
             is_static=self.is_static,
+            default_label=self.default_label,
             all_edges=all_edges,
         )
 

--- a/agents/file_index_models.py
+++ b/agents/file_index_models.py
@@ -87,33 +87,28 @@ class FileEntry(BaseModel):
     )
 
     def merge_from(self, other: FileEntry) -> FileEntry:
-        """Merge another entry while retaining independent, canonical method metadata."""
+        """Merge another entry while retaining independent, canonical method metadata.
+
+        Why linear: an entry is merged once per component that touches its file, so copying
+        every method it already owns on each merge made a large file quadratic to index.
+        """
         if not self.content_hash:
             self.content_hash = other.content_hash
         if not self.module_hash:
             self.module_hash = other.module_hash
 
         methods_by_qname: dict[str, MethodEntry] = {}
-        for method in [*self.methods, *other.methods]:
-            candidate = method.model_copy(deep=True)
-            indexed = methods_by_qname.get(candidate.qualified_name)
-            if indexed is None:
-                methods_by_qname[candidate.qualified_name] = candidate
-                continue
-
-            if bool(indexed.content_hash) != bool(candidate.content_hash) and candidate.content_hash:
-                preferred, fallback = candidate, indexed
-            else:
-                preferred, fallback = indexed, candidate
-            preferred.start_line = preferred.start_line or fallback.start_line
-            preferred.end_line = preferred.end_line or fallback.end_line
-            preferred.content_hash = preferred.content_hash or fallback.content_hash
-            methods_by_qname[candidate.qualified_name] = preferred
-
-        self.methods = sorted(
-            methods_by_qname.values(),
-            key=lambda method: (method.start_line, method.end_line, method.qualified_name),
-        )
+        for method in self.methods:
+            _fold_method(methods_by_qname, method)
+        changed = False
+        for method in other.methods:
+            # A copy keeps this entry's metadata independent of ``other``; the fields are flat.
+            changed = _fold_method(methods_by_qname, method.model_copy()) or changed
+        if changed or len(methods_by_qname) != len(self.methods):
+            self.methods = sorted(
+                methods_by_qname.values(),
+                key=lambda method: (method.start_line, method.end_line, method.qualified_name),
+            )
         return self
 
     def merge_method_spans(self, spans: dict[str, tuple[int, int]]) -> None:
@@ -126,3 +121,21 @@ class FileEntry(BaseModel):
             method.start_line = method.start_line or start_line
             method.end_line = method.end_line or end_line
         self.methods.sort(key=lambda method: (method.start_line, method.end_line, method.qualified_name))
+
+
+def _fold_method(methods_by_qname: dict[str, MethodEntry], candidate: MethodEntry) -> bool:
+    """Index ``candidate`` by name, keeping the entry that knows its hash; returns whether anything changed."""
+    indexed = methods_by_qname.get(candidate.qualified_name)
+    if indexed is None:
+        methods_by_qname[candidate.qualified_name] = candidate
+        return True
+    if candidate.content_hash and not indexed.content_hash:
+        preferred, fallback = candidate, indexed
+        methods_by_qname[candidate.qualified_name] = preferred
+    else:
+        preferred, fallback = indexed, candidate
+    before = (preferred.start_line, preferred.end_line, preferred.content_hash)
+    preferred.start_line = preferred.start_line or fallback.start_line
+    preferred.end_line = preferred.end_line or fallback.end_line
+    preferred.content_hash = preferred.content_hash or fallback.content_hash
+    return preferred is not indexed or before != (preferred.start_line, preferred.end_line, preferred.content_hash)

--- a/agents/llm_renderers/scope.py
+++ b/agents/llm_renderers/scope.py
@@ -10,7 +10,7 @@ from typing import Any
 
 from agents.agent_responses import AnalysisInsights
 from repo_utils.path_utils import normalize_repo_path
-from static_analyzer.cfg.edge import EdgeKind
+from static_analyzer.cfg.edge import CALL_EDGE_KIND, EdgeKind
 from static_analyzer.clustering import ClusterConnectionEdge, ClusterGroup, ClusterScopeResult
 from static_analyzer.node import Node
 
@@ -146,12 +146,15 @@ def _known_connections(scope: ClusterScopeResult, repo_dir: Path) -> list[dict[s
             seen.add(key)
             distinct.append(edge)
         distinct.sort(key=lambda edge: (edge.source_qualified_name, edge.target_qualified_name))
+        calls = [edge for edge in distinct if edge.kind == CALL_EDGE_KIND]
+        references = [edge for edge in distinct if edge.kind != CALL_EDGE_KIND]
         connections.append(
             {
                 "source_group_id": source_group_id,
                 "target_group_id": target_group_id,
-                "calls": len(distinct),
-                "examples": [_example(edge, scope, repo_dir) for edge in distinct[:MAX_EXAMPLE_EDGES]],
+                "calls": len(calls),
+                "type_references": len(references),
+                "examples": [_example(edge, scope, repo_dir) for edge in (calls + references)[:MAX_EXAMPLE_EDGES]],
             }
         )
     return connections
@@ -186,6 +189,10 @@ def _boundary_reasons(
     }
     for connection in scope.connections:
         for edge in connection.edges:
+            # Only calls border a file here; a type reference is counted per pair in
+            # ``known_connections`` instead, or it would border nearly every file.
+            if edge.kind != CALL_EDGE_KIND:
+                continue
             graph = scope.graphs_by_language.get(edge.language)
             if graph is None:
                 continue
@@ -200,7 +207,9 @@ def _boundary_reasons(
 
     for language, graph in scope.graphs_by_language.items():
         for reference in graph.reference_edges:
-            if reference.kind is EdgeKind.CONTAINS:
+            # TYPEREF is dense enough to border nearly every file; its count rides on
+            # ``known_connections`` instead, where a pair costs one line.
+            if reference.kind is not EdgeKind.INHERITS:
                 continue
             source_group = owners.get((language, reference.src))
             target_group = owners.get((language, reference.dst))

--- a/agents/llm_renderers/scope.py
+++ b/agents/llm_renderers/scope.py
@@ -10,7 +10,7 @@ from typing import Any
 
 from agents.agent_responses import AnalysisInsights
 from repo_utils.path_utils import normalize_repo_path
-from static_analyzer.cfg.edge import CALL_EDGE_KIND, EdgeKind
+from static_analyzer.cfg.edge import EdgeKind
 from static_analyzer.clustering import ClusterConnectionEdge, ClusterGroup, ClusterScopeResult
 from static_analyzer.node import Node
 
@@ -146,8 +146,8 @@ def _known_connections(scope: ClusterScopeResult, repo_dir: Path) -> list[dict[s
             seen.add(key)
             distinct.append(edge)
         distinct.sort(key=lambda edge: (edge.source_qualified_name, edge.target_qualified_name))
-        calls = [edge for edge in distinct if edge.kind == CALL_EDGE_KIND]
-        references = [edge for edge in distinct if edge.kind != CALL_EDGE_KIND]
+        calls = [edge for edge in distinct if edge.kind is EdgeKind.CALL]
+        references = [edge for edge in distinct if edge.kind is not EdgeKind.CALL]
         connections.append(
             {
                 "source_group_id": source_group_id,
@@ -191,7 +191,7 @@ def _boundary_reasons(
         for edge in connection.edges:
             # Only calls border a file here; a type reference is counted per pair in
             # ``known_connections`` instead, or it would border nearly every file.
-            if edge.kind != CALL_EDGE_KIND:
+            if edge.kind is not EdgeKind.CALL:
                 continue
             graph = scope.graphs_by_language.get(edge.language)
             if graph is None:

--- a/agents/relation_edges.py
+++ b/agents/relation_edges.py
@@ -1,11 +1,29 @@
 """Merge component relations and index their source endpoints."""
 
-from collections.abc import Callable, Collection
+from collections.abc import Callable, Collection, Sequence
 from pathlib import Path
 
-from agents.agent_responses import AnalysisInsights, Relation, RelationEdge, SourceCodeReference
+from agents.agent_responses import (
+    REFERENCE_EDGE_DESCRIPTIONS,
+    AnalysisInsights,
+    Relation,
+    RelationEdge,
+    SourceCodeReference,
+)
 from clustering_ids import is_self_or_descendant
 from repo_utils.path_utils import normalize_repo_path
+from constants import DEFAULT_STATIC_RELATION_LABEL, INHERITANCE_RELATION_LABEL, TYPE_REFERENCE_RELATION_LABEL
+from static_analyzer.cfg.edge import EdgeKind
+
+
+def static_relation_label(edges: Sequence[RelationEdge]) -> str:
+    """The label a relation gets from its static edges alone: a single call outranks any reference."""
+    descriptions = {edge.description for edge in edges}
+    if not descriptions or descriptions - set(REFERENCE_EDGE_DESCRIPTIONS.values()):
+        return DEFAULT_STATIC_RELATION_LABEL
+    if descriptions == {REFERENCE_EDGE_DESCRIPTIONS[EdgeKind.INHERITS]}:
+        return INHERITANCE_RELATION_LABEL
+    return TYPE_REFERENCE_RELATION_LABEL
 
 
 def append_or_merge_relation(

--- a/agents/relation_edges.py
+++ b/agents/relation_edges.py
@@ -1,29 +1,11 @@
 """Merge component relations and index their source endpoints."""
 
-from collections.abc import Callable, Collection, Sequence
+from collections.abc import Callable, Collection
 from pathlib import Path
 
-from agents.agent_responses import (
-    REFERENCE_EDGE_DESCRIPTIONS,
-    AnalysisInsights,
-    Relation,
-    RelationEdge,
-    SourceCodeReference,
-)
+from agents.agent_responses import AnalysisInsights, Relation, RelationEdge, SourceCodeReference
 from clustering_ids import is_self_or_descendant
 from repo_utils.path_utils import normalize_repo_path
-from constants import DEFAULT_STATIC_RELATION_LABEL, INHERITANCE_RELATION_LABEL, TYPE_REFERENCE_RELATION_LABEL
-from static_analyzer.cfg.edge import EdgeKind
-
-
-def static_relation_label(edges: Sequence[RelationEdge]) -> str:
-    """The label a relation gets from its static edges alone: a single call outranks any reference."""
-    descriptions = {edge.description for edge in edges}
-    if not descriptions or descriptions - set(REFERENCE_EDGE_DESCRIPTIONS.values()):
-        return DEFAULT_STATIC_RELATION_LABEL
-    if descriptions == {REFERENCE_EDGE_DESCRIPTIONS[EdgeKind.INHERITS]}:
-        return INHERITANCE_RELATION_LABEL
-    return TYPE_REFERENCE_RELATION_LABEL
 
 
 def append_or_merge_relation(
@@ -364,7 +346,11 @@ def _restore_baseline_orientation(relation: Relation, baseline_by_pair: dict) ->
 
 def _restore_baseline_wording(fresh: Relation, previous: Relation) -> Relation:
     """Restore baseline wording and highlighting onto fresh edge metadata."""
-    wording = {"relation": previous.relation, "evidence": previous.evidence}
+    wording = {
+        "relation": previous.relation,
+        "evidence": previous.evidence,
+        "default_label": previous.default_label,
+    }
     if not previous.key_edges:
         return fresh.model_copy(update=wording)
     highlighted = {

--- a/constants.py
+++ b/constants.py
@@ -18,6 +18,10 @@ PERSISTED_ANALYSIS_ARTIFACT_FILENAMES = (
 GITIGNORE_FILENAME = ".gitignore"
 CODEBOARDINGIGNORE_FILENAME = ".codeboardingignore"
 DEFAULT_STATIC_RELATION_LABEL = "calls"
+# Labels for a relation backed only by reference edges (see ``static_relation_label``).
+INHERITANCE_RELATION_LABEL = "inherits from"
+TYPE_REFERENCE_RELATION_LABEL = "uses"
+STATIC_RELATION_LABELS = (DEFAULT_STATIC_RELATION_LABEL, INHERITANCE_RELATION_LABEL, TYPE_REFERENCE_RELATION_LABEL)
 # Document names the renderers give the root analysis; no expanded component may take one.
 DEFAULT_ROOT_DOCUMENT_NAME = "overview"
 CLI_ROOT_DOCUMENT_NAME = "on_boarding"

--- a/constants.py
+++ b/constants.py
@@ -17,11 +17,6 @@ PERSISTED_ANALYSIS_ARTIFACT_FILENAMES = (
 # ``.codeboardingignore`` under ``CODEBOARDING_DIR_NAME``).
 GITIGNORE_FILENAME = ".gitignore"
 CODEBOARDINGIGNORE_FILENAME = ".codeboardingignore"
-DEFAULT_STATIC_RELATION_LABEL = "calls"
-# Labels for a relation backed only by reference edges (see ``static_relation_label``).
-INHERITANCE_RELATION_LABEL = "inherits from"
-TYPE_REFERENCE_RELATION_LABEL = "uses"
-STATIC_RELATION_LABELS = (DEFAULT_STATIC_RELATION_LABEL, INHERITANCE_RELATION_LABEL, TYPE_REFERENCE_RELATION_LABEL)
 # Document names the renderers give the root analysis; no expanded component may take one.
 DEFAULT_ROOT_DOCUMENT_NAME = "overview"
 CLI_ROOT_DOCUMENT_NAME = "on_boarding"

--- a/diagram_analysis/analysis_json.py
+++ b/diagram_analysis/analysis_json.py
@@ -16,8 +16,12 @@ from agents.agent_responses import (
 from agents.file_index_models import FileEntry, FileMethodGroup, MethodEntry, MethodIndexEntry
 from agents.relation_edges import merge_relations_by_pair
 from repo_utils.path_utils import normalize_repo_path
+from static_analyzer.cfg.edge import RELATION_REFERENCE_KINDS, EdgeKind
 
 logger = logging.getLogger(__name__)
+
+# Every label ``static_relation_label`` can produce; only a file predating ``default_label`` needs it.
+_STATIC_LABELS = frozenset(kind.relation_label for kind in (EdgeKind.CALL, *RELATION_REFERENCE_KINDS))
 
 
 class RelationEdgeJson(BaseModel):
@@ -37,6 +41,10 @@ class RelationJson(Relation):
     src_id: str = Field(default="", description="Component ID of the source.")
     dst_id: str = Field(default="", description="Component ID of the destination.")
     is_static: bool = Field(default=False, description="True if derived from static CFG analysis.")
+    default_label: bool = Field(
+        default=False,
+        description="True when the label is what the static edges give the pair, not a description someone wrote.",
+    )
     all_edges: list[RelationEdgeJson] = Field(
         default_factory=list,
         description="All known source-to-target edges for this relation.",
@@ -315,6 +323,7 @@ def _relation_to_json(r: Relation, repo_dir: Path) -> RelationJson:
         src_id=r.src_id,
         dst_id=r.dst_id,
         is_static=r.is_static,
+        default_label=r.default_label,
         all_edges=[_relation_edge_to_json(edge, repo_dir) for edge in r.all_edges],
     )
 
@@ -657,6 +666,8 @@ def _extract_analysis_recursive(
                 src_id=r.get("src_id", ""),
                 dst_id=r.get("dst_id", ""),
                 is_static=r.get("is_static", False),
+                # A file written before the flag existed can only be judged by its wording.
+                default_label=r.get("default_label", r["relation"] in _STATIC_LABELS),
                 all_edges=all_edges,
             )
         )

--- a/diagram_analysis/scope_assembly.py
+++ b/diagram_analysis/scope_assembly.py
@@ -14,15 +14,13 @@ from agents.relation_edges import (
     edge_crosses_components,
     ground_relation_edges,
     prune_ungrounded_edges,
-    static_relation_label,
 )
 from agents.scope_analysis_agent import ScopeAnalysisResult
 from agents.scope_ids import ROOT_SCOPE_ID
 from clustering_ids import CodeBoardingClusterIds
-from constants import STATIC_RELATION_LABELS
 from diagram_analysis.file_index import build_file_methods_from_nodes, build_files_index
 from static_analyzer import StaticAnalysisFatalError
-from static_analyzer.cfg import CALL_EDGE_KIND, Edge, EdgeKind
+from static_analyzer.cfg import Edge, EdgeKind
 from repo_utils.path_utils import normalize_repo_path
 from static_analyzer.clustering import ClusterGroup, ClusterScopeResult, GroupConnection
 from static_analyzer.reference_resolver import StaticReferenceResolver
@@ -218,14 +216,15 @@ class ScopeAssembler:
 
         # A group the model was asked about drops every relation it touches. Where the model did
         # not label one back, keep the label the previous run gave it rather than resetting a
-        # still-connected edge to the generic default.
+        # still-connected edge to the generic default. A label that was itself the static default
+        # is not carried: the merge recomputes it from today's edges.
         carried = [
             relation.model_copy(deep=True)
             for pair, relation in existing_by_pair.items()
             if pair not in seen_pairs
             and pair not in preserved_pairs
             and relation.relation.strip()
-            and relation.relation not in STATIC_RELATION_LABELS
+            and not relation.default_label
             and scope.connection_between(*pair) is not None
         ]
         for relation in carried:
@@ -290,6 +289,7 @@ class ScopeAssembler:
                     src_id=src_id,
                     dst_id=dst_id,
                     is_static=bool(static_edges),
+                    default_label=llm_relation.default_label,
                     all_edges=all_edges,
                 ),
             )
@@ -306,13 +306,11 @@ class ScopeAssembler:
             append_or_merge_relation(
                 merged,
                 Relation.from_edges(
-                    static_relation_label(edges),
                     source.name if source is not None else connection.source_group_id,
                     target.name if target is not None else connection.target_group_id,
                     connection.source_group_id,
                     connection.target_group_id,
                     edges,
-                    True,
                 ),
             )
 
@@ -405,8 +403,10 @@ class ScopeAssembler:
             target = graph.nodes.get(connection_edge.target_qualified_name)
             if source is None or target is None:
                 continue
-            if connection_edge.kind == CALL_EDGE_KIND:
+            if connection_edge.kind is EdgeKind.CALL:
                 edges.append(RelationEdge.from_edge(Edge(source, target, connection_edge.call_sites)))
             else:
-                edges.append(RelationEdge.from_reference(source, target, EdgeKind(connection_edge.kind)))
+                edges.append(
+                    RelationEdge.from_reference(source, target, connection_edge.kind, connection_edge.call_sites)
+                )
         return edges

--- a/diagram_analysis/scope_assembly.py
+++ b/diagram_analysis/scope_assembly.py
@@ -14,14 +14,15 @@ from agents.relation_edges import (
     edge_crosses_components,
     ground_relation_edges,
     prune_ungrounded_edges,
+    static_relation_label,
 )
 from agents.scope_analysis_agent import ScopeAnalysisResult
 from agents.scope_ids import ROOT_SCOPE_ID
 from clustering_ids import CodeBoardingClusterIds
-from constants import DEFAULT_STATIC_RELATION_LABEL
+from constants import STATIC_RELATION_LABELS
 from diagram_analysis.file_index import build_file_methods_from_nodes, build_files_index
 from static_analyzer import StaticAnalysisFatalError
-from static_analyzer.cfg import Edge
+from static_analyzer.cfg import CALL_EDGE_KIND, Edge, EdgeKind
 from repo_utils.path_utils import normalize_repo_path
 from static_analyzer.clustering import ClusterGroup, ClusterScopeResult, GroupConnection
 from static_analyzer.reference_resolver import StaticReferenceResolver
@@ -224,7 +225,7 @@ class ScopeAssembler:
             if pair not in seen_pairs
             and pair not in preserved_pairs
             and relation.relation.strip()
-            and relation.relation != DEFAULT_STATIC_RELATION_LABEL
+            and relation.relation not in STATIC_RELATION_LABELS
             and scope.connection_between(*pair) is not None
         ]
         for relation in carried:
@@ -305,7 +306,7 @@ class ScopeAssembler:
             append_or_merge_relation(
                 merged,
                 Relation.from_edges(
-                    DEFAULT_STATIC_RELATION_LABEL,
+                    static_relation_label(edges),
                     source.name if source is not None else connection.source_group_id,
                     target.name if target is not None else connection.target_group_id,
                     connection.source_group_id,
@@ -404,5 +405,8 @@ class ScopeAssembler:
             target = graph.nodes.get(connection_edge.target_qualified_name)
             if source is None or target is None:
                 continue
-            edges.append(RelationEdge.from_edge(Edge(source, target, connection_edge.call_sites)))
+            if connection_edge.kind == CALL_EDGE_KIND:
+                edges.append(RelationEdge.from_edge(Edge(source, target, connection_edge.call_sites)))
+            else:
+                edges.append(RelationEdge.from_reference(source, target, EdgeKind(connection_edge.kind)))
         return edges

--- a/output_generators/rendering.py
+++ b/output_generators/rendering.py
@@ -53,6 +53,7 @@ def project_relations_to_level(
                 src_id=src,
                 dst_id=dst,
                 is_static=rel.is_static,
+                default_label=rel.default_label,
                 all_edges=rel.all_edges,
             ),
             key=(src, dst),

--- a/static_analyzer/__init__.py
+++ b/static_analyzer/__init__.py
@@ -1020,6 +1020,14 @@ class StaticAnalyzer:
             logger.info(
                 "Type references for %s: %s in %.1fs", language.value, stats.summary(), time.monotonic() - t_start
             )
+            if stats.unreadable_files:
+                logger.warning(
+                    "Type references for %s: %d source file(s) could not be read, so their references are "
+                    "missing from the graph: %s",
+                    language.value,
+                    len(stats.unreadable_files),
+                    ", ".join(stats.unreadable_files[:5]),
+                )
 
     def _validate_analysis_results(self, results: StaticAnalysisResults) -> None:
         """Reject non-empty language buckets that would otherwise cache zero-symbol output."""

--- a/static_analyzer/__init__.py
+++ b/static_analyzer/__init__.py
@@ -30,6 +30,7 @@ from static_analyzer.typescript_config_scanner import TypeScriptConfigScanner
 from telemetry.events import track_lsp_result
 from tool_registry import ensure_node_on_path
 from utils import get_artifact_dir
+from static_analyzer.engine.type_reference_builder import complete_type_references
 
 logger = logging.getLogger(__name__)
 
@@ -682,6 +683,7 @@ class StaticAnalyzer:
                 )
                 results = self._update_cached_results(cached_results, cached_sha)
 
+        self._complete_type_references(results)
         self._validate_analysis_results(results)
         results.diagnostics = self.collected_diagnostics
         self._cached_results = results
@@ -1003,6 +1005,21 @@ class StaticAnalyzer:
         result = convert_to_codeboarding_format(builder.symbol_table, engine_result, adapter, self.ignore_manager)
         logger.info(f"convert_to_codeboarding_format for {adapter.language}: {time.monotonic() - t_convert:.1f}s")
         return result
+
+    def _complete_type_references(self, results: StaticAnalysisResults) -> None:
+        """Derive TYPEREF edges over each merged graph, so a name resolves across sub-projects."""
+        inspector = SourceInspector()
+        for language in results.get_languages():
+            try:
+                graph = results.get_cfg(language)
+            except ValueError:
+                continue
+            t_start = time.monotonic()
+            source_files = [Path(path) for path in results.get_source_files(language)]
+            stats = complete_type_references(graph, source_files, inspector)
+            logger.info(
+                "Type references for %s: %s in %.1fs", language.value, stats.summary(), time.monotonic() - t_start
+            )
 
     def _validate_analysis_results(self, results: StaticAnalysisResults) -> None:
         """Reject non-empty language buckets that would otherwise cache zero-symbol output."""

--- a/static_analyzer/analysis_cache.py
+++ b/static_analyzer/analysis_cache.py
@@ -67,8 +67,11 @@ _LEGACY_CACHE_SUBDIR = "cache"
 # named after.
 # v7: the pickle no longer carries cluster lineage; components come from the tree
 # specification in analysis.json, replayed over the graph.
+# v8: every call edge derived from a variable reference changes. A mention inside a callback
+# body and the receiver of a member chain are no longer the value passed or returned, so a
+# file-scope global stops absorbing its file's edges.
 # Older pickles are treated as cache misses and re-run.
-_TAG_VERSION = "v7"
+_TAG_VERSION = "v8"
 
 
 class StaticAnalysisCache:

--- a/static_analyzer/cfg/__init__.py
+++ b/static_analyzer/cfg/__init__.py
@@ -5,6 +5,23 @@ the physical-location identity used to dedup LSP qualified-name aliases.
 """
 
 from static_analyzer.cfg.call_graph import CallGraph
-from static_analyzer.cfg.edge import CallSiteLocation, DEFAULT_REFERENCE_KINDS, Edge, EdgeKind, ReferenceEdge
+from static_analyzer.cfg.edge import (
+    CALL_EDGE_KIND,
+    CallSiteLocation,
+    DEFAULT_REFERENCE_KINDS,
+    Edge,
+    EdgeKind,
+    RELATION_REFERENCE_KINDS,
+    ReferenceEdge,
+)
 
-__all__ = ["DEFAULT_REFERENCE_KINDS", "CallGraph", "CallSiteLocation", "Edge", "EdgeKind", "ReferenceEdge"]
+__all__ = [
+    "CALL_EDGE_KIND",
+    "DEFAULT_REFERENCE_KINDS",
+    "RELATION_REFERENCE_KINDS",
+    "CallGraph",
+    "CallSiteLocation",
+    "Edge",
+    "EdgeKind",
+    "ReferenceEdge",
+]

--- a/static_analyzer/cfg/__init__.py
+++ b/static_analyzer/cfg/__init__.py
@@ -6,7 +6,6 @@ the physical-location identity used to dedup LSP qualified-name aliases.
 
 from static_analyzer.cfg.call_graph import CallGraph
 from static_analyzer.cfg.edge import (
-    CALL_EDGE_KIND,
     CallSiteLocation,
     DEFAULT_REFERENCE_KINDS,
     Edge,
@@ -16,7 +15,6 @@ from static_analyzer.cfg.edge import (
 )
 
 __all__ = [
-    "CALL_EDGE_KIND",
     "DEFAULT_REFERENCE_KINDS",
     "RELATION_REFERENCE_KINDS",
     "CallGraph",

--- a/static_analyzer/cfg/call_graph.py
+++ b/static_analyzer/cfg/call_graph.py
@@ -116,7 +116,7 @@ class CallGraph:
         """
         src, dst = self._resolve_name(ref.src), self._resolve_name(ref.dst)
         if src in self.nodes and dst in self.nodes and src != dst:
-            self.reference_edges.append(ReferenceEdge(src, dst, ref.kind))
+            self.reference_edges.append(ReferenceEdge(src, dst, ref.kind, ref.sites))
 
     def filter(self, keep_node: Callable[[Node], bool]) -> CallGraph:
         """Return a new CallGraph of the nodes matching ``keep_node`` and the edges between them.
@@ -226,7 +226,9 @@ class CallGraph:
                 # Resolve through the SOURCE's alias map: an endpoint stored under a short
                 # alias must map to the canonical name ``out`` promoted it to, or a call edge
                 # (which add_edge resolves) survives while its reference edge is silently dropped.
-                resolved = ReferenceEdge(source._resolve_name(ref.src), source._resolve_name(ref.dst), ref.kind)
+                resolved = ReferenceEdge(
+                    source._resolve_name(ref.src), source._resolve_name(ref.dst), ref.kind, ref.sites
+                )
                 if resolved.src in out.nodes and resolved.dst in out.nodes and resolved.src != resolved.dst:
                     carried.append(resolved)
         out.reference_edges = list(dict.fromkeys(carried))

--- a/static_analyzer/cfg/edge.py
+++ b/static_analyzer/cfg/edge.py
@@ -26,10 +26,14 @@ class EdgeKind(StrEnum):
 
 # What structural consumers fold into ``to_networkx`` on top of call edges. The call graph
 # leaves ~a fifth of symbols isolated (constructors, dunders, DI/interface methods), so
-# completing it with these avoids grab-bag components. TYPEREF and IMPORT are plumbed through
-# ``LanguageAnalysisResult`` but no engine emits them yet, and IMPORT is expected to over-merge
-# (coarse, dense, file-level) when one does.
+# completing it with these avoids grab-bag components. TYPEREF is derived from source once
+# the per-project graphs merge (``engine.type_reference_builder``); IMPORT has no producer
+# yet and is expected to over-merge (coarse, dense, file-level) when one does.
 DEFAULT_REFERENCE_KINDS: tuple[EdgeKind, ...] = (EdgeKind.CONTAINS, EdgeKind.INHERITS)
+# The reference kinds that, like a call, make one component depend on another.
+RELATION_REFERENCE_KINDS: tuple[EdgeKind, ...] = (EdgeKind.INHERITS, EdgeKind.TYPEREF)
+# ``ClusterConnectionEdge.kind`` of a plain call; reference edges carry their ``EdgeKind`` value.
+CALL_EDGE_KIND = "call"
 
 
 @dataclass(frozen=True)

--- a/static_analyzer/cfg/edge.py
+++ b/static_analyzer/cfg/edge.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Hashable, Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import NotRequired, TypedDict
 
@@ -11,18 +11,32 @@ from static_analyzer.node import Node
 
 
 class EdgeKind(StrEnum):
-    """Kind of a *reference* edge — the structural relationships a call graph misses.
+    """Kind of an edge: a call, or one of the structural relationships a call graph misses.
 
-    A method belongs to its class (CONTAINS), a class extends another (INHERITS),
-    code names a type (TYPEREF), a module imports another (IMPORT). Call edges are
-    not listed: they live in ``CallGraph.edges`` and carry no kind tag.
+    CALL is what ``CallGraph.edges`` holds. The rest are ``ReferenceEdge`` kinds: a method
+    belongs to its class (CONTAINS), a class extends another (INHERITS), code names a type
+    (TYPEREF), a module imports another (IMPORT).
     """
 
+    CALL = "call"
     CONTAINS = "contains"
     INHERITS = "inherits"
     TYPEREF = "typeref"
     IMPORT = "import"
 
+    @property
+    def relation_label(self) -> str:
+        """The verb a relation gets when edges of this kind alone connect two components."""
+        return _RELATION_LABEL_BY_KIND[self]
+
+
+_RELATION_LABEL_BY_KIND: dict[EdgeKind, str] = {
+    EdgeKind.CALL: "calls",
+    EdgeKind.CONTAINS: "contains",
+    EdgeKind.INHERITS: "inherits from",
+    EdgeKind.TYPEREF: "uses",
+    EdgeKind.IMPORT: "imports",
+}
 
 # What structural consumers fold into ``to_networkx`` on top of call edges. The call graph
 # leaves ~a fifth of symbols isolated (constructors, dunders, DI/interface methods), so
@@ -32,25 +46,32 @@ class EdgeKind(StrEnum):
 DEFAULT_REFERENCE_KINDS: tuple[EdgeKind, ...] = (EdgeKind.CONTAINS, EdgeKind.INHERITS)
 # The reference kinds that, like a call, make one component depend on another.
 RELATION_REFERENCE_KINDS: tuple[EdgeKind, ...] = (EdgeKind.INHERITS, EdgeKind.TYPEREF)
-# ``ClusterConnectionEdge.kind`` of a plain call; reference edges carry their ``EdgeKind`` value.
-CALL_EDGE_KIND = "call"
-
-
-@dataclass(frozen=True)
-class ReferenceEdge:
-    """A non-call relationship between two qualified names."""
-
-    src: str
-    dst: str
-    kind: EdgeKind
 
 
 class CallSiteLocation(TypedDict):
-    """A one-based source location where a call occurs."""
+    """A one-based source location where an edge occurs: a call, or a type being named."""
 
     line: int
     file: NotRequired[str]
     column: NotRequired[int]
+
+
+@dataclass(frozen=True)
+class ReferenceEdge:
+    """A non-call relationship between two qualified names, and where the source names the target.
+
+    Two edges are the same edge when they join the same names the same way; the sites are what
+    the source wrote and never decide identity.
+    """
+
+    src: str
+    dst: str
+    kind: EdgeKind
+    sites: tuple[CallSiteLocation, ...] = field(default=(), compare=False)
+
+    def __post_init__(self) -> None:
+        if self.kind is EdgeKind.CALL:
+            raise ValueError("a call is an Edge with call sites, not a ReferenceEdge")
 
 
 class Edge:

--- a/static_analyzer/cluster_relations.py
+++ b/static_analyzer/cluster_relations.py
@@ -17,7 +17,6 @@ from agents.relation_edges import (
     drop_reverse_duplicates,
     edge_crosses_components,
     ground_relation_edges,
-    static_relation_label,
 )
 from clustering_ids import is_self_or_descendant  # noqa: F401  (re-exported)
 from static_analyzer.cfg import RELATION_REFERENCE_KINDS, CallGraph
@@ -81,7 +80,7 @@ def build_component_relations(
             source, target = cfg.nodes.get(ref.src), cfg.nodes.get(ref.dst)
             if not (src_comp and dst_comp) or src_comp == dst_comp or source is None or target is None:
                 continue
-            edge_pairs[(src_comp, dst_comp)].append(RelationEdge.from_reference(source, target, ref.kind))
+            edge_pairs[(src_comp, dst_comp)].append(RelationEdge.from_reference(source, target, ref.kind, ref.sites))
 
     relations = []
     for (src_c, dst_c), edges in sorted(edge_pairs.items()):
@@ -192,13 +191,11 @@ def build_global_relations(
         llm_relation = _ancestor_relation(src_id, dst_id, llm_relations_by_pair)
         if llm_relation is None:
             relation = Relation.from_edges(
-                static_relation_label(static_rel.all_edges),
                 id_to_name.get(src_id, src_id),
                 id_to_name.get(dst_id, dst_id),
                 src_id,
                 dst_id,
                 static_rel.all_edges,
-                True,
             )
         else:
             inherited_key_edges = _relation_key_edges_for_pair(llm_relation, src_id, dst_id, node_to_component)
@@ -212,6 +209,7 @@ def build_global_relations(
                 src_id=src_id,
                 dst_id=dst_id,
                 is_static=True,
+                default_label=llm_relation.default_label,
                 all_edges=all_edges,
             )
         global_relations[(src_id, dst_id)] = relation

--- a/static_analyzer/cluster_relations.py
+++ b/static_analyzer/cluster_relations.py
@@ -19,7 +19,7 @@ from agents.relation_edges import (
     ground_relation_edges,
     static_relation_label,
 )
-from clustering_ids import is_self_or_descendant
+from clustering_ids import is_self_or_descendant  # noqa: F401  (re-exported)
 from static_analyzer.cfg import RELATION_REFERENCE_KINDS, CallGraph
 
 logger = logging.getLogger(__name__)
@@ -129,14 +129,19 @@ def _collect_authoritative_relations(
     return list(relations_by_pair.values())
 
 
-def _ancestor_relation(src_id: str, dst_id: str, llm_relations: list[Relation]) -> Relation | None:
+def _ancestor_relation(
+    src_id: str, dst_id: str, llm_relations_by_pair: dict[tuple[str, str], Relation]
+) -> Relation | None:
+    """The deepest semantic relation whose pair encloses ``(src_id, dst_id)``.
+
+    Why a pair lookup: scanning every semantic relation per static pair is quadratic, and a
+    type-complete graph has thousands of each.
+    """
     candidates = [
-        rel
-        for rel in llm_relations
-        if rel.src_id
-        and rel.dst_id
-        and is_self_or_descendant(src_id, rel.src_id)
-        and is_self_or_descendant(dst_id, rel.dst_id)
+        relation
+        for src_ancestor in iter_ancestor_ids(src_id)
+        for dst_ancestor in iter_ancestor_ids(dst_id)
+        if (relation := llm_relations_by_pair.get((src_ancestor, dst_ancestor))) is not None
     ]
     if not candidates:
         return None
@@ -175,19 +180,16 @@ def build_global_relations(
     global_relations: dict[tuple[str, str], Relation] = {}
     static_pairs = {(rel.src_cluster_id, rel.dst_cluster_id) for rel in static_relations}
     superseded_llm_pairs: set[tuple[str, str]] = set()
+    llm_relations_by_pair = {(rel.src_id, rel.dst_id): rel for rel in llm_relations if rel.src_id and rel.dst_id}
 
     for static_rel in static_relations:
         src_id = static_rel.src_cluster_id
         dst_id = static_rel.dst_cluster_id
-        for llm_rel in llm_relations:
-            if (
-                llm_rel.src_id
-                and llm_rel.dst_id
-                and is_self_or_descendant(src_id, llm_rel.src_id)
-                and is_self_or_descendant(dst_id, llm_rel.dst_id)
-            ):
-                superseded_llm_pairs.add((llm_rel.src_id, llm_rel.dst_id))
-        llm_relation = _ancestor_relation(src_id, dst_id, llm_relations)
+        for src_ancestor in iter_ancestor_ids(src_id):
+            for dst_ancestor in iter_ancestor_ids(dst_id):
+                if (src_ancestor, dst_ancestor) in llm_relations_by_pair:
+                    superseded_llm_pairs.add((src_ancestor, dst_ancestor))
+        llm_relation = _ancestor_relation(src_id, dst_id, llm_relations_by_pair)
         if llm_relation is None:
             relation = Relation.from_edges(
                 static_relation_label(static_rel.all_edges),

--- a/static_analyzer/cluster_relations.py
+++ b/static_analyzer/cluster_relations.py
@@ -10,7 +10,6 @@ from collections import defaultdict
 from collections.abc import Iterator
 from dataclasses import dataclass, field
 
-from constants import DEFAULT_STATIC_RELATION_LABEL
 from agents.agent_responses import AnalysisInsights, Relation, RelationEdge
 from agents.component_ownership import ComponentOwnershipIndex
 from agents.relation_edges import (
@@ -18,9 +17,10 @@ from agents.relation_edges import (
     drop_reverse_duplicates,
     edge_crosses_components,
     ground_relation_edges,
+    static_relation_label,
 )
 from clustering_ids import is_self_or_descendant
-from static_analyzer.cfg import CallGraph
+from static_analyzer.cfg import RELATION_REFERENCE_KINDS, CallGraph
 
 logger = logging.getLogger(__name__)
 
@@ -53,8 +53,8 @@ def build_component_relations(
 ) -> list[ClusterRelation]:
     """Build inter-component relations from actual CFG edges.
 
-    For every CFG edge where src and dst belong to different components,
-    count and collect the concrete bridge methods.
+    For every call edge, and every reference edge of a ``RELATION_REFERENCE_KINDS`` kind,
+    whose ends belong to different components, collect the concrete bridge symbols.
 
     Args:
         node_to_component: Mapping from node qualified_name to component_id.
@@ -73,6 +73,15 @@ def build_component_relations(
             if src_comp and dst_comp and src_comp != dst_comp:
                 key = (src_comp, dst_comp)
                 edge_pairs[key].append(RelationEdge.from_edge(edge))
+        for ref in cfg.reference_edges:
+            if ref.kind not in RELATION_REFERENCE_KINDS:
+                continue
+            src_comp = node_to_component.get(ref.src)
+            dst_comp = node_to_component.get(ref.dst)
+            source, target = cfg.nodes.get(ref.src), cfg.nodes.get(ref.dst)
+            if not (src_comp and dst_comp) or src_comp == dst_comp or source is None or target is None:
+                continue
+            edge_pairs[(src_comp, dst_comp)].append(RelationEdge.from_reference(source, target, ref.kind))
 
     relations = []
     for (src_c, dst_c), edges in sorted(edge_pairs.items()):
@@ -181,7 +190,7 @@ def build_global_relations(
         llm_relation = _ancestor_relation(src_id, dst_id, llm_relations)
         if llm_relation is None:
             relation = Relation.from_edges(
-                DEFAULT_STATIC_RELATION_LABEL,
+                static_relation_label(static_rel.all_edges),
                 id_to_name.get(src_id, src_id),
                 id_to_name.get(dst_id, dst_id),
                 src_id,

--- a/static_analyzer/clustering/models.py
+++ b/static_analyzer/clustering/models.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, field
 
 from clustering_ids import ClusterId, ComponentId, GroupId, ScopeId
 from static_analyzer.cfg import CallGraph, CallSiteLocation
+from static_analyzer.cfg.edge import CALL_EDGE_KIND
 
 
 @dataclass
@@ -36,11 +37,13 @@ class ClusterConnectionEdge:
     source_qualified_name: str
     target_qualified_name: str
     call_sites: list[CallSiteLocation] = field(default_factory=list)
+    # ``CALL_EDGE_KIND`` for a call, else the ``EdgeKind`` value of the reference edge behind it.
+    kind: str = CALL_EDGE_KIND
 
 
 @dataclass
 class GroupConnection:
-    """All concrete calls from one sibling group to another."""
+    """All concrete calls and type references from one sibling group to another."""
 
     source_group_id: GroupId
     target_group_id: GroupId

--- a/static_analyzer/clustering/models.py
+++ b/static_analyzer/clustering/models.py
@@ -5,8 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 from clustering_ids import ClusterId, ComponentId, GroupId, ScopeId
-from static_analyzer.cfg import CallGraph, CallSiteLocation
-from static_analyzer.cfg.edge import CALL_EDGE_KIND
+from static_analyzer.cfg import CallGraph, CallSiteLocation, EdgeKind
 
 
 @dataclass
@@ -36,9 +35,9 @@ class ClusterConnectionEdge:
     language: str
     source_qualified_name: str
     target_qualified_name: str
+    # Where the edge occurs: the call sites of a call, the positions naming the type for a reference.
     call_sites: list[CallSiteLocation] = field(default_factory=list)
-    # ``CALL_EDGE_KIND`` for a call, else the ``EdgeKind`` value of the reference edge behind it.
-    kind: str = CALL_EDGE_KIND
+    kind: EdgeKind = EdgeKind.CALL
 
 
 @dataclass

--- a/static_analyzer/clustering/service.py
+++ b/static_analyzer/clustering/service.py
@@ -424,7 +424,8 @@ class ClusteringService:
                         language=language,
                         source_qualified_name=ref.src,
                         target_qualified_name=ref.dst,
-                        kind=ref.kind.value,
+                        call_sites=list(ref.sites),
+                        kind=ref.kind,
                     )
                 )
         return [by_pair[pair] for pair in sorted(by_pair)]

--- a/static_analyzer/clustering/service.py
+++ b/static_analyzer/clustering/service.py
@@ -11,7 +11,7 @@ from clustering_ids import ROOT_SCOPE_ID, ClusterId, ComponentId, ScopeId
 from repo_utils.path_utils import normalize_repo_path
 from static_analyzer.analysis_result import StaticAnalysisResults
 from static_analyzer.cfg import CallGraph
-from static_analyzer.cfg.edge import EdgeKind
+from static_analyzer.cfg.edge import RELATION_REFERENCE_KINDS, EdgeKind
 from static_analyzer.clustering.exceptions import IncrementalCacheMissingError, PlannerUnavailableError
 from static_analyzer.clustering.models import (
     ClusterConnectionEdge,
@@ -406,6 +406,25 @@ class ClusteringService:
                         source_qualified_name=source,
                         target_qualified_name=target,
                         call_sites=edge.call_sites,
+                    )
+                )
+            for ref in graph.reference_edges:
+                if ref.kind not in RELATION_REFERENCE_KINDS:
+                    continue
+                source_group = group_id_by_qualified_name.get((language, ref.src), "")
+                target_group = group_id_by_qualified_name.get((language, ref.dst), "")
+                if not source_group or not target_group or source_group == target_group:
+                    continue
+                connection = by_pair.setdefault(
+                    (source_group, target_group),
+                    GroupConnection(source_group_id=source_group, target_group_id=target_group),
+                )
+                connection.edges.append(
+                    ClusterConnectionEdge(
+                        language=language,
+                        source_qualified_name=ref.src,
+                        target_qualified_name=ref.dst,
+                        kind=ref.kind.value,
                     )
                 )
         return [by_pair[pair] for pair in sorted(by_pair)]

--- a/static_analyzer/clustering/service.py
+++ b/static_analyzer/clustering/service.py
@@ -40,9 +40,16 @@ from static_analyzer.clustering.names.spec import Prefix, is_root
 from static_analyzer.clustering.names.spec import UNPLACED
 from static_analyzer.config import CALLABLE_TYPES, CLASS_TYPES
 
-AFFINE_REFERENCE_KINDS = frozenset({EdgeKind.INHERITS, EdgeKind.TYPEREF})
+AFFINE_REFERENCE_KINDS = frozenset({EdgeKind.INHERITS})
 """Reference edges that count as links between files, with the call edges. CONTAINS never
-crosses a file; IMPORT is not emitted yet and would be too dense to weigh."""
+crosses a file; IMPORT is not emitted yet and would be too dense to weigh.
+
+TYPEREF is deliberately absent although it is drawn as a relation. A type reference is dense
+exactly where a shared contract is: on eShop every service names the event bus's types without
+calling them, so counting them here folds Payment into the bus and Basket into the client app,
+and the partition loses two of the nine boxes its maintainers publish. Whether a hub's links
+should be damped so this can be reconsidered is an open question; until it is answered, drawing
+the edge and moving the boxes stay separate decisions."""
 
 FILE_STRATEGY = "file_leaves"
 """Recorded on a ``ClusterResult`` whose leaves are files: the unit the names partition."""

--- a/static_analyzer/engine/models.py
+++ b/static_analyzer/engine/models.py
@@ -65,6 +65,35 @@ class CallSite:
         return self.column - 1
 
 
+@dataclass(frozen=True)
+class TypeReferenceSite:
+    """A position naming a type without calling it: a parameter, base, generic argument, ``typeof``."""
+
+    file: str
+    line: int  # one-based, like ``CallSite``
+    column: int
+    name: str
+    # The dotted prefix written before the name (``Volo.Abp`` in ``Volo.Abp.Foo``), else empty.
+    qualifier: str = ""
+
+
+@dataclass(frozen=True)
+class NamespaceContext:
+    """What a C# file can name unqualified: its usings and the namespaces it declares."""
+
+    usings: tuple[str, ...]
+    # (dotted namespace, first line, last line), one-based inclusive; nested names are joined.
+    namespaces: tuple[tuple[str, int, int], ...]
+
+
+@dataclass(frozen=True)
+class ImportBinding:
+    """One local name a TS/JS file imports: the module specifier and the exported name."""
+
+    source: str
+    imported_name: str
+
+
 @dataclass
 class Edge:
     """A directed edge in the call flow graph."""
@@ -105,7 +134,8 @@ class LanguageAnalysisResult:
     # Non-call relationship edges completing the graph for clustering. Each entry
     # is (source_qname, target_qname). type_references: code names a type (param,
     # return, annotation, cast); import_edges: module A imports symbol/module B.
-    # No engine populates either yet — the converter reads them, nothing writes them.
+    # TYPEREF is normally derived after the per-config graphs merge (see
+    # ``type_reference_builder``); an engine may still pre-fill either list.
     type_references: list[tuple[str, str]] = field(default_factory=list)
     import_edges: list[tuple[str, str]] = field(default_factory=list)
 

--- a/static_analyzer/engine/models.py
+++ b/static_analyzer/engine/models.py
@@ -69,7 +69,8 @@ class CallSite:
 class TypeReferenceSite:
     """A position naming a type without calling it: a parameter, base, generic argument, ``typeof``."""
 
-    file: str
+    # The string form ``Node.file_path`` uses, which is what the site is matched against.
+    file_path: str
     line: int  # one-based, like ``CallSite``
     column: int
     name: str
@@ -77,36 +78,48 @@ class TypeReferenceSite:
     qualifier: str = ""
 
 
-@dataclass(frozen=True)
-class UsingDirective:
-    """One C# ``using`` and the lines it governs."""
+# The ``name`` an import directive carries for a TS/JS default binding.
+DEFAULT_EXPORT_NAME = "default"
 
-    target: str
-    # The enclosing scope's range: C# requires usings to precede declarations, so every site
-    # that can see this directive is inside it.
+
+@dataclass(frozen=True)
+class ImportDirective:
+    """One import and the lines it governs: a name a file can use, and the container it comes from.
+
+    ``container`` is spelled the way the language names it: a dotted namespace or type in C#
+    (``A.B`` in ``using A.B;``), a module specifier in TS/JS (``./svc`` in ``import { X } from "./svc"``).
+    A directive with no ``name`` opens the whole container (``using A.B;``, ``import * as NS``);
+    one with a ``name`` binds that one member of it, under ``alias`` when the file renames it.
+    """
+
+    container: str
+    # One-based inclusive: from the directive to the end of the scope it is written in, or the
+    # whole file where imports are hoisted.
     first_line: int
     last_line: int
-    # The name an alias binds (``Item`` in ``using Item = A.B.Item``), else empty.
+    name: str = ""
     alias: str = ""
-    # ``using static N.T``: T's members become nameable unqualified, T's own name does not.
-    static: bool = False
+    # ``global using``: in force in every file of the compilation, not only in this one.
+    compilation_wide: bool = False
+
+    @property
+    def local_name(self) -> str:
+        """What the file writes to mean this import; empty when the container is opened unqualified."""
+        return self.alias or self.name
 
 
 @dataclass(frozen=True)
-class NamespaceContext:
-    """What a C# file can name unqualified: its usings and the namespaces it declares."""
+class NameScope:
+    """What a file can name and where: its imports and the namespaces it declares.
 
-    usings: tuple[UsingDirective, ...]
-    # (dotted namespace, first line, last line), one-based inclusive; nested names are joined.
-    namespaces: tuple[tuple[str, int, int], ...]
+    ``namespaces`` are ``(dotted name, first line, last line)``, one-based inclusive, nested names
+    joined. C# declares them in source; a TS/JS module declares none, its file is its container.
+    ``default_export`` is the declaration a TS/JS module exports as ``default``, else empty.
+    """
 
-
-@dataclass(frozen=True)
-class ImportBinding:
-    """One local name a TS/JS file imports: the module specifier and the exported name."""
-
-    source: str
-    imported_name: str
+    imports: tuple[ImportDirective, ...] = ()
+    namespaces: tuple[tuple[str, int, int], ...] = ()
+    default_export: str = ""
 
 
 @dataclass

--- a/static_analyzer/engine/models.py
+++ b/static_analyzer/engine/models.py
@@ -78,10 +78,25 @@ class TypeReferenceSite:
 
 
 @dataclass(frozen=True)
+class UsingDirective:
+    """One C# ``using`` and the lines it governs."""
+
+    target: str
+    # The enclosing scope's range: C# requires usings to precede declarations, so every site
+    # that can see this directive is inside it.
+    first_line: int
+    last_line: int
+    # The name an alias binds (``Item`` in ``using Item = A.B.Item``), else empty.
+    alias: str = ""
+    # ``using static N.T``: T's members become nameable unqualified, T's own name does not.
+    static: bool = False
+
+
+@dataclass(frozen=True)
 class NamespaceContext:
     """What a C# file can name unqualified: its usings and the namespaces it declares."""
 
-    usings: tuple[str, ...]
+    usings: tuple[UsingDirective, ...]
     # (dotted namespace, first line, last line), one-based inclusive; nested names are joined.
     namespaces: tuple[tuple[str, int, int], ...]
 

--- a/static_analyzer/engine/source_inspector.py
+++ b/static_analyzer/engine/source_inspector.py
@@ -14,7 +14,7 @@ from tree_sitter import Node as TreeSitterNode
 from tree_sitter import Parser, Tree
 
 from static_analyzer.config import LANGUAGE_EXTENSIONS, Language
-from static_analyzer.engine.models import CallSite
+from static_analyzer.engine.models import CallSite, ImportBinding, NamespaceContext, TypeReferenceSite
 
 import tree_sitter_c_sharp
 import tree_sitter_go
@@ -159,6 +159,44 @@ BODY_DECLARATION_LANGUAGES = (Language.TYPESCRIPT, Language.JAVASCRIPT)
 _BODY_FIELD_SUFFIXES = frozenset(
     suffix for language in BODY_DECLARATION_LANGUAGES for suffix in LANGUAGE_EXTENSIONS[language]
 )
+
+# C#: a name is a type when it fills its parent's type slot, sits in a type list, or is the
+# operand of ``as``/``is``. A creation's type is left out: naming it there already yields the
+# constructor's call edge.
+_CSHARP_TYPE_SLOT_FIELDS = frozenset({"type", "returns"})
+_CSHARP_TYPE_LIST_NODE_TYPES = frozenset({"type_argument_list", "base_list"})
+_CSHARP_TYPE_OPERAND_NODE_TYPES = frozenset({"as_expression", "is_expression"})
+# ``Consts.Value`` / ``Kind.Member``: the receiver of a member access is a type when it resolves
+# to one, and nothing else names an enum or a constants class. C# only: a script's receivers are
+# mostly variables, and a promoted one (``data``, ``options``) would resolve to the wrong file.
+_CSHARP_MEMBER_ACCESS_NODE_TYPES = frozenset({"member_access_expression"})
+_CSHARP_CREATION_NODE_TYPES = frozenset({"object_creation_expression"})
+_CSHARP_TYPE_NAME_NODE_TYPES = frozenset({"identifier", "qualified_name", "alias_qualified_name", "generic_name"})
+_CSHARP_NAMESPACE_NODE_TYPES = frozenset({"namespace_declaration", "file_scoped_namespace_declaration"})
+# ``namespace X;`` is one statement whose declarations follow as siblings, so its range is the file's.
+_CSHARP_FILE_SCOPED_NAMESPACE_NODE_TYPES = frozenset({"file_scoped_namespace_declaration"})
+_CSHARP_USING_NODE_TYPES = frozenset({"using_directive"})
+_TRANSPARENT_SCOPE_NODE_TYPES = frozenset({"declaration_list"})
+# TS/JS: every ``type_identifier`` outside a declaration's own name, a class's ``extends``
+# operand, and a class named inside a decorator's arrays (Angular's module wiring).
+_SCRIPT_TYPE_NAME_NODE_TYPES = frozenset({"type_identifier", "nested_type_identifier"})
+_SCRIPT_TYPE_DECLARATION_NODE_TYPES = frozenset(
+    {
+        "class_declaration",
+        "abstract_class_declaration",
+        "interface_declaration",
+        "type_alias_declaration",
+        "enum_declaration",
+        "type_parameter",
+    }
+)
+# TypeScript wraps ``extends`` in a clause; JavaScript puts the expression straight under the heritage.
+_SCRIPT_HERITAGE_NODE_TYPES = frozenset({"extends_clause", "class_heritage"})
+_DECORATOR_NODE_TYPES = frozenset({"decorator"})
+_DECORATOR_SEARCH_DEPTH = 12
+_SCRIPT_IMPORT_NODE_TYPES = frozenset({"import_statement"})
+_TYPESCRIPT_SUFFIXES = frozenset({".ts", ".tsx", ".mts", ".cts"})
+_SCRIPT_SUFFIXES = _TYPESCRIPT_SUFFIXES | frozenset(LANGUAGE_EXTENSIONS[Language.JAVASCRIPT])
 
 # Ceiling on retained tree-sitter nodes. Trees are by far the largest thing this
 # class touches — retaining one per file cost 2.2GB on a 5k-file C# repo — and
@@ -602,6 +640,115 @@ class SourceInspector:
             node = parent
         return False
 
+    def find_type_reference_sites(self, file_path: Path) -> list[TypeReferenceSite]:
+        """Positions where the file names a type without calling it.
+
+        Why: a parameter type, a base class, a generic argument or a ``typeof`` operand never
+        reaches the call graph, and in module-oriented code that is where the wiring is written.
+        """
+        parsed = self._parse(file_path)
+        if parsed is None:
+            return []
+        suffix = file_path.suffix.lower()
+        if suffix in _PREPROCESSOR_SUFFIXES:
+            select = self._csharp_type_name
+        elif suffix in _SCRIPT_SUFFIXES:
+            select = self._script_type_name
+        else:
+            return []
+
+        def text(node: TreeSitterNode) -> str:
+            return parsed.content[node.start_byte : node.end_byte].decode("utf8", "replace")
+
+        sites: list[TypeReferenceSite] = []
+        seen: set[tuple[int, int]] = set()
+        for node in self._walk(parsed.tree.root_node):
+            named = select(node)
+            if named is None:
+                continue
+            name_node, qualifier_node = named
+            position = (name_node.start_point.row, name_node.start_point.column)
+            if position in seen:
+                continue
+            seen.add(position)
+            sites.append(
+                TypeReferenceSite(
+                    file=str(file_path),
+                    line=position[0] + 1,
+                    column=position[1] + 1,
+                    name=text(name_node),
+                    qualifier=text(qualifier_node) if qualifier_node is not None else "",
+                )
+            )
+        return sites
+
+    def find_namespace_context(self, file_path: Path) -> NamespaceContext:
+        """The usings and declared namespaces of a C# file; empty for any other language."""
+        parsed = self._parse(file_path)
+        if parsed is None or file_path.suffix.lower() not in _PREPROCESSOR_SUFFIXES:
+            return NamespaceContext((), ())
+
+        def text(node: TreeSitterNode) -> str:
+            return parsed.content[node.start_byte : node.end_byte].decode("utf8", "replace")
+
+        usings: list[str] = []
+        namespaces: list[tuple[str, int, int]] = []
+
+        def visit(scope: TreeSitterNode, prefix: str) -> None:
+            for child in scope.named_children:
+                if child.type in _CSHARP_USING_NODE_TYPES:
+                    target = self._using_target(child)
+                    if target is not None:
+                        usings.append(text(target))
+                elif child.type in _CSHARP_NAMESPACE_NODE_TYPES:
+                    name_node = child.child_by_field_name("name")
+                    name = text(name_node) if name_node is not None else ""
+                    full = ".".join(part for part in (prefix, name) if part)
+                    last = scope if child.type in _CSHARP_FILE_SCOPED_NAMESPACE_NODE_TYPES else child
+                    namespaces.append((full, child.start_point.row + 1, last.end_point.row + 1))
+                    visit(child, full)
+                elif child.type in _TRANSPARENT_SCOPE_NODE_TYPES:
+                    visit(child, prefix)
+
+        visit(parsed.tree.root_node, "")
+        return NamespaceContext(tuple(usings), tuple(namespaces))
+
+    def find_import_bindings(self, file_path: Path) -> dict[str, ImportBinding]:
+        """Local name -> what a TS/JS file imported it as; empty for any other language."""
+        parsed = self._parse(file_path)
+        if parsed is None or file_path.suffix.lower() not in _SCRIPT_SUFFIXES:
+            return {}
+
+        def text(node: TreeSitterNode) -> str:
+            return parsed.content[node.start_byte : node.end_byte].decode("utf8", "replace")
+
+        bindings: dict[str, ImportBinding] = {}
+        for statement in parsed.tree.root_node.named_children:
+            if statement.type not in _SCRIPT_IMPORT_NODE_TYPES:
+                continue
+            source_node = statement.child_by_field_name("source")
+            if source_node is None:
+                continue
+            source = text(source_node).strip("'\"`")
+            for clause in statement.named_children:
+                if clause.type != "import_clause":
+                    continue
+                for part in clause.named_children:
+                    if part.type == "identifier":
+                        bindings[text(part)] = ImportBinding(source, "default")
+                    elif part.type == "namespace_import":
+                        for alias in part.named_children:
+                            bindings[text(alias)] = ImportBinding(source, "*")
+                    elif part.type == "named_imports":
+                        for specifier in part.named_children:
+                            name_node = specifier.child_by_field_name("name")
+                            if name_node is None:
+                                continue
+                            alias_node = specifier.child_by_field_name("alias")
+                            local = text(alias_node if alias_node is not None else name_node)
+                            bindings[local] = ImportBinding(source, text(name_node))
+        return bindings
+
     def find_type_bases(self, file_path: Path) -> list[tuple[str, list[str]]]:
         """Return ``(declared type name, base type names)`` for each type in the file.
 
@@ -800,6 +947,75 @@ class SourceInspector:
             if child is not node and child.type in node_types:
                 result = child
         return result
+
+    def _csharp_type_name(self, node: TreeSitterNode) -> tuple[TreeSitterNode, TreeSitterNode | None] | None:
+        parent = node.parent
+        if parent is None or node.type not in _CSHARP_TYPE_NAME_NODE_TYPES:
+            return None
+        field = self._field_name(node)
+        in_slot = field in _CSHARP_TYPE_SLOT_FIELDS and parent.type not in _CSHARP_CREATION_NODE_TYPES
+        in_list = parent.type in _CSHARP_TYPE_LIST_NODE_TYPES
+        as_operand = parent.type in _CSHARP_TYPE_OPERAND_NODE_TYPES and field == "right"
+        receiver = (
+            node.type == "identifier" and parent.type in _CSHARP_MEMBER_ACCESS_NODE_TYPES and field == "expression"
+        )
+        if not (in_slot or in_list or as_operand or receiver):
+            return None
+        if node.type == "qualified_name":
+            name = node.child_by_field_name("name")
+            return (name, node.child_by_field_name("qualifier")) if name is not None else None
+        if node.type == "alias_qualified_name":
+            name = node.child_by_field_name("name")
+            return (name, None) if name is not None else None
+        if node.type == "generic_name":
+            name = self._first_named_child_of_type(node, _NAME_NODE_TYPES)
+            return (name, None) if name is not None else None
+        return (node, None)
+
+    def _script_type_name(self, node: TreeSitterNode) -> tuple[TreeSitterNode, TreeSitterNode | None] | None:
+        parent = node.parent
+        if parent is None:
+            return None
+        if node.type == "type_identifier":
+            if parent.type in _SCRIPT_TYPE_DECLARATION_NODE_TYPES and self._field_name(node) == "name":
+                return None
+            if parent.type in _SCRIPT_TYPE_NAME_NODE_TYPES:
+                return None
+            return (node, None)
+        if node.type == "nested_type_identifier":
+            name = node.child_by_field_name("name")
+            return (name, node.child_by_field_name("module")) if name is not None else None
+        if parent.type in _SCRIPT_HERITAGE_NODE_TYPES and self._field_name(node) in ("value", None):
+            if node.type == "identifier":
+                return (node, None)
+            if node.type == "member_expression":
+                name = node.child_by_field_name("property")
+                return (name, node.child_by_field_name("object")) if name is not None else None
+            return None
+        if node.type == "identifier" and self._inside_decorator(node):
+            if parent.type == "array" or (parent.type == "pair" and self._field_name(node) == "value"):
+                return (node, None)
+        return None
+
+    @staticmethod
+    def _using_target(directive: TreeSitterNode) -> TreeSitterNode | None:
+        """The namespace (or type) a ``using`` names, skipping an alias's own name."""
+        alias = directive.child_by_field_name("name")
+        for child in reversed(directive.named_children):
+            if child.type in ("qualified_name", "identifier") and (alias is None or child.id != alias.id):
+                return child
+        return None
+
+    @staticmethod
+    def _inside_decorator(node: TreeSitterNode) -> bool:
+        ancestor = node.parent
+        for _ in range(_DECORATOR_SEARCH_DEPTH):
+            if ancestor is None:
+                return False
+            if ancestor.type in _DECORATOR_NODE_TYPES:
+                return True
+            ancestor = ancestor.parent
+        return False
 
     @staticmethod
     def _field_name(node: TreeSitterNode) -> str | None:

--- a/static_analyzer/engine/source_inspector.py
+++ b/static_analyzer/engine/source_inspector.py
@@ -14,7 +14,7 @@ from tree_sitter import Node as TreeSitterNode
 from tree_sitter import Parser, Tree
 
 from static_analyzer.config import LANGUAGE_EXTENSIONS, Language
-from static_analyzer.engine.models import CallSite, ImportBinding, NamespaceContext, TypeReferenceSite
+from static_analyzer.engine.models import CallSite, ImportBinding, NamespaceContext, TypeReferenceSite, UsingDirective
 
 import tree_sitter_c_sharp
 import tree_sitter_go
@@ -29,6 +29,10 @@ logger = logging.getLogger(__name__)
 
 
 LanguageFactory = Callable[[], object]
+_NodeText = Callable[["TreeSitterNode"], str]
+# What a type-site selector returns: the node to anchor the position on, the looked-up name,
+# and the prefix written before it.
+_TypeName = tuple["TreeSitterNode", str, str]
 
 _LANGUAGE_FACTORY_BY_LANGUAGE: dict[Language, LanguageFactory] = {
     Language.PYTHON: tree_sitter_python.language,
@@ -172,6 +176,10 @@ _CSHARP_TYPE_OPERAND_NODE_TYPES = frozenset({"as_expression", "is_expression"})
 _CSHARP_MEMBER_ACCESS_NODE_TYPES = frozenset({"member_access_expression"})
 _CSHARP_CREATION_NODE_TYPES = frozenset({"object_creation_expression"})
 _CSHARP_TYPE_NAME_NODE_TYPES = frozenset({"identifier", "qualified_name", "alias_qualified_name", "generic_name"})
+# Both spell ``A.B``; only ``qualified_name`` carries a ``qualifier`` field — an alias root is not one.
+_CSHARP_QUALIFIED_NAME_NODE_TYPES = frozenset({"qualified_name", "alias_qualified_name"})
+# What a ``using`` can name. ``alias_qualified_name`` covers ``using global::System;``.
+_CSHARP_USING_TARGET_NODE_TYPES = frozenset({"qualified_name", "identifier", "alias_qualified_name"})
 _CSHARP_NAMESPACE_NODE_TYPES = frozenset({"namespace_declaration", "file_scoped_namespace_declaration"})
 # ``namespace X;`` is one statement whose declarations follow as siblings, so its range is the file's.
 _CSHARP_FILE_SCOPED_NAMESPACE_NODE_TYPES = frozenset({"file_scoped_namespace_declaration"})
@@ -204,6 +212,41 @@ _SCRIPT_SUFFIXES = _TYPESCRIPT_SUFFIXES | frozenset(LANGUAGE_EXTENSIONS[Language
 # which is cached separately and outlives the tree. Measured: going from
 # unbounded to 500k costs no wall-clock, because nothing re-reads a tree.
 TREE_NODE_BUDGET = 500_000
+
+
+def split_type_name(written: str) -> tuple[str, str]:
+    """A written type name as ``(prefix, simple name)``, split at the last dot outside a generic list.
+
+    Why depth-aware: a type argument can be dotted (``Box<a.b.T>``, where the last dot is inside
+    the brackets) and a generic segment need not be the last one (``A.Repo<T>.Entry``, where the
+    first bracket precedes the dot that matters). Neither the last dot nor the first bracket finds
+    the boundary alone, and the two callers here — the index keyed by qualified name, and the site
+    read out of source — sit on opposite sides of that.
+    """
+    depth = 0
+    cut = -1
+    for index, char in enumerate(written):
+        if char == "<":
+            depth += 1
+        elif char == ">":
+            depth -= 1
+        elif char == "." and depth == 0:
+            cut = index
+    if depth != 0:
+        # Unbalanced: a symbol carrying prose rather than a type name (an LSP-reported test title
+        # with a ``<=`` in it). Fall back to the last dot so the segment is still recoverable.
+        cut = written.rfind(".")
+    return written[:cut] if cut >= 0 else "", written[cut + 1 :].split("<", 1)[0]
+
+
+def simple_type_name(qualified_name: str) -> str:
+    """``Box`` for ``a.b.Box<x.y.T>``, ``Entry`` for ``a.Repo<T>.Entry``."""
+    return split_type_name(qualified_name)[1]
+
+
+def _without_alias_qualifier(name: str) -> str:
+    """``global::A.B`` -> ``A.B``: an extern-alias root names an assembly, not a namespace."""
+    return name.rpartition("::")[2]
 
 
 def _error_node_count(tree: Tree) -> int:
@@ -663,11 +706,11 @@ class SourceInspector:
         sites: list[TypeReferenceSite] = []
         seen: set[tuple[int, int]] = set()
         for node in self._walk(parsed.tree.root_node):
-            named = select(node)
+            named = select(node, text)
             if named is None:
                 continue
-            name_node, qualifier_node = named
-            position = (name_node.start_point.row, name_node.start_point.column)
+            anchor, name, qualifier = named
+            position = (anchor.start_point.row, anchor.start_point.column)
             if position in seen:
                 continue
             seen.add(position)
@@ -676,8 +719,8 @@ class SourceInspector:
                     file=str(file_path),
                     line=position[0] + 1,
                     column=position[1] + 1,
-                    name=text(name_node),
-                    qualifier=text(qualifier_node) if qualifier_node is not None else "",
+                    name=name,
+                    qualifier=qualifier,
                 )
             )
         return sites
@@ -691,26 +734,38 @@ class SourceInspector:
         def text(node: TreeSitterNode) -> str:
             return parsed.content[node.start_byte : node.end_byte].decode("utf8", "replace")
 
-        usings: list[str] = []
+        usings: list[UsingDirective] = []
         namespaces: list[tuple[str, int, int]] = []
 
-        def visit(scope: TreeSitterNode, prefix: str) -> None:
+        def visit(scope: TreeSitterNode, prefix: str, first_line: int, last_line: int) -> None:
             for child in scope.named_children:
                 if child.type in _CSHARP_USING_NODE_TYPES:
                     target = self._using_target(child)
                     if target is not None:
-                        usings.append(text(target))
+                        alias = child.child_by_field_name("name")
+                        usings.append(
+                            UsingDirective(
+                                target=_without_alias_qualifier(text(target)),
+                                first_line=first_line,
+                                last_line=last_line,
+                                alias=text(alias) if alias is not None else "",
+                                # ``static`` is an anonymous token, so it is not a named child.
+                                static=any(part.type == "static" for part in child.children),
+                            )
+                        )
                 elif child.type in _CSHARP_NAMESPACE_NODE_TYPES:
                     name_node = child.child_by_field_name("name")
                     name = text(name_node) if name_node is not None else ""
                     full = ".".join(part for part in (prefix, name) if part)
                     last = scope if child.type in _CSHARP_FILE_SCOPED_NAMESPACE_NODE_TYPES else child
-                    namespaces.append((full, child.start_point.row + 1, last.end_point.row + 1))
-                    visit(child, full)
+                    start, end = child.start_point.row + 1, last.end_point.row + 1
+                    namespaces.append((full, start, end))
+                    visit(child, full, start, end)
                 elif child.type in _TRANSPARENT_SCOPE_NODE_TYPES:
-                    visit(child, prefix)
+                    visit(child, prefix, first_line, last_line)
 
-        visit(parsed.tree.root_node, "")
+        root = parsed.tree.root_node
+        visit(root, "", 1, root.end_point.row + 1)
         return NamespaceContext(tuple(usings), tuple(namespaces))
 
     def find_import_bindings(self, file_path: Path) -> dict[str, ImportBinding]:
@@ -948,7 +1003,7 @@ class SourceInspector:
                 result = child
         return result
 
-    def _csharp_type_name(self, node: TreeSitterNode) -> tuple[TreeSitterNode, TreeSitterNode | None] | None:
+    def _csharp_type_name(self, node: TreeSitterNode, text: _NodeText) -> _TypeName | None:
         parent = node.parent
         if parent is None or node.type not in _CSHARP_TYPE_NAME_NODE_TYPES:
             return None
@@ -961,18 +1016,16 @@ class SourceInspector:
         )
         if not (in_slot or in_list or as_operand or receiver):
             return None
-        if node.type == "qualified_name":
+        if node.type in _CSHARP_QUALIFIED_NAME_NODE_TYPES:
             name = node.child_by_field_name("name")
-            return (name, node.child_by_field_name("qualifier")) if name is not None else None
-        if node.type == "alias_qualified_name":
-            name = node.child_by_field_name("name")
-            return (name, None) if name is not None else None
-        if node.type == "generic_name":
-            name = self._first_named_child_of_type(node, _NAME_NODE_TYPES)
-            return (name, None) if name is not None else None
-        return (node, None)
+            qualifier = node.child_by_field_name("qualifier")
+        else:
+            name, qualifier = node, None
+        if name is None:
+            return None
+        return name, simple_type_name(text(name)), _without_alias_qualifier(text(qualifier)) if qualifier else ""
 
-    def _script_type_name(self, node: TreeSitterNode) -> tuple[TreeSitterNode, TreeSitterNode | None] | None:
+    def _script_type_name(self, node: TreeSitterNode, text: _NodeText) -> _TypeName | None:
         parent = node.parent
         if parent is None:
             return None
@@ -981,28 +1034,37 @@ class SourceInspector:
                 return None
             if parent.type in _SCRIPT_TYPE_NAME_NODE_TYPES:
                 return None
-            return (node, None)
+            return node, text(node), ""
         if node.type == "nested_type_identifier":
-            name = node.child_by_field_name("name")
-            return (name, node.child_by_field_name("module")) if name is not None else None
+            return self._script_member_name(node, "name", "module", text)
         if parent.type in _SCRIPT_HERITAGE_NODE_TYPES and self._field_name(node) in ("value", None):
             if node.type == "identifier":
-                return (node, None)
+                return node, text(node), ""
             if node.type == "member_expression":
-                name = node.child_by_field_name("property")
-                return (name, node.child_by_field_name("object")) if name is not None else None
+                return self._script_member_name(node, "property", "object", text)
             return None
         if node.type == "identifier" and self._inside_decorator(node):
             if parent.type == "array" or (parent.type == "pair" and self._field_name(node) == "value"):
-                return (node, None)
+                return node, text(node), ""
         return None
+
+    @staticmethod
+    def _script_member_name(
+        node: TreeSitterNode, name_field: str, owner_field: str, text: _NodeText
+    ) -> _TypeName | None:
+        """``NS.Thing`` split into the name and the module that owns it."""
+        name = node.child_by_field_name(name_field)
+        if name is None:
+            return None
+        owner = node.child_by_field_name(owner_field)
+        return name, text(name), text(owner) if owner else ""
 
     @staticmethod
     def _using_target(directive: TreeSitterNode) -> TreeSitterNode | None:
         """The namespace (or type) a ``using`` names, skipping an alias's own name."""
         alias = directive.child_by_field_name("name")
         for child in reversed(directive.named_children):
-            if child.type in ("qualified_name", "identifier") and (alias is None or child.id != alias.id):
+            if child.type in _CSHARP_USING_TARGET_NODE_TYPES and (alias is None or child.id != alias.id):
                 return child
         return None
 

--- a/static_analyzer/engine/source_inspector.py
+++ b/static_analyzer/engine/source_inspector.py
@@ -689,15 +689,18 @@ class SourceInspector:
         Why: a parameter type, a base class, a generic argument or a ``typeof`` operand never
         reaches the call graph, and in module-oriented code that is where the wiring is written.
         """
-        parsed = self._parse(file_path)
-        if parsed is None:
-            return []
+        # The language is decided before the file is read: only C# and the script family have a
+        # selector, and parsing first made every Python, Java, Go, PHP and Rust file pay a full
+        # tree-sitter parse to be thrown away (1.9s over django's 2,894 files).
         suffix = file_path.suffix.lower()
         if suffix in _PREPROCESSOR_SUFFIXES:
             select = self._csharp_type_name
         elif suffix in _SCRIPT_SUFFIXES:
             select = self._script_type_name
         else:
+            return []
+        parsed = self._parse(file_path)
+        if parsed is None:
             return []
 
         def text(node: TreeSitterNode) -> str:

--- a/static_analyzer/engine/source_inspector.py
+++ b/static_analyzer/engine/source_inspector.py
@@ -84,6 +84,38 @@ _CONSTRUCTION_NODE_TYPES = (
     | frozenset({"explicit_constructor_invocation"})
 )
 _CALLABLE_USAGE_ANCESTORS = frozenset({"argument_list", "arguments"})
+# The receiver of a member chain (``abp`` in ``f(abp.x.y)``) is never the value passed or returned.
+_RECEIVER_FIELD_BY_NODE_TYPE = {
+    "member_expression": "object",
+    "attribute": "object",
+    "member_access_expression": "expression",
+    "selector_expression": "operand",
+    "field_access": "object",
+    "field_expression": "value",
+}
+# A callback's body is not "passed as a callable": the walk up to an argument list stops here.
+_FUNCTION_BOUNDARY_NODE_TYPES = frozenset(
+    {
+        "function_expression",
+        "function_declaration",
+        "arrow_function",
+        "method_definition",
+        "generator_function",
+        "generator_function_declaration",
+        "lambda",
+        "function_definition",
+        "func_literal",
+        "method_declaration",
+        "anonymous_function",
+        "anonymous_function_creation_expression",
+        "closure_expression",
+        "function_item",
+        "lambda_expression",
+        "anonymous_method_expression",
+        "local_function_statement",
+        "constructor_declaration",
+    }
+)
 _NAME_NODE_TYPES = frozenset(
     {
         "identifier",
@@ -658,8 +690,9 @@ class SourceInspector:
             for field in _BODY_FIELD_NAMES
         )
 
-    @staticmethod
-    def _node_is_return_value(target: TreeSitterNode) -> bool:
+    def _node_is_return_value(self, target: TreeSitterNode) -> bool:
+        if self._is_receiver(target):
+            return False
         node = target
         while node.parent is not None:
             parent = node.parent
@@ -671,15 +704,24 @@ class SourceInspector:
         return False
 
     def _node_is_call_argument(self, target: TreeSitterNode) -> bool:
+        if self._is_receiver(target):
+            return False
         node = target
         while node.parent is not None:
             parent = node.parent
             if parent.type in _CALLABLE_USAGE_ANCESTORS and self._parent_is_call_like(parent):
                 return True
-            if self._call_target_node(parent) == target:
+            if parent.type in _FUNCTION_BOUNDARY_NODE_TYPES or self._call_target_node(parent) == target:
                 return False
             node = parent
         return False
+
+    def _is_receiver(self, node: TreeSitterNode) -> bool:
+        parent = node.parent
+        if parent is None:
+            return False
+        receiver_field = _RECEIVER_FIELD_BY_NODE_TYPE.get(parent.type)
+        return receiver_field is not None and self._field_name(node) == receiver_field
 
     @staticmethod
     def _parent_is_call_like(node: TreeSitterNode) -> bool:
@@ -758,6 +800,16 @@ class SourceInspector:
             if child is not node and child.type in node_types:
                 result = child
         return result
+
+    @staticmethod
+    def _field_name(node: TreeSitterNode) -> str | None:
+        parent = node.parent
+        if parent is None:
+            return None
+        for index, child in enumerate(parent.children):
+            if child.id == node.id:
+                return parent.field_name_for_child(index)
+        return None
 
     def _walk(self, node: TreeSitterNode):
         yield node

--- a/static_analyzer/engine/source_inspector.py
+++ b/static_analyzer/engine/source_inspector.py
@@ -14,7 +14,7 @@ from tree_sitter import Node as TreeSitterNode
 from tree_sitter import Parser, Tree
 
 from static_analyzer.config import LANGUAGE_EXTENSIONS, Language
-from static_analyzer.engine.models import CallSite, ImportBinding, NamespaceContext, TypeReferenceSite, UsingDirective
+from static_analyzer.engine.models import DEFAULT_EXPORT_NAME, CallSite, ImportDirective, NameScope, TypeReferenceSite
 
 import tree_sitter_c_sharp
 import tree_sitter_go
@@ -203,6 +203,11 @@ _SCRIPT_HERITAGE_NODE_TYPES = frozenset({"extends_clause", "class_heritage"})
 _DECORATOR_NODE_TYPES = frozenset({"decorator"})
 _DECORATOR_SEARCH_DEPTH = 12
 _SCRIPT_IMPORT_NODE_TYPES = frozenset({"import_statement"})
+_SCRIPT_EXPORT_NODE_TYPES = frozenset({"export_statement"})
+# What ``export default`` can name: a declaration, or a bare identifier declared elsewhere.
+_SCRIPT_DEFAULT_EXPORT_NODE_TYPES = frozenset(
+    {"class_declaration", "abstract_class_declaration", "function_declaration", "identifier"}
+)
 _TYPESCRIPT_SUFFIXES = frozenset({".ts", ".tsx", ".mts", ".cts"})
 _SCRIPT_SUFFIXES = _TYPESCRIPT_SUFFIXES | frozenset(LANGUAGE_EXTENSIONS[Language.JAVASCRIPT])
 
@@ -683,15 +688,15 @@ class SourceInspector:
             node = parent
         return False
 
-    def find_type_reference_sites(self, file_path: Path) -> list[TypeReferenceSite]:
-        """Positions where the file names a type without calling it.
+    def find_type_reference_sites(self, file_path: Path) -> list[TypeReferenceSite] | None:
+        """Positions where the file names a type without calling it; ``None`` when it cannot be read.
 
         Why: a parameter type, a base class, a generic argument or a ``typeof`` operand never
         reaches the call graph, and in module-oriented code that is where the wiring is written.
+        Why None rather than empty: the caller rebuilds the whole type-reference layer from these,
+        so a file it cannot read is a gap to report, not a file that names nothing.
         """
-        # The language is decided before the file is read: only C# and the script family have a
-        # selector, and parsing first made every Python, Java, Go, PHP and Rust file pay a full
-        # tree-sitter parse to be thrown away (1.9s over django's 2,894 files).
+        # Only C# and the script family have a selector; the rest are never parsed for this.
         suffix = file_path.suffix.lower()
         if suffix in _PREPROCESSOR_SUFFIXES:
             select = self._csharp_type_name
@@ -701,7 +706,7 @@ class SourceInspector:
             return []
         parsed = self._parse(file_path)
         if parsed is None:
-            return []
+            return None
 
         def text(node: TreeSitterNode) -> str:
             return parsed.content[node.start_byte : node.end_byte].decode("utf8", "replace")
@@ -719,7 +724,7 @@ class SourceInspector:
             seen.add(position)
             sites.append(
                 TypeReferenceSite(
-                    file=str(file_path),
+                    file_path=str(file_path),
                     line=position[0] + 1,
                     column=position[1] + 1,
                     name=name,
@@ -728,84 +733,21 @@ class SourceInspector:
             )
         return sites
 
-    def find_namespace_context(self, file_path: Path) -> NamespaceContext:
-        """The usings and declared namespaces of a C# file; empty for any other language."""
+    def find_name_scope(self, file_path: Path) -> NameScope:
+        """The imports a file names things through, and the namespaces it declares.
+
+        C# reads ``using`` directives and namespace blocks; TS/JS reads ``import`` statements and
+        the ``export default`` declaration. Any other language, or an unreadable file, is empty.
+        """
+        suffix = file_path.suffix.lower()
+        if suffix in _PREPROCESSOR_SUFFIXES:
+            read = self._csharp_name_scope
+        elif suffix in _SCRIPT_SUFFIXES:
+            read = self._script_name_scope
+        else:
+            return NameScope()
         parsed = self._parse(file_path)
-        if parsed is None or file_path.suffix.lower() not in _PREPROCESSOR_SUFFIXES:
-            return NamespaceContext((), ())
-
-        def text(node: TreeSitterNode) -> str:
-            return parsed.content[node.start_byte : node.end_byte].decode("utf8", "replace")
-
-        usings: list[UsingDirective] = []
-        namespaces: list[tuple[str, int, int]] = []
-
-        def visit(scope: TreeSitterNode, prefix: str, first_line: int, last_line: int) -> None:
-            for child in scope.named_children:
-                if child.type in _CSHARP_USING_NODE_TYPES:
-                    target = self._using_target(child)
-                    if target is not None:
-                        alias = child.child_by_field_name("name")
-                        usings.append(
-                            UsingDirective(
-                                target=_without_alias_qualifier(text(target)),
-                                first_line=first_line,
-                                last_line=last_line,
-                                alias=text(alias) if alias is not None else "",
-                                # ``static`` is an anonymous token, so it is not a named child.
-                                static=any(part.type == "static" for part in child.children),
-                            )
-                        )
-                elif child.type in _CSHARP_NAMESPACE_NODE_TYPES:
-                    name_node = child.child_by_field_name("name")
-                    name = text(name_node) if name_node is not None else ""
-                    full = ".".join(part for part in (prefix, name) if part)
-                    last = scope if child.type in _CSHARP_FILE_SCOPED_NAMESPACE_NODE_TYPES else child
-                    start, end = child.start_point.row + 1, last.end_point.row + 1
-                    namespaces.append((full, start, end))
-                    visit(child, full, start, end)
-                elif child.type in _TRANSPARENT_SCOPE_NODE_TYPES:
-                    visit(child, prefix, first_line, last_line)
-
-        root = parsed.tree.root_node
-        visit(root, "", 1, root.end_point.row + 1)
-        return NamespaceContext(tuple(usings), tuple(namespaces))
-
-    def find_import_bindings(self, file_path: Path) -> dict[str, ImportBinding]:
-        """Local name -> what a TS/JS file imported it as; empty for any other language."""
-        parsed = self._parse(file_path)
-        if parsed is None or file_path.suffix.lower() not in _SCRIPT_SUFFIXES:
-            return {}
-
-        def text(node: TreeSitterNode) -> str:
-            return parsed.content[node.start_byte : node.end_byte].decode("utf8", "replace")
-
-        bindings: dict[str, ImportBinding] = {}
-        for statement in parsed.tree.root_node.named_children:
-            if statement.type not in _SCRIPT_IMPORT_NODE_TYPES:
-                continue
-            source_node = statement.child_by_field_name("source")
-            if source_node is None:
-                continue
-            source = text(source_node).strip("'\"`")
-            for clause in statement.named_children:
-                if clause.type != "import_clause":
-                    continue
-                for part in clause.named_children:
-                    if part.type == "identifier":
-                        bindings[text(part)] = ImportBinding(source, "default")
-                    elif part.type == "namespace_import":
-                        for alias in part.named_children:
-                            bindings[text(alias)] = ImportBinding(source, "*")
-                    elif part.type == "named_imports":
-                        for specifier in part.named_children:
-                            name_node = specifier.child_by_field_name("name")
-                            if name_node is None:
-                                continue
-                            alias_node = specifier.child_by_field_name("alias")
-                            local = text(alias_node if alias_node is not None else name_node)
-                            bindings[local] = ImportBinding(source, text(name_node))
-        return bindings
+        return NameScope() if parsed is None else read(parsed)
 
     def find_type_bases(self, file_path: Path) -> list[tuple[str, list[str]]]:
         """Return ``(declared type name, base type names)`` for each type in the file.
@@ -1050,6 +992,113 @@ class SourceInspector:
             if parent.type == "array" or (parent.type == "pair" and self._field_name(node) == "value"):
                 return node, text(node), ""
         return None
+
+    def _csharp_name_scope(self, parsed: ParsedSource) -> NameScope:
+        """``using`` directives with the range each governs, and the namespaces declared."""
+
+        def text(node: TreeSitterNode) -> str:
+            return parsed.content[node.start_byte : node.end_byte].decode("utf8", "replace")
+
+        imports: list[ImportDirective] = []
+        namespaces: list[tuple[str, int, int]] = []
+
+        def visit(scope: TreeSitterNode, prefix: str, last_line: int) -> None:
+            for child in scope.named_children:
+                if child.type in _CSHARP_USING_NODE_TYPES:
+                    target = self._using_target(child)
+                    if target is None:
+                        continue
+                    alias = child.child_by_field_name("name")
+                    written = _without_alias_qualifier(text(target))
+                    # An alias binds one name to a path; a plain or ``static`` using opens the path.
+                    container, name = split_type_name(written) if alias is not None else (written, "")
+                    imports.append(
+                        ImportDirective(
+                            container=container,
+                            # A using precedes the members of its scope, so it governs from its own
+                            # line to the scope's end.
+                            first_line=child.start_point.row + 1,
+                            last_line=last_line,
+                            name=name,
+                            alias=text(alias) if alias is not None else "",
+                            # ``global`` is an anonymous token, so it is not a named child.
+                            compilation_wide=any(part.type == "global" for part in child.children),
+                        )
+                    )
+                elif child.type in _CSHARP_NAMESPACE_NODE_TYPES:
+                    name_node = child.child_by_field_name("name")
+                    name = text(name_node) if name_node is not None else ""
+                    full = ".".join(part for part in (prefix, name) if part)
+                    last = scope if child.type in _CSHARP_FILE_SCOPED_NAMESPACE_NODE_TYPES else child
+                    namespaces.append((full, child.start_point.row + 1, last.end_point.row + 1))
+                    visit(child, full, last.end_point.row + 1)
+                elif child.type in _TRANSPARENT_SCOPE_NODE_TYPES:
+                    visit(child, prefix, last_line)
+
+        root = parsed.tree.root_node
+        visit(root, "", root.end_point.row + 1)
+        return NameScope(tuple(imports), tuple(namespaces))
+
+    def _script_name_scope(self, parsed: ParsedSource) -> NameScope:
+        """``import`` bindings, each hoisted over the whole file, and the ``export default`` name."""
+
+        def text(node: TreeSitterNode) -> str:
+            return parsed.content[node.start_byte : node.end_byte].decode("utf8", "replace")
+
+        root = parsed.tree.root_node
+        last_line = root.end_point.row + 1
+        imports: list[ImportDirective] = []
+        default_export = ""
+        for statement in root.named_children:
+            if statement.type in _SCRIPT_EXPORT_NODE_TYPES:
+                if any(part.type == "default" for part in statement.children):
+                    default_export = self._script_default_export(statement, text) or default_export
+                continue
+            if statement.type not in _SCRIPT_IMPORT_NODE_TYPES:
+                continue
+            source_node = statement.child_by_field_name("source")
+            if source_node is None:
+                continue
+            container = text(source_node).strip("'\"`")
+            for clause in statement.named_children:
+                if clause.type != "import_clause":
+                    continue
+                for part in clause.named_children:
+                    if part.type == "identifier":
+                        imports.append(
+                            ImportDirective(container, 1, last_line, name=DEFAULT_EXPORT_NAME, alias=text(part))
+                        )
+                    elif part.type == "namespace_import":
+                        imports.extend(
+                            ImportDirective(container, 1, last_line, alias=text(alias)) for alias in part.named_children
+                        )
+                    elif part.type == "named_imports":
+                        for specifier in part.named_children:
+                            name_node = specifier.child_by_field_name("name")
+                            if name_node is None:
+                                continue
+                            alias_node = specifier.child_by_field_name("alias")
+                            imports.append(
+                                ImportDirective(
+                                    container,
+                                    1,
+                                    last_line,
+                                    name=text(name_node),
+                                    alias=text(alias_node) if alias_node is not None else "",
+                                )
+                            )
+        return NameScope(tuple(imports), (), default_export)
+
+    @staticmethod
+    def _script_default_export(statement: TreeSitterNode, text: _NodeText) -> str:
+        """The declaration ``export default`` names, else empty for an anonymous value."""
+        exported = next(
+            (part for part in statement.named_children if part.type in _SCRIPT_DEFAULT_EXPORT_NODE_TYPES), None
+        )
+        if exported is None:
+            return ""
+        named = exported if exported.type == "identifier" else exported.child_by_field_name("name")
+        return text(named) if named is not None else ""
 
     @staticmethod
     def _script_member_name(

--- a/static_analyzer/engine/type_reference_builder.py
+++ b/static_analyzer/engine/type_reference_builder.py
@@ -1,0 +1,212 @@
+"""Type-reference edges from source: what names a type without calling it.
+
+Runs over a language's merged graph rather than inside one engine, so a name resolves
+across every sub-project of a monorepo the same way — a template's ``AbpModule`` finds
+the framework's class even though its own solution only sees it as a package reference.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from collections import defaultdict
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from static_analyzer.cfg import CallGraph, EdgeKind, ReferenceEdge
+from static_analyzer.engine.models import ImportBinding, TypeReferenceSite
+from static_analyzer.engine.source_inspector import SourceInspector
+from static_analyzer.internal_references import is_self_or_container_edge
+from static_analyzer.node import Node
+
+logger = logging.getLogger(__name__)
+
+_NAMESPACE_IMPORT = "*"
+_SCRIPT_MODULE_SUFFIXES = (".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs")
+
+
+@dataclass
+class TypeReferenceStats:
+    sites: int = 0
+    resolved: int = 0
+    unresolved: int = 0
+    ambiguous: int = 0
+    edges: int = 0
+    unresolved_names: dict[str, int] = field(default_factory=lambda: defaultdict(int))
+
+    def summary(self) -> str:
+        return (
+            f"{self.sites} sites -> {self.edges} edges "
+            f"({self.resolved} resolved, {self.unresolved} unknown, {self.ambiguous} ambiguous)"
+        )
+
+
+class TypeIndex:
+    """Class-like symbols by simple name, and what each file can name unqualified."""
+
+    def __init__(self, nodes: Iterable[Node], inspector: SourceInspector) -> None:
+        self._inspector = inspector
+        self._by_name: dict[str, list[Node]] = defaultdict(list)
+        self._containers_by_file: dict[str, list[Node]] = defaultdict(list)
+        self._namespace_cache: dict[str, tuple[tuple[str, ...], tuple[tuple[str, int, int], ...]]] = {}
+        self._import_cache: dict[str, dict[str, ImportBinding]] = {}
+        for node in nodes:
+            if node.is_class():
+                self._by_name[simple_type_name(node.fully_qualified_name)].append(node)
+            if node.is_class() or node.is_callable():
+                self._containers_by_file[node.file_path].append(node)
+        for containers in self._containers_by_file.values():
+            containers.sort(key=lambda node: (node.line_start, -(node.line_end - node.line_start)))
+
+    def has_candidates(self, name: str) -> bool:
+        """Whether any indexed type has this simple name (unresolved vs. undecidable, for stats)."""
+        return bool(self._by_name.get(name))
+
+    def container_at(self, file_path: str, line: int) -> Node | None:
+        """The innermost callable or type declared around ``line``."""
+        best: Node | None = None
+        for node in self._containers_by_file.get(file_path, ()):
+            if node.line_start > line:
+                break
+            if node.line_end >= line and (
+                best is None or node.line_end - node.line_start <= best.line_end - best.line_start
+            ):
+                best = node
+        return best
+
+    def resolve(self, site: TypeReferenceSite) -> Node | None:
+        """The declaration ``site`` names, or ``None`` when unknown or not decidable."""
+        if site.file.lower().endswith(_SCRIPT_MODULE_SUFFIXES):
+            return self._resolve_script(site)
+        return self._resolve_csharp(site)
+
+    def _resolve_csharp(self, site: TypeReferenceSite) -> Node | None:
+        candidates = self._by_name.get(site.name, [])
+        if site.qualifier:
+            candidates = [node for node in candidates if self._namespace_of(node).endswith(site.qualifier)]
+        if len(candidates) <= 1:
+            return candidates[0] if candidates else None
+        visible = self._visible_namespaces(site.file, site.line)
+        narrowed = [node for node in candidates if self._namespace_of(node) in visible]
+        if len(narrowed) == 1:
+            return narrowed[0]
+        return _closest(narrowed or candidates, site.file)
+
+    def _resolve_script(self, site: TypeReferenceSite) -> Node | None:
+        bindings = self._imports_of(site.file)
+        binding = bindings.get(site.qualifier or site.name)
+        if binding is None:
+            candidates = self._by_name.get(site.name, [])
+            same_file = [node for node in candidates if node.file_path == site.file]
+            if len(same_file) == 1:
+                return same_file[0]
+            return candidates[0] if len(candidates) == 1 else None
+        if not binding.source.startswith("."):
+            return None
+        wanted = site.name if binding.imported_name in (_NAMESPACE_IMPORT, "default") else binding.imported_name
+        module = os.path.normpath(os.path.join(os.path.dirname(site.file), binding.source))
+        candidates = [
+            node
+            for node in self._by_name.get(wanted, [])
+            if node.file_path.startswith(module + ".") or node.file_path.startswith(module + os.sep)
+        ]
+        return candidates[0] if len(candidates) == 1 else None
+
+    def _namespace_of(self, node: Node) -> str:
+        _, namespaces = self._namespace_context(node.file_path)
+        return _innermost_namespace(namespaces, node.line_start)
+
+    def _visible_namespaces(self, file_path: str, line: int) -> set[str]:
+        usings, namespaces = self._namespace_context(file_path)
+        visible = {"", *usings}
+        enclosing = _innermost_namespace(namespaces, line)
+        parts = enclosing.split(".") if enclosing else []
+        visible.update(".".join(parts[:count]) for count in range(1, len(parts) + 1))
+        return visible
+
+    def _namespace_context(self, file_path: str) -> tuple[tuple[str, ...], tuple[tuple[str, int, int], ...]]:
+        cached = self._namespace_cache.get(file_path)
+        if cached is None:
+            context = self._inspector.find_namespace_context(Path(file_path))
+            cached = self._namespace_cache[file_path] = (context.usings, context.namespaces)
+        return cached
+
+    def _imports_of(self, file_path: str) -> dict[str, ImportBinding]:
+        cached = self._import_cache.get(file_path)
+        if cached is None:
+            cached = self._import_cache[file_path] = self._inspector.find_import_bindings(Path(file_path))
+        return cached
+
+
+def simple_type_name(qualified_name: str) -> str:
+    """``Foo`` for ``a.b.Foo<T>``."""
+    return qualified_name.rsplit(".", 1)[-1].split("<", 1)[0]
+
+
+def build_type_references(
+    inspector: SourceInspector, index: TypeIndex, source_files: Iterable[Path], stats: TypeReferenceStats
+) -> list[tuple[str, str]]:
+    """``(source, target)`` qualified-name pairs for every resolvable type mention in ``source_files``."""
+    pairs: dict[tuple[str, str], None] = {}
+    for file_path in source_files:
+        for site in inspector.find_type_reference_sites(file_path):
+            stats.sites += 1
+            container = index.container_at(site.file, site.line)
+            if container is None:
+                continue
+            target = index.resolve(site)
+            if target is None:
+                if index.has_candidates(site.name):
+                    stats.ambiguous += 1
+                else:
+                    stats.unresolved += 1
+                    stats.unresolved_names[site.name] += 1
+                continue
+            stats.resolved += 1
+            if is_self_or_container_edge(container.fully_qualified_name, target.fully_qualified_name):
+                continue
+            pairs.setdefault((container.fully_qualified_name, target.fully_qualified_name), None)
+    return list(pairs)
+
+
+def complete_type_references(
+    graph: CallGraph, source_files: Iterable[Path], inspector: SourceInspector
+) -> TypeReferenceStats:
+    """Replace the graph's TYPEREF edges with what its source files name today."""
+    graph.reference_edges = [ref for ref in graph.reference_edges if ref.kind is not EdgeKind.TYPEREF]
+    stats = TypeReferenceStats()
+    index = TypeIndex(graph.nodes.values(), inspector)
+    for source, target in build_type_references(inspector, index, source_files, stats):
+        graph.add_reference_edge(ReferenceEdge(source, target, EdgeKind.TYPEREF))
+    stats.edges = sum(1 for ref in graph.reference_edges if ref.kind is EdgeKind.TYPEREF)
+    return stats
+
+
+def _innermost_namespace(namespaces: Iterable[tuple[str, int, int]], line: int) -> str:
+    best = ""
+    best_span = -1
+    for name, start, end in namespaces:
+        if start <= line <= end and (best_span < 0 or end - start <= best_span):
+            best, best_span = name, end - start
+    return best
+
+
+def _closest(candidates: list[Node], file_path: str) -> Node | None:
+    """The unique candidate declared in the same file, else the one sharing the longest directory path."""
+    same_file = [node for node in candidates if node.file_path == file_path]
+    if len(same_file) == 1:
+        return same_file[0]
+    ranked = sorted(candidates, key=lambda node: -_common_prefix(node.file_path, file_path))
+    if len(ranked) > 1 and _common_prefix(ranked[0].file_path, file_path) == _common_prefix(
+        ranked[1].file_path, file_path
+    ):
+        return None
+    return ranked[0]
+
+
+def _common_prefix(left: str, right: str) -> int:
+    try:
+        return len(os.path.commonpath([left, right]))
+    except ValueError:  # one absolute, one relative: nothing in common
+        return 0

--- a/static_analyzer/engine/type_reference_builder.py
+++ b/static_analyzer/engine/type_reference_builder.py
@@ -10,20 +10,22 @@ from __future__ import annotations
 import logging
 import os
 from collections import defaultdict
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from static_analyzer.cfg import CallGraph, EdgeKind, ReferenceEdge
-from static_analyzer.engine.models import ImportBinding, NamespaceContext, TypeReferenceSite, UsingDirective
+from static_analyzer.cfg import CallGraph, CallSiteLocation, EdgeKind, ReferenceEdge
+from static_analyzer.engine.models import DEFAULT_EXPORT_NAME, ImportDirective, NameScope, TypeReferenceSite
 from static_analyzer.engine.source_inspector import SourceInspector, simple_type_name, split_type_name
 from static_analyzer.internal_references import is_self_or_container_edge
 from static_analyzer.node import Node
 
 logger = logging.getLogger(__name__)
 
-_NAMESPACE_IMPORT = "*"
 _SCRIPT_MODULE_SUFFIXES = (".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs")
+# What marks the root of a compilation, by source suffix: a ``global using`` governs every
+# file under it. Languages without an entry have no compilation-wide directive.
+_COMPILATION_MARKERS = {".cs": "*.csproj"}
 
 
 @dataclass
@@ -34,23 +36,41 @@ class TypeReferenceStats:
     ambiguous: int = 0
     edges: int = 0
     unresolved_names: dict[str, int] = field(default_factory=lambda: defaultdict(int))
+    # Listed source files the pass could not read: their references are missing from the graph.
+    unreadable_files: list[str] = field(default_factory=list)
 
     def summary(self) -> str:
-        return (
+        text = (
             f"{self.sites} sites -> {self.edges} edges "
             f"({self.resolved} resolved, {self.unresolved} unknown, {self.ambiguous} ambiguous)"
         )
+        if self.unreadable_files:
+            text += f", {len(self.unreadable_files)} unreadable file(s)"
+        return text
 
 
 class TypeIndex:
-    """Class-like symbols by simple name, and what each file can name unqualified."""
+    """Class-like symbols by simple name, and what each file can name where.
+
+    A written name is matched against *containers*: the dotted path source writes to reach a
+    declaration. In C# that is the declared namespace and the types enclosing it, read from the
+    file; in TS/JS it is the module, which is the file's own path. The graph's qualified names
+    stay path-based in every language; a container only decides what a written name means.
+    """
 
     def __init__(self, nodes: Iterable[Node], inspector: SourceInspector) -> None:
         self._inspector = inspector
         self._by_name: dict[str, list[Node]] = defaultdict(list)
         self._containers_by_file: dict[str, list[Node]] = defaultdict(list)
-        self._namespace_cache: dict[str, NamespaceContext] = {}
-        self._import_cache: dict[str, dict[str, ImportBinding]] = {}
+        self._scope_cache: dict[str, NameScope] = {}
+        self._container_cache: dict[str, str] = {}
+        # Every container an indexed type sits in, with its prefixes: what a relative using can name.
+        self._known_containers: set[str] = set()
+        # ``global using`` directives by the compilation that declared them.
+        self._compilation_imports: dict[str, list[ImportDirective]] = defaultdict(list)
+        self._compilation_cache: dict[str, str] = {}
+        # What each TS/JS module exports as ``default``, by module stem.
+        self._default_export_by_module: dict[str, str] = {}
         for node in nodes:
             if node.is_class():
                 self._by_name[simple_type_name(node.fully_qualified_name)].append(node)
@@ -75,102 +95,236 @@ class TypeIndex:
                 best = node
         return best
 
+    def container_of(self, node: Node) -> str:
+        """The path source writes to reach ``node``: namespace and enclosing types in C#, the module in TS/JS."""
+        cached = self._container_cache.get(node.fully_qualified_name)
+        if cached is None:
+            if _is_script(node.file_path):
+                cached = _module_stem(node.file_path)
+            else:
+                enclosing = self._enclosing_types(node.file_path, node.line_start, node.line_end, node)
+                names = [simple_type_name(outer.fully_qualified_name) for outer in enclosing]
+                cached = ".".join(
+                    part for part in (self._namespace_at(node.file_path, node.line_start), *names) if part
+                )
+            self._container_cache[node.fully_qualified_name] = cached
+        return cached
+
+    def scope_of(self, file_path: str) -> NameScope:
+        """The file's name scope, read once, registering what other files can see of it.
+
+        Why other files: a ``global using`` governs every file of its compilation and a module's
+        ``export default`` names what an importer's default binding means, so every file's scope
+        is read before any site is resolved (``build_type_references``).
+        """
+        cached = self._scope_cache.get(file_path)
+        if cached is not None:
+            return cached
+        scope = self._scope_cache[file_path] = self._inspector.find_name_scope(Path(file_path))
+        compilation_wide = [directive for directive in scope.imports if directive.compilation_wide]
+        if compilation_wide:
+            self._compilation_imports[self._compilation_root(file_path)].extend(compilation_wide)
+        if scope.default_export:
+            self._default_export_by_module[_module_stem(file_path)] = scope.default_export
+        for node in self._containers_by_file.get(file_path, ()):
+            if node.is_class():
+                self._known_containers.update(_prefixes(self.container_of(node)))
+        return scope
+
     def resolve(self, site: TypeReferenceSite) -> Node | None:
         """The declaration ``site`` names, or ``None`` when unknown or not decidable."""
-        if site.file.lower().endswith(_SCRIPT_MODULE_SUFFIXES):
+        if _is_script(site.file_path):
             return self._resolve_script(site)
         return self._resolve_csharp(site)
 
     def _resolve_csharp(self, site: TypeReferenceSite) -> Node | None:
+        """C# lookup: an alias in scope decides outright; otherwise the scopes around the site, inward out.
+
+        A name unique in the graph resolves from anywhere: the graph holds only the repository's
+        own types, so an import it cannot see (implicit usings, a package) is the usual reason a
+        name is not in scope, not a sign that it means something else.
+        """
         written = f"{site.qualifier}.{site.name}" if site.qualifier else site.name
-        alias_target = _expand_alias(written, self._usings_at(site.file, site.line))
-        if alias_target:
-            # C# 7.8: an alias in scope decides the name outright. It never competes with a
-            # namespace import, so a miss means the target is outside the graph, not ambiguous.
-            bound = self._by_qualifier(alias_target)
-            return _closest(bound, site.file) if bound else None
-        candidates = self._by_qualifier(written)
+        head, _, rest = written.partition(".")
+        alias = self._binding_at(site.file_path, site.line, head)
+        if alias is not None:
+            # C# 7.8: the alias decides the leftmost segment (``using Io = System.IO;`` makes
+            # ``Io.File`` ``System.IO.File``) and never competes with a namespace import, so a
+            # miss means the target is outside the graph, not that it is ambiguous.
+            full = ".".join(part for part in (alias.container, alias.name, rest) if part)
+            bound = self._in_container(*split_type_name(full))
+            return _closest(bound, site.file_path) if bound else None
+        candidates = self._in_container(site.qualifier, site.name)
         if len(candidates) <= 1:
             return candidates[0] if candidates else None
-        visible = self._visible_namespaces(site.file, site.line)
-        narrowed = [node for node in candidates if self._namespace_of(node) in visible]
-        if len(narrowed) == 1:
-            return narrowed[0]
-        return _closest(narrowed or candidates, site.file)
+        # What the site did not write must be reachable from where it stands: the first scope,
+        # inward out, that holds any candidate's unwritten prefix decides.
+        for scope in self._lookup_scopes(site.file_path, site.line):
+            found = [node for node in candidates if _unwritten_prefix(self.container_of(node), site.qualifier) in scope]
+            if found:
+                return found[0] if len(found) == 1 else _closest(found, site.file_path)
+        return _closest(candidates, site.file_path)
 
     def _resolve_script(self, site: TypeReferenceSite) -> Node | None:
-        bindings = self._imports_of(site.file)
-        binding = bindings.get(site.qualifier or site.name)
+        """TS/JS lookup: an import decides the module, else the name must be unique in the file or the graph."""
+        binding = self._binding_at(site.file_path, site.line, site.qualifier or site.name)
         if binding is None:
             candidates = self._by_name.get(site.name, [])
-            same_file = [node for node in candidates if node.file_path == site.file]
-            if len(same_file) == 1:
-                return same_file[0]
+            own = _module_stem(site.file_path)
+            same_module = [node for node in candidates if self.container_of(node) == own]
+            if len(same_module) == 1:
+                return same_module[0]
             return candidates[0] if len(candidates) == 1 else None
-        if not binding.source.startswith("."):
-            return None
-        wanted = site.name if binding.imported_name in (_NAMESPACE_IMPORT, "default") else binding.imported_name
-        module = _module_stem(os.path.normpath(os.path.join(os.path.dirname(site.file), binding.source)))
+        if not binding.container.startswith("."):
+            return None  # a package import is external, even when a repo class shares the name
+        module = _module_stem(os.path.normpath(os.path.join(os.path.dirname(site.file_path), binding.container)))
+        if binding.name == DEFAULT_EXPORT_NAME:
+            # The module says what its default is; an importer may bind it under any name.
+            wanted = self._default_export_by_module.get(module, site.name)
+        else:
+            # A namespace import (``NS.Thing``) names the member written after it.
+            wanted = binding.name or site.name
         candidates = [
             node
             for node in self._by_name.get(wanted, [])
-            if _module_stem(node.file_path) == module or node.file_path.startswith(module + os.sep)
+            if self.container_of(node) == module or node.file_path.startswith(module + os.sep)
         ]
         return candidates[0] if len(candidates) == 1 else None
 
-    def _by_qualifier(self, written: str) -> list[Node]:
-        """Indexed types whose declared namespace matches the dotted prefix written before the name."""
-        qualifier, name = split_type_name(written)
+    def _in_container(self, qualifier: str, name: str) -> list[Node]:
+        """Indexed types of this simple name whose container is, or ends in, the written qualifier.
+
+        Why a suffix: a name written from inside an ancestor namespace is only partially qualified
+        (``Domain.Order`` in ``namespace Lib`` against ``Lib.Domain.Order``). Segment-bounded, so
+        ``Domain`` never matches ``FooDomain``.
+        """
         candidates = self._by_name.get(name, [])
         if not qualifier:
             return candidates
-        # ``endswith``, not equality: a name written from inside an ancestor namespace is only
-        # partially qualified (``Domain.Order`` in ``namespace Lib`` against ``Lib.Domain.Order``).
-        return [node for node in candidates if self._namespace_of(node).endswith(qualifier)]
+        return [node for node in candidates if _container_matches(self.container_of(node), qualifier)]
 
-    def _namespace_of(self, node: Node) -> str:
-        return _innermost_namespace(self._namespace_context(node.file_path).namespaces, node.line_start)
+    def _binding_at(self, file_path: str, line: int, local_name: str) -> ImportDirective | None:
+        """The import in force at ``line`` that binds ``local_name``, the compilation's global ones included."""
+        for directive in self._imports_in_force(file_path, line):
+            if directive.local_name == local_name:
+                return directive
+        return None
 
-    def _usings_at(self, file_path: str, line: int) -> list[UsingDirective]:
-        """The directives in force at ``line``: the file's, plus the enclosing namespace block's."""
-        return [
+    def _lookup_scopes(self, file_path: str, line: int) -> Iterator[set[str]]:
+        """The containers a simple name at ``line`` is looked up in, in C#'s order.
+
+        The types enclosing the site, innermost first, each for what it nests. Then every
+        namespace enclosing the site, innermost first, and the global namespace last: what
+        the namespace itself holds, then what the usings written in that namespace's own
+        declaration open. Compilation-unit usings, the ``global`` ones included, belong to
+        the global namespace. Why the order matters: a using written after a file-scoped
+        namespace beats a project-wide one that brings a second type of the same name.
+        """
+        namespace = self._namespace_at(file_path, line)
+        own = self._container_path_at(file_path, line)
+        while own != namespace:
+            yield {own}
+            own = own.rpartition(".")[0]
+        in_force = self._imports_in_force(file_path, line)
+        for level in [*sorted(_prefixes(namespace), key=len, reverse=True), ""]:
+            yield {level}
+            opened = {
+                self._opened_container(directive, file_path)
+                for directive in in_force
+                if not directive.local_name and self._declared_in(directive, file_path) == level
+            }
+            if opened:
+                yield opened
+
+    def _declared_in(self, directive: ImportDirective, file_path: str) -> str:
+        """The namespace a using is written in; a ``global using`` precedes every namespace."""
+        return "" if directive.compilation_wide else self._namespace_at(file_path, directive.first_line)
+
+    def _imports_in_force(self, file_path: str, line: int) -> list[ImportDirective]:
+        own = [
             directive
-            for directive in self._namespace_context(file_path).usings
+            for directive in self.scope_of(file_path).imports
             if directive.first_line <= line <= directive.last_line
         ]
+        compilation = self._compilation_imports.get(self._compilation_root(file_path), [])
+        return own + [directive for directive in compilation if directive not in own]
 
-    def _visible_namespaces(self, file_path: str, line: int) -> set[str]:
-        visible = {""}
-        # Only a plain ``using N;`` makes a namespace nameable: an alias binds one name, and
-        # ``using static N.T`` brings in T's members rather than T itself.
-        visible.update(d.target for d in self._usings_at(file_path, line) if not d.alias and not d.static)
-        enclosing = _innermost_namespace(self._namespace_context(file_path).namespaces, line)
-        parts = enclosing.split(".") if enclosing else []
-        visible.update(".".join(parts[:count]) for count in range(1, len(parts) + 1))
-        return visible
+    def _opened_container(self, directive: ImportDirective, file_path: str) -> str:
+        """The container a plain using names, resolved from the namespace it is written in outward.
 
-    def _namespace_context(self, file_path: str) -> NamespaceContext:
-        cached = self._namespace_cache.get(file_path)
-        if cached is None:
-            cached = self._namespace_cache[file_path] = self._inspector.find_namespace_context(Path(file_path))
-        return cached
+        Why: inside ``namespace Root``, ``using Models;`` means ``Root.Models`` when that exists.
+        """
+        enclosing = self._declared_in(directive, file_path)
+        for prefix in sorted(_prefixes(enclosing), key=len, reverse=True):
+            candidate = f"{prefix}.{directive.container}"
+            if candidate in self._known_containers:
+                return candidate
+        return directive.container
 
-    def _imports_of(self, file_path: str) -> dict[str, ImportBinding]:
-        cached = self._import_cache.get(file_path)
-        if cached is None:
-            cached = self._import_cache[file_path] = self._inspector.find_import_bindings(Path(file_path))
-        return cached
+    def _container_path_at(self, file_path: str, line: int) -> str:
+        """The container a site at ``line`` is written in: its namespace, then the types around it."""
+        names = [simple_type_name(node.fully_qualified_name) for node in self._enclosing_types(file_path, line, line)]
+        return ".".join(part for part in (self._namespace_at(file_path, line), *names) if part)
+
+    def _enclosing_types(
+        self, file_path: str, first_line: int, last_line: int, exclude: Node | None = None
+    ) -> list[Node]:
+        """The class-like declarations whose range holds the lines, outermost first."""
+        found: list[Node] = []
+        for node in self._containers_by_file.get(file_path, ()):
+            if node.line_start > first_line:
+                break
+            if node is not exclude and node.is_class() and node.line_end >= last_line:
+                found.append(node)
+        return found
+
+    def _namespace_at(self, file_path: str, line: int) -> str:
+        return _innermost_namespace(self.scope_of(file_path).namespaces, line)
+
+    def _compilation_root(self, file_path: str) -> str:
+        """The nearest directory above the file holding a project file, else empty: one compilation."""
+        marker = _COMPILATION_MARKERS.get(os.path.splitext(file_path)[1].lower())
+        if marker is None:
+            return ""
+        directory = os.path.dirname(file_path)
+        visited: list[str] = []
+        root = ""
+        while directory not in self._compilation_cache:
+            visited.append(directory)
+            if next(Path(directory).glob(marker), None) is not None:
+                root = directory
+                break
+            parent = os.path.dirname(directory)
+            if parent == directory:
+                break
+            directory = parent
+        else:
+            root = self._compilation_cache[directory]
+        for seen in visited:
+            self._compilation_cache[seen] = root
+        return root
 
 
 def build_type_references(
     inspector: SourceInspector, index: TypeIndex, source_files: Iterable[Path], stats: TypeReferenceStats
-) -> list[tuple[str, str]]:
-    """``(source, target)`` qualified-name pairs for every resolvable type mention in ``source_files``."""
-    pairs: dict[tuple[str, str], None] = {}
+) -> list[ReferenceEdge]:
+    """A TYPEREF edge for every resolvable type mention in ``source_files``, with the sites that made it."""
+    # Every file is read before any site is resolved: a ``global using`` in one file governs
+    # its siblings, and a module's ``export default`` names what an importer binds.
+    scanned: list[list[TypeReferenceSite]] = []
     for file_path in source_files:
-        for site in inspector.find_type_reference_sites(file_path):
+        sites = inspector.find_type_reference_sites(file_path)
+        if sites is None:
+            stats.unreadable_files.append(str(file_path))
+            continue
+        index.scope_of(str(file_path))
+        scanned.append(sites)
+
+    sites_by_pair: dict[tuple[str, str], list[CallSiteLocation]] = {}
+    for sites in scanned:
+        for site in sites:
             stats.sites += 1
-            container = index.container_at(site.file, site.line)
+            container = index.container_at(site.file_path, site.line)
             if container is None:
                 continue
             target = index.resolve(site)
@@ -184,8 +338,13 @@ def build_type_references(
             stats.resolved += 1
             if is_self_or_container_edge(container.fully_qualified_name, target.fully_qualified_name):
                 continue
-            pairs.setdefault((container.fully_qualified_name, target.fully_qualified_name), None)
-    return list(pairs)
+            pair = (container.fully_qualified_name, target.fully_qualified_name)
+            # The site is in the source's own file, so its position is all the edge needs.
+            sites_by_pair.setdefault(pair, []).append(CallSiteLocation(line=site.line, column=site.column))
+    return [
+        ReferenceEdge(source, target, EdgeKind.TYPEREF, tuple(sites))
+        for (source, target), sites in sites_by_pair.items()
+    ]
 
 
 def complete_type_references(
@@ -195,23 +354,34 @@ def complete_type_references(
     graph.reference_edges = [ref for ref in graph.reference_edges if ref.kind is not EdgeKind.TYPEREF]
     stats = TypeReferenceStats()
     index = TypeIndex(graph.nodes.values(), inspector)
-    for source, target in build_type_references(inspector, index, source_files, stats):
-        graph.add_reference_edge(ReferenceEdge(source, target, EdgeKind.TYPEREF))
+    # A base written in a base list is the inheritance the graph already records, not a second edge.
+    inherited = {(ref.src, ref.dst) for ref in graph.reference_edges if ref.kind is EdgeKind.INHERITS}
+    for edge in build_type_references(inspector, index, source_files, stats):
+        if (edge.src, edge.dst) not in inherited:
+            graph.add_reference_edge(edge)
     stats.edges = sum(1 for ref in graph.reference_edges if ref.kind is EdgeKind.TYPEREF)
     return stats
 
 
-def _expand_alias(written: str, directives: Iterable[UsingDirective]) -> str:
-    """What an alias in scope binds the leftmost segment to, else empty.
+def _is_script(file_path: str) -> bool:
+    return file_path.lower().endswith(_SCRIPT_MODULE_SUFFIXES)
 
-    Why the leftmost only: C# looks the alias up for the first identifier of a name, which is
-    what makes ``using Io = System.IO;`` resolve ``Io.File``.
-    """
-    head, _, rest = written.partition(".")
-    for directive in directives:
-        if directive.alias == head:
-            return ".".join(part for part in (directive.target, rest) if part)
-    return ""
+
+def _prefixes(container: str) -> set[str]:
+    """``A.B.C`` -> ``{A, A.B, A.B.C}``; empty for the global namespace."""
+    segments = container.split(".") if container else []
+    return {".".join(segments[:count]) for count in range(1, len(segments) + 1)}
+
+
+def _container_matches(container: str, qualifier: str) -> bool:
+    return container == qualifier or container.endswith("." + qualifier)
+
+
+def _unwritten_prefix(container: str, qualifier: str) -> str:
+    """What a site left unwritten of a candidate's container: ``Lib`` for ``Lib.Domain`` written as ``Domain``."""
+    if not qualifier:
+        return container
+    return "" if container == qualifier else container[: -len(qualifier) - 1]
 
 
 def _module_stem(path: str) -> str:

--- a/static_analyzer/engine/type_reference_builder.py
+++ b/static_analyzer/engine/type_reference_builder.py
@@ -154,7 +154,7 @@ class TypeIndex:
             full = ".".join(part for part in (alias.container, alias.name, rest) if part)
             bound = self._in_container(*split_type_name(full))
             return _closest(bound, site.file_path) if bound else None
-        candidates = self._in_container(site.qualifier, site.name)
+        candidates = [node for node in self._in_container(site.qualifier, site.name) if self._is_nameable(node, site)]
         if len(candidates) <= 1:
             return candidates[0] if candidates else None
         # What the site did not write must be reachable from where it stands: the first scope,
@@ -202,6 +202,20 @@ class TypeIndex:
         if not qualifier:
             return candidates
         return [node for node in candidates if _container_matches(self.container_of(node), qualifier)]
+
+    def _is_nameable(self, node: Node, site: TypeReferenceSite) -> bool:
+        """Whether the name ``site`` wrote can mean ``node`` from where it stands.
+
+        Only a type nested in another type is asked. A namespace can be opened by an import
+        this layer cannot see, so a top-level type answers from anywhere; a nested type is
+        named unqualified only inside its enclosing type or under ``using static``, and
+        without the rule a repository's ``TranslateCommand.Options.File`` answers every
+        ``File`` in the project.
+        """
+        unwritten = _unwritten_prefix(self.container_of(node), site.qualifier)
+        if unwritten == self._namespace_at(node.file_path, node.line_start):
+            return True
+        return any(unwritten in scope for scope in self._lookup_scopes(site.file_path, site.line))
 
     def _binding_at(self, file_path: str, line: int, local_name: str) -> ImportDirective | None:
         """The import in force at ``line`` that binds ``local_name``, the compilation's global ones included."""

--- a/static_analyzer/engine/type_reference_builder.py
+++ b/static_analyzer/engine/type_reference_builder.py
@@ -15,8 +15,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from static_analyzer.cfg import CallGraph, EdgeKind, ReferenceEdge
-from static_analyzer.engine.models import ImportBinding, TypeReferenceSite
-from static_analyzer.engine.source_inspector import SourceInspector
+from static_analyzer.engine.models import ImportBinding, NamespaceContext, TypeReferenceSite, UsingDirective
+from static_analyzer.engine.source_inspector import SourceInspector, simple_type_name, split_type_name
 from static_analyzer.internal_references import is_self_or_container_edge
 from static_analyzer.node import Node
 
@@ -49,7 +49,7 @@ class TypeIndex:
         self._inspector = inspector
         self._by_name: dict[str, list[Node]] = defaultdict(list)
         self._containers_by_file: dict[str, list[Node]] = defaultdict(list)
-        self._namespace_cache: dict[str, tuple[tuple[str, ...], tuple[tuple[str, int, int], ...]]] = {}
+        self._namespace_cache: dict[str, NamespaceContext] = {}
         self._import_cache: dict[str, dict[str, ImportBinding]] = {}
         for node in nodes:
             if node.is_class():
@@ -82,9 +82,14 @@ class TypeIndex:
         return self._resolve_csharp(site)
 
     def _resolve_csharp(self, site: TypeReferenceSite) -> Node | None:
-        candidates = self._by_name.get(site.name, [])
-        if site.qualifier:
-            candidates = [node for node in candidates if self._namespace_of(node).endswith(site.qualifier)]
+        written = f"{site.qualifier}.{site.name}" if site.qualifier else site.name
+        alias_target = _expand_alias(written, self._usings_at(site.file, site.line))
+        if alias_target:
+            # C# 7.8: an alias in scope decides the name outright. It never competes with a
+            # namespace import, so a miss means the target is outside the graph, not ambiguous.
+            bound = self._by_qualifier(alias_target)
+            return _closest(bound, site.file) if bound else None
+        candidates = self._by_qualifier(written)
         if len(candidates) <= 1:
             return candidates[0] if candidates else None
         visible = self._visible_namespaces(site.file, site.line)
@@ -105,31 +110,49 @@ class TypeIndex:
         if not binding.source.startswith("."):
             return None
         wanted = site.name if binding.imported_name in (_NAMESPACE_IMPORT, "default") else binding.imported_name
-        module = os.path.normpath(os.path.join(os.path.dirname(site.file), binding.source))
+        module = _module_stem(os.path.normpath(os.path.join(os.path.dirname(site.file), binding.source)))
         candidates = [
             node
             for node in self._by_name.get(wanted, [])
-            if node.file_path.startswith(module + ".") or node.file_path.startswith(module + os.sep)
+            if _module_stem(node.file_path) == module or node.file_path.startswith(module + os.sep)
         ]
         return candidates[0] if len(candidates) == 1 else None
 
+    def _by_qualifier(self, written: str) -> list[Node]:
+        """Indexed types whose declared namespace matches the dotted prefix written before the name."""
+        qualifier, name = split_type_name(written)
+        candidates = self._by_name.get(name, [])
+        if not qualifier:
+            return candidates
+        # ``endswith``, not equality: a name written from inside an ancestor namespace is only
+        # partially qualified (``Domain.Order`` in ``namespace Lib`` against ``Lib.Domain.Order``).
+        return [node for node in candidates if self._namespace_of(node).endswith(qualifier)]
+
     def _namespace_of(self, node: Node) -> str:
-        _, namespaces = self._namespace_context(node.file_path)
-        return _innermost_namespace(namespaces, node.line_start)
+        return _innermost_namespace(self._namespace_context(node.file_path).namespaces, node.line_start)
+
+    def _usings_at(self, file_path: str, line: int) -> list[UsingDirective]:
+        """The directives in force at ``line``: the file's, plus the enclosing namespace block's."""
+        return [
+            directive
+            for directive in self._namespace_context(file_path).usings
+            if directive.first_line <= line <= directive.last_line
+        ]
 
     def _visible_namespaces(self, file_path: str, line: int) -> set[str]:
-        usings, namespaces = self._namespace_context(file_path)
-        visible = {"", *usings}
-        enclosing = _innermost_namespace(namespaces, line)
+        visible = {""}
+        # Only a plain ``using N;`` makes a namespace nameable: an alias binds one name, and
+        # ``using static N.T`` brings in T's members rather than T itself.
+        visible.update(d.target for d in self._usings_at(file_path, line) if not d.alias and not d.static)
+        enclosing = _innermost_namespace(self._namespace_context(file_path).namespaces, line)
         parts = enclosing.split(".") if enclosing else []
         visible.update(".".join(parts[:count]) for count in range(1, len(parts) + 1))
         return visible
 
-    def _namespace_context(self, file_path: str) -> tuple[tuple[str, ...], tuple[tuple[str, int, int], ...]]:
+    def _namespace_context(self, file_path: str) -> NamespaceContext:
         cached = self._namespace_cache.get(file_path)
         if cached is None:
-            context = self._inspector.find_namespace_context(Path(file_path))
-            cached = self._namespace_cache[file_path] = (context.usings, context.namespaces)
+            cached = self._namespace_cache[file_path] = self._inspector.find_namespace_context(Path(file_path))
         return cached
 
     def _imports_of(self, file_path: str) -> dict[str, ImportBinding]:
@@ -137,11 +160,6 @@ class TypeIndex:
         if cached is None:
             cached = self._import_cache[file_path] = self._inspector.find_import_bindings(Path(file_path))
         return cached
-
-
-def simple_type_name(qualified_name: str) -> str:
-    """``Foo`` for ``a.b.Foo<T>``."""
-    return qualified_name.rsplit(".", 1)[-1].split("<", 1)[0]
 
 
 def build_type_references(
@@ -181,6 +199,31 @@ def complete_type_references(
         graph.add_reference_edge(ReferenceEdge(source, target, EdgeKind.TYPEREF))
     stats.edges = sum(1 for ref in graph.reference_edges if ref.kind is EdgeKind.TYPEREF)
     return stats
+
+
+def _expand_alias(written: str, directives: Iterable[UsingDirective]) -> str:
+    """What an alias in scope binds the leftmost segment to, else empty.
+
+    Why the leftmost only: C# looks the alias up for the first identifier of a name, which is
+    what makes ``using Io = System.IO;`` resolve ``Io.File``.
+    """
+    head, _, rest = written.partition(".")
+    for directive in directives:
+        if directive.alias == head:
+            return ".".join(part for part in (directive.target, rest) if part)
+    return ""
+
+
+def _module_stem(path: str) -> str:
+    """The module a path names: no script extension, no trailing ``/index``.
+
+    Why: a specifier and the file it resolves to spell the same module differently
+    (``./svc.js`` -> ``svc.ts``, ``./lib/index.js`` -> ``lib/``), so both sides normalise.
+    """
+    root, suffix = os.path.splitext(path)
+    stem = root if suffix.lower() in _SCRIPT_MODULE_SUFFIXES else path
+    parent, name = os.path.split(stem)
+    return parent if name == "index" and parent else stem
 
 
 def _innermost_namespace(namespaces: Iterable[tuple[str, int, int]], line: int) -> str:

--- a/tests/agents/test_llm_renderers.py
+++ b/tests/agents/test_llm_renderers.py
@@ -114,7 +114,7 @@ class TestRenderScopeContext(unittest.TestCase):
         graph.add_node(Node("client.Payload", NodeType.CLASS, "/repo/payload.py", 1, 8))
         graph.add_node(Node("server.receive", NodeType.FUNCTION, "/repo/server.py", 30, 40))
         graph.add_edge("client.submit", "server.receive")
-        graph.add_reference_edge(ReferenceEdge("client.Payload", "server.receive", EdgeKind.TYPEREF))
+        graph.add_reference_edge(ReferenceEdge("client.Payload", "server.receive", EdgeKind.INHERITS))
         scope = ClusterScopeResult(
             scope_id="root",
             graphs_by_language={"python": graph},
@@ -191,6 +191,7 @@ class TestRenderScopeContext(unittest.TestCase):
                 "source_group_id": "1",
                 "target_group_id": "2",
                 "calls": 1,
+                "type_references": 0,
                 "examples": [
                     {
                         "source": "client.submit",
@@ -203,6 +204,45 @@ class TestRenderScopeContext(unittest.TestCase):
         )
         self.assertEqual(payload["enclosing_components"], [])
         self.assertEqual(payload["existing_relations"][0]["relation"], "submits to")
+
+    def test_a_pair_counts_calls_and_type_references_apart_and_shows_calls_first(self):
+        graph = CallGraph(language="csharp")
+        graph.add_node(Node("a.Cls", NodeType.CLASS, "/repo/a.cs", 1, 9))
+        graph.add_node(Node("a.Cls.run()", NodeType.METHOD, "/repo/a.cs", 2, 3))
+        graph.add_node(Node("b.Cls", NodeType.CLASS, "/repo/b.cs", 1, 9))
+        graph.add_node(Node("b.Cls.go()", NodeType.METHOD, "/repo/b.cs", 2, 3))
+        scope = ClusterScopeResult(
+            scope_id="root",
+            graphs_by_language={"csharp": graph},
+            groups=[
+                ClusterGroup("1", [1], symbol_members_by_language={"csharp": {"a.Cls", "a.Cls.run()"}}),
+                ClusterGroup("2", [2], symbol_members_by_language={"csharp": {"b.Cls", "b.Cls.go()"}}),
+            ],
+            connections=[
+                GroupConnection(
+                    "1",
+                    "2",
+                    edges=[
+                        ClusterConnectionEdge("csharp", "a.Cls", "b.Cls", kind="typeref"),
+                        ClusterConnectionEdge("csharp", "a.Cls.run()", "b.Cls.go()"),
+                    ],
+                )
+            ],
+        )
+        analysis = AnalysisInsights(description="", components=[], components_relations=[])
+
+        payload = json.loads(
+            render_scope_context(scope, analysis, Path("/repo"), {"1", "2"}, set(), set(), incremental=False)
+        )
+
+        (pair,) = payload["known_connections"]
+        self.assertEqual((pair["calls"], pair["type_references"]), (1, 1))
+        self.assertEqual([example["source"] for example in pair["examples"]], ["a.Cls.run()", "a.Cls"])
+        # the call borders both files; the type reference borders none
+        bordering = {group["group_id"]: group["bordering_files"] for group in payload["groups"]}
+        self.assertEqual([item["path"] for item in bordering["1"]], ["a.cs"])
+        self.assertEqual(bordering["1"][0]["reasons"], ["calls group 2"])
+        self.assertEqual([item["path"] for item in bordering["2"]], ["b.cs"])
 
     def test_a_dense_pair_is_a_count_and_a_few_examples_not_every_edge(self):
         graph = CallGraph(language="python")

--- a/tests/agents/test_llm_renderers.py
+++ b/tests/agents/test_llm_renderers.py
@@ -223,7 +223,7 @@ class TestRenderScopeContext(unittest.TestCase):
                     "1",
                     "2",
                     edges=[
-                        ClusterConnectionEdge("csharp", "a.Cls", "b.Cls", kind="typeref"),
+                        ClusterConnectionEdge("csharp", "a.Cls", "b.Cls", kind=EdgeKind.TYPEREF),
                         ClusterConnectionEdge("csharp", "a.Cls.run()", "b.Cls.go()"),
                     ],
                 )

--- a/tests/diagram_analysis/test_diagram_analysis.py
+++ b/tests/diagram_analysis/test_diagram_analysis.py
@@ -532,6 +532,35 @@ class TestAnalysisJsonConversion(unittest.TestCase):
             [site.model_dump() for site in edge.call_sites], [{"line": 14, "column": 6}, {"line": 16, "column": 10}]
         )
 
+    def test_default_label_survives_the_round_trip_and_is_inferred_for_older_files(self):
+        self.analysis.components_relations = [
+            Relation(
+                src_name="Component1",
+                dst_name="Component2",
+                relation="uses",
+                src_id="1",
+                dst_id="2",
+                is_static=True,
+                default_label=True,
+            )
+        ]
+        data = json.loads(
+            build_unified_analysis_json(
+                self.analysis, [], "repo", repo_dir=self.repo_dir, source_tree_hash="", depth_cap=1
+            )
+        )
+        self.assertTrue(data["components_relations"][0]["default_label"])
+        parsed, _ = parse_unified_analysis(data)
+        self.assertTrue(parsed.components_relations[0].default_label)
+
+        # A file written before the flag existed can only be judged by its wording.
+        del data["components_relations"][0]["default_label"]
+        parsed, _ = parse_unified_analysis(data)
+        self.assertTrue(parsed.components_relations[0].default_label)
+        data["components_relations"][0]["relation"] = "dispatches through"
+        parsed, _ = parse_unified_analysis(data)
+        self.assertFalse(parsed.components_relations[0].default_label)
+
     def test_unified_analysis_parse_recovers_edges_missing_from_methods_index(self):
         data = json.loads(
             build_unified_analysis_json(

--- a/tests/diagram_analysis/test_scope_assembly.py
+++ b/tests/diagram_analysis/test_scope_assembly.py
@@ -6,7 +6,7 @@ from agents.agent_responses import AnalysisInsights, Component, Relation, Relati
 from agents.scope_analysis_agent import ScopeAnalysisResult, ScopeComponentSemantics, ScopeRelationSemantics
 from diagram_analysis.scope_assembly import ScopeAssembler
 from static_analyzer import StaticAnalysisFatalError, StaticAnalysisResults
-from static_analyzer.cfg import CallGraph
+from static_analyzer.cfg import CallGraph, EdgeKind
 from static_analyzer.clustering import (
     ClusterConnectionEdge,
     ClusterGroup,
@@ -153,6 +153,7 @@ class TestScopeAssembler(unittest.TestCase):
         relation = analysis.components_relations[0]
         self.assertEqual(relation.relation, "dispatches to")
         self.assertTrue(relation.is_static)
+        self.assertFalse(relation.default_label)
         self.assertEqual(relation.all_edges[0].source.reference_file, "src/1.py")
         self.assertEqual(relation.all_edges[0].target.reference_file, "src/2.py")
 
@@ -170,10 +171,11 @@ class TestScopeAssembler(unittest.TestCase):
             [(relation.src_id, relation.dst_id, relation.relation) for relation in analysis.components_relations],
             [("2", "3", "calls")],
         )
+        self.assertTrue(analysis.components_relations[0].default_label)
 
     def test_a_reference_only_connection_is_labelled_uses(self) -> None:
         scope = _scope(("2", "3"))
-        scope.connections[0].edges[0].kind = "typeref"
+        scope.connections[0].edges[0].kind = EdgeKind.TYPEREF
         analysis = AnalysisInsights(
             description="relations",
             components=[_component("1", "A"), _component("2", "B"), _component("3", "C")],
@@ -185,7 +187,8 @@ class TestScopeAssembler(unittest.TestCase):
         (relation,) = analysis.components_relations
         self.assertEqual((relation.src_id, relation.dst_id, relation.relation), ("2", "3", "uses"))
         self.assertTrue(relation.is_static)
-        self.assertEqual(relation.all_edges[0].description, "references type")
+        self.assertTrue(relation.default_label)
+        self.assertEqual((relation.all_edges[0].kind, relation.all_edges[0].description), (EdgeKind.TYPEREF, "uses"))
         self.assertEqual(relation.all_edges[0].call_sites, [])
 
     def test_fallback_descriptions_name_files_relative_to_the_repository(self) -> None:
@@ -340,6 +343,35 @@ class TestScopeAssembler(unittest.TestCase):
             [(relation.src_id, relation.dst_id, relation.relation) for relation in analysis.components_relations],
             [("1", "2", "dispatches to")],
         )
+
+    def test_a_default_label_is_recomputed_while_an_authored_one_that_reads_the_same_is_carried(self) -> None:
+        """Provenance, not wording, decides: the model may well describe a pair as ``uses``."""
+        for default_label, expected in ((True, "calls"), (False, "uses")):
+            with self.subTest(default_label=default_label):
+                scope = _scope(("1", "2"))
+                assembler = ScopeAssembler(Path("/repo"))
+                analysis = assembler.build(scope)
+                analysis.components_relations = [
+                    Relation(
+                        relation="uses",
+                        src_name=analysis.components[0].name,
+                        dst_name=analysis.components[1].name,
+                        src_id="1",
+                        dst_id="2",
+                        is_static=True,
+                        default_label=default_label,
+                    )
+                ]
+                result = ScopeAnalysisResult(
+                    components=[
+                        ScopeComponentSemantics(group_id="1", name="Runner", description="Runs.", key_entities=[])
+                    ],
+                )
+
+                assembler.apply_semantics(analysis, scope, result, {"1"}, set(), _resolver(scope))
+
+                (relation,) = analysis.components_relations
+                self.assertEqual((relation.relation, relation.default_label), (expected, default_label))
 
     def test_semantics_cannot_change_fixed_ids_membership_or_a_locked_name(self) -> None:
         scope = _scope(("1", "2"))

--- a/tests/diagram_analysis/test_scope_assembly.py
+++ b/tests/diagram_analysis/test_scope_assembly.py
@@ -171,6 +171,23 @@ class TestScopeAssembler(unittest.TestCase):
             [("2", "3", "calls")],
         )
 
+    def test_a_reference_only_connection_is_labelled_uses(self) -> None:
+        scope = _scope(("2", "3"))
+        scope.connections[0].edges[0].kind = "typeref"
+        analysis = AnalysisInsights(
+            description="relations",
+            components=[_component("1", "A"), _component("2", "B"), _component("3", "C")],
+            components_relations=[],
+        )
+
+        ScopeAssembler.merge_scope_relations(analysis, scope)
+
+        (relation,) = analysis.components_relations
+        self.assertEqual((relation.src_id, relation.dst_id, relation.relation), ("2", "3", "uses"))
+        self.assertTrue(relation.is_static)
+        self.assertEqual(relation.all_edges[0].description, "references type")
+        self.assertEqual(relation.all_edges[0].call_sites, [])
+
     def test_fallback_descriptions_name_files_relative_to_the_repository(self) -> None:
         analysis = ScopeAssembler(Path("/repo")).build(_scope(absolute=True))
 

--- a/tests/static_analyzer/test_analysis_cache.py
+++ b/tests/static_analyzer/test_analysis_cache.py
@@ -273,6 +273,15 @@ class TestLoadWithSha(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self.temp_dir, ignore_errors=True)
 
+    def test_the_previous_engines_artifact_is_not_warm_started(self):
+        # Why the literal "v7": a v7 graph credits a callback body and a member-chain receiver
+        # as call edges, which this engine no longer reproduces. A generic bad tag would pass
+        # whether or not the bump happened.
+        self.cache.save(StaticAnalysisResults(), source_sha="sha-current")
+        self.cache.sha_path.write_text("v7\nsha-current\n")
+
+        self.assertIsNone(self.cache.load_with_sha())
+
     def test_returns_results_and_sha_when_both_present(self):
         results = StaticAnalysisResults()
         results.add_source_files(Language.PYTHON, [str(self.repo_root / "main.py")])

--- a/tests/static_analyzer/test_cluster_relations.py
+++ b/tests/static_analyzer/test_cluster_relations.py
@@ -24,8 +24,10 @@ from static_analyzer.cluster_relations import (
     build_component_relations,
     is_self_or_descendant,
 )
+from agents.relation_edges import static_relation_label
+from constants import DEFAULT_STATIC_RELATION_LABEL, INHERITANCE_RELATION_LABEL, TYPE_REFERENCE_RELATION_LABEL
 from static_analyzer.config import NodeType
-from static_analyzer.cfg import CallGraph, Edge
+from static_analyzer.cfg import CallGraph, Edge, EdgeKind, ReferenceEdge
 from static_analyzer.node import Node
 
 
@@ -75,6 +77,44 @@ def _make_component(name: str, methods: list[tuple[str, str]], component_id: str
 
 def _owner_of(nodes: dict[str, str]) -> Callable[[SourceCodeReference], str]:
     return ComponentOwnershipIndex.from_node_owners(nodes).owner_of
+
+
+class TestReferenceEdgesBecomeRelations(unittest.TestCase):
+    OWNERS = {"a.Cls": "1", "a.Cls.run": "1", "b.Cls": "2", "b.Cls.run": "2"}
+
+    def _graph(self, kind: EdgeKind, with_call: bool = False) -> CallGraph:
+        cfg = CallGraph(edges=[_make_edge("a.Cls.run", "b.Cls.run", "src/a.py", "src/b.py")] if with_call else [])
+        cfg.add_node(_make_node("a.Cls", "src/a.py"))
+        cfg.add_node(_make_node("b.Cls", "src/b.py"))
+        cfg.add_reference_edge(ReferenceEdge("a.Cls", "b.Cls", kind))
+        return cfg
+
+    def test_a_type_reference_alone_is_a_uses_relation(self):
+        relations = build_component_relations(self.OWNERS, {"python": self._graph(EdgeKind.TYPEREF)})
+        self.assertEqual([(r.src_cluster_id, r.dst_cluster_id) for r in relations], [("1", "2")])
+        (edge,) = relations[0].all_edges
+        self.assertEqual((edge.source.qualified_name, edge.target.qualified_name), ("a.Cls", "b.Cls"))
+        self.assertEqual(edge.description, "references type")
+        self.assertEqual(static_relation_label(relations[0].all_edges), TYPE_REFERENCE_RELATION_LABEL)
+
+    def test_inheritance_alone_is_an_inherits_relation(self):
+        relations = build_component_relations(self.OWNERS, {"python": self._graph(EdgeKind.INHERITS)})
+        self.assertEqual(static_relation_label(relations[0].all_edges), INHERITANCE_RELATION_LABEL)
+
+    def test_a_call_outranks_references(self):
+        relations = build_component_relations(self.OWNERS, {"python": self._graph(EdgeKind.TYPEREF, with_call=True)})
+        self.assertEqual(len(relations[0].all_edges), 2)
+        self.assertEqual(static_relation_label(relations[0].all_edges), DEFAULT_STATIC_RELATION_LABEL)
+
+    def test_containment_is_not_a_relation(self):
+        self.assertEqual(build_component_relations(self.OWNERS, {"python": self._graph(EdgeKind.CONTAINS)}), [])
+
+    def test_a_reference_inside_one_component_is_not_a_relation(self):
+        owners = dict.fromkeys(self.OWNERS, "1")
+        self.assertEqual(build_component_relations(owners, {"python": self._graph(EdgeKind.TYPEREF)}), [])
+
+    def test_no_edges_means_the_call_label(self):
+        self.assertEqual(static_relation_label([]), DEFAULT_STATIC_RELATION_LABEL)
 
 
 class TestAnalysisNodeOwners(unittest.TestCase):

--- a/tests/static_analyzer/test_cluster_relations.py
+++ b/tests/static_analyzer/test_cluster_relations.py
@@ -7,9 +7,11 @@ from agents.agent_responses import (
     AnalysisInsights,
     Component,
     Relation,
+    RelationCallSite,
     RelationEdge,
     SourceCodeReference,
     assign_component_ids,
+    static_relation_label,
 )
 from agents.component_ownership import ComponentOwnershipIndex
 from agents.file_index_models import FileMethodGroup, MethodEntry
@@ -24,8 +26,6 @@ from static_analyzer.cluster_relations import (
     build_component_relations,
     is_self_or_descendant,
 )
-from agents.relation_edges import static_relation_label
-from constants import DEFAULT_STATIC_RELATION_LABEL, INHERITANCE_RELATION_LABEL, TYPE_REFERENCE_RELATION_LABEL
 from static_analyzer.config import NodeType
 from static_analyzer.cfg import CallGraph, Edge, EdgeKind, ReferenceEdge
 from static_analyzer.node import Node
@@ -82,11 +82,11 @@ def _owner_of(nodes: dict[str, str]) -> Callable[[SourceCodeReference], str]:
 class TestReferenceEdgesBecomeRelations(unittest.TestCase):
     OWNERS = {"a.Cls": "1", "a.Cls.run": "1", "b.Cls": "2", "b.Cls.run": "2"}
 
-    def _graph(self, kind: EdgeKind, with_call: bool = False) -> CallGraph:
+    def _graph(self, kind: EdgeKind, with_call: bool = False, sites: tuple = ()) -> CallGraph:
         cfg = CallGraph(edges=[_make_edge("a.Cls.run", "b.Cls.run", "src/a.py", "src/b.py")] if with_call else [])
         cfg.add_node(_make_node("a.Cls", "src/a.py"))
         cfg.add_node(_make_node("b.Cls", "src/b.py"))
-        cfg.add_reference_edge(ReferenceEdge("a.Cls", "b.Cls", kind))
+        cfg.add_reference_edge(ReferenceEdge("a.Cls", "b.Cls", kind, sites))
         return cfg
 
     def test_a_type_reference_alone_is_a_uses_relation(self):
@@ -94,17 +94,30 @@ class TestReferenceEdgesBecomeRelations(unittest.TestCase):
         self.assertEqual([(r.src_cluster_id, r.dst_cluster_id) for r in relations], [("1", "2")])
         (edge,) = relations[0].all_edges
         self.assertEqual((edge.source.qualified_name, edge.target.qualified_name), ("a.Cls", "b.Cls"))
-        self.assertEqual(edge.description, "references type")
-        self.assertEqual(static_relation_label(relations[0].all_edges), TYPE_REFERENCE_RELATION_LABEL)
+        self.assertEqual((edge.kind, edge.description), (EdgeKind.TYPEREF, "uses"))
+        self.assertEqual(static_relation_label(relations[0].all_edges), EdgeKind.TYPEREF.relation_label)
+
+    def test_a_reference_edge_keeps_the_sites_that_made_it(self):
+        graph = self._graph(EdgeKind.TYPEREF, sites=({"line": 3, "column": 19}, {"line": 8, "column": 5}))
+        relations = build_component_relations(self.OWNERS, {"python": graph})
+        (edge,) = relations[0].all_edges
+        self.assertEqual(edge.call_sites, [RelationCallSite(line=3, column=19), RelationCallSite(line=8, column=5)])
 
     def test_inheritance_alone_is_an_inherits_relation(self):
         relations = build_component_relations(self.OWNERS, {"python": self._graph(EdgeKind.INHERITS)})
-        self.assertEqual(static_relation_label(relations[0].all_edges), INHERITANCE_RELATION_LABEL)
+        self.assertEqual(static_relation_label(relations[0].all_edges), "inherits from")
+
+    def test_mixed_references_read_as_uses(self):
+        graph = self._graph(EdgeKind.INHERITS)
+        graph.add_node(_make_node("a.Cls.run", "src/a.py"))
+        graph.add_reference_edge(ReferenceEdge("a.Cls.run", "b.Cls", EdgeKind.TYPEREF))
+        relations = build_component_relations(self.OWNERS, {"python": graph})
+        self.assertEqual(static_relation_label(relations[0].all_edges), "uses")
 
     def test_a_call_outranks_references(self):
         relations = build_component_relations(self.OWNERS, {"python": self._graph(EdgeKind.TYPEREF, with_call=True)})
         self.assertEqual(len(relations[0].all_edges), 2)
-        self.assertEqual(static_relation_label(relations[0].all_edges), DEFAULT_STATIC_RELATION_LABEL)
+        self.assertEqual(static_relation_label(relations[0].all_edges), "calls")
 
     def test_containment_is_not_a_relation(self):
         self.assertEqual(build_component_relations(self.OWNERS, {"python": self._graph(EdgeKind.CONTAINS)}), [])
@@ -114,7 +127,7 @@ class TestReferenceEdgesBecomeRelations(unittest.TestCase):
         self.assertEqual(build_component_relations(owners, {"python": self._graph(EdgeKind.TYPEREF)}), [])
 
     def test_no_edges_means_the_call_label(self):
-        self.assertEqual(static_relation_label([]), DEFAULT_STATIC_RELATION_LABEL)
+        self.assertEqual(static_relation_label([]), EdgeKind.CALL.relation_label)
 
 
 class TestAnalysisNodeOwners(unittest.TestCase):

--- a/tests/static_analyzer/test_clustering_service.py
+++ b/tests/static_analyzer/test_clustering_service.py
@@ -191,7 +191,12 @@ class TestFullHierarchy(unittest.TestCase):
     def test_connections_carry_reference_edges_with_their_kind(self):
         csharp = graph("csharp", eshop())
         csharp.add_reference_edge(
-            ReferenceEdge("Catalog.API.Model.CatalogType0", "Ordering.API.Apis.OrderingType0", EdgeKind.TYPEREF)
+            ReferenceEdge(
+                "Catalog.API.Model.CatalogType0",
+                "Ordering.API.Apis.OrderingType0",
+                EdgeKind.TYPEREF,
+                ({"line": 3, "column": 19},),
+            )
         )
         csharp.add_reference_edge(
             ReferenceEdge("Catalog.API.Model.CatalogType0.Run()", "Catalog.API.Model.CatalogType0", EdgeKind.CONTAINS)
@@ -200,7 +205,8 @@ class TestFullHierarchy(unittest.TestCase):
         self.assertEqual([(c.source_group_id, c.target_group_id) for c in hierarchy.connections], [("2", "1")])
         (edge,) = hierarchy.connections[0].edges
         self.assertEqual(
-            (edge.kind, edge.source_qualified_name, edge.call_sites), ("typeref", "Catalog.API.Model.CatalogType0", [])
+            (edge.kind, edge.source_qualified_name, edge.call_sites),
+            (EdgeKind.TYPEREF, "Catalog.API.Model.CatalogType0", [{"line": 3, "column": 19}]),
         )
 
     def test_materialized_groups_explain_every_file_placement(self):

--- a/tests/static_analyzer/test_clustering_service.py
+++ b/tests/static_analyzer/test_clustering_service.py
@@ -188,6 +188,21 @@ class TestFullHierarchy(unittest.TestCase):
         self.assertEqual([(c.source_group_id, c.target_group_id) for c in hierarchy.connections], [("2", "1")])
         self.assertEqual(hierarchy.connections[0].edges[0].call_sites, [{"file": "x.cs", "line": 1}])
 
+    def test_connections_carry_reference_edges_with_their_kind(self):
+        csharp = graph("csharp", eshop())
+        csharp.add_reference_edge(
+            ReferenceEdge("Catalog.API.Model.CatalogType0", "Ordering.API.Apis.OrderingType0", EdgeKind.TYPEREF)
+        )
+        csharp.add_reference_edge(
+            ReferenceEdge("Catalog.API.Model.CatalogType0.Run()", "Catalog.API.Model.CatalogType0", EdgeKind.CONTAINS)
+        )
+        hierarchy = ClusteringService().build_full_hierarchy(analysis_for(csharp), max_depth=1)
+        self.assertEqual([(c.source_group_id, c.target_group_id) for c in hierarchy.connections], [("2", "1")])
+        (edge,) = hierarchy.connections[0].edges
+        self.assertEqual(
+            (edge.kind, edge.source_qualified_name, edge.call_sites), ("typeref", "Catalog.API.Model.CatalogType0", [])
+        )
+
     def test_materialized_groups_explain_every_file_placement(self):
         hierarchy = ClusteringService().build_full_hierarchy(analysis_for(graph("csharp", eshop())), max_depth=1)
         clustered_files = {

--- a/tests/static_analyzer/test_engine_configs.py
+++ b/tests/static_analyzer/test_engine_configs.py
@@ -14,6 +14,7 @@ from static_analyzer import (
     _adapter_names_for,
     _create_engine_configs,
 )
+from static_analyzer.analysis_cache import StaticAnalysisCache
 from static_analyzer.analysis_result import StaticAnalysisResults
 from static_analyzer.config import Language
 from static_analyzer.engine.adapters.python_adapter import PythonAdapter
@@ -124,6 +125,24 @@ class TestIncrementalRefusesAnIncompatibleCache(unittest.TestCase):
         (artifacts / "static_analysis.sha").write_text("v1\ndeadbeef\n")
 
         # The scanner shells out to tokei, which the analyzer only needs to pick engines.
+        with patch.object(ProjectScanner, "scan", return_value=[]):
+            analyzer = StaticAnalyzer(tmp, changed_files={tmp / "a.py"})
+        analyzer._clients_started = True
+
+        with self.assertRaises(StaticAnalysisFatalError) as caught:
+            analyzer.analyze(artifacts)
+        self.assertIn("full analysis", str(caught.exception))
+
+    def test_a_readable_artifact_from_the_previous_engine_is_refused(self):
+        # The sibling above writes an unreadable pkl, so it passes with or without a tag bump.
+        # This one is readable: only the version gate can refuse it.
+        tmp = Path(tempfile.mkdtemp()).resolve()
+        (tmp / "a.py").write_text("def a():\n    pass\n")
+        artifacts = tmp / ".codeboarding"
+        cache = StaticAnalysisCache(artifacts, tmp)
+        cache.save(StaticAnalysisResults(), source_sha="deadbeef")
+        cache.sha_path.write_text("v7\ndeadbeef\n")
+
         with patch.object(ProjectScanner, "scan", return_value=[]):
             analyzer = StaticAnalyzer(tmp, changed_files={tmp / "a.py"})
         analyzer._clients_started = True

--- a/tests/static_analyzer/test_source_inspector.py
+++ b/tests/static_analyzer/test_source_inspector.py
@@ -2,8 +2,14 @@
 
 from pathlib import Path
 
-from static_analyzer.engine.models import CallSite, ImportBinding, UsingDirective
+from static_analyzer.engine.models import CallSite, ImportDirective, NameScope, TypeReferenceSite
 from static_analyzer.engine.source_inspector import SourceInspector
+
+
+def _type_sites(path: Path) -> list[TypeReferenceSite]:
+    sites = SourceInspector().find_type_reference_sites(path)
+    assert sites is not None
+    return sites
 
 
 def _positions(sites: list[CallSite]) -> set[tuple[int, int]]:
@@ -738,7 +744,7 @@ class TestFindTypeReferenceSites:
             "    Volo.Abp.Settings.SettingValue Read() { return BlogKind.Draft; }\n"
             "}\n"
         )
-        sites = SourceInspector().find_type_reference_sites(f)
+        sites = _type_sites(f)
         names = {(site.line, site.name) for site in sites}
         assert (3, "CoreModule") in names
         assert (4, "AbpModule") in names
@@ -769,7 +775,7 @@ class TestFindTypeReferenceSites:
             "}\n"
             "export interface Shape extends Base<Q> { a: Qux; }\n"
         )
-        sites = SourceInspector().find_type_reference_sites(f)
+        sites = _type_sites(f)
         names = {(site.line, site.name) for site in sites}
         assert {(2, "CoreModule"), (2, "Impl")} <= names
         assert {(3, "BaseModule"), (3, "OnInit")} <= names
@@ -783,7 +789,7 @@ class TestFindTypeReferenceSites:
     def test_javascript_heritage_is_a_type_position(self, tmp_path: Path):
         f = tmp_path / "a.js"
         f.write_text("class A extends B { make() { return new C(); } }\n")
-        sites = SourceInspector().find_type_reference_sites(f)
+        sites = _type_sites(f)
         assert [site.name for site in sites] == ["B"]
 
     def test_other_languages_have_no_type_sites(self, tmp_path: Path):
@@ -799,6 +805,9 @@ class TestFindTypeReferenceSites:
         assert inspector.find_type_reference_sites(f) == []
         assert inspector.cache_stats()["parsed_files"] == 0
 
+    def test_an_unreadable_file_is_none_not_a_file_naming_nothing(self, tmp_path: Path):
+        assert SourceInspector().find_type_reference_sites(tmp_path / "missing.cs") is None
+
 
 class TestCSharpTypeNameNormalization:
     """The written name is reduced to what the index is keyed by, and the prefix to a namespace."""
@@ -806,7 +815,7 @@ class TestCSharpTypeNameNormalization:
     def _sites(self, tmp_path: Path, body: str) -> dict[str, tuple[str, str]]:
         f = tmp_path / "a.cs"
         f.write_text(body)
-        return {s.name: (s.name, s.qualifier) for s in SourceInspector().find_type_reference_sites(f)}
+        return {s.name: (s.name, s.qualifier) for s in _type_sites(f)}
 
     def test_a_generic_written_with_a_namespace_keeps_only_the_outer_name(self, tmp_path: Path):
         sites = self._sites(tmp_path, "class K { Lib.Domain.Box<Lib.Domain.Order> F; }\n")
@@ -823,7 +832,7 @@ class TestCSharpTypeNameNormalization:
         assert sites["Order"] == ("Order", "Lib.Domain")
 
 
-class TestFindNamespaceContext:
+class TestFindNameScope:
     def test_block_and_nested_namespaces_with_ranges(self, tmp_path: Path):
         f = tmp_path / "a.cs"
         f.write_text(
@@ -835,48 +844,49 @@ class TestFindNamespaceContext:
             "    namespace C { class K { } }\n"
             "}\n"
         )
-        context = SourceInspector().find_namespace_context(f)
-        # A file-level directive governs the whole file; the block-level one governs its block.
-        assert [(d.target, d.first_line) for d in context.usings] == [("System", 1), ("Volo.Abp", 1), ("Inner.Use", 3)]
-        assert [d.last_line for d in context.usings] == [8, 8, 7]
-        assert context.namespaces == (("A.B", 3, 7), ("A.B.C", 6, 6))
+        scope = SourceInspector().find_name_scope(f)
+        # A directive governs from its own line to the end of its scope: the file, or its block.
+        assert [(d.container, d.first_line, d.last_line, d.compilation_wide) for d in scope.imports] == [
+            ("System", 1, 8, False),
+            ("Volo.Abp", 2, 8, True),
+            ("Inner.Use", 5, 7, False),
+        ]
+        assert scope.namespaces == (("A.B", 3, 7), ("A.B.C", 6, 6))
 
     def test_a_file_scoped_namespace_spans_the_rest_of_the_file(self, tmp_path: Path):
         f = tmp_path / "a.cs"
-        f.write_text("namespace Volo.CmsKit;\npublic class X { }\npublic class Y { }\n")
-        ((name, start, end),) = SourceInspector().find_namespace_context(f).namespaces
+        f.write_text("namespace Volo.CmsKit;\nusing A;\npublic class X { }\npublic class Y { }\n")
+        scope = SourceInspector().find_name_scope(f)
+        ((name, start, end),) = scope.namespaces
         assert (name, start) == ("Volo.CmsKit", 1)
-        assert end >= 3
+        assert end >= 4
+        # The using after the declaration is written inside that namespace, at its own line.
+        assert [(d.container, d.first_line) for d in scope.imports] == [("A", 2)]
 
-    def test_an_alias_using_keeps_both_its_name_and_its_target(self, tmp_path: Path):
+    def test_an_alias_using_binds_one_name_to_a_member_of_its_container(self, tmp_path: Path):
         f = tmp_path / "a.cs"
         f.write_text("using Alias = Volo.Abp.Foo;\n")
-        (directive,) = SourceInspector().find_namespace_context(f).usings
-        assert (directive.target, directive.alias, directive.static) == ("Volo.Abp.Foo", "Alias", False)
+        (directive,) = SourceInspector().find_name_scope(f).imports
+        assert (directive.container, directive.name, directive.alias) == ("Volo.Abp", "Foo", "Alias")
+        assert directive.local_name == "Alias"
 
-    def test_a_static_using_is_marked_as_one(self, tmp_path: Path):
+    def test_a_static_using_opens_its_target_as_a_container(self, tmp_path: Path):
         f = tmp_path / "a.cs"
         f.write_text("using static Volo.Abp.Check;\n")
-        (directive,) = SourceInspector().find_namespace_context(f).usings
-        assert (directive.target, directive.alias, directive.static) == ("Volo.Abp.Check", "", True)
+        (directive,) = SourceInspector().find_name_scope(f).imports
+        assert (directive.container, directive.name, directive.alias) == ("Volo.Abp.Check", "", "")
+        assert directive.local_name == ""
 
     def test_an_extern_alias_root_is_not_part_of_the_target(self, tmp_path: Path):
         """``global::`` names an assembly; keeping it made the directive match no namespace."""
         f = tmp_path / "a.cs"
         f.write_text("using global::System.Collections;\nusing global::System;\n")
-        assert [d.target for d in SourceInspector().find_namespace_context(f).usings] == [
+        assert [d.container for d in SourceInspector().find_name_scope(f).imports] == [
             "System.Collections",
             "System",
         ]
 
-    def test_other_languages_are_empty(self, tmp_path: Path):
-        f = tmp_path / "a.ts"
-        f.write_text("namespace A { }\n")
-        assert SourceInspector().find_namespace_context(f).namespaces == ()
-
-
-class TestFindImportBindings:
-    def test_named_alias_namespace_and_default_imports(self, tmp_path: Path):
+    def test_script_imports_govern_the_whole_file(self, tmp_path: Path):
         f = tmp_path / "a.ts"
         f.write_text(
             "import { A, B as Bee } from './mod';\n"
@@ -885,15 +895,28 @@ class TestFindImportBindings:
             "import type { T1 } from './t';\n"
             "export { X } from './x';\n"
         )
-        assert SourceInspector().find_import_bindings(f) == {
-            "A": ImportBinding("./mod", "A"),
-            "Bee": ImportBinding("./mod", "B"),
-            "NS": ImportBinding("../ns", "*"),
-            "D": ImportBinding("./d", "default"),
-            "T1": ImportBinding("./t", "T1"),
-        }
+        assert SourceInspector().find_name_scope(f) == NameScope(
+            imports=(
+                ImportDirective("./mod", 1, 6, name="A"),
+                ImportDirective("./mod", 1, 6, name="B", alias="Bee"),
+                ImportDirective("../ns", 1, 6, alias="NS"),
+                ImportDirective("./d", 1, 6, name="default", alias="D"),
+                ImportDirective("./t", 1, 6, name="T1"),
+            )
+        )
+
+    def test_a_script_default_export_names_its_declaration(self, tmp_path: Path):
+        declared = tmp_path / "a.ts"
+        declared.write_text("export default class Service { }\n")
+        assert SourceInspector().find_name_scope(declared).default_export == "Service"
+        named = tmp_path / "b.ts"
+        named.write_text("class S { }\nexport default S;\n")
+        assert SourceInspector().find_name_scope(named).default_export == "S"
+        anonymous = tmp_path / "c.ts"
+        anonymous.write_text("export default { a: 1 };\n")
+        assert SourceInspector().find_name_scope(anonymous).default_export == ""
 
     def test_other_languages_are_empty(self, tmp_path: Path):
-        f = tmp_path / "a.cs"
-        f.write_text("using A;\n")
-        assert SourceInspector().find_import_bindings(f) == {}
+        f = tmp_path / "a.py"
+        f.write_text("import os\n")
+        assert SourceInspector().find_name_scope(f) == NameScope()

--- a/tests/static_analyzer/test_source_inspector.py
+++ b/tests/static_analyzer/test_source_inspector.py
@@ -791,6 +791,14 @@ class TestFindTypeReferenceSites:
         f.write_text("class A(B):\n    def m(self, x: C) -> D: ...\n")
         assert SourceInspector().find_type_reference_sites(f) == []
 
+    def test_a_language_without_a_selector_is_never_parsed(self, tmp_path: Path):
+        """Why: the pass runs over every source file, and a parse thrown away is the whole cost."""
+        f = tmp_path / "a.py"
+        f.write_text("class A(B): ...\n")
+        inspector = SourceInspector()
+        assert inspector.find_type_reference_sites(f) == []
+        assert inspector.cache_stats()["parsed_files"] == 0
+
 
 class TestCSharpTypeNameNormalization:
     """The written name is reduced to what the index is keyed by, and the prefix to a namespace."""

--- a/tests/static_analyzer/test_source_inspector.py
+++ b/tests/static_analyzer/test_source_inspector.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 
-from static_analyzer.engine.models import CallSite
+from static_analyzer.engine.models import CallSite, ImportBinding
 from static_analyzer.engine.source_inspector import SourceInspector
 
 
@@ -202,10 +202,6 @@ class TestIsCallableUsage:
         f.write_text("    register(handlers.on_start)\n")
         si = SourceInspector()
         assert si.is_callable_usage(f, 0, 13, 21) is False
-
-    def test_conservative_on_missing_file(self):
-        si = SourceInspector()
-        assert si.is_callable_usage(Path("/nonexistent.py"), 0, 0, 5) is True
 
     def test_conservative_on_missing_file(self):
         si = SourceInspector()
@@ -719,3 +715,136 @@ class TestIteratedExpression:
         si = SourceInspector()
         positions = _positions(si.find_iterated_expression_sites(f))
         assert (1, 46) in positions  # `Items`, whose type is what gets enumerated
+
+
+class TestFindTypeReferenceSites:
+    def test_csharp_type_positions(self, tmp_path: Path):
+        f = tmp_path / "Module.cs"
+        f.write_text(
+            "using Volo.Abp.Modularity;\n"
+            "namespace App;\n"
+            "[DependsOn(typeof(CoreModule))]\n"
+            "public class AppModule : AbpModule\n"
+            "{\n"
+            "    public DbSet<Blog> Blogs { get; set; }\n"
+            "    private readonly IRepository<Blog, Guid> _repo;\n"
+            "    public List<BlogDto> Convert(IEnumerable<Blog> items, Blog? single, Blog[] many)\n"
+            "    {\n"
+            "        var x = (BlogDto)null; if (single is BlogDto b) { } var o = items as Other;\n"
+            "        try { } catch (BusinessException e) { }\n"
+            "        return new List<BlogDto>();\n"
+            "    }\n"
+            "    void Register(ServiceConfigurationContext context) { context.Services.AddTransient<IBlogService, BlogService>(); }\n"
+            "    Volo.Abp.Settings.SettingValue Read() { return BlogKind.Draft; }\n"
+            "}\n"
+        )
+        sites = SourceInspector().find_type_reference_sites(f)
+        names = {(site.line, site.name) for site in sites}
+        assert (3, "CoreModule") in names
+        assert (4, "AbpModule") in names
+        assert {(6, "DbSet"), (6, "Blog"), (7, "IRepository"), (7, "Guid")} <= names
+        assert {(8, "List"), (8, "BlogDto"), (8, "IEnumerable"), (8, "Blog")} <= names
+        assert {(10, "BlogDto"), (10, "Other")} <= names
+        assert (11, "BusinessException") in names
+        assert {(14, "IBlogService"), (14, "BlogService")} <= names
+        assert (15, "BlogKind") in names
+        qualified = next(site for site in sites if site.name == "SettingValue")
+        assert qualified.qualifier == "Volo.Abp.Settings"
+        assert not any(site.name in ("var", "void", "AppModule", "DependsOn") for site in sites)
+        # a member-access receiver is a candidate too; ``context`` fails to resolve later, ``BlogKind`` resolves
+        assert (14, "context") in names
+        # ``new List<BlogDto>()`` names the created type only through its constructor call
+        assert [site.name for site in sites if site.line == 12] == ["BlogDto"]
+
+    def test_typescript_type_positions(self, tmp_path: Path):
+        f = tmp_path / "blog.ts"
+        f.write_text(
+            "import { BlogService } from './blog.service';\n"
+            "@NgModule({ imports: [CoreModule], providers: [{ provide: TOKEN, useClass: Impl }] })\n"
+            "export class BlogModule extends BaseModule implements OnInit {\n"
+            "  items: BlogDto[] = [];\n"
+            "  constructor(private svc: BlogService, cfg: Config<BlogDto>) { super(); }\n"
+            "  load(id: string): Observable<BlogDto> { return this.svc.get(id) as BlogDto; }\n"
+            "  make(): Foo { return new Foo(); }\n"
+            "}\n"
+            "export interface Shape extends Base<Q> { a: Qux; }\n"
+        )
+        sites = SourceInspector().find_type_reference_sites(f)
+        names = {(site.line, site.name) for site in sites}
+        assert {(2, "CoreModule"), (2, "Impl")} <= names
+        assert {(3, "BaseModule"), (3, "OnInit")} <= names
+        assert (4, "BlogDto") in names
+        assert {(5, "BlogService"), (5, "Config"), (5, "BlogDto")} <= names
+        assert {(6, "Observable"), (6, "BlogDto")} <= names
+        assert {(9, "Base"), (9, "Q"), (9, "Qux")} <= names
+        assert not any(site.name in ("BlogModule", "Shape", "string", "NgModule") for site in sites)
+        assert [site.name for site in sites if site.line == 7] == ["Foo"]
+
+    def test_javascript_heritage_is_a_type_position(self, tmp_path: Path):
+        f = tmp_path / "a.js"
+        f.write_text("class A extends B { make() { return new C(); } }\n")
+        sites = SourceInspector().find_type_reference_sites(f)
+        assert [site.name for site in sites] == ["B"]
+
+    def test_other_languages_have_no_type_sites(self, tmp_path: Path):
+        f = tmp_path / "a.py"
+        f.write_text("class A(B):\n    def m(self, x: C) -> D: ...\n")
+        assert SourceInspector().find_type_reference_sites(f) == []
+
+
+class TestFindNamespaceContext:
+    def test_block_and_nested_namespaces_with_ranges(self, tmp_path: Path):
+        f = tmp_path / "a.cs"
+        f.write_text(
+            "using System;\n"
+            "global using Volo.Abp;\n"
+            "namespace A.B\n"
+            "{\n"
+            "    using Inner.Use;\n"
+            "    namespace C { class K { } }\n"
+            "}\n"
+        )
+        context = SourceInspector().find_namespace_context(f)
+        assert context.usings == ("System", "Volo.Abp", "Inner.Use")
+        assert context.namespaces == (("A.B", 3, 7), ("A.B.C", 6, 6))
+
+    def test_a_file_scoped_namespace_spans_the_rest_of_the_file(self, tmp_path: Path):
+        f = tmp_path / "a.cs"
+        f.write_text("namespace Volo.CmsKit;\npublic class X { }\npublic class Y { }\n")
+        ((name, start, end),) = SourceInspector().find_namespace_context(f).namespaces
+        assert (name, start) == ("Volo.CmsKit", 1)
+        assert end >= 3
+
+    def test_an_alias_using_keeps_its_target(self, tmp_path: Path):
+        f = tmp_path / "a.cs"
+        f.write_text("using Alias = Volo.Abp.Foo;\n")
+        assert SourceInspector().find_namespace_context(f).usings == ("Volo.Abp.Foo",)
+
+    def test_other_languages_are_empty(self, tmp_path: Path):
+        f = tmp_path / "a.ts"
+        f.write_text("namespace A { }\n")
+        assert SourceInspector().find_namespace_context(f).namespaces == ()
+
+
+class TestFindImportBindings:
+    def test_named_alias_namespace_and_default_imports(self, tmp_path: Path):
+        f = tmp_path / "a.ts"
+        f.write_text(
+            "import { A, B as Bee } from './mod';\n"
+            "import * as NS from '../ns';\n"
+            'import D from "./d";\n'
+            "import type { T1 } from './t';\n"
+            "export { X } from './x';\n"
+        )
+        assert SourceInspector().find_import_bindings(f) == {
+            "A": ImportBinding("./mod", "A"),
+            "Bee": ImportBinding("./mod", "B"),
+            "NS": ImportBinding("../ns", "*"),
+            "D": ImportBinding("./d", "default"),
+            "T1": ImportBinding("./t", "T1"),
+        }
+
+    def test_other_languages_are_empty(self, tmp_path: Path):
+        f = tmp_path / "a.cs"
+        f.write_text("using A;\n")
+        assert SourceInspector().find_import_bindings(f) == {}

--- a/tests/static_analyzer/test_source_inspector.py
+++ b/tests/static_analyzer/test_source_inspector.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 
-from static_analyzer.engine.models import CallSite, ImportBinding
+from static_analyzer.engine.models import CallSite, ImportBinding, UsingDirective
 from static_analyzer.engine.source_inspector import SourceInspector
 
 
@@ -792,6 +792,29 @@ class TestFindTypeReferenceSites:
         assert SourceInspector().find_type_reference_sites(f) == []
 
 
+class TestCSharpTypeNameNormalization:
+    """The written name is reduced to what the index is keyed by, and the prefix to a namespace."""
+
+    def _sites(self, tmp_path: Path, body: str) -> dict[str, tuple[str, str]]:
+        f = tmp_path / "a.cs"
+        f.write_text(body)
+        return {s.name: (s.name, s.qualifier) for s in SourceInspector().find_type_reference_sites(f)}
+
+    def test_a_generic_written_with_a_namespace_keeps_only_the_outer_name(self, tmp_path: Path):
+        sites = self._sites(tmp_path, "class K { Lib.Domain.Box<Lib.Domain.Order> F; }\n")
+        # Not "Box<Lib.Domain.Order>", and not the "Order>" a last-dot split would give.
+        assert sites["Box"] == ("Box", "Lib.Domain")
+        assert sites["Order"] == ("Order", "Lib.Domain")
+
+    def test_an_extern_alias_root_is_stripped_from_the_qualifier(self, tmp_path: Path):
+        sites = self._sites(tmp_path, "class K { global::Lib.Domain.Order F; }\n")
+        assert sites["Order"] == ("Order", "Lib.Domain")
+
+    def test_a_plain_qualified_name_is_unchanged(self, tmp_path: Path):
+        sites = self._sites(tmp_path, "class K { Lib.Domain.Order F; }\n")
+        assert sites["Order"] == ("Order", "Lib.Domain")
+
+
 class TestFindNamespaceContext:
     def test_block_and_nested_namespaces_with_ranges(self, tmp_path: Path):
         f = tmp_path / "a.cs"
@@ -805,7 +828,9 @@ class TestFindNamespaceContext:
             "}\n"
         )
         context = SourceInspector().find_namespace_context(f)
-        assert context.usings == ("System", "Volo.Abp", "Inner.Use")
+        # A file-level directive governs the whole file; the block-level one governs its block.
+        assert [(d.target, d.first_line) for d in context.usings] == [("System", 1), ("Volo.Abp", 1), ("Inner.Use", 3)]
+        assert [d.last_line for d in context.usings] == [8, 8, 7]
         assert context.namespaces == (("A.B", 3, 7), ("A.B.C", 6, 6))
 
     def test_a_file_scoped_namespace_spans_the_rest_of_the_file(self, tmp_path: Path):
@@ -815,10 +840,26 @@ class TestFindNamespaceContext:
         assert (name, start) == ("Volo.CmsKit", 1)
         assert end >= 3
 
-    def test_an_alias_using_keeps_its_target(self, tmp_path: Path):
+    def test_an_alias_using_keeps_both_its_name_and_its_target(self, tmp_path: Path):
         f = tmp_path / "a.cs"
         f.write_text("using Alias = Volo.Abp.Foo;\n")
-        assert SourceInspector().find_namespace_context(f).usings == ("Volo.Abp.Foo",)
+        (directive,) = SourceInspector().find_namespace_context(f).usings
+        assert (directive.target, directive.alias, directive.static) == ("Volo.Abp.Foo", "Alias", False)
+
+    def test_a_static_using_is_marked_as_one(self, tmp_path: Path):
+        f = tmp_path / "a.cs"
+        f.write_text("using static Volo.Abp.Check;\n")
+        (directive,) = SourceInspector().find_namespace_context(f).usings
+        assert (directive.target, directive.alias, directive.static) == ("Volo.Abp.Check", "", True)
+
+    def test_an_extern_alias_root_is_not_part_of_the_target(self, tmp_path: Path):
+        """``global::`` names an assembly; keeping it made the directive match no namespace."""
+        f = tmp_path / "a.cs"
+        f.write_text("using global::System.Collections;\nusing global::System;\n")
+        assert [d.target for d in SourceInspector().find_namespace_context(f).usings] == [
+            "System.Collections",
+            "System",
+        ]
 
     def test_other_languages_are_empty(self, tmp_path: Path):
         f = tmp_path / "a.ts"

--- a/tests/static_analyzer/test_source_inspector.py
+++ b/tests/static_analyzer/test_source_inspector.py
@@ -172,6 +172,41 @@ class TestIsCallableUsage:
         si = SourceInspector()
         assert si.is_callable_usage(f, 0, 8, 12) is False
 
+    def test_a_mention_inside_a_callback_body_is_not_an_argument(self, tmp_path: Path):
+        """``abp`` here is used by the callback, not handed to ``$``."""
+        f = tmp_path / "test.js"
+        f.write_text("$(function () { abp.run(); });\n")
+        si = SourceInspector()
+        assert si.is_callable_usage(f, 0, 16, 19) is False
+
+    def test_a_value_passed_directly_still_is(self, tmp_path: Path):
+        f = tmp_path / "test.js"
+        f.write_text("$(abp);\n")
+        si = SourceInspector()
+        assert si.is_callable_usage(f, 0, 2, 5) is True
+
+    def test_a_receiver_inside_an_argument_is_not_the_value_passed(self, tmp_path: Path):
+        f = tmp_path / "test.js"
+        f.write_text("show(abp.localization.get(key));\n")
+        si = SourceInspector()
+        assert si.is_callable_usage(f, 0, 5, 8) is False
+
+    def test_a_receiver_inside_a_returned_expression_is_not_the_value_returned(self, tmp_path: Path):
+        f = tmp_path / "test.js"
+        f.write_text("return { locale: abp.localization.currentCulture };\n")
+        si = SourceInspector()
+        assert si.is_callable_usage(f, 0, 17, 20) is False
+
+    def test_a_python_receiver_is_not_the_value_passed(self, tmp_path: Path):
+        f = tmp_path / "test.py"
+        f.write_text("    register(handlers.on_start)\n")
+        si = SourceInspector()
+        assert si.is_callable_usage(f, 0, 13, 21) is False
+
+    def test_conservative_on_missing_file(self):
+        si = SourceInspector()
+        assert si.is_callable_usage(Path("/nonexistent.py"), 0, 0, 5) is True
+
     def test_conservative_on_missing_file(self):
         si = SourceInspector()
         assert si.is_callable_usage(Path("/nonexistent.py"), 0, 0, 5) is True

--- a/tests/static_analyzer/test_type_reference_builder.py
+++ b/tests/static_analyzer/test_type_reference_builder.py
@@ -30,12 +30,16 @@ def _write(path: Path, text: str) -> Path:
 
 
 def _site(path: Path, name: str, line: int = 2, qualifier: str = "") -> TypeReferenceSite:
-    return TypeReferenceSite(file=str(path), line=line, column=1, name=name, qualifier=qualifier)
+    return TypeReferenceSite(file_path=str(path), line=line, column=1, name=name, qualifier=qualifier)
 
 
 def _resolved_name(index: TypeIndex, site: TypeReferenceSite) -> str | None:
     node = index.resolve(site)
     return node.fully_qualified_name if node is not None else None
+
+
+def _pairs(edges: list[ReferenceEdge]) -> set[tuple[str, str]]:
+    return {(edge.src, edge.dst) for edge in edges}
 
 
 def test_simple_type_name_strips_path_and_arity():
@@ -84,6 +88,42 @@ class TestTypeIndexCSharp:
         user = _write(tmp_path / "c" / "User.cs", "namespace A;\npublic class User { }\n")
         index = TypeIndex([_class("a.Foo", a), _class("b.Foo", b)], SourceInspector())
         assert _resolved_name(index, _site(user, "Foo", qualifier="B")) == "b.Foo"
+
+    def test_a_qualifier_matches_whole_segments_only(self, tmp_path: Path):
+        """``Domain`` written as a qualifier must not match a ``FooDomain`` namespace."""
+        foo = _write(tmp_path / "a" / "Order.cs", "namespace Lib.FooDomain;\npublic class Order { }\n")
+        domain = _write(tmp_path / "b" / "Order.cs", "namespace Lib.Domain;\npublic class Order { }\n")
+        user = _write(tmp_path / "a" / "User.cs", "namespace Lib;\npublic class User { }\n")
+        index = TypeIndex([_class("a.Order", foo), _class("b.Order", domain)], SourceInspector())
+        # Without the segment rule the nearer ``a/Order.cs`` survives the suffix test and wins on proximity.
+        assert _resolved_name(index, _site(user, "Order", qualifier="Domain")) == "b.Order"
+        assert _resolved_name(index, _site(user, "Order", qualifier="FooDomain")) == "a.Order"
+
+    def test_a_nested_type_resolves_through_its_enclosing_type(self, tmp_path: Path):
+        outer = _write(
+            tmp_path / "n" / "Outer.cs", "namespace N;\npublic class Outer\n{\n    public class Inner { }\n}\n"
+        )
+        other = _write(tmp_path / "m" / "Inner.cs", "namespace M;\npublic class Inner { }\n")
+        user = _write(tmp_path / "u" / "User.cs", "namespace N;\npublic class User { }\n")
+        nodes = [_class("n.Outer", outer, 2, 5), _class("n.Outer.Inner", outer, 4, 4), _class("m.Inner", other)]
+        index = TypeIndex(nodes, SourceInspector())
+        assert _resolved_name(index, _site(user, "Inner", qualifier="Outer")) == "n.Outer.Inner"
+        assert _resolved_name(index, _site(user, "Inner", qualifier="N.Outer")) == "n.Outer.Inner"
+
+    def test_a_nested_type_is_nameable_unqualified_inside_its_enclosing_type(self, tmp_path: Path):
+        outer = _write(
+            tmp_path / "n" / "Outer.cs",
+            "namespace N;\npublic class Outer\n{\n    public class Inner { }\n    Inner Make() { return null; }\n}\n",
+        )
+        other = _write(tmp_path / "m" / "Inner.cs", "namespace M;\npublic class Inner { }\n")
+        nodes = [
+            _class("n.Outer", outer, 2, 6),
+            _class("n.Outer.Inner", outer, 4, 4),
+            _method("n.Outer.Make()", outer, 5, 5),
+            _class("m.Inner", other),
+        ]
+        index = TypeIndex(nodes, SourceInspector())
+        assert _resolved_name(index, _site(outer, "Inner", line=5)) == "n.Outer.Inner"
 
     def test_equally_visible_copies_prefer_the_closest_directory(self, tmp_path: Path):
         """Every project template declares the same ``Program``; a reference means its own copy."""
@@ -150,13 +190,67 @@ class TestTypeIndexCSharpUsings:
         assert _resolved_name(index, _site(user, "Widget", line=4)) == "a.Widget"
         assert _resolved_name(index, _site(user, "Widget", line=9)) == "b.Widget"
 
-    def test_a_static_using_does_not_make_its_namespace_nameable(self, tmp_path: Path):
-        """``using static A.B`` brings in B's members, not the types alongside B."""
-        held = _write(tmp_path / "a" / "X.cs", "namespace A.B;\npublic class X { }\n")
+    def test_a_using_inside_a_namespace_names_the_relative_namespace_first(self, tmp_path: Path):
+        """Inside ``namespace Root``, ``using Models;`` means ``Root.Models`` when that exists."""
+        nested = _write(tmp_path / "r" / "Foo.cs", "namespace Root.Models;\npublic class Foo { }\n")
+        top = _write(tmp_path / "m" / "Foo.cs", "namespace Models;\npublic class Foo { }\n")
+        user = _write(tmp_path / "u" / "User.cs", "namespace Root\n{\n    using Models;\n    class User { }\n}\n")
+        index = TypeIndex([_class("r.Foo", nested), _class("m.Foo", top)], SourceInspector())
+        for declaring in (nested, top):
+            index.scope_of(str(declaring))
+        assert _resolved_name(index, _site(user, "Foo", line=4)) == "r.Foo"
+
+    def test_a_using_written_in_the_namespace_beats_a_global_using_that_brings_a_second_type(self, tmp_path: Path):
+        """C# looks a name up scope by scope: the namespace's own usings decide before the compilation unit's."""
+        domain = _write(tmp_path / "lib" / "Order.cs", "namespace Shop.Domain;\npublic class Order { }\n")
+        _write(tmp_path / "api" / "Api.csproj", "<Project />\n")
+        view = _write(
+            tmp_path / "api" / "Queries" / "OrderView.cs", "namespace Shop.Api.Queries;\npublic record Order { }\n"
+        )
+        globals_file = _write(
+            tmp_path / "api" / "GlobalUsings.cs", "global using Shop.Api.Queries;\nglobal using Shop.Domain;\n"
+        )
+        handler = _write(
+            tmp_path / "api" / "Commands" / "Handler.cs",
+            "namespace Shop.Api.Commands;\n\nusing Shop.Domain;\n\npublic class Handler { }\n",
+        )
+        index = TypeIndex([_class("lib.Order", domain), _class("api.Queries.OrderView.Order", view)], SourceInspector())
+        index.scope_of(str(globals_file))
+        # Directory proximity alone would pick the record beside the handler.
+        assert _resolved_name(index, _site(handler, "Order", line=5)) == "lib.Order"
+
+    def test_a_static_using_does_not_make_the_types_beside_its_target_nameable(self, tmp_path: Path):
+        """``using static A.B.Check`` brings in Check's members, not the types alongside Check."""
+        held = _write(tmp_path / "a" / "X.cs", "namespace A.B;\npublic class X { }\npublic class Check { }\n")
         own = _write(tmp_path / "c" / "X.cs", "namespace C;\npublic class X { }\n")
-        user = _write(tmp_path / "u" / "User.cs", "using static A.B;\nnamespace C;\npublic class User { }\n")
-        index = TypeIndex([_class("a.X", held), _class("c.X", own)], SourceInspector())
+        user = _write(tmp_path / "u" / "User.cs", "using static A.B.Check;\nnamespace C;\npublic class User { }\n")
+        nodes = [_class("a.X", held, 2, 2), _class("a.Check", held, 3, 3), _class("c.X", own)]
+        index = TypeIndex(nodes, SourceInspector())
         assert _resolved_name(index, _site(user, "X", line=3)) == "c.X"
+
+    def test_a_static_using_makes_the_types_its_target_holds_nameable(self, tmp_path: Path):
+        held = _write(
+            tmp_path / "a" / "Check.cs", "namespace A.B;\npublic class Check\n{\n    public class Inner { }\n}\n"
+        )
+        other = _write(tmp_path / "d" / "Inner.cs", "namespace D;\npublic class Inner { }\n")
+        user = _write(tmp_path / "u" / "User.cs", "using static A.B.Check;\nnamespace C;\npublic class User { }\n")
+        nodes = [_class("a.Check", held, 2, 5), _class("a.Check.Inner", held, 4, 4), _class("d.Inner", other)]
+        index = TypeIndex(nodes, SourceInspector())
+        assert _resolved_name(index, _site(user, "Inner", line=3)) == "a.Check.Inner"
+
+    def test_a_global_using_governs_every_file_of_its_compilation(self, tmp_path: Path):
+        a = _write(tmp_path / "lib" / "a" / "Foo.cs", "namespace A;\npublic class Foo { }\n")
+        b = _write(tmp_path / "lib" / "b" / "Foo.cs", "namespace B;\npublic class Foo { }\n")
+        _write(tmp_path / "app" / "App.csproj", "<Project />\n")
+        globals_file = _write(tmp_path / "app" / "GlobalUsings.cs", "global using A;\n")
+        user = _write(tmp_path / "app" / "src" / "User.cs", "namespace C;\npublic class User { }\n")
+        _write(tmp_path / "other" / "Other.csproj", "<Project />\n")
+        outsider = _write(tmp_path / "other" / "User.cs", "namespace C;\npublic class User { }\n")
+        index = TypeIndex([_class("a.Foo", a), _class("b.Foo", b)], SourceInspector())
+        index.scope_of(str(globals_file))
+        assert _resolved_name(index, _site(user, "Foo")) == "a.Foo"
+        # The other project never sees the directive, and its two candidates are equidistant.
+        assert index.resolve(_site(outsider, "Foo")) is None
 
 
 class TestTypeIndexScript:
@@ -177,6 +271,13 @@ class TestTypeIndexScript:
         user = _write(tmp_path / "user.ts", "import * as NS from './lib/svc';\n")
         index = TypeIndex([_class("lib.svc.Svc", svc)], SourceInspector())
         assert _resolved_name(index, _site(user, "Svc", qualifier="NS")) == "lib.svc.Svc"
+
+    def test_a_renamed_default_import_resolves_to_the_modules_default_export(self, tmp_path: Path):
+        svc = _write(tmp_path / "svc.ts", "export default class Service { }\n")
+        user = _write(tmp_path / "user.ts", "import Client from './svc';\n")
+        index = TypeIndex([_class("svc.Service", svc)], SourceInspector())
+        index.scope_of(str(svc))
+        assert _resolved_name(index, _site(user, "Client")) == "svc.Service"
 
     def test_a_package_import_is_external_even_when_a_repo_class_shares_the_name(self, tmp_path: Path):
         svc = _write(tmp_path / "svc.ts", "export class Svc { }\n")
@@ -230,7 +331,7 @@ class TestTypeIndexScript:
         assert both.resolve(_site(user, "Svc")) is None
 
 
-class TestContainerAt:
+class TestContainers:
     def test_innermost_declaration_wins(self, tmp_path: Path):
         path = tmp_path / "A.cs"
         method = _method("A.M()", path, 5, 10)
@@ -240,6 +341,15 @@ class TestContainerAt:
         assert outer is not None and outer.fully_qualified_name == "A"
         assert index.container_at(str(path), 30) is None
         assert index.container_at("elsewhere.cs", 7) is None
+
+    def test_a_container_is_the_namespace_and_enclosing_types_or_the_module(self, tmp_path: Path):
+        outer = _write(
+            tmp_path / "n" / "Outer.cs", "namespace N.M;\npublic class Outer\n{\n    public class Inner { }\n}\n"
+        )
+        script = _write(tmp_path / "lib" / "svc.ts", "export class Svc { }\n")
+        nodes = [_class("n.Outer", outer, 2, 5), _class("n.Outer.Inner", outer, 4, 4), _class("lib.svc.Svc", script)]
+        index = TypeIndex(nodes, SourceInspector())
+        assert [index.container_of(node) for node in nodes] == ["N.M", "N.M.Outer", str(tmp_path / "lib" / "svc")]
 
 
 class TestBuildTypeReferences:
@@ -271,13 +381,22 @@ class TestBuildTypeReferences:
         module, core, nodes = self._fixture(tmp_path)
         inspector = SourceInspector()
         stats = TypeReferenceStats()
-        pairs = build_type_references(inspector, TypeIndex(nodes, inspector), [module, core], stats)
-        assert set(pairs) == {
+        edges = build_type_references(inspector, TypeIndex(nodes, inspector), [module, core], stats)
+        assert _pairs(edges) == {
             ("app.AppModule", "volo.Core.CoreModule"),
             ("app.AppModule", "volo.Core.AbpModule"),
             ("app.AppModule.Configure(AbpOptions options)", "volo.Core.AbpOptions"),
         }
         assert (stats.sites, stats.resolved, stats.unresolved, stats.ambiguous) == (3, 3, 0, 0)
+
+    def test_an_edge_carries_the_sites_that_made_it(self, tmp_path: Path):
+        module, core, nodes = self._fixture(tmp_path)
+        inspector = SourceInspector()
+        edges = build_type_references(inspector, TypeIndex(nodes, inspector), [module, core], TypeReferenceStats())
+        by_pair = {(edge.src, edge.dst): edge for edge in edges}
+        assert by_pair[("app.AppModule", "volo.Core.CoreModule")].sites == ({"line": 3, "column": 19},)
+        assert by_pair[("app.AppModule", "volo.Core.AbpModule")].sites == ({"line": 4, "column": 26},)
+        assert all(edge.kind is EdgeKind.TYPEREF for edge in edges)
 
     def test_a_declaration_naming_its_own_type_is_not_an_edge(self, tmp_path: Path):
         path = _write(tmp_path / "A.cs", "public class A\n{\n    public A Clone(A other) { return other; }\n}\n")
@@ -300,9 +419,33 @@ class TestBuildTypeReferences:
         ]
         inspector = SourceInspector()
         stats = TypeReferenceStats()
-        pairs = build_type_references(inspector, TypeIndex(nodes, inspector), [svc, user], stats)
-        assert ("src.u.U.run(s)", "src.svc.Svc") in pairs
+        edges = build_type_references(inspector, TypeIndex(nodes, inspector), [svc, user], stats)
+        assert ("src.u.U.run(s)", "src.svc.Svc") in _pairs(edges)
         assert (stats.resolved, stats.ambiguous) == (1, 0)
+
+    def test_every_file_is_read_before_any_site_is_resolved(self, tmp_path: Path):
+        """A ``global using`` declared in the last file governs a site in the first."""
+        a = _write(tmp_path / "lib" / "a" / "Foo.cs", "namespace A;\npublic class Foo { }\n")
+        b = _write(tmp_path / "lib" / "b" / "Foo.cs", "namespace B;\npublic class Foo { }\n")
+        _write(tmp_path / "app" / "App.csproj", "<Project />\n")
+        user = _write(tmp_path / "app" / "User.cs", "namespace C;\npublic class User { Foo Make() { return null; } }\n")
+        globals_file = _write(tmp_path / "app" / "Usings.cs", "global using A;\n")
+        nodes = [_class("a.Foo", a), _class("b.Foo", b), _class("app.User", user, 2, 2)]
+        inspector = SourceInspector()
+        edges = build_type_references(
+            inspector, TypeIndex(nodes, inspector), [user, globals_file], TypeReferenceStats()
+        )
+        assert _pairs(edges) == {("app.User", "a.Foo")}
+
+    def test_an_unreadable_file_is_reported(self, tmp_path: Path):
+        module, core, nodes = self._fixture(tmp_path)
+        missing = tmp_path / "gone" / "Gone.cs"
+        inspector = SourceInspector()
+        stats = TypeReferenceStats()
+        edges = build_type_references(inspector, TypeIndex(nodes, inspector), [module, missing, core], stats)
+        assert len(edges) == 3
+        assert stats.unreadable_files == [str(missing)]
+        assert "1 unreadable file(s)" in stats.summary()
 
     def test_complete_type_references_replaces_stale_edges_and_keeps_other_kinds(self, tmp_path: Path):
         module, core, nodes = self._fixture(tmp_path)
@@ -310,18 +453,34 @@ class TestBuildTypeReferences:
         for node in nodes:
             graph.add_node(node)
         graph.add_reference_edge(ReferenceEdge("app.AppModule", "volo.Core.AbpOptions", EdgeKind.TYPEREF))
-        graph.add_reference_edge(ReferenceEdge("app.AppModule", "volo.Core.AbpModule", EdgeKind.INHERITS))
 
         stats = complete_type_references(graph, [module, core], SourceInspector())
         stats_again = complete_type_references(graph, [module, core], SourceInspector())
 
-        typerefs = {(ref.src, ref.dst) for ref in graph.reference_edges if ref.kind is EdgeKind.TYPEREF}
-        assert typerefs == {
+        typerefs = [ref for ref in graph.reference_edges if ref.kind is EdgeKind.TYPEREF]
+        assert _pairs(typerefs) == {
             ("app.AppModule", "volo.Core.CoreModule"),
             ("app.AppModule", "volo.Core.AbpModule"),
             ("app.AppModule.Configure(AbpOptions options)", "volo.Core.AbpOptions"),
         }
-        assert stats.edges == stats_again.edges == 3
-        assert sum(1 for ref in graph.reference_edges if ref.kind is EdgeKind.TYPEREF) == 3
-        assert ReferenceEdge("app.AppModule", "volo.Core.AbpModule", EdgeKind.INHERITS) in graph.reference_edges
+        assert stats.edges == stats_again.edges == len(typerefs) == 3
+        assert all(ref.sites for ref in typerefs)
         assert "3 sites -> 3 edges" in stats.summary()
+
+    def test_a_base_already_recorded_as_inheritance_is_not_doubled_as_a_type_reference(self, tmp_path: Path):
+        module, core, nodes = self._fixture(tmp_path)
+        graph = CallGraph(language="csharp")
+        for node in nodes:
+            graph.add_node(node)
+        inherits = ReferenceEdge("app.AppModule", "volo.Core.AbpModule", EdgeKind.INHERITS)
+        graph.add_reference_edge(inherits)
+
+        stats = complete_type_references(graph, [module, core], SourceInspector())
+
+        typerefs = [ref for ref in graph.reference_edges if ref.kind is EdgeKind.TYPEREF]
+        assert _pairs(typerefs) == {
+            ("app.AppModule", "volo.Core.CoreModule"),
+            ("app.AppModule.Configure(AbpOptions options)", "volo.Core.AbpOptions"),
+        }
+        assert inherits in graph.reference_edges
+        assert stats.edges == 2

--- a/tests/static_analyzer/test_type_reference_builder.py
+++ b/tests/static_analyzer/test_type_reference_builder.py
@@ -5,13 +5,12 @@ from pathlib import Path
 from static_analyzer.cfg import CallGraph, EdgeKind, ReferenceEdge
 from static_analyzer.config import NodeType
 from static_analyzer.engine.models import TypeReferenceSite
-from static_analyzer.engine.source_inspector import SourceInspector
+from static_analyzer.engine.source_inspector import SourceInspector, simple_type_name
 from static_analyzer.engine.type_reference_builder import (
     TypeIndex,
     TypeReferenceStats,
     build_type_references,
     complete_type_references,
-    simple_type_name,
 )
 from static_analyzer.node import Node
 
@@ -42,6 +41,13 @@ def _resolved_name(index: TypeIndex, site: TypeReferenceSite) -> str | None:
 def test_simple_type_name_strips_path_and_arity():
     assert simple_type_name("a.b.Foo<T>") == "Foo"
     assert simple_type_name("Foo") == "Foo"
+    # A dotted type argument must not win the last-dot split...
+    assert simple_type_name("a.b.Box<x.y.T>") == "Box"
+    # ...and a generic segment that is not the last one must not swallow the name after it.
+    assert simple_type_name("A.B.Repo<T>.Entry") == "Entry"
+    assert simple_type_name("A.Outer<x.y.T>.Inner") == "Inner"
+    # A symbol whose name carries prose with an unbalanced bracket still yields its last segment.
+    assert simple_type_name("suite('release <= version') callback.downloadUrls") == "downloadUrls"
 
 
 class TestTypeIndexCSharp:
@@ -102,6 +108,57 @@ class TestTypeIndexCSharp:
         assert not index.has_candidates("Guid")
 
 
+class TestTypeIndexCSharpUsings:
+    """A ``using`` decides a name; the reader records what was written and the resolver applies it."""
+
+    def test_an_alias_decides_the_name_over_directory_proximity(self, tmp_path: Path):
+        vendor = _write(tmp_path / "vendor" / "Widget.cs", "namespace Vendor;\npublic class Widget { }\n")
+        core = _write(tmp_path / "core" / "Widget.cs", "namespace Core;\npublic class Widget { }\n")
+        user = _write(
+            tmp_path / "core" / "ui" / "User.cs",
+            "using Widget = Vendor.Widget;\nnamespace Core.Ui;\npublic class User { }\n",
+        )
+        index = TypeIndex([_class("vendor.Widget", vendor), _class("core.Widget", core)], SourceInspector())
+        # Without the alias the nearer `core/Widget.cs` wins on shared directory prefix.
+        assert _resolved_name(index, _site(user, "Widget", line=3)) == "vendor.Widget"
+
+    def test_an_alias_expands_the_leftmost_segment_of_a_qualified_name(self, tmp_path: Path):
+        leaf = _write(tmp_path / "a" / "Leaf.cs", "namespace A.Inner;\npublic class Leaf { }\n")
+        user = _write(tmp_path / "u" / "User.cs", "using Io = A.Inner;\nnamespace U;\npublic class User { }\n")
+        index = TypeIndex([_class("a.Leaf", leaf)], SourceInspector())
+        assert _resolved_name(index, _site(user, "Leaf", line=3, qualifier="Io")) == "a.Leaf"
+
+    def test_an_alias_naming_something_outside_the_graph_resolves_to_nothing(self, tmp_path: Path):
+        """It must not fall through and guess: C# says the alias decided the name."""
+        core = _write(tmp_path / "core" / "Widget.cs", "namespace Core;\npublic class Widget { }\n")
+        user = _write(
+            tmp_path / "core" / "ui" / "User.cs",
+            "using Widget = Nuget.Package.Widget;\nnamespace Core.Ui;\npublic class User { }\n",
+        )
+        index = TypeIndex([_class("core.Widget", core)], SourceInspector())
+        assert index.resolve(_site(user, "Widget", line=3)) is None
+
+    def test_a_using_inside_a_namespace_block_does_not_reach_its_sibling(self, tmp_path: Path):
+        a = _write(tmp_path / "a" / "Widget.cs", "namespace A;\npublic class Widget { }\n")
+        b = _write(tmp_path / "b" / "Widget.cs", "namespace B;\npublic class Widget { }\n")
+        user = _write(
+            tmp_path / "u" / "User.cs",
+            "namespace N1\n{\n    using A;\n    class C1 { }\n}\n"
+            "namespace N2\n{\n    using B;\n    class C2 { }\n}\n",
+        )
+        index = TypeIndex([_class("a.Widget", a), _class("b.Widget", b)], SourceInspector())
+        assert _resolved_name(index, _site(user, "Widget", line=4)) == "a.Widget"
+        assert _resolved_name(index, _site(user, "Widget", line=9)) == "b.Widget"
+
+    def test_a_static_using_does_not_make_its_namespace_nameable(self, tmp_path: Path):
+        """``using static A.B`` brings in B's members, not the types alongside B."""
+        held = _write(tmp_path / "a" / "X.cs", "namespace A.B;\npublic class X { }\n")
+        own = _write(tmp_path / "c" / "X.cs", "namespace C;\npublic class X { }\n")
+        user = _write(tmp_path / "u" / "User.cs", "using static A.B;\nnamespace C;\npublic class User { }\n")
+        index = TypeIndex([_class("a.X", held), _class("c.X", own)], SourceInspector())
+        assert _resolved_name(index, _site(user, "X", line=3)) == "c.X"
+
+
 class TestTypeIndexScript:
     def test_resolves_through_a_relative_import(self, tmp_path: Path):
         svc = _write(tmp_path / "svc.ts", "export class Svc { }\n")
@@ -131,6 +188,38 @@ class TestTypeIndexScript:
         user = _write(tmp_path / "user.ts", "class Local { }\n")
         index = TypeIndex([_class("user.Local", user)], SourceInspector())
         assert _resolved_name(index, _site(user, "Local")) == "user.Local"
+
+    def test_an_explicit_js_extension_resolves_to_the_typescript_module(self, tmp_path: Path):
+        """What NodeNext forces you to write: the specifier says .js, the module is .ts."""
+        svc = _write(tmp_path / "src" / "svc.ts", "export class Svc { }\n")
+        user = _write(tmp_path / "src" / "u.ts", "import { Svc } from './svc.js';\n")
+        index = TypeIndex([_class("src.svc.Svc", svc)], SourceInspector())
+        assert _resolved_name(index, _site(user, "Svc")) == "src.svc.Svc"
+
+    def test_an_explicit_extension_resolves_when_the_module_really_is_javascript(self, tmp_path: Path):
+        svc = _write(tmp_path / "src" / "svc.js", "export class Svc { }\n")
+        user = _write(tmp_path / "src" / "u.js", "import { Svc } from './svc.js';\n")
+        index = TypeIndex([_class("src.svc.Svc", svc)], SourceInspector())
+        assert _resolved_name(index, _site(user, "Svc")) == "src.svc.Svc"
+
+    def test_a_directory_import_through_index_resolves(self, tmp_path: Path):
+        svc = _write(tmp_path / "src" / "lib" / "svc.ts", "export class Svc { }\n")
+        user = _write(tmp_path / "src" / "u.ts", "import { Svc } from './lib/index.js';\n")
+        index = TypeIndex([_class("src.lib.svc.Svc", svc)], SourceInspector())
+        assert _resolved_name(index, _site(user, "Svc")) == "src.lib.svc.Svc"
+
+    def test_an_aliased_import_with_an_extension_resolves_to_the_exported_name(self, tmp_path: Path):
+        svc = _write(tmp_path / "src" / "svc.ts", "export class Svc { }\n")
+        user = _write(tmp_path / "src" / "u.ts", "import { Svc as S } from './svc.js';\n")
+        index = TypeIndex([_class("src.svc.Svc", svc)], SourceInspector())
+        assert _resolved_name(index, _site(user, "S")) == "src.svc.Svc"
+
+    def test_a_sibling_module_of_the_same_name_is_not_matched(self, tmp_path: Path):
+        """The precision fence: dropping the extension must not degrade into basename matching."""
+        elsewhere = _write(tmp_path / "a" / "svc.ts", "export class Svc { }\n")
+        user = _write(tmp_path / "src" / "u.ts", "import { Svc } from './svc.js';\n")
+        index = TypeIndex([_class("a.svc.Svc", elsewhere)], SourceInspector())
+        assert index.resolve(_site(user, "Svc")) is None
 
     def test_an_unimported_name_resolves_only_when_unique(self, tmp_path: Path):
         first = _write(tmp_path / "a" / "svc.ts", "export class Svc { }\n")
@@ -197,6 +286,23 @@ class TestBuildTypeReferences:
         stats = TypeReferenceStats()
         assert build_type_references(inspector, TypeIndex(nodes, inspector), [path], stats) == []
         assert stats.resolved == 2
+
+    def test_script_type_references_survive_an_explicit_extension(self, tmp_path: Path):
+        svc = _write(tmp_path / "src" / "svc.ts", "export class Svc { }\n")
+        user = _write(
+            tmp_path / "src" / "u.ts",
+            "import { Svc } from './svc.js';\nexport class U { run(s: Svc) { } }\n",
+        )
+        nodes = [
+            _class("src.svc.Svc", svc, 1, 1),
+            _class("src.u.U", user, 2, 2),
+            _method("src.u.U.run(s)", user, 2, 2),
+        ]
+        inspector = SourceInspector()
+        stats = TypeReferenceStats()
+        pairs = build_type_references(inspector, TypeIndex(nodes, inspector), [svc, user], stats)
+        assert ("src.u.U.run(s)", "src.svc.Svc") in pairs
+        assert (stats.resolved, stats.ambiguous) == (1, 0)
 
     def test_complete_type_references_replaces_stale_edges_and_keeps_other_kinds(self, tmp_path: Path):
         module, core, nodes = self._fixture(tmp_path)

--- a/tests/static_analyzer/test_type_reference_builder.py
+++ b/tests/static_analyzer/test_type_reference_builder.py
@@ -1,0 +1,221 @@
+"""Tests for static_analyzer.engine.type_reference_builder."""
+
+from pathlib import Path
+
+from static_analyzer.cfg import CallGraph, EdgeKind, ReferenceEdge
+from static_analyzer.config import NodeType
+from static_analyzer.engine.models import TypeReferenceSite
+from static_analyzer.engine.source_inspector import SourceInspector
+from static_analyzer.engine.type_reference_builder import (
+    TypeIndex,
+    TypeReferenceStats,
+    build_type_references,
+    complete_type_references,
+    simple_type_name,
+)
+from static_analyzer.node import Node
+
+
+def _class(qualified_name: str, path: Path, start: int = 1, end: int = 20) -> Node:
+    return Node(qualified_name, NodeType.CLASS, str(path), start, end)
+
+
+def _method(qualified_name: str, path: Path, start: int, end: int) -> Node:
+    return Node(qualified_name, NodeType.METHOD, str(path), start, end)
+
+
+def _write(path: Path, text: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text)
+    return path
+
+
+def _site(path: Path, name: str, line: int = 2, qualifier: str = "") -> TypeReferenceSite:
+    return TypeReferenceSite(file=str(path), line=line, column=1, name=name, qualifier=qualifier)
+
+
+def _resolved_name(index: TypeIndex, site: TypeReferenceSite) -> str | None:
+    node = index.resolve(site)
+    return node.fully_qualified_name if node is not None else None
+
+
+def test_simple_type_name_strips_path_and_arity():
+    assert simple_type_name("a.b.Foo<T>") == "Foo"
+    assert simple_type_name("Foo") == "Foo"
+
+
+class TestTypeIndexCSharp:
+    def test_a_unique_name_resolves_from_anywhere(self, tmp_path: Path):
+        foo = _write(tmp_path / "lib" / "Foo.cs", "namespace Lib;\npublic class Foo { }\n")
+        user = _write(tmp_path / "app" / "User.cs", "namespace App;\npublic class User { }\n")
+        index = TypeIndex([_class("lib.Foo", foo)], SourceInspector())
+        assert _resolved_name(index, _site(user, "Foo")) == "lib.Foo"
+
+    def test_the_enclosing_namespace_wins(self, tmp_path: Path):
+        a = _write(tmp_path / "a" / "Foo.cs", "namespace A;\npublic class Foo { }\n")
+        b = _write(tmp_path / "b" / "Foo.cs", "namespace B;\npublic class Foo { }\n")
+        user = _write(tmp_path / "c" / "User.cs", "namespace B;\npublic class User { }\n")
+        index = TypeIndex([_class("a.Foo", a), _class("b.Foo", b)], SourceInspector())
+        assert _resolved_name(index, _site(user, "Foo")) == "b.Foo"
+
+    def test_a_using_directive_makes_a_namespace_visible(self, tmp_path: Path):
+        a = _write(tmp_path / "a" / "Foo.cs", "namespace A;\npublic class Foo { }\n")
+        b = _write(tmp_path / "b" / "Foo.cs", "namespace B;\npublic class Foo { }\n")
+        user = _write(tmp_path / "c" / "User.cs", "using A;\nnamespace C;\npublic class User { }\n")
+        index = TypeIndex([_class("a.Foo", a), _class("b.Foo", b)], SourceInspector())
+        assert _resolved_name(index, _site(user, "Foo")) == "a.Foo"
+
+    def test_a_parent_namespace_is_visible(self, tmp_path: Path):
+        a = _write(tmp_path / "a" / "Foo.cs", "namespace Root;\npublic class Foo { }\n")
+        b = _write(tmp_path / "b" / "Foo.cs", "namespace Other;\npublic class Foo { }\n")
+        user = _write(tmp_path / "c" / "User.cs", "namespace Root.Sub;\npublic class User { }\n")
+        index = TypeIndex([_class("a.Foo", a), _class("b.Foo", b)], SourceInspector())
+        assert _resolved_name(index, _site(user, "Foo")) == "a.Foo"
+
+    def test_the_written_qualifier_narrows_candidates(self, tmp_path: Path):
+        a = _write(tmp_path / "a" / "Foo.cs", "namespace A;\npublic class Foo { }\n")
+        b = _write(tmp_path / "b" / "Foo.cs", "namespace B;\npublic class Foo { }\n")
+        user = _write(tmp_path / "c" / "User.cs", "namespace A;\npublic class User { }\n")
+        index = TypeIndex([_class("a.Foo", a), _class("b.Foo", b)], SourceInspector())
+        assert _resolved_name(index, _site(user, "Foo", qualifier="B")) == "b.Foo"
+
+    def test_equally_visible_copies_prefer_the_closest_directory(self, tmp_path: Path):
+        """Every project template declares the same ``Program``; a reference means its own copy."""
+        first = _write(tmp_path / "t1" / "Program.cs", "public class Program { }\n")
+        second = _write(tmp_path / "t2" / "Program.cs", "public class Program { }\n")
+        user = _write(tmp_path / "t1" / "Startup.cs", "public class Startup { }\n")
+        index = TypeIndex([_class("t1.Program", first), _class("t2.Program", second)], SourceInspector())
+        assert _resolved_name(index, _site(user, "Program")) == "t1.Program"
+
+    def test_equidistant_copies_are_undecidable(self, tmp_path: Path):
+        x = _write(tmp_path / "x" / "Foo.cs", "namespace N;\npublic class Foo { }\n")
+        y = _write(tmp_path / "y" / "Foo.cs", "namespace N;\npublic class Foo { }\n")
+        user = _write(tmp_path / "z" / "User.cs", "namespace N;\npublic class User { }\n")
+        index = TypeIndex([_class("x.Foo", x), _class("y.Foo", y)], SourceInspector())
+        assert index.resolve(_site(user, "Foo")) is None
+        assert index.has_candidates("Foo")
+
+    def test_an_unknown_name_is_none(self, tmp_path: Path):
+        user = _write(tmp_path / "User.cs", "public class User { }\n")
+        index = TypeIndex([_class("User", user)], SourceInspector())
+        assert index.resolve(_site(user, "Guid")) is None
+        assert not index.has_candidates("Guid")
+
+
+class TestTypeIndexScript:
+    def test_resolves_through_a_relative_import(self, tmp_path: Path):
+        svc = _write(tmp_path / "svc.ts", "export class Svc { }\n")
+        user = _write(tmp_path / "user.ts", "import { Svc } from './svc';\n")
+        index = TypeIndex([_class("svc.Svc", svc)], SourceInspector())
+        assert _resolved_name(index, _site(user, "Svc")) == "svc.Svc"
+
+    def test_an_alias_resolves_to_the_exported_name(self, tmp_path: Path):
+        svc = _write(tmp_path / "svc.ts", "export class Svc { }\n")
+        user = _write(tmp_path / "user.ts", "import { Svc as S } from './svc';\n")
+        index = TypeIndex([_class("svc.Svc", svc)], SourceInspector())
+        assert _resolved_name(index, _site(user, "S")) == "svc.Svc"
+
+    def test_a_namespace_import_resolves_the_qualified_name(self, tmp_path: Path):
+        svc = _write(tmp_path / "lib" / "svc.ts", "export class Svc { }\n")
+        user = _write(tmp_path / "user.ts", "import * as NS from './lib/svc';\n")
+        index = TypeIndex([_class("lib.svc.Svc", svc)], SourceInspector())
+        assert _resolved_name(index, _site(user, "Svc", qualifier="NS")) == "lib.svc.Svc"
+
+    def test_a_package_import_is_external_even_when_a_repo_class_shares_the_name(self, tmp_path: Path):
+        svc = _write(tmp_path / "svc.ts", "export class Svc { }\n")
+        user = _write(tmp_path / "user.ts", "import { Svc } from '@abp/ng.core';\n")
+        index = TypeIndex([_class("svc.Svc", svc)], SourceInspector())
+        assert index.resolve(_site(user, "Svc")) is None
+
+    def test_a_same_file_class_needs_no_import(self, tmp_path: Path):
+        user = _write(tmp_path / "user.ts", "class Local { }\n")
+        index = TypeIndex([_class("user.Local", user)], SourceInspector())
+        assert _resolved_name(index, _site(user, "Local")) == "user.Local"
+
+    def test_an_unimported_name_resolves_only_when_unique(self, tmp_path: Path):
+        first = _write(tmp_path / "a" / "svc.ts", "export class Svc { }\n")
+        second = _write(tmp_path / "b" / "svc.ts", "export class Svc { }\n")
+        user = _write(tmp_path / "user.ts", "const x = 1;\n")
+        assert TypeIndex([_class("a.svc.Svc", first)], SourceInspector()).resolve(_site(user, "Svc")) is not None
+        both = TypeIndex([_class("a.svc.Svc", first), _class("b.svc.Svc", second)], SourceInspector())
+        assert both.resolve(_site(user, "Svc")) is None
+
+
+class TestContainerAt:
+    def test_innermost_declaration_wins(self, tmp_path: Path):
+        path = tmp_path / "A.cs"
+        method = _method("A.M()", path, 5, 10)
+        index = TypeIndex([_class("A", path, 1, 20), method], SourceInspector())
+        assert index.container_at(str(path), 7) is method
+        outer = index.container_at(str(path), 3)
+        assert outer is not None and outer.fully_qualified_name == "A"
+        assert index.container_at(str(path), 30) is None
+        assert index.container_at("elsewhere.cs", 7) is None
+
+
+class TestBuildTypeReferences:
+    def _fixture(self, tmp_path: Path) -> tuple[Path, Path, list[Node]]:
+        module = _write(
+            tmp_path / "app" / "AppModule.cs",
+            "using Volo;\n"
+            "namespace App;\n"
+            "[DependsOn(typeof(CoreModule))]\n"
+            "public class AppModule : AbpModule\n"
+            "{\n"
+            "    public void Configure(AbpOptions options) { }\n"
+            "}\n",
+        )
+        core = _write(
+            tmp_path / "volo" / "Core.cs",
+            "namespace Volo;\npublic class AbpModule { }\npublic class CoreModule { }\npublic class AbpOptions { }\n",
+        )
+        nodes = [
+            _class("app.AppModule", module, 3, 7),
+            _method("app.AppModule.Configure(AbpOptions options)", module, 6, 6),
+            _class("volo.Core.AbpModule", core, 2, 2),
+            _class("volo.Core.CoreModule", core, 3, 3),
+            _class("volo.Core.AbpOptions", core, 4, 4),
+        ]
+        return module, core, nodes
+
+    def test_edges_run_from_the_enclosing_declaration_to_the_named_type(self, tmp_path: Path):
+        module, core, nodes = self._fixture(tmp_path)
+        inspector = SourceInspector()
+        stats = TypeReferenceStats()
+        pairs = build_type_references(inspector, TypeIndex(nodes, inspector), [module, core], stats)
+        assert set(pairs) == {
+            ("app.AppModule", "volo.Core.CoreModule"),
+            ("app.AppModule", "volo.Core.AbpModule"),
+            ("app.AppModule.Configure(AbpOptions options)", "volo.Core.AbpOptions"),
+        }
+        assert (stats.sites, stats.resolved, stats.unresolved, stats.ambiguous) == (3, 3, 0, 0)
+
+    def test_a_declaration_naming_its_own_type_is_not_an_edge(self, tmp_path: Path):
+        path = _write(tmp_path / "A.cs", "public class A\n{\n    public A Clone(A other) { return other; }\n}\n")
+        nodes = [_class("A", path, 1, 4), _method("A.Clone(A other)", path, 3, 3)]
+        inspector = SourceInspector()
+        stats = TypeReferenceStats()
+        assert build_type_references(inspector, TypeIndex(nodes, inspector), [path], stats) == []
+        assert stats.resolved == 2
+
+    def test_complete_type_references_replaces_stale_edges_and_keeps_other_kinds(self, tmp_path: Path):
+        module, core, nodes = self._fixture(tmp_path)
+        graph = CallGraph(language="csharp")
+        for node in nodes:
+            graph.add_node(node)
+        graph.add_reference_edge(ReferenceEdge("app.AppModule", "volo.Core.AbpOptions", EdgeKind.TYPEREF))
+        graph.add_reference_edge(ReferenceEdge("app.AppModule", "volo.Core.AbpModule", EdgeKind.INHERITS))
+
+        stats = complete_type_references(graph, [module, core], SourceInspector())
+        stats_again = complete_type_references(graph, [module, core], SourceInspector())
+
+        typerefs = {(ref.src, ref.dst) for ref in graph.reference_edges if ref.kind is EdgeKind.TYPEREF}
+        assert typerefs == {
+            ("app.AppModule", "volo.Core.CoreModule"),
+            ("app.AppModule", "volo.Core.AbpModule"),
+            ("app.AppModule.Configure(AbpOptions options)", "volo.Core.AbpOptions"),
+        }
+        assert stats.edges == stats_again.edges == 3
+        assert sum(1 for ref in graph.reference_edges if ref.kind is EdgeKind.TYPEREF) == 3
+        assert ReferenceEdge("app.AppModule", "volo.Core.AbpModule", EdgeKind.INHERITS) in graph.reference_edges
+        assert "3 sites -> 3 edges" in stats.summary()

--- a/tests/static_analyzer/test_type_reference_builder.py
+++ b/tests/static_analyzer/test_type_reference_builder.py
@@ -125,6 +125,35 @@ class TestTypeIndexCSharp:
         index = TypeIndex(nodes, SourceInspector())
         assert _resolved_name(index, _site(outer, "Inner", line=5)) == "n.Outer.Inner"
 
+    def test_a_bare_name_does_not_reach_a_type_nested_in_another(self, tmp_path: Path):
+        """A bare ``File`` is the framework's, whatever ``Options.File`` the repository declares."""
+        outer = _write(
+            tmp_path / "n" / "Outer.cs", "namespace N;\npublic class Outer\n{\n    public class Inner { }\n}\n"
+        )
+        user = _write(tmp_path / "u" / "User.cs", "using N;\nnamespace U;\npublic class User { }\n")
+        nodes = [_class("n.Outer", outer, 2, 5), _class("n.Outer.Inner", outer, 4, 4)]
+        index = TypeIndex(nodes, SourceInspector())
+        assert index.resolve(_site(user, "Inner", line=3)) is None
+
+    def test_a_static_using_names_a_nested_type_bare(self, tmp_path: Path):
+        outer = _write(
+            tmp_path / "n" / "Outer.cs", "namespace N;\npublic class Outer\n{\n    public class Inner { }\n}\n"
+        )
+        user = _write(tmp_path / "u" / "User.cs", "using static N.Outer;\nnamespace U;\npublic class User { }\n")
+        nodes = [_class("n.Outer", outer, 2, 5), _class("n.Outer.Inner", outer, 4, 4)]
+        index = TypeIndex(nodes, SourceInspector())
+        assert _resolved_name(index, _site(user, "Inner", line=3)) == "n.Outer.Inner"
+
+    def test_a_top_level_type_answers_the_bare_name_instead(self, tmp_path: Path):
+        outer = _write(
+            tmp_path / "n" / "Outer.cs", "namespace N;\npublic class Outer\n{\n    public class Inner { }\n}\n"
+        )
+        other = _write(tmp_path / "m" / "Inner.cs", "namespace M;\npublic class Inner { }\n")
+        user = _write(tmp_path / "u" / "User.cs", "namespace U;\npublic class User { }\n")
+        nodes = [_class("n.Outer", outer, 2, 5), _class("n.Outer.Inner", outer, 4, 4), _class("m.Inner", other)]
+        index = TypeIndex(nodes, SourceInspector())
+        assert _resolved_name(index, _site(user, "Inner")) == "m.Inner"
+
     def test_equally_visible_copies_prefer_the_closest_directory(self, tmp_path: Path):
         """Every project template declares the same ``Program``; a reference means its own copy."""
         first = _write(tmp_path / "t1" / "Program.cs", "public class Program { }\n")


### PR DESCRIPTION
Answers "where do abp's disconnected components come from?" and closes the C# half of it: a type-reference (`TYPEREF`) layer read from source with tree-sitter, reference edges drawn as relations, the callable-usage walk fixed, and the two save-path quadratics that a type-complete graph exposes. Measured on abp (6,615 files, 29 .NET solutions) across three full runs.

## Where the floating boxes came from (0.14.0 run, 504 components)

| cause | scale | evidence |
|---|---|---|
| **C#: missing *type* edges, not missing calls** | 43 of 456 components | every one is a type-wired shape — `*Module`/`*Installer` (`[DependsOn(typeof(X))]`), Mapperly mappers (generic base args), DbContexts (`DbSet<T>`), `templates/*` (framework only via NuGet), consts/enums; 885 hard-isolated C# nodes, 777 of them classes |
| **TS/JS: a hub fan-in bug, then genuinely independent scripts** | 40 of 44 | 29 copies of `var abp = abp \|\| {}` absorbed **95.9% of all TS edges** (11,368 of 11,859); of the 29,725 call sites behind them, 58 genuinely passed or returned the object |
| **root/L1: attribution** | 9/9 → 3/9 rolled up | relations credit the deepest owner, so parents look floating |

## The commits

1. **`fix(edges)`** — the callable-usage walk climbed through function boundaries and member chains, so `$(function () { abp.x(); })`, `f(abp.x.y)` and `return { k: abp.x }` all counted as "abp passed as a callable". Stop at a function boundary; a member-chain receiver is never the value passed or returned (both walks, every grammar's receiver field). abp TS edges 11,859 → 1,263; the 783 hub edges left are the genuine `f(abp)` uses.
2. **`feat(cfg)`** — `SourceInspector.find_type_reference_sites` reads type positions (C# type slots, `type_argument_list`, `base_list`, `typeof`, `as`/`is`, catch, member-access receivers; TS `type_identifier`, `extends`, decorator arrays). `type_reference_builder.TypeIndex` resolves names against the **merged** graph's class-like nodes — C# by declared-namespace visibility (`find_namespace_context`; a file-scoped `namespace X;` spans the file, its declarations are siblings in this grammar), then usings, then directory proximity; TS through relative imports (`find_import_bindings`), package imports stay external. `StaticAnalyzer.analyze` rebuilds the layer after the per-project graphs merge, which is what lets a template's `AbpModule` resolve into `framework/`. abp: 163,509 sites → 29,887 edges in 10 s; hard-isolated C# nodes 885 → 224; isolated files 625 → 53. Receivers are C#-only: in a script a promoted variable like `data` resolves to the wrong file.
3. **`feat(relations)`** — `RELATION_REFERENCE_KINDS = (INHERITS, TYPEREF)` count as relations in `build_component_relations`, the clustering service's group connections (`ClusterConnectionEdge.kind`) and the per-scope merge. A pair with calls keeps "calls"; reference-only pairs get "uses" / "inherits from" (`static_relation_label`), and `RelationEdge.from_reference` tags the edge's `description` — no schema change. The scope prompt gains a per-pair `type_references` count; reference edges stay out of `bordering_files` (one line per file per reference bordered nearly every abp file and grew the root prompt 472k → 598k tokens in the partial run).
4. **`perf(save)`** — `FileEntry.merge_from` deep-copied every owned method on every merge, and every progress save re-merges every file of every scope: 4.4M deepcopies per save on abp (81.5 s → 5.7 s). `build_global_relations` scanned every semantic relation per static pair (28M `is_self_or_descendant` calls, 11.3 s → 0.3 s).

11. **`feat(clustering)`** — `TYPEREF` was already in `AFFINE_REFERENCE_KINDS` on main, where nothing emitted it and it was inert; this branch makes it live, which would have re-partitioned every repository as a side effect. It is now excluded, so the layer draws an edge and leaves the boxes alone. Measured both ways: on eShop counting it costs two of the nine boxes its maintainers publish (7/9 → 5/9, because every service names the event bus's types and the fold reads that density as affinity); on abp it would help (largest box 53.8% → 24.9%). Helping where names cannot separate and hurting where they already do is not one switch, so drawing and partitioning stay separate decisions.

Three more from the review round, after the bot comments (9 findings: 4 real, 5 declined with evidence — see [the reply](https://github.com/CodeBoarding/CodeBoarding/pull/568#issuecomment-5577581381)):

5. **`fix(cfg)`** — the C# reader threw away part of what the source wrote and the resolver guessed at the rest. A `using` was flattened to its target, losing the alias name (so `using BasketItem = ...Models.Basket.BasketItem;` was decided by directory proximity, and on eShop picked the generated gRPC type), the `static` kind, and the lexical scope (a using inside one namespace block was in force in its siblings). A written type name reached the index unnormalised: `A.Box<T>` looked up as `Box<T>` where the index is keyed `Box`, `global::A.Foo` carrying a qualifier no namespace can end with. And a TS relative import that writes its extension matched nothing — `./svc.js` never string-prefixes `svc.ts`, which is most of what a NodeNext project writes.
6. **`chore(cache)`** — `_TAG_VERSION` v7 → v8. Commit 1 changes which call edges come out of identical source, and the freshness gate is the source SHA, so without a bump a warm start keeps serving the old graph.
7. **`perf(cfg)`** — the pass decided the language *after* parsing the file, so every Python, Java, Go, PHP and Rust file paid a full tree-sitter parse to have the tree thrown away.
8. **`refactor(relations)`** — one vocabulary for edge kinds. `EdgeKind` gains `CALL` and a `relation_label` per kind, `RelationEdge` carries the kind of the static edge behind it, and `Relation.default_label` records that a label was computed rather than written — the carry filter used to decide that by comparing the text, so a model that described a pair as "uses" had its own wording and evidence thrown away on the next incremental run. `ReferenceEdge` now carries the sites that produced it, so a type reference reaches the prompt and the relation with the positions where the type is named, the way a call does with its call sites.
9. **`feat(cfg)`** — resolution now walks the scopes C# and TS actually have. One `ImportDirective`/`NameScope` describes a using and an import alike; lookup goes enclosing types, then each namespace with the usings written in *its* declaration, then the compilation unit with its `global using`s, stopping at the first scope holding a candidate. Consequences: a qualifier matches whole segments (`Domain` no longer accepts `FooDomain`), `Outer.Inner` resolves through the enclosing type instead of comparing it with a namespace, a `global using` governs its whole compilation rather than its own file, and a base written in a base list is no longer doubled as a type reference on top of the inheritance edge the graph already has. Replayed offline on eShop: 20 edges gained, one lost; serilog and nest identical.
10. **`fix(cfg)`** — a bare name never means a type nested in another type. A namespace can be opened by an import this layer cannot see, so a name unique in the graph resolves from anywhere; a nested type is not like that, and abp's `TranslateCommand.Options.File` was answering every `File.Create(...)` in the repository. 440 edges over 10 targets and 47 component pairs removed, 4 added where the wrong candidate had made a name ambiguous. See "Where the edge was simply wrong" below.

## What kind of edge this actually discovers

A call is a **runtime** dependency: this path executes that one. A type reference is a
**compile-time** dependency: this code does not build without that type. Both are real and they
break differently, which is why these carry the label `uses` rather than `calls` and stay off
`CallGraph.edges`.

Everything below is measured on abp itself rather than on a fixture, by resolving each type
position against the real index and grouping the resulting edges by the syntax that produced them
(`runs/abp-type-references/tools/edge_positions.py` in the evals PR). 163,509 C# positions read,
37,367 resolving to a type of this repository, **19,123 crossing a component boundary**. They
touch 2,687 component pairs, and **1,659 of those pairs have no call edge in either direction** —
those relations could not be drawn at all before this branch.

| position | edges | on a pair no call connects | as written in abp |
|---|---:|---:|---|
| static member receiver | 5,872 | 2,524 | `request.Headers.Add(TimeZoneConsts.DefaultTimeZoneKey, …)` |
| generic argument | 4,100 | 1,611 | `Configure<AbpLocalizationOptions>(…)` |
| parameter type | 3,565 | 1,478 | `MauiBlazorContentFileProvider(IVirtualFileProvider provider)` |
| base type or interface | 2,743 | 1,804 | `public class AbpAIAbstractionsModule : AbpModule` |
| field or property type | 1,490 | 573 | `protected IClock Clock { get; }` |
| `typeof(…)` | 627 | 142 | `typeof(IApplicationService).IsAssignableFrom(t)` |
| return type | 280 | 72 | `public static NumberBag BuildBag()` |
| generic constraint | 172 | 61 | `where TDestination : IHasExtraProperties` |
| pattern, `as`, `is`, cast | 220 | 39 | `if (o is Container c)` |
| `catch` type | 24 | 16 | `catch (AbpDbConcurrencyException ex)` |
| array creation | 12 | 12 | `.AddRange(new EntityAction[] { … })` |
| local variable type | 17 | 7 | rare in C#, which writes `var` |

The tool splits the generic row further by what the generic sits on — 1,331 on a static member
receiver, 802 on a return type, 717 on a call's arguments, 339 on a parameter — which is where to
look if one of these groups deserves to be dropped.

Of the 2,743 base-list references, 1,353 are inheritance the language server already recorded:
those stay `INHERITS` and read "inherits from". The other **1,390 are inheritance no server ever
saw**, because the base type lives in a solution that only references it as a NuGet package.

### Groups that no call graph could have found

**The module graph.** abp wires itself with `[DependsOn(typeof(X))]` and `Configure<TOptions>`;
not one of those is a call. `AbpIoLocalizationModule.cs:37` names `AbpValidationResource`, line 22
names `AbpVirtualFileSystemOptions`, line 18 declares `: AbpModule`. Before this branch that whole
module, and every `*Module` like it, was a box with no edges. This is the clearest case where the
edge is not merely defensible but is the architecture.

**Constructor injection.** `MauiBlazorContentFileProvider(IVirtualFileProvider virtualFileProvider)`
is the strongest dependency in a DI codebase and produces no call site anywhere: the container does
the constructing. 3,565 edges, 1,478 of them the only thing joining their two components.

**Implementing an interface from another module.**
`public class ChatClientAccessor : IChatClientAccessor, ITransientDependency` — the implementer
never calls the interface, so a call graph sees nothing. 1,804 of these join components that were
otherwise unconnected, and they are the reason abp's `*Installer` classes and Mapperly mappers
stopped floating.

**Constants, enums and options classes** — the case you named. `TimeZoneConsts.DefaultTimeZoneKey`
is a field read, not a call, so the class holding the constants was unreachable by any call edge;
same for an enum's member and for a `static class` of option names. This is what the "static member
receiver" row is mostly made of, and it is the only way such a class is reachable at all.

**Exception contracts.** `catch (AbpDbConcurrencyException ex)` in `IdentityRoleStore` is a real
compile-time dependency on `Volo.Abp.Data`, and one nobody would draw by hand. Small (24), and
honestly closer to incidental than to architecture.

### Where the edge is real but the signal is weaker

- **A static member receiver double counts.** `Formatter.FormatLabel(name)` is both a call and a
  type reference: the pair usually already has a call edge, and the reference adds the *class*
  where the call named the method. It stays because dropping it would lose every consts class and
  enum, which are never called — but it inflates a pair that was already connected. 3,348 of the
  5,872 are on pairs a call already joins.
- **A local variable type** is inside a method body rather than on an interface, so it says less
  about the architecture than a parameter does. In C# this is nearly nothing (17) because the
  language writes `var`.
- **`as` / `is` / a cast** is genuine and usually incidental.

### Where the edge was simply wrong

Grouping abp's real edges this way is what turned up a defect, and it is the largest single
false-positive family I found:

**A nested type answering a bare name.** abp declares `class TranslateCommand { … static class
Options { static class File } }`. `File` is then the only type of that name in the repository, so
every `File.Create(…)`, `Directory.Exists(…)` and `Url` written anywhere in abp — all meaning
`System.IO` — resolved to the CLI's nested option classes. 440 edges over 10 targets, and **47
component pairs that existed for no other reason**, nearly all of them an arrow from some component
into abp's CLI. A nested type is reachable unqualified only from inside its enclosing type or
through `using static`, never through an import the reader failed to see, so the last commit stops
treating it like a namespace. 4 edges appear in exchange, where the wrong candidate had been making
a name ambiguous.

**A receiver that is a property, not a type.** `if (Clock.SupportsMultipleTimezone)` reads the
enclosing class's own injected `IClock` property, but the reader sees an identifier in a receiver
position and the index answers with abp's concrete `Clock` class. The C# graph keeps no property
symbols (27 in 24k nodes), so there is nothing to check the name against. Counting receiver names
that are also bound as a member, parameter or local within reach puts an **upper bound of 1,158 of
the 5,872 receiver edges (19.7%)** on this — an upper bound because one name can be both, so some
of those are genuine. The names are abp's injected base-class properties: `CurrentTenant` 143,
`Clock` 63, `UnitOfWorkManager` 58, `CurrentUser` 33. Not fixed here; the fix is to let the reader
skip a receiver the file itself binds, and I would rather measure that on more than one repository
before shipping it.

### What is deliberately not drawn

- **`new Other()`** — the constructor call already carries that edge; counting the type as well
  would double the pair.
- **A declaration's own name** — `class Service` is not a reference to `Service`.
- **A Go method's receiver** — `func (e *Entity) SetType(…)` is containment, already `CONTAINS`
  (fixed in #574 after this same exercise; it was 42% of Go's references).
- **Anything outside the repository.** 126,142 of the 163,509 positions resolve to nothing —
  `Guid`, `Task`, `DateTime`, `CancellationToken`, lambda parameters. That is load-bearing rather
  than wasted work: the layer only ever draws between two components of *this* repository, so a
  framework type cannot manufacture an edge.

## Where the type references come from, and what they cost

Nothing queries the language server for them. `SourceInspector.find_type_reference_sites` walks the tree-sitter parse a file already needs and yields the positions where a type is *named* rather than called; `TypeIndex` then resolves each name against the class-like nodes of the **merged** graph, which is what lets a template resolve into `framework/` although its own solution only sees a package reference. The C# rule is namespace visibility — an alias in scope decides outright, then plain `using` imports, then directory proximity for a genuine tie. The TypeScript rule is the import table, with package specifiers left external on purpose.

**Two of the eight wired languages produce them.** C# reads type slots, `type_argument_list`, `base_list`, `typeof`, `as`/`is`, `catch` and member-access receivers; TypeScript reads `type_identifier`, `extends` and the class names inside decorator arrays. JavaScript shares the TS selector but has almost nothing for it to find — it has no type annotations, so only `class X extends Y` and decorators qualify. Python, Java, Go, PHP and Rust have no selector and return immediately.

Measured over exactly the files a real run analyses (ignore rules applied), after commit 7:

| language | repo | files | MB | pass | sites found |
|---|---|---:|---:|---:|---:|
| C# | abp | 6,284 | 14.4 | **9.4 s** | 163,509 |
| TypeScript | mermaid | 388 | 1.5 | **1.3 s** | 3,281 |
| JavaScript | abp | 210 | 0.6 | **0.5 s** | 0 |
| Python | django | 894 | 5.6 | **0.00 s** | 0 |
| Java | mockito | 990 | 3.5 | **0.00 s** | 0 |
| Go | fzf | 53 | 0.6 | **0.00 s** | 0 |
| Rust | regex | 181 | 5.3 | **0.00 s** | 0 |

So the cost is ~0.7 s per MB of C# or TypeScript source and nothing at all elsewhere. In the abp run it is 10.1 s of a 55-minute analysis. Before commit 7 the languages in the bottom half of that table paid for a parse they could not use — 1.9 s on django, 0.4 s on regex, 0.3 s on mockito, always for zero sites.

The private integration suite was dispatched against this branch per language (`workflow_dispatch` → `CodeBoarding-tests`). Python: `integration-tests (windows-latest, python)` **passed**; the run is red only on `live-provider-checks`, an unrelated model-capability coverage assertion about ids like `o1-mini` and `claude-3-5-sonnet-20241022` falling back to generic capabilities. C# dispatched at `7474129`.

## Three full abp runs, Kimi-K2.6 over Azure

| | main `e38c07e3` | branch, commits 1-3 partial | branch, all four |
|---|---:|---:|---:|
| wall clock | 55.5 min | 2h09m | **55.5 min** |
| static / LLM phase | 25.5 / 30.1 | 25.3 / 104 | 25.8 / 29.8 |
| TYPEREF pass | — | 10 s | 10 s |
| disconnected components (rolled up) | 85 / 504 | 50 / 482 | **50 / 485** |
| disconnected leaves | 73 / 417 | 42 / 397 | 42 / 399 |
| disconnected C# | 43 / 456 | 0 / 426 | **0 / 429** |
| relations (global) | 1,955 | 3,585 | 3,612 (678 "uses", 14 "inherits from") |
| reference-backed edges in relations | 0 | 24,647 | 24,730 |
| scopes falling back to deterministic names | 2 / 88 | 2 / 86 (scope 1 = 34 children) | **1 / 87** (root only) |
| largest non-root prompt | 207k | 236k | **145k** |
| TS call edges / into `abp` hubs | 11,859 / 11,368 | 8,515 / 8,033 | 1,263 / 783 |
| tokens in / out | 1.80M / 0.86M | 1.96M / 0.95M | 1.77M / 0.91M |

> [!IMPORTANT]
> **These three runs predate the last commit, and the columns that depend on the grouping no longer
> describe what this PR does.** They were made while `TYPEREF` still counted as a link for the fold
> — the line `AFFINE_REFERENCE_KINDS` has since been narrowed to inheritance alone, so the partition
> is now left exactly as it is on `main`.
>
> Unaffected: everything about the *edges* — the TYPEREF pass and its cost, the C# isolation figures,
> the callable-usage fix and its TS edge counts, and the two save-path quadratics.
> Affected: `components`, `disconnected components`, `disconnected leaves`, `scopes falling back to
> deterministic names` and `largest non-root prompt`, all of which move with the partition. On the
> shipped setting abp keeps main's 504 components and gains relations rather than re-partitioning.
>
> Measured like for like instead, same graph and same fold, no model: abp gains **4,695 concrete
> edges** across 11 new component pairs at depth 1, and eShop 74 across 5. Both are browsable, with
> the file and line behind every edge, in [CodeBoarding-evals#25](https://github.com/CodeBoarding/CodeBoarding-evals/pull/25)
> (`ui/edges.html`). A fresh depth-3 abp run on the shipped setting has not been made.

The partial run's 2h09m was the save path, not the analysis: 85 progress saves at 50-80 s each. Commit 4 makes the tail faster than main's (265+405 s of CPU-bound gaps vs 580 s).

All 50 remaining floating boxes are JS/TS/Go — per-module page scripts, Angular apps depending on gitignored `@abp/ng.*`, build scripts, service workers. They cannot connect statically today: the `abp.*` API is built by property assignment (`abp.ui.setBusy = function`), which `documentSymbol` never reports, and the C# side is reached over HTTP.

## What it looks like

The same scope of abp on each side, drawn by the graph viewer from the two analyses recorded in
[CodeBoarding-evals#25](https://github.com/CodeBoarding/CodeBoarding-evals/pull/25). Each side is
rendered as its own document so both sit at a comparable zoom; the heights differ because the
layouts do — a scope with no relations is one flat rank of boxes, and edges are what give it depth.

**abp's `Host Applications`, the whole scope.** Seven boxes and not one edge, against six boxes and
three, the module template's hosts wired to the HttpApi host they share. The C# was always there to
read — `[DependsOn(typeof(...))]`, constructor parameter types — but none of it was a call, so none
of it was an edge.

<img alt="The Host Applications scope before the change: seven component boxes in a single row with no edges between any of them." src="https://github.com/CodeBoarding/CodeBoarding/blob/84739dcbe2716d42392786caa94975f97f6f4db9/host-applications-before.png?raw=true" width="900" />

*Before — `main` e38c07e3: 7 components, 0 relations.*

<img alt="The Host Applications scope after the change: six component boxes, three with arrows converging on the Module Template HttpApi Host and Shared component." src="https://github.com/CodeBoarding/CodeBoarding/blob/84739dcbe2716d42392786caa94975f97f6f4db9/host-applications-after.png?raw=true" width="900" />

*After — this branch: 6 components, 3 relations.*

**`CmsKit`, a whole top-level component**, at the scale a reader actually opens: 30 boxes with 13
relations before, 18 with 31 after. The four boxes still floating along the top right are the
JavaScript and TypeScript ones, which is the residue described under "Not in this PR".

<img alt="The CmsKit component before the change: thirty component boxes in flat rows, with a long right-hand tail of boxes carrying no edge at all." src="https://github.com/CodeBoarding/CodeBoarding/blob/84739dcbe2716d42392786caa94975f97f6f4db9/cmskit-before.png?raw=true" width="900" />

*Before — `main` e38c07e3: 30 components, 13 relations, and a long tail of boxes with no edge.*

<img alt="The CmsKit component after the change: eighteen boxes in a layered graph with thirty-one edges, and four unconnected boxes at the top right." src="https://github.com/CodeBoarding/CodeBoarding/blob/84739dcbe2716d42392786caa94975f97f6f4db9/cmskit-after.png?raw=true" width="900" />

*After — 18 components, 31 relations, and the four JS/TS boxes that still float.*

## Not in this PR

- The root scope still overflows (492k tokens; `groups[].files` at 6,428 entries is 81% of it) — the #565 gap, unchanged by this work.
- An LLM relation labelled literally "uses" is treated as a static default by the carry filter in `scope_assembly` (it is not carried across runs). Cosmetic; a distinct label would avoid it.
- Incremental runs rebuild the TYPEREF layer from scratch (10 s on abp) rather than re-deriving per changed file; correct, not optimal.
- `IMPORT` edges still have no producer.
- A member-access receiver that is a property rather than a type still resolves to the class of that name — `Clock.SupportsMultipleTimezone` on an injected `IClock` property finds abp's concrete `Clock`. Upper bound 1,158 of 5,872 receiver edges; measured, not fixed (see "Where the edge was simply wrong").

## Tests

Type sites for C#/TS/JS, name scopes and import directives, every `TypeIndex` resolution rule (including the three new nested-type cases), the builder end to end, reference-edge relations and labels, group connections, scope merge, renderer counts, the walk rules. `uv run mypy .` and `black --check` clean; **2,153 passed** — the 3 failures in `tests/test_cli_parser.py::test_main_renders_after_any_successful_analysis` fail identically on pristine `e38c07e3`.

The runs, the zero-LLM harnesses (offline TYPEREF replay against a committed pkl, hub call-site classifier, run comparison) and the write-up are in [CodeBoarding-evals#25](https://github.com/CodeBoarding/CodeBoarding-evals/pull/25); the `analysis.json` artifacts are on the CodeBoarding/abp fork — run 1 on `codeboarding-analysis-20260907` ([abp#2](https://github.com/CodeBoarding/abp/pull/2)), run 3 on `codeboarding-analysis-20260907-typeref`, one commit on top of it so the two diff directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Diagrams now include type-reference and inheritance relationships alongside call relationships.
  * Static relationships are labeled more clearly, including “inherits from” and “uses.”
  * Type references resolve across merged projects, namespaces, aliases, global imports, and module imports.
  * Scope views distinguish calls from type references and provide more accurate connection and boundary details.
  * Analysis now reports unreadable source files and preserves reference locations.

* **Bug Fixes**
  * Improved detection of callable usage and type names across supported languages.
  * Older analysis results are safely rejected and reprocessed when necessary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



