### PR TITLE
Intern analysis.json method identity behind content-derived ids

### DIFF
--- a/codeboarding_cli/expand.py
+++ b/codeboarding_cli/expand.py
@@ -1,0 +1,89 @@
+"""Standalone expansion of a stored analysis.json into its fully self-describing form."""
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+
+from diagram_analysis.analysis_json import expand_analysis_document
+from logging_config import setup_logging
+
+logger = logging.getLogger(__name__)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the standalone expansion argument parser."""
+    parser = argparse.ArgumentParser(
+        prog="codeboarding-expand",
+        description=(
+            "Expand a stored analysis.json: resolve interned method ids back to "
+            "'<file_path>|<qualified_name>' keys and write out every field the stored "
+            "form derives. Reads on stdin and writes to stdout when no paths are given."
+        ),
+    )
+    parser.add_argument(
+        "analysis_path",
+        type=Path,
+        nargs="?",
+        help="Path to analysis.json (default: stdin)",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Where to write the expanded document (default: stdout)",
+    )
+    parser.add_argument(
+        "--indent",
+        type=int,
+        default=2,
+        help="JSON indentation; 0 writes it minified (default: 2)",
+    )
+    return parser
+
+
+def run_from_args(args: argparse.Namespace, parser: argparse.ArgumentParser) -> None:
+    """Expand one stored analysis according to parsed arguments."""
+    if args.analysis_path is None:
+        try:
+            data = json.load(sys.stdin)
+        except json.JSONDecodeError as exc:
+            parser.error(f"Could not parse analysis JSON on stdin: {exc}")
+    else:
+        analysis_path = args.analysis_path.resolve()
+        if not analysis_path.is_file():
+            parser.error(f"Analysis file not found: {analysis_path}")
+        try:
+            with analysis_path.open("r", encoding="utf-8") as analysis_file:
+                data = json.load(analysis_file)
+        except (OSError, json.JSONDecodeError) as exc:
+            parser.error(f"Could not read analysis file '{analysis_path}': {exc}")
+
+    if not isinstance(data, dict):
+        parser.error("Analysis JSON must be an object")
+
+    try:
+        expanded = expand_analysis_document(data)
+    except ValueError as exc:
+        parser.error(f"Could not expand analysis: {exc}")
+
+    payload = json.dumps(expanded, indent=args.indent or None)
+    if args.output is None:
+        sys.stdout.write(payload + "\n")
+        return
+
+    output = args.output.resolve()
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(payload + "\n", encoding="utf-8")
+    setup_logging()
+    logger.info("Expanded analysis written to %s", output)
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Run the standalone expansion CLI."""
+    parser = build_parser()
+    run_from_args(parser.parse_args(sys.argv[1:] if argv is None else argv), parser)
+
+
+if __name__ == "__main__":
+    main()

--- a/diagram_analysis/analysis_json.py
+++ b/diagram_analysis/analysis_json.py
@@ -1,4 +1,6 @@
+import base64
 import copy
+import hashlib
 import logging
 import json
 from datetime import datetime, timezone
@@ -20,9 +22,14 @@ from repo_utils.path_utils import normalize_repo_path
 
 logger = logging.getLogger(__name__)
 
-# Documents at this version omit fields that are recoverable from what remains
-# (see ``expand_analysis_document``). Version 1 documents spelled them all out.
-ANALYSIS_FORMAT_VERSION = 2
+# Documents at this version omit fields that are recoverable from what remains and
+# reference methods by short content-derived ids (see ``expand_analysis_document``).
+# Version 2 dropped the derivable fields; version 1 spelled everything out.
+ANALYSIS_FORMAT_VERSION = 3
+
+# 60 bits of SHA-256 over the method key. Collisions are resolved by widening every id
+# at once, so the table stays a pure function of its content.
+_SYMBOL_ID_WIDTH = 10
 
 
 class RelationEdgeJson(BaseModel):
@@ -423,7 +430,7 @@ def from_analysis_to_json(
         "components_relations": [r.model_dump() for r in relations_json],
     }
 
