### PR TITLE
feat(analysis): record what backs a relation edge in the artifact

### DIFF
--- a/agents/agent_responses.py
+++ b/agents/agent_responses.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel, Field
 from clustering_ids import ComponentId
 from agents.file_index_models import FileEntry, FileMethodGroup, MethodIndexEntry
 from agents.scope_ids import ROOT_SCOPE_ID
-from static_analyzer.cfg.edge import EdgeKind
+from static_analyzer.cfg.edge import CALL_EDGE_KIND, EdgeKind
 
 logger = logging.getLogger(__name__)
 
@@ -96,6 +96,10 @@ class RelationEdge(LLMBaseModel):
         description="Call-site line and column pairs for this edge.",
         exclude=True,
     )
+    kind: str = Field(
+        default=CALL_EDGE_KIND,
+        description="What backs this edge: a call, or the reference kind that stands in for one.",
+    )
 
     @classmethod
     def from_dict(cls, edge: dict, methods_index: dict[str, MethodIndexEntry]) -> RelationEdge:
@@ -109,6 +113,7 @@ class RelationEdge(LLMBaseModel):
             target=_relation_endpoint_from_key(target_key, methods_index),
             description=edge.get("description", ""),
             call_sites=[RelationCallSite.model_validate(site) for site in call_sites],
+            kind=edge.get("kind") or CALL_EDGE_KIND,
         )
 
     @classmethod
@@ -146,6 +151,7 @@ class RelationEdge(LLMBaseModel):
                 reference_end_line=target.line_end,
             ),
             description=REFERENCE_EDGE_DESCRIPTIONS[kind],
+            kind=kind.value,
         )
 
     def llm_str(self) -> str:

