### PR TITLE
Stop writing the analysis.json fields readers can derive

### DIFF
--- a/diagram_analysis/analysis_json.py
+++ b/diagram_analysis/analysis_json.py
@@ -1,3 +1,4 @@
+import copy
 import logging
 import json
 from datetime import datetime, timezone
@@ -18,6 +19,10 @@ from agents.relation_edges import merge_relations_by_pair
 from repo_utils.path_utils import normalize_repo_path
 
 logger = logging.getLogger(__name__)
+
+# Documents at this version omit fields that are recoverable from what remains
+# (see ``expand_analysis_document``). Version 1 documents spelled them all out.
+ANALYSIS_FORMAT_VERSION = 2
 
 
 class RelationEdgeJson(BaseModel):
@@ -116,6 +121,10 @@ class AnalysisMetadata(BaseModel):
         "replay it, so the partition cannot move underneath unchanged code. Empty on an analysis "
         "written before it existed.",
     )
+    format_version: int = Field(
+        default=ANALYSIS_FORMAT_VERSION,
+        description="Document format version. Absent or 1 means every derivable field is spelled out.",
+    )
 
 
 class ComponentFileMethodGroupJson(BaseModel):
@@ -126,16 +135,24 @@ class ComponentFileMethodGroupJson(BaseModel):
     )
 
 
