### PR TITLE
fix(lsp): wait for overlay processing after bulk didOpen

### DIFF
--- a/static_analyzer/engine/call_graph_builder.py
+++ b/static_analyzer/engine/call_graph_builder.py
@@ -170,6 +170,7 @@ class CallGraphBuilder:
             probe_result = self._send_sync_probe(source_files, probe_timeout)
             if not interleave_open:
                 self._bulk_did_open(source_files)
+                probe_result = self._send_sync_probe(source_files, probe_timeout, phase="overlay processing")
         else:
             self._bulk_did_open(source_files)
             probe_result = self._send_sync_probe(source_files, probe_timeout)
@@ -214,10 +215,10 @@ class CallGraphBuilder:
         pbar.finish()
         logger.info("did_open %d files: %.1fs", total, time.monotonic() - t_open_start)
 
-    def _send_sync_probe(self, source_files: list[Path], probe_timeout: int) -> list[dict]:
-        """Send a documentSymbol probe to wait for the LSP server to finish indexing."""
+    def _send_sync_probe(self, source_files: list[Path], probe_timeout: int, phase: str = "indexing") -> list[dict]:
+        """Send a documentSymbol probe to wait for the LSP server to finish a bulk phase."""
         probe_result: list[dict] = []
-        logger.info("Waiting for LSP server indexing (timeout=%ds)...", probe_timeout)
+        logger.info("Waiting for LSP server %s (timeout=%ds)...", phase, probe_timeout)
         t_probe = time.monotonic()
         if source_files:
             probe_result = self._lsp.document_symbol(source_files[0], timeout=probe_timeout)

--- a/tests/static_analyzer/test_call_graph_builder.py
+++ b/tests/static_analyzer/test_call_graph_builder.py
@@ -169,6 +169,38 @@ class TestDiscoverSymbols:
         probe_call = lsp.document_symbol.call_args_list[0]
         assert probe_call.kwargs.get("timeout") == 1800
 
+    def test_probe_before_open_waits_after_every_did_open(self):
+        lsp = _make_lsp()
+        adapter = _make_adapter()
+        adapter.probe_before_open = True
+        builder = CallGraphBuilder(lsp, adapter, Path("/project"))
+        files = [Path(f"/project/file_{i}.cs") for i in range(100)]
+        post_open_symbols = [
+            {
+                "name": "ReadyAfterOpen",
+                "kind": NodeType.CLASS,
+                "range": {"start": {"line": 0, "character": 0}, "end": {"line": 5, "character": 0}},
+                "selectionRange": {"start": {"line": 0, "character": 0}, "end": {"line": 0, "character": 14}},
+            }
+        ]
+        lsp.document_symbol.side_effect = [[], post_open_symbols, *([[]] * 99)]
+
+        builder._discover_symbols(files)
+
+        synchronization_calls = [
+            (call[0], call.args[0], call.kwargs.get("timeout"))
+            for call in lsp.method_calls
+            if call[0] in {"did_open", "document_symbol"}
+        ]
+        assert synchronization_calls == [
+            ("document_symbol", files[0], 260),
+            *(("did_open", file_path, None) for file_path in files),
+            ("document_symbol", files[0], 260),
+            *(("document_symbol", file_path, None) for file_path in files[1:]),
+        ]
+        assert lsp.document_symbol.call_count == 101
+        assert "file_0.ReadyAfterOpen" in builder.symbol_table.symbols
+
     def test_interleaves_did_open_with_symbol_queries(self):
         lsp = _make_lsp()
         adapter = _make_adapter()


### PR DESCRIPTION
## Problem

Workspace-probing LSP servers can continue processing overlays after a bulk
`didOpen`. The first Phase 1 `documentSymbol` request then waits behind that
work while using the adapter's normal per-request timeout.

For C#, the normal timeout is 120 seconds. On a large workspace, overlay
processing can take substantially longer even though csharp-ls remains healthy.

## Change

Add a second synchronization probe after bulk `didOpen` when
`probe_before_open` is enabled and document opening is not interleaved.

The post-open probe:

- uses the existing file-count-scaled `probe_timeout`;
- is logged as `overlay processing`;
- supplies the symbol result for the first source file.

Existing interleaved and probe-after-open paths retain their current behavior.

## Verification

- `uv run pytest tests/static_analyzer/test_call_graph_builder.py::TestDiscoverSymbols -q`
  — 8 passed
- `uv run black --check .`
  — 303 files unchanged
- Regression coverage verifies the exact sequence:
  initial probe → every `didOpen` → post-open probe
- Regression coverage verifies that the post-open result is reused for the
  first source file

### End-to-end C# validation

Generated a synthetic solution containing 290 projects and 7,726 C# files.

- Initial workspace probe: 56.4 seconds
- Bulk `didOpen`: 7,726 files in 20.6 seconds
- Post-open overlay probe: 379.5 seconds
- Phase 1: 7,726/7,726 files in 106.8 seconds
- Pipeline result: 31,194 symbols, 15,452 nodes, and 23,468 references

The post-open request took longer than C#'s normal 120-second request timeout
but completed under the existing scaled probe timeout. Static analysis
completed in 800.8 seconds.

The later semantic-analysis request encountered an unrelated OpenAI TPM limit;
static analysis completed and its artifacts were written successfully.
<img width="1084" height="370" alt="cf1c27d1-f5ee-4d17-93c9-378fa9c68691" src="https://github.com/user-attachments/assets/2e37f3af-10e7-429c-b369-77375ec064b2" />

Fixes #529