-    return json.dumps(data, indent=2)
+    return json.dumps(intern_analysis_document(data), indent=2)
 
 
 def _compute_depth_level(
@@ -523,19 +530,49 @@ def build_unified_analysis_json(
         components=components_json,
         components_relations=relations_json,
     )
-    return unified.model_dump_json(indent=2, exclude_none=True)
+    return json.dumps(intern_analysis_document(unified.model_dump(mode="json", exclude_none=True)), indent=2)
+
+
+def intern_analysis_document(data: dict) -> dict:
+    """Replace every repeated method key with a short content-derived id.
+
+    A method key is ~200 bytes of path and signature and is repeated once per relation
+    edge endpoint and once per component that owns it. Each ``methods_index`` entry gains
+    an ``id``; edge endpoints and component members cite that id instead. Endpoints with
+    no indexed method (external libraries, unresolved references) keep their raw key —
+    a key always contains '|' and an id never does, so the two never blur.
+    """
+    interned = copy.deepcopy(data)
+    methods_index = interned.get("methods_index") or {}
+    ids = _symbol_ids(list(methods_index))
+    for key, entry in methods_index.items():
+        entry["id"] = ids[key]
+
+    _intern_components(interned.get("components") or [], ids)
+    _intern_relations(interned.get("components_relations") or [], ids)
+    interned.setdefault("metadata", {})["format_version"] = ANALYSIS_FORMAT_VERSION
+    return interned
 
 
 def expand_analysis_document(data: dict) -> dict:
     """Return *data* with every field the lean format omits written back out.
 
-    Restores the pre-v2 shape: each ``methods_index`` value regains the two halves of its
-    own key, each file regains its ``method_keys``, and each parent component regains the
-    union of its children's ``file_methods``. Version 1 documents already carry all three
-    and pass through untouched. The result is what ``codeboarding expand`` writes.
+    Restores the version 1 shape: interned ids become method keys again, each
+    ``methods_index`` value regains the two halves of its own key, each file regains its
+    ``method_keys``, and each parent component regains the union of its children's
+    ``file_methods``. Version 1 documents already carry all of it and pass through
+    untouched. The result is what ``codeboarding expand`` writes.
     """
     expanded = copy.deepcopy(data)
     methods_index = expanded.get("methods_index") or {}
+    version = (expanded.get("metadata") or {}).get("format_version", 1)
+
+    if version >= 3:
+        keys_by_id = {entry["id"]: key for key, entry in methods_index.items() if "id" in entry}
+        _expand_components(expanded.get("components") or [], keys_by_id)
+        _expand_relations(expanded.get("components_relations") or [], keys_by_id)
+        for entry in methods_index.values():
+            entry.pop("id", None)
 
     for key, entry in methods_index.items():
         if "file_path" in entry and "qualified_name" in entry:
@@ -589,6 +626,60 @@ def parse_unified_analysis(
         _hydrate_component_methods_from_refs(sub, methods_index)
 
     return root_analysis, sub_analyses
+
+
+def _symbol_ids(keys: list[str]) -> dict[str, str]:
+    """Map each method key to a short id derived from the key itself, widening on collision."""
+    width = _SYMBOL_ID_WIDTH
+    digests = {
+        key: base64.urlsafe_b64encode(hashlib.sha256(key.encode("utf-8")).digest()).decode("ascii") for key in keys
+    }
+    while True:
+        ids = {key: digest[:width] for key, digest in digests.items()}
+        if len(set(ids.values())) == len(ids):
+            return ids
+        width += 2
+        logger.warning("Symbol id collision at width %d; widening to %d", width - 2, width)
+
+
+def _intern_components(components: list[dict], ids: dict[str, str]) -> None:
+    for component in components:
+        component["file_methods"] = [
+            ids.get(key, key)
+            for group in (component.get("file_methods") or [])
+            for key in (_method_key(group["file_path"], qname) for qname in group.get("methods", []))
+        ]
+        _intern_relations(component.get("components_relations") or [], ids)
+        _intern_components(component.get("components") or [], ids)
+
+
+def _intern_relations(relations: list[dict], ids: dict[str, str]) -> None:
+    for relation in relations:
+        for field in ("key_edges", "all_edges"):
+            for edge in relation.get(field) or []:
+                edge["source"] = ids.get(edge["source"], edge["source"])
+                edge["target"] = ids.get(edge["target"], edge["target"])
+                edge["call_sites"] = [[site["line"], site["column"]] for site in edge.get("call_sites") or []]
+
+
+def _expand_components(components: list[dict], keys_by_id: dict[str, str]) -> None:
+    for component in components:
+        groups: dict[str, list[str]] = {}
+        for ref in component.get("file_methods") or []:
+            file_path, _, qualified_name = keys_by_id.get(ref, ref).partition("|")
+            groups.setdefault(file_path, []).append(qualified_name)
+        component["file_methods"] = [{"file_path": path, "methods": names} for path, names in groups.items()]
+        _expand_relations(component.get("components_relations") or [], keys_by_id)
+        _expand_components(component.get("components") or [], keys_by_id)
+
+
+def _expand_relations(relations: list[dict], keys_by_id: dict[str, str]) -> None:
+    for relation in relations:
+        for field in ("key_edges", "all_edges"):
+            for edge in relation.get(field) or []:
+                edge["source"] = keys_by_id.get(edge["source"], edge["source"])
+                edge["target"] = keys_by_id.get(edge["target"], edge["target"])
+                edge["call_sites"] = [{"line": line, "column": column} for line, column in edge.get("call_sites") or []]
 
 
 def _restore_parent_file_methods(components: list[dict]) -> list[dict]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,7 @@ include-package-data = true
 codeboarding = "main:main"
 codeboarding-setup = "install:main"
 codeboarding-render = "codeboarding_cli.render:main"
+codeboarding-expand = "codeboarding_cli.expand:main"
 
 [project.urls]
 Repository = "https://github.com/CodeBoarding/CodeBoarding"

--- a/tests/codeboarding_cli/test_expand.py
+++ b/tests/codeboarding_cli/test_expand.py
@@ -1,0 +1,68 @@
+"""Tests for the standalone ``codeboarding-expand`` CLI."""
+
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from codeboarding_cli import expand
+
+
+STORED = {
+    "metadata": {"generated_at": "t", "repo_name": "r", "depth_level": 1, "depth_cap": 1, "format_version": 3},
+    "description": "d",
+    "files": {"a.py": {"content_hash": "h", "module_hash": ""}},
+    "methods_index": {
+        "a.py|a.one": {"id": "AAAAAAAAAA", "start_line": 1, "end_line": 6, "type": "FUNCTION", "content_hash": ""}
+    },
+    "components": [
+        {
+            "name": "c1",
+            "component_id": "1",
+            "description": "d",
+            "key_entities": [],
+            "file_methods": ["AAAAAAAAAA"],
+            "can_expand": False,
+            "components": [],
+            "components_relations": [],
+        }
+    ],
+    "components_relations": [],
+}
+
+
+def run(*argv: str) -> None:
+    parser = expand.build_parser()
+    expand.run_from_args(parser.parse_args(list(argv)), parser)
+
+
+class TestExpandCli(unittest.TestCase):
+    def test_writes_the_expanded_document(self):
+        with TemporaryDirectory() as tmp:
+            stored = Path(tmp) / "analysis.json"
+            stored.write_text(json.dumps(STORED), encoding="utf-8")
+            out = Path(tmp) / "expanded.json"
+
+            run(str(stored), "--output", str(out))
+            expanded = json.loads(out.read_text(encoding="utf-8"))
+
+        self.assertEqual(expanded["methods_index"]["a.py|a.one"]["qualified_name"], "a.one")
+        self.assertNotIn("id", expanded["methods_index"]["a.py|a.one"])
+        self.assertEqual(expanded["files"]["a.py"]["method_keys"], ["a.py|a.one"])
+        self.assertEqual(expanded["components"][0]["file_methods"], [{"file_path": "a.py", "methods": ["a.one"]}])
+
+    def test_a_missing_file_exits_with_an_error(self):
+        with self.assertRaises(SystemExit):
+            run("/nonexistent/analysis.json")
+
+    def test_a_malformed_method_key_exits_with_an_error(self):
+        with TemporaryDirectory() as tmp:
+            stored = Path(tmp) / "analysis.json"
+            stored.write_text(json.dumps({"methods_index": {"no-separator": {"start_line": 1}}}), encoding="utf-8")
+
+            with self.assertRaises(SystemExit):
+                run(str(stored))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/diagram_analysis/test_analysis_json_format.py
+++ b/tests/diagram_analysis/test_analysis_json_format.py
@@ -1,10 +1,17 @@
-"""Tests for the lean (v2) analysis.json shape and its expansion back to v1."""
+"""Tests for the on-disk analysis.json shape and its expansion back to v1."""
 
 import json
 import unittest
 from pathlib import Path
 
-from agents.agent_responses import AnalysisInsights, Component
+from agents.agent_responses import (
+    AnalysisInsights,
+    Component,
+    Relation,
+    RelationCallSite,
+    RelationEdge,
+    SourceCodeReference,
+)
 from agents.file_index_models import FileEntry, FileMethodGroup, MethodEntry
 from diagram_analysis.analysis_json import (
     ANALYSIS_FORMAT_VERSION,
@@ -78,12 +85,72 @@ class TestLeanDocumentOmitsDerivableFields(unittest.TestCase):
         doc = build(root, {"1": (sub, [])})
 
         self.assertEqual(doc["components"][0]["file_methods"], [])
-        self.assertEqual(doc["components"][0]["components"][0]["file_methods"][0]["file_path"], "b.py")
+        self.assertEqual(
+            doc["components"][0]["components"][0]["file_methods"], [doc["methods_index"]["b.py|b.one"]["id"]]
+        )
 
     def test_metadata_declares_the_format_version(self):
         doc = build(analysis(component("1", {"a.py": ["a.one"]}), files={"a.py": ["a.one"]}))
 
         self.assertEqual(doc["metadata"]["format_version"], ANALYSIS_FORMAT_VERSION)
+
+
+class TestInternedIdentity(unittest.TestCase):
+    def _doc_with_edge(self, source: str, target: str) -> dict:
+        root = analysis(component("1", {"a.py": ["a.one", "a.two"]}), files={"a.py": ["a.one", "a.two"]})
+        root.components_relations = [
+            Relation(
+                relation="calls",
+                src_name="c1",
+                dst_name="c1",
+                src_id="1",
+                dst_id="1",
+                all_edges=[
+                    RelationEdge(
+                        source=SourceCodeReference(qualified_name=source, reference_file="a.py"),
+                        target=SourceCodeReference(qualified_name=target, reference_file="a.py"),
+                        call_sites=[RelationCallSite(line=12, column=8)],
+                    )
+                ],
+            )
+        ]
+        return build(root)
+
+    def test_edge_endpoints_become_ids_and_call_sites_become_pairs(self):
+        doc = self._doc_with_edge("a.one", "a.two")
+
+        edge = doc["components_relations"][0]["all_edges"][0]
+        self.assertEqual(edge["source"], doc["methods_index"]["a.py|a.one"]["id"])
+        self.assertEqual(edge["target"], doc["methods_index"]["a.py|a.two"]["id"])
+        self.assertEqual(edge["call_sites"], [[12, 8]])
+
+    def test_an_endpoint_with_no_indexed_method_keeps_its_raw_key(self):
+        """External and unresolved references have no symbol to point at; dropping them would lose the edge."""
+        doc = self._doc_with_edge("a.one", "vendor.absent")
+
+        edge = doc["components_relations"][0]["all_edges"][0]
+        self.assertEqual(edge["target"], "a.py|vendor.absent")
+        self.assertEqual(
+            expand_analysis_document(doc)["components_relations"][0]["all_edges"][0]["target"], "a.py|vendor.absent"
+        )
+
+    def test_ids_are_a_pure_function_of_the_method_key(self):
+        first = build(analysis(component("1", {"a.py": ["a.one"]}), files={"a.py": ["a.one"]}))
+        # A second file ahead of it in path order must not renumber anything.
+        second = build(
+            analysis(
+                component("1", {"a.py": ["a.one"], "0.py": ["z.one"]}), files={"0.py": ["z.one"], "a.py": ["a.one"]}
+            )
+        )
+
+        self.assertEqual(first["methods_index"]["a.py|a.one"]["id"], second["methods_index"]["a.py|a.one"]["id"])
+
+    def test_ids_are_distinct_for_overloads_sharing_a_name(self):
+        qnames = ["ns.Tag.Tag()", "ns.Tag.Tag(Guid id)"]
+        doc = build(analysis(component("1", {"a.cs": qnames}), files={"a.cs": qnames}))
+
+        ids = {entry["id"] for entry in doc["methods_index"].values()}
+        self.assertEqual(len(ids), 2)
 
 
 class TestExpandRestoresEverything(unittest.TestCase):

--- a/tests/diagram_analysis/test_diagram_analysis.py
+++ b/tests/diagram_analysis/test_diagram_analysis.py
@@ -30,6 +30,7 @@ from diagram_analysis.analysis_json import (
     RelationJson,
     UnifiedAnalysisJson,
     build_unified_analysis_json,
+    expand_analysis_document,
     from_analysis_to_json,
     from_component_to_json_component,
     parse_unified_analysis,
@@ -366,7 +367,7 @@ class TestAnalysisJsonConversion(unittest.TestCase):
             )
         ]
 
-        data = json.loads(from_analysis_to_json(self.analysis, [], self.repo_dir))
+        data = expand_analysis_document(json.loads(from_analysis_to_json(self.analysis, [], self.repo_dir)))
 
         relation = data["components_relations"][0]
         self.assertNotIn("edge_count", relation)
@@ -431,7 +432,7 @@ class TestAnalysisJsonConversion(unittest.TestCase):
             ),
         ]
 