--- a/agents/relation_edges.py
+++ b/agents/relation_edges.py
@@ -4,7 +4,6 @@ from collections.abc import Callable, Collection, Sequence
 from pathlib import Path
 
 from agents.agent_responses import (
-    REFERENCE_EDGE_DESCRIPTIONS,
     AnalysisInsights,
     Relation,
     RelationEdge,
@@ -13,15 +12,15 @@ from agents.agent_responses import (
 from clustering_ids import is_self_or_descendant
 from repo_utils.path_utils import normalize_repo_path
 from constants import DEFAULT_STATIC_RELATION_LABEL, INHERITANCE_RELATION_LABEL, TYPE_REFERENCE_RELATION_LABEL
-from static_analyzer.cfg.edge import EdgeKind
+from static_analyzer.cfg.edge import CALL_EDGE_KIND, EdgeKind
 
 
 def static_relation_label(edges: Sequence[RelationEdge]) -> str:
     """The label a relation gets from its static edges alone: a single call outranks any reference."""
-    descriptions = {edge.description for edge in edges}
-    if not descriptions or descriptions - set(REFERENCE_EDGE_DESCRIPTIONS.values()):
+    kinds = {edge.kind for edge in edges}
+    if not kinds or CALL_EDGE_KIND in kinds:
         return DEFAULT_STATIC_RELATION_LABEL
-    if descriptions == {REFERENCE_EDGE_DESCRIPTIONS[EdgeKind.INHERITS]}:
+    if kinds == {EdgeKind.INHERITS.value}:
         return INHERITANCE_RELATION_LABEL
     return TYPE_REFERENCE_RELATION_LABEL
 

--- a/diagram_analysis/analysis_json.py
+++ b/diagram_analysis/analysis_json.py
@@ -16,6 +16,7 @@ from agents.agent_responses import (
 from agents.file_index_models import FileEntry, FileMethodGroup, MethodEntry, MethodIndexEntry
 from agents.relation_edges import merge_relations_by_pair
 from repo_utils.path_utils import normalize_repo_path
+from static_analyzer.cfg.edge import CALL_EDGE_KIND
 
 logger = logging.getLogger(__name__)
 
@@ -25,6 +26,12 @@ class RelationEdgeJson(BaseModel):
     target: str = Field(description="Key into methods_index for the target method.")
     call_sites: list[RelationCallSite] = Field(default_factory=list)
     description: str = Field(default="", description="Short explanation of how source reaches or configures target.")
+    # Absent means a call, which is two thirds of the edges in a large analysis. Writing it out
+    # anyway costs 26 bytes each — 1.7% of abp's artifact — to say what the reader already assumes.
+    kind: str | None = Field(
+        default=None,
+        description="The reference kind standing in for a call; absent when the edge is a call.",
+    )
 
 
 class RelationJson(Relation):
@@ -212,6 +219,7 @@ def _relation_edge_to_json(edge: RelationEdge, repo_dir: Path) -> RelationEdgeJs
         target=_source_reference_method_key(edge.target, repo_dir),
         call_sites=edge.call_sites,
         description=edge.description,
+        kind=edge.kind if edge.kind != CALL_EDGE_KIND else None,
     )
 
 

--- a/tests/diagram_analysis/test_diagram_analysis.py
+++ b/tests/diagram_analysis/test_diagram_analysis.py
@@ -442,6 +442,50 @@ class TestAnalysisJsonConversion(unittest.TestCase):
             relations_by_label["dispatches to"]["key_edges"][0]["source"], "component1.py|component1.dispatch"
         )
 
+    def test_the_edge_kind_survives_the_artifact_and_is_omitted_for_a_call(self):
+        """A call is the default, so writing it on every edge would cost 1.7% of a large artifact."""
+        self._add_edge_methods_to_index()
+
+        def edge(kind: str, target: str, call_sites: list[RelationCallSite] | None = None) -> RelationEdge:
+            return RelationEdge(
+                source=SourceCodeReference(qualified_name="component1.run", reference_file="component1.py"),
+                target=SourceCodeReference(qualified_name=target, reference_file="component2.py"),
+                call_sites=call_sites or [],
+                kind=kind,
+            )
+
+        self.analysis.components_relations = [
+            Relation(
+                src_name="Component1",
+                dst_name="Component2",
+                relation="uses",
+                src_id="1",
+                dst_id="2",
+                is_static=True,
+                # The last two share a pair: a call and a type reference between the same symbols
+                # are distinct edges, and stay distinct because `identity()` keys on the call sites.
+                all_edges=[
+                    edge("typeref", "component2.Widget"),
+                    edge("inherits", "component2.Base"),
+                    edge("call", "component2.load", [RelationCallSite(line=12, column=8)]),
+                    edge("typeref", "component2.load"),
+                ],
+            )
+        ]
+
+        data = json.loads(
+            build_unified_analysis_json(
+                self.analysis, [], "repo", repo_dir=self.repo_dir, source_tree_hash="", depth_cap=1
+            )
+        )
+        written = data["components_relations"][0]["all_edges"]
+        self.assertEqual([e.get("kind") for e in written], ["typeref", "inherits", None, "typeref"])
+
+        parsed, _ = parse_unified_analysis(data)
+        self.assertEqual(
+            [e.kind for e in parsed.components_relations[0].all_edges], ["typeref", "inherits", "call", "typeref"]
+        )
+
     def test_unified_analysis_parse_preserves_all_edges(self):
         self._add_edge_methods_to_index()
         self.analysis.components_relations = [

--- a/tests/static_analyzer/test_cluster_relations.py
+++ b/tests/static_analyzer/test_cluster_relations.py
@@ -113,6 +113,15 @@ class TestReferenceEdgesBecomeRelations(unittest.TestCase):
         owners = dict.fromkeys(self.OWNERS, "1")
         self.assertEqual(build_component_relations(owners, {"python": self._graph(EdgeKind.TYPEREF)}), [])
 
+    def test_the_label_reads_the_kind_and_not_the_description(self):
+        """``ground_relation_edges`` overwrites an edge's description with the model's prose, so a
+        label derived from that text is lost on exactly the edges the side panel renders."""
+        edge = _make_relation_edge("a.Cls", "b.Cls")
+        edge.kind = "typeref"
+        edge.description = "orchestrates the widget lifecycle"
+
+        self.assertEqual(static_relation_label([edge]), TYPE_REFERENCE_RELATION_LABEL)
+
     def test_no_edges_means_the_call_label(self):
         self.assertEqual(static_relation_label([]), DEFAULT_STATIC_RELATION_LABEL)
 


### PR DESCRIPTION
Stacked on [#568](https://github.com/CodeBoarding/CodeBoarding/pull/568) — **base is `feat/type-references`, not `main`**. One field, three call sites, two tests.

## Why

A consumer of `analysis.json` cannot currently tell a call from a type reference, so nothing downstream can draw or filter the distinction #568 introduces. Two things that look like they carry it do not:

- **The edge description is destroyed where it matters.** `RelationEdge.from_reference` writes `"references type"` / `"inherits from"`, but `ground_relation_edges` overwrites the description with the model's prose. On abp **0 of the 1,060 root `key_edges` keeps a marker** — and `key_edges` is what the side panel renders when it is non-empty.
- **The relation label is wrong too often.** **1,348 of abp's 3,612 relations are labelled `"calls"` with no call edge behind them** (44% of everything so labelled).

## What

`RelationEdge.kind`, defaulting to a call, set from `EdgeKind` where the edge is a reference, read back with the same default so an artifact written before this change still loads. `static_relation_label` now derives the label from the kind instead of the prose, which is what makes it immune to the overwrite.

`identity()` deliberately does **not** gain the field — it keys `unique_edges`, `preserve_unchanged_relations` and the incremental pruning, where two edges differing only in kind should still be one edge. A call and a type reference between the same two symbols stay distinct anyway, because the call carries call sites and the reference does not; there is a test for exactly that.

## Size

Measured by rebuilding abp's artifact (the largest we have) from its committed run, three ways:

| | size | delta |
|---|---:|---:|
| today | 49.16 MB | — |
| field on every edge | 50.00 MB | **+1.70%** |
| **field only where it is not a call** | **49.64 MB** | **+0.96%** |

The artifact omits the field for calls, which are two thirds of the 32,229 serialized edge objects: writing `"kind": "call"` costs 26 bytes each to state what the reader already assumes. `exclude_none=True` was already the dump mode, so this needed no new machinery. The remaining +0.48 MB is 24,730 edges each carrying information that was not previously recoverable.

## Tests

`test_the_edge_kind_survives_the_artifact_and_is_omitted_for_a_call` pins the round trip and the omission, including the call-and-reference-on-one-pair case. `test_the_label_reads_the_kind_and_not_the_description` pins the label against an edge whose description has been overwritten with prose — the case that fails today.

Full suite 2,134 passed; the 3 `test_cli_parser` failures are pre-existing and fail identically on `main` at `e38c07e3`. mypy and black clean.

## Not in this PR

The viewer side. This only makes the distinction *available*; nothing renders or filters it yet. That is the follow-up, and it is what the field exists for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Relation details now preserve whether connections represent calls, inheritance, or type references.
  * Diagram data retains relevant connection types while keeping standard call connections concise.
  * Relationship labels are now based on the connection type, ensuring accurate labels even when descriptive text changes.

* **Tests**
  * Added coverage confirming connection types are preserved when analysis results are saved and loaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->