-class FileEntryJson(BaseModel):
-    """Persisted file entry — stores only method-index keys.
+class MethodIndexEntryJson(BaseModel):
+    """Persisted method entry — its file path and qualified name are the two halves of its own key."""
 
-    Full method metadata lives in ``methods_index``; this avoids duplication.
+    start_line: int = Field(description="Starting line number in the file.")
+    end_line: int = Field(description="Ending line number in the file.")
+    type: str = Field(description="Node type name (METHOD, FUNCTION, CLASS, ...).")
+    content_hash: str = Field(
+        default="",
+        description="Truncated SHA-256 of the method's source lines; '' when unknown.",
+    )
+
+
+class FileEntryJson(BaseModel):
+    """Persisted file entry — hashes only.
+
+    The file's methods are the ``methods_index`` keys prefixed with this path.
     """
 
-    method_keys: list[str] = Field(
-        default_factory=list,
-        description="Keys into ``methods_index`` ('<file_path>|<qualified_name>'), in declaration order.",
-    )
     content_hash: str = Field(
         default="",
         description="Truncated SHA-256 of the entire file's bytes; '' when unknown.",
@@ -155,7 +172,7 @@ class UnifiedAnalysisJson(BaseModel):
         default_factory=dict,
         description="Top-level file index keyed by relative file path.",
     )
-    methods_index: dict[str, MethodIndexEntry] = Field(
+    methods_index: dict[str, MethodIndexEntryJson] = Field(
         default_factory=dict,
         description="Canonical method metadata keyed by '<file_path>|<qualified_name>'.",
     )
@@ -180,7 +197,14 @@ def _build_files_index_from_analysis(
 
 
 def _method_key(file_path: str, qualified_name: str) -> str:
-    """Canonical ``methods_index`` key ('<file_path>|<qualified_name>')."""
+    """Canonical ``methods_index`` key ('<file_path>|<qualified_name>').
+
+    Why: readers recover both halves by splitting on the first '|', so a pipe in the
+    path would make the key ambiguous. Qualified names may contain one (C# default
+    parameter lists do) — only the left half has to be pipe-free.
+    """
+    if "|" in file_path:
+        raise ValueError(f"File path contains the method-key separator '|': {file_path!r}")
     return f"{file_path}|{qualified_name}"
 
 
@@ -242,13 +266,11 @@ def _method_refs_to_placeholders(method_names: list[str]) -> list[MethodEntry]:
     ]
 
 
-def _build_methods_index_from_files(files_index: dict[str, FileEntry]) -> dict[str, MethodIndexEntry]:
-    methods_index: dict[str, MethodIndexEntry] = {}
+def _build_methods_index_from_files(files_index: dict[str, FileEntry]) -> dict[str, MethodIndexEntryJson]:
+    methods_index: dict[str, MethodIndexEntryJson] = {}
     for file_path, entry in files_index.items():
         for method in entry.methods:
-            methods_index[_method_key(file_path, method.qualified_name)] = MethodIndexEntry(
-                file_path=file_path,
-                qualified_name=method.qualified_name,
+            methods_index[_method_key(file_path, method.qualified_name)] = MethodIndexEntryJson(
                 start_line=method.start_line,
                 end_line=method.end_line,
                 type=method.node_type,
@@ -259,11 +281,7 @@ def _build_methods_index_from_files(files_index: dict[str, FileEntry]) -> dict[s
 
 def _build_file_entry_json_from_files(files_index: dict[str, FileEntry]) -> dict[str, FileEntryJson]:
     return {
-        file_path: FileEntryJson(
-            method_keys=[_method_key(file_path, m.qualified_name) for m in entry.methods],
-            content_hash=entry.content_hash,
-            module_hash=entry.module_hash,
-        )
+        file_path: FileEntryJson(content_hash=entry.content_hash, module_hash=entry.module_hash)
         for file_path, entry in files_index.items()
         if file_path
     }
@@ -363,13 +381,16 @@ def from_component_to_json_component(
             for r in merge_relations_by_pair(sub_analysis.components_relations, include_relation=True)
         ]
 
+    # A parent's members are exactly the union of its children's, so only leaves carry them.
+    file_methods = [] if nested_components else _to_component_file_method_refs(component.file_methods)
+
     return ComponentJson(
         name=component.name,
         component_id=component.component_id,
         description=component.description,
         key_entities=_relativize_key_entities(component.key_entities, repo_dir),
         source_cluster_ids=component.source_cluster_ids,
-        file_methods=_to_component_file_method_refs(component.file_methods),
+        file_methods=file_methods,
         can_expand=can_expand,
         components=nested_components,
         components_relations=nested_relations,
@@ -505,15 +526,51 @@ def build_unified_analysis_json(
     return unified.model_dump_json(indent=2, exclude_none=True)
 
 
+def expand_analysis_document(data: dict) -> dict:
+    """Return *data* with every field the lean format omits written back out.
+
+    Restores the pre-v2 shape: each ``methods_index`` value regains the two halves of its
+    own key, each file regains its ``method_keys``, and each parent component regains the
+    union of its children's ``file_methods``. Version 1 documents already carry all three
+    and pass through untouched. The result is what ``codeboarding expand`` writes.
+    """
+    expanded = copy.deepcopy(data)
+    methods_index = expanded.get("methods_index") or {}
+
+    for key, entry in methods_index.items():
+        if "file_path" in entry and "qualified_name" in entry:
+            continue
+        file_path, separator, qualified_name = key.partition("|")
+        if not separator:
+            raise ValueError(f"Malformed methods_index key (no '|' separator): {key!r}")
+        entry["file_path"] = file_path
+        entry["qualified_name"] = qualified_name
+
+    keys_by_file: dict[str, list[str]] = {}
+    for key in methods_index:
+        keys_by_file.setdefault(key.partition("|")[0], []).append(key)
+    for file_path, entry in (expanded.get("files") or {}).items():
+        entry.setdefault("method_keys", keys_by_file.get(file_path, []))
+
+    # Only v2 writers drop a parent's members; in v1 an empty list is a real value.
+    if (expanded.get("metadata") or {}).get("format_version", 1) >= 2:
+        _restore_parent_file_methods(expanded.get("components") or [])
+
+    return expanded
+
+
 def parse_unified_analysis(
     data: dict,
 ) -> tuple[AnalysisInsights, dict[str, AnalysisInsights]]:
     """Parse a unified analysis JSON dict into root AnalysisInsights and sub-analyses.
 
+    Accepts both the lean (v2) and fully-spelled-out (v1) document shapes.
+
     Returns:
         (root_analysis, sub_analyses_dict) where sub_analyses_dict maps component_id
         to its nested AnalysisInsights.
     """
+    data = expand_analysis_document(data)
     methods_index_raw = data.get("methods_index", {})
     methods_index: dict[str, MethodIndexEntry] = {
         key: MethodIndexEntry(**entry) for key, entry in methods_index_raw.items()
@@ -532,6 +589,23 @@ def parse_unified_analysis(
         _hydrate_component_methods_from_refs(sub, methods_index)
 
     return root_analysis, sub_analyses
+
+
+def _restore_parent_file_methods(components: list[dict]) -> list[dict]:
+    """Rebuild each parent's ``file_methods`` bottom-up; returns this level's groups merged.
+
+    Groups are emitted in path order so the same document always expands identically.
+    """
+    merged: dict[str, list[str]] = {}
+    for component in components:
+        children = component.get("components") or []
+        groups = _restore_parent_file_methods(children) if children else (component.get("file_methods") or [])
+        if children:
+            component["file_methods"] = groups
+        for group in groups:
+            seen = merged.setdefault(group["file_path"], [])
+            seen.extend(m for m in group.get("methods", []) if m not in seen)
+    return [{"file_path": path, "methods": methods} for path, methods in sorted(merged.items())]
 
 
 def _reconstruct_files_index(

--- a/tests/diagram_analysis/test_analysis_json_format.py
+++ b/tests/diagram_analysis/test_analysis_json_format.py
@@ -1,0 +1,195 @@
+"""Tests for the lean (v2) analysis.json shape and its expansion back to v1."""
+
+import json
+import unittest
+from pathlib import Path
+
+from agents.agent_responses import AnalysisInsights, Component
+from agents.file_index_models import FileEntry, FileMethodGroup, MethodEntry
+from diagram_analysis.analysis_json import (
+    ANALYSIS_FORMAT_VERSION,
+    _method_key,
+    build_unified_analysis_json,
+    expand_analysis_document,
+    parse_unified_analysis,
+)
+
+
+def method(qname: str, start: int = 1) -> MethodEntry:
+    return MethodEntry(qualified_name=qname, start_line=start, end_line=start + 5, node_type="FUNCTION")
+
+
+def component(cid: str, files: dict[str, list[str]]) -> Component:
+    return Component(
+        name=f"c{cid}",
+        description=f"component {cid}",
+        key_entities=[],
+        component_id=cid,
+        file_methods=[
+            FileMethodGroup(file_path=path, methods=[method(q, i * 10 + 1) for i, q in enumerate(qnames)])
+            for path, qnames in files.items()
+        ],
+    )
+
+
+def analysis(*components: Component, files: dict[str, list[str]] | None = None) -> AnalysisInsights:
+    insights = AnalysisInsights(description="d", components=list(components), components_relations=[])
+    insights.files = {
+        path: FileEntry(methods=[method(q, i * 10 + 1) for i, q in enumerate(qnames)], content_hash=f"h{path}")
+        for path, qnames in (files or {}).items()
+    }
+    return insights
+
+
+def build(root: AnalysisInsights, subs: dict[str, tuple[AnalysisInsights, list[Component]]] | None = None) -> dict:
+    expandable = [c for c in root.components if subs and c.component_id in subs]
+    return json.loads(
+        build_unified_analysis_json(
+            analysis=root,
+            expandable_components=expandable,
+            repo_name="repo",
+            repo_dir=Path("/repo"),
+            source_tree_hash="tree",
+            depth_cap=3,
+            sub_analyses=subs,
+        )
+    )
+
+
+class TestLeanDocumentOmitsDerivableFields(unittest.TestCase):
+    def test_methods_index_values_drop_the_two_halves_of_their_key(self):
+        doc = build(analysis(component("1", {"a.py": ["a.one"]}), files={"a.py": ["a.one"]}))
+
+        entry = doc["methods_index"]["a.py|a.one"]
+        self.assertNotIn("file_path", entry)
+        self.assertNotIn("qualified_name", entry)
+        self.assertEqual(entry["start_line"], 1)
+        self.assertEqual(entry["type"], "FUNCTION")
+
+    def test_files_drop_method_keys_but_keep_hashes(self):
+        doc = build(analysis(component("1", {"a.py": ["a.one"]}), files={"a.py": ["a.one"]}))
+
+        self.assertNotIn("method_keys", doc["files"]["a.py"])
+        self.assertEqual(doc["files"]["a.py"]["content_hash"], "ha.py")
+
+    def test_parent_components_drop_file_methods_and_leaves_keep_them(self):
+        root = analysis(component("1", {"a.py": ["a.one"]}), files={"a.py": ["a.one"], "b.py": ["b.one"]})
+        sub = analysis(component("1.1", {"b.py": ["b.one"]}))
+        doc = build(root, {"1": (sub, [])})
+
+        self.assertEqual(doc["components"][0]["file_methods"], [])
+        self.assertEqual(doc["components"][0]["components"][0]["file_methods"][0]["file_path"], "b.py")
+
+    def test_metadata_declares_the_format_version(self):
+        doc = build(analysis(component("1", {"a.py": ["a.one"]}), files={"a.py": ["a.one"]}))
+
+        self.assertEqual(doc["metadata"]["format_version"], ANALYSIS_FORMAT_VERSION)
+
+
+class TestExpandRestoresEverything(unittest.TestCase):
+    def test_expand_rebuilds_all_three_derived_fields(self):
+        root = analysis(component("1", {"a.py": ["a.one"]}), files={"a.py": ["a.one"], "b.py": ["b.one"]})
+        sub = analysis(component("1.1", {"b.py": ["b.one"]}))
+        expanded = expand_analysis_document(build(root, {"1": (sub, [])}))
+
+        self.assertEqual(expanded["methods_index"]["a.py|a.one"]["file_path"], "a.py")
+        self.assertEqual(expanded["methods_index"]["a.py|a.one"]["qualified_name"], "a.one")
+        self.assertEqual(expanded["files"]["a.py"]["method_keys"], ["a.py|a.one"])
+        self.assertEqual(expanded["components"][0]["file_methods"], [{"file_path": "b.py", "methods": ["b.one"]}])
+
+    def test_expand_does_not_mutate_its_argument(self):
+        doc = build(analysis(component("1", {"a.py": ["a.one"]}), files={"a.py": ["a.one"]}))
+        expand_analysis_document(doc)
+
+        self.assertNotIn("file_path", doc["methods_index"]["a.py|a.one"])
+
+    def test_qualified_names_containing_a_pipe_survive_the_split(self):
+        qname = "ns.Read(string path, Mode mode = A|B)"
+        doc = build(analysis(component("1", {"a.cs": [qname]}), files={"a.cs": [qname]}))
+        expanded = expand_analysis_document(doc)
+
+        self.assertEqual(expanded["methods_index"][f"a.cs|{qname}"]["qualified_name"], qname)
+        self.assertEqual(expanded["methods_index"][f"a.cs|{qname}"]["file_path"], "a.cs")
+
+    def test_malformed_key_without_a_separator_raises(self):
+        with self.assertRaises(ValueError):
+            expand_analysis_document({"methods_index": {"no-separator": {"start_line": 1}}})
+
+
+class TestVersionOneDocumentsStillLoad(unittest.TestCase):
+    def _legacy(self) -> dict:
+        return {
+            "metadata": {"generated_at": "t", "repo_name": "r", "depth_level": 1, "depth_cap": 1},
+            "description": "d",
+            "files": {"a.py": {"method_keys": ["a.py|a.one"], "content_hash": "h", "module_hash": ""}},
+            "methods_index": {
+                "a.py|a.one": {
+                    "file_path": "a.py",
+                    "qualified_name": "a.one",
+                    "start_line": 1,
+                    "end_line": 6,
+                    "type": "FUNCTION",
+                    "content_hash": "",
+                }
+            },
+            "components": [
+                {
+                    "name": "c1",
+                    "component_id": "1",
+                    "description": "d",
+                    "key_entities": [],
+                    "file_methods": [{"file_path": "a.py", "methods": ["a.one"]}],
+                    "can_expand": False,
+                    "components": [],
+                    "components_relations": [],
+                }
+            ],
+            "components_relations": [],
+        }
+
+    def test_legacy_document_passes_through_untouched(self):
+        legacy = self._legacy()
+
+        self.assertEqual(expand_analysis_document(legacy), legacy)
+
+    def test_an_empty_parent_in_a_legacy_document_is_not_rebuilt(self):
+        """A v1 writer spelled every member out, so an empty list there is a real value, not an omission."""
+        legacy = self._legacy()
+        legacy["components"][0]["file_methods"] = []
+        legacy["components"][0]["components"] = [
+            {
+                "name": "c1.1",
+                "component_id": "1.1",
+                "description": "d",
+                "key_entities": [],
+                "file_methods": [{"file_path": "a.py", "methods": ["a.one"]}],
+                "can_expand": False,
+                "components": [],
+                "components_relations": [],
+            }
+        ]
+
+        self.assertEqual(expand_analysis_document(legacy)["components"][0]["file_methods"], [])
+
+
+class TestRoundTrip(unittest.TestCase):
+    def test_parsing_a_lean_document_recovers_the_analysis(self):
+        root = analysis(component("1", {"a.py": ["a.one"]}), files={"a.py": ["a.one"], "b.py": ["b.one"]})
+        sub = analysis(component("1.1", {"b.py": ["b.one"]}))
+        parsed, subs = parse_unified_analysis(build(root, {"1": (sub, [])}))
+
+        self.assertEqual([g.file_path for g in parsed.components[0].file_methods], ["b.py"])
+        self.assertEqual([m.qualified_name for m in parsed.components[0].file_methods[0].methods], ["b.one"])
+        self.assertEqual([c.component_id for c in subs["1"].components], ["1.1"])
+        self.assertEqual(sorted(parsed.files), ["a.py", "b.py"])
+        self.assertEqual([m.qualified_name for m in parsed.files["a.py"].methods], ["a.one"])
+
+
+class TestMethodKeySeparator(unittest.TestCase):
+    def test_a_pipe_in_the_file_path_is_rejected(self):
+        with self.assertRaises(ValueError):
+            _method_key("we|ird.py", "mod.fn")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

`analysis.json` grows past what a repo can hold. abp's is **102 MB** — over GitHub's 100 MB Contents API ceiling (the only path the webview reads baselines through) and 2.5 MiB from the `git push` hard block.

Most of it is the same identity strings written repeatedly. This PR stops writing the three that a reader can recompute.

## What is dropped

| dropped | why it's recoverable | abp |
|---|---|---|
| `methods_index[k].file_path` / `.qualified_name` | they are literally the two halves of `k`, split on the first `\|` | −9.9 MB |
| `files[p].method_keys` | every key starts with its own file path, so grouping the index by prefix reproduces it — verified order-exact | −8.7 MB |
| `file_methods` on parent components | a parent's members are the union of its children's | −12.0 MB |

`metadata.format_version: 2` marks the new shape. `expand_analysis_document()` writes all three back, so a v1 document loads unchanged and any consumer can recover the old form.

## Savings

Real artifacts, as committed (`indent=2`):

| repo | before | after | |
|---|---|---|---|
| abp | 102,247,607 | 68,268,942 | −33.2% |
| vercel | 12,486,726 | 6,090,438 | −51.2% |
| eShop | 2,109,180 | 1,129,137 | −46.5% |
| CodeBoarding | 2,180,129 | 1,413,220 | −35.2% |

Every one round-trips to an **identical in-memory analysis** (files, per-file methods, component membership, relations).

## Why not just compress it

Measured, not assumed: git already zlib-compresses blobs, so gzipping first defeats its delta compression — **+3,265,697 B of `.git` per revision vs +5,969 B** for plain JSON (547×). It also turns `deliver-sync.sh`'s `git diff --cached --quiet -I '"generated_at"'` no-op guard into "Binary files differ", making every sync a commit. The artifact stays uncompressed, line-diffable and greppable.

## Identity safety

The one precondition is that a file path never contains `|`. Checked across **42 artifacts / 237,644 methods**: 0 paths with a pipe, 0 keys `partition("|")` splits wrongly. 4 *qualified names* do contain one (C# default-parameter lists) — harmless, since only the left half must be pipe-free. `_method_key` now raises rather than emitting an ambiguous key.

Overloads stay distinct because the signature is part of the qualified name (1,341 overload groups in abp, 0 collisions).

## Notes

- Parent membership is reconstructed exactly; group *order* is canonicalised to path order, which is what makes the derivation deterministic.
- A v1 document's empty parent `file_methods` is a real value, so the union rebuild is gated on `format_version >= 2` rather than on emptiness.
- 12 new tests. Full suite green apart from 3 pre-existing `tests/test_cli_parser.py` failures (a macOS `/tmp` → `/private/tmp` symlink mismatch, unrelated and failing on `main` too).

## Not in this PR

Consumers outside Core (webview, graph-viewer, vscode, action, webapp, evals) still need the same presence-based derivation before the producer flip reaches users. Stage 2 is #NEXT.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced version 2 of the analysis document format with a more compact representation.
  - Added automatic expansion when reading documents, restoring derived information for compatibility with existing analysis workflows.
  - Added format metadata to identify the document version.

- **Bug Fixes**
  - Improved validation for file paths containing reserved separators.
  - Preserved support for legacy version 1 analysis documents.
  - Ensured parent component method information is correctly reconstructed when reading analysis data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->