-        data = json.loads(from_analysis_to_json(self.analysis, [], self.repo_dir))
+        data = expand_analysis_document(json.loads(from_analysis_to_json(self.analysis, [], self.repo_dir)))
 
         self.assertEqual(len(data["components_relations"]), 2)
         relations_by_label = {relation["relation"]: relation for relation in data["components_relations"]}
@@ -673,7 +674,7 @@ class TestAnalysisJsonConversion(unittest.TestCase):
                 )
             ]
 
-            data = json.loads(from_analysis_to_json(self.analysis, [], self.repo_dir))
+            data = expand_analysis_document(json.loads(from_analysis_to_json(self.analysis, [], self.repo_dir)))
 
         key_edge = data["components_relations"][0]["key_edges"][0]
         self.assertEqual(key_edge["call_sites"], [])
@@ -715,7 +716,7 @@ class TestAnalysisJsonConversion(unittest.TestCase):
                 )
             ]
 
-            data = json.loads(from_analysis_to_json(self.analysis, [], repo_dir=repo_dir))
+            data = expand_analysis_document(json.loads(from_analysis_to_json(self.analysis, [], repo_dir=repo_dir)))
 
         key_edge = data["components_relations"][0]["key_edges"][0]
         self.assertEqual(key_edge["source"], "component1.py|component1.run")


### PR DESCRIPTION
> Stacked on #571 — review that first; this PR's diff is against it.

## Why

With the derivable fields gone (#571), abp is 52 MB minified and the breakdown is stark:

```
components_relations  19.40 MB   ← 25.8 MB of it is endpoint STRINGS
components            19.29 MB   ←  6.1 MB of it is leaf file_methods
methods_index         11.77 MB
files                  1.42 MB
```

A method key is ~200 bytes of path and signature, and it is written once per relation edge endpoint and once per owning component. abp repeats them across 113,836 endpoints.

## What changes

Each indexed method gains a 10-char `id` — `base64url(sha256(key))[:10]`, widened globally on collision. Edge endpoints and component members cite the id:

```jsonc
// before
{ "source": "framework/src/Volo.Abp.AspNetCore.Bundling/.../BundleManagerBase.cs|Volo.Abp...BundleManagerBase.AddToBundleCache(string bundleName, IBundler bundler, List<string> bundleFiles)",
  "target": "framework/src/.../BundleManager.cs|Volo.Abp...BundleManager.IsMinficationEnabled()",
  "call_sites": [{ "line": 119, "column": 21 }] }

// after
{ "source": "ch1hoDF6DO", "target": "7gLBFHDpSG", "call_sites": [[119, 21]] }
```

734 B → 53 B for that edge.

**The id is a pure function of the key.** Nothing is addressed by position, so adding a file or a method renumbers nothing and the diff stays proportional to the change. This is deliberate: a positional scheme measured a 24,605-line / 8.6 MB diff for a single added file, which would breach GitHub's per-file diff caps on every incremental run.

## Savings

Real artifacts, as committed, v1 → after both stages:

| repo | before | after #571 | after this | total |
|---|---|---|---|---|
| abp | 102,247,607 | 68,268,942 | **36,738,435** | −64.1% |
| vercel | 12,486,726 | 6,090,438 | 5,133,519 | −58.9% |
| eShop | 2,109,180 | 1,129,137 | 845,862 | −59.9% |
| CodeBoarding-webview | 3,375,180 | 2,003,090 | 1,683,851 | −50.1% |

All round-trip to an **identical in-memory analysis**, endpoint-by-endpoint and call-site-by-call-site.

## Unindexed endpoints keep their raw key

Not every endpoint resolves — external libraries and unresolved references. Measured: **10 of 42 artifacts** have some, e.g. `'|MediatR.IMediator.Publish'` (eShop) and `'src/Ordering.Domain/SeedWork/Entity.cs|...Entity.DomainEvents'`.

Those keep the raw key rather than being dropped or crashing the writer. A key always contains `|`, an id never does, so readers disambiguate without a flag and today's graceful degradation is preserved.

## Reading it back

The stored form is no longer greppable by method key, so `codeboarding-expand` writes the fully self-describing v1 shape:

```
codeboarding-expand .codeboarding/analysis.json --output /tmp/readable.json
cat .codeboarding/analysis.json | codeboarding-expand | jq '.components[0]'
```

Verified on eShop: 845,862 B stored → 2,109,206 B expanded, with `methods_index`, `files` and every `all_edges` entry byte-identical to the original.

## Notes

- Interning is a post-processing pass over the built document — the exact inverse of `expand_analysis_document`, which keeps the two readable side by side and avoids threading an id map through every serializer signature.
- File paths stay literal. Interning them too would save ~1.7 MB more but costs greppability-by-path and adds an indirection; not worth it.
- Three `from_analysis_to_json` tests now assert through `expand_analysis_document`, so they keep testing meaning rather than encoding.
- Deliberately left alone: `key_entities` (0.4 MB, and it has dangling entries on 4 of 6 artifacts), short schema keys (saves 1.7% after gzip), interning content hashes (makes the raw file *bigger*).
- 10 new tests here, 15 total across the stack. Same 3 pre-existing CLI failures as #571.

## Not in this PR

The reader work in webview, graph-viewer, vscode, action, webapp and evals. Both format flips should land behind one reader release that accepts v1, v2 and v3 by field presence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `codeboarding-expand` command to expand stored analysis JSON into a fully self-describing format.
  * Supports reading from files or standard input and writing to standard output or a specified file.
  * Added configurable output indentation and clear errors for invalid or missing input.

* **Enhancements**
  * Updated analysis JSON to use a more compact, deterministic representation while preserving expanded method and relationship details when read.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->