### PR TITLE
feat(cfg): type references for Java and Python

### DIFF
--- a/static_analyzer/engine/source_inspector.py
+++ b/static_analyzer/engine/source_inspector.py
@@ -205,6 +205,22 @@ _DECORATOR_SEARCH_DEPTH = 12
 _SCRIPT_IMPORT_NODE_TYPES = frozenset({"import_statement"})
 _TYPESCRIPT_SUFFIXES = frozenset({".ts", ".tsx", ".mts", ".cts"})
 _SCRIPT_SUFFIXES = _TYPESCRIPT_SUFFIXES | frozenset(LANGUAGE_EXTENSIONS[Language.JAVASCRIPT])
+_JAVA_SUFFIXES = frozenset(LANGUAGE_EXTENSIONS[Language.JAVA])
+_PYTHON_SUFFIXES = frozenset(LANGUAGE_EXTENSIONS[Language.PYTHON])
+# Java: every ``type_identifier`` is a type position — a declaration names itself with a plain
+# ``identifier`` — so the selector only has to exclude the segments of a dotted name and the
+# type of a creation, which is already a constructor call.
+_JAVA_SCOPED_TYPE_NODE_TYPES = frozenset({"scoped_type_identifier"})
+_JAVA_CREATION_NODE_TYPES = frozenset({"object_creation_expression"})
+_JAVA_ANNOTATION_NODE_TYPES = frozenset({"marker_annotation", "annotation"})
+_JAVA_IMPORT_NODE_TYPES = frozenset({"import_declaration"})
+_JAVA_PACKAGE_NODE_TYPES = frozenset({"package_declaration"})
+# Python: an annotation is always wrapped in a ``type`` node, and a base class is an argument
+# of the class's ``superclasses`` list.
+_PYTHON_TYPE_NODE_TYPES = frozenset({"type", "generic_type"})
+_PYTHON_SUPERCLASS_FIELD = "superclasses"
+_PYTHON_IMPORT_NODE_TYPES = frozenset({"import_statement", "import_from_statement"})
+_PYTHON_RELATIVE_IMPORT_NODE_TYPES = frozenset({"relative_import"})
 
 # Ceiling on retained tree-sitter nodes. Trees are by far the largest thing this
 # class touches — retaining one per file cost 2.2GB on a 5k-file C# repo — and
@@ -693,11 +709,20 @@ class SourceInspector:
         # selector, and parsing first made every Python, Java, Go, PHP and Rust file pay a full
         # tree-sitter parse to be thrown away (1.9s over django's 2,894 files).
         suffix = file_path.suffix.lower()
-        if suffix in _PREPROCESSOR_SUFFIXES:
-            select = self._csharp_type_name
-        elif suffix in _SCRIPT_SUFFIXES:
-            select = self._script_type_name
-        else:
+        select = next(
+            (
+                selector
+                for suffixes, selector in (
+                    (_PREPROCESSOR_SUFFIXES, self._csharp_type_name),
+                    (_SCRIPT_SUFFIXES, self._script_type_name),
+                    (_JAVA_SUFFIXES, self._java_type_name),
+                    (_PYTHON_SUFFIXES, self._python_type_name),
+                )
+                if suffix in suffixes
+            ),
+            None,
+        )
+        if select is None:
             return []
         parsed = self._parse(file_path)
         if parsed is None:
@@ -729,10 +754,19 @@ class SourceInspector:
         return sites
 
     def find_namespace_context(self, file_path: Path) -> NamespaceContext:
-        """The usings and declared namespaces of a C# file; empty for any other language."""
-        parsed = self._parse(file_path)
-        if parsed is None or file_path.suffix.lower() not in _PREPROCESSOR_SUFFIXES:
+        """The declared scope and the directives of a C# or Java file; empty for any other.
+
+        Both languages resolve a bare type name the same way — against the scope the file
+        declares plus what it imports — so they share one record and one resolver.
+        """
+        suffix = file_path.suffix.lower()
+        if suffix not in _PREPROCESSOR_SUFFIXES and suffix not in _JAVA_SUFFIXES:
             return NamespaceContext((), ())
+        parsed = self._parse(file_path)
+        if parsed is None:
+            return NamespaceContext((), ())
+        if suffix in _JAVA_SUFFIXES:
+            return self._java_namespace_context(parsed)
 
         def text(node: TreeSitterNode) -> str:
             return parsed.content[node.start_byte : node.end_byte].decode("utf8", "replace")
@@ -771,11 +805,52 @@ class SourceInspector:
         visit(root, "", 1, root.end_point.row + 1)
         return NamespaceContext(tuple(usings), tuple(namespaces))
 
+    def _java_namespace_context(self, parsed: ParsedSource) -> NamespaceContext:
+        """``package`` as the declared scope; each ``import`` as a directive.
+
+        A single-type import decides a name outright, exactly as a C# alias does, so it is
+        recorded as one; a wildcard import offers a package, which is a plain namespace import.
+        """
+
+        def text(node: TreeSitterNode) -> str:
+            return parsed.content[node.start_byte : node.end_byte].decode("utf8", "replace")
+
+        last_line = parsed.tree.root_node.end_point.row + 1
+        usings: list[UsingDirective] = []
+        namespaces: list[tuple[str, int, int]] = []
+        for child in parsed.tree.root_node.named_children:
+            if child.type in _JAVA_PACKAGE_NODE_TYPES:
+                name = next((c for c in child.named_children if c.type in ("scoped_identifier", "identifier")), None)
+                if name is not None:
+                    namespaces.append((text(name), 1, last_line))
+            elif child.type in _JAVA_IMPORT_NODE_TYPES:
+                target = next((c for c in child.named_children if c.type in ("scoped_identifier", "identifier")), None)
+                if target is None:
+                    continue
+                wildcard = any(c.type == "asterisk" for c in child.children)
+                static = any(c.type == "static" for c in child.children)
+                written = text(target)
+                usings.append(
+                    UsingDirective(
+                        target=written,
+                        first_line=1,
+                        last_line=last_line,
+                        alias="" if wildcard or static else written.rpartition(".")[2],
+                        static=static,
+                    )
+                )
+        return NamespaceContext(tuple(usings), tuple(namespaces))
+
     def find_import_bindings(self, file_path: Path) -> dict[str, ImportBinding]:
-        """Local name -> what a TS/JS file imported it as; empty for any other language."""
-        parsed = self._parse(file_path)
-        if parsed is None or file_path.suffix.lower() not in _SCRIPT_SUFFIXES:
+        """Local name -> the module and export a TS/JS or Python file bound it from."""
+        suffix = file_path.suffix.lower()
+        if suffix not in _SCRIPT_SUFFIXES and suffix not in _PYTHON_SUFFIXES:
             return {}
+        parsed = self._parse(file_path)
+        if parsed is None:
+            return {}
+        if suffix in _PYTHON_SUFFIXES:
+            return self._python_import_bindings(parsed)
 
         def text(node: TreeSitterNode) -> str:
             return parsed.content[node.start_byte : node.end_byte].decode("utf8", "replace")
@@ -805,6 +880,44 @@ class SourceInspector:
                             alias_node = specifier.child_by_field_name("alias")
                             local = text(alias_node if alias_node is not None else name_node)
                             bindings[local] = ImportBinding(source, text(name_node))
+        return bindings
+
+    def _python_import_bindings(self, parsed: ParsedSource) -> dict[str, ImportBinding]:
+        """``from a.b import C as D`` -> ``D`` bound to ``C`` of module ``a.b``.
+
+        ``import a.b`` binds the dotted name itself rather than its head, because that is what a
+        type site writes: ``a.b.Thing`` arrives with ``a.b`` as its qualifier.
+        """
+
+        def text(node: TreeSitterNode) -> str:
+            return parsed.content[node.start_byte : node.end_byte].decode("utf8", "replace")
+
+        def module_of(node: TreeSitterNode) -> str:
+            if node.type not in _PYTHON_RELATIVE_IMPORT_NODE_TYPES:
+                return text(node)
+            # ``from .. import x``: the dots are the module, and there may be no name after them.
+            dots = "".join(text(c) for c in node.children if c.type == "import_prefix")
+            rest = next((text(c) for c in node.named_children if c.type == "dotted_name"), "")
+            return dots + rest
+
+        bindings: dict[str, ImportBinding] = {}
+        for statement in parsed.tree.root_node.named_children:
+            if statement.type not in _PYTHON_IMPORT_NODE_TYPES:
+                continue
+            module_node = statement.child_by_field_name("module_name")
+            module = module_of(module_node) if module_node is not None else ""
+            for imported in statement.children_by_field_name("name"):
+                if imported.type == "aliased_import":
+                    name_node = imported.child_by_field_name("name")
+                    alias_node = imported.child_by_field_name("alias")
+                    if name_node is None or alias_node is None:
+                        continue
+                    written = text(name_node)
+                    bindings[text(alias_node)] = ImportBinding(module or written, "*" if not module else written)
+                elif imported.type == "dotted_name":
+                    written = text(imported)
+                    # ``import a.b`` has no module of its own; the dotted name is the module.
+                    bindings[written] = ImportBinding(module or written, written if module else "*")
         return bindings
 
     def find_type_bases(self, file_path: Path) -> list[tuple[str, list[str]]]:
@@ -1049,6 +1162,39 @@ class SourceInspector:
         if node.type == "identifier" and self._inside_decorator(node):
             if parent.type == "array" or (parent.type == "pair" and self._field_name(node) == "value"):
                 return node, text(node), ""
+        return None
+
+    def _java_type_name(self, node: TreeSitterNode, text: _NodeText) -> _TypeName | None:
+        parent = node.parent
+        if parent is None:
+            return None
+        if node.type in _JAVA_ANNOTATION_NODE_TYPES:
+            # An annotation names a type, and in a framework-wired codebase it is the wiring.
+            annotated = node.child_by_field_name("name")
+            return (annotated, text(annotated), "") if annotated is not None else None
+        if node.type in _JAVA_SCOPED_TYPE_NODE_TYPES:
+            if parent.type in _JAVA_SCOPED_TYPE_NODE_TYPES:
+                return None
+            qualifier, _, name = text(node).rpartition(".")
+            return node, name, qualifier
+        if node.type != "type_identifier":
+            return None
+        if parent.type in _JAVA_SCOPED_TYPE_NODE_TYPES or parent.type in _JAVA_CREATION_NODE_TYPES:
+            return None
+        return node, text(node), ""
+
+    def _python_type_name(self, node: TreeSitterNode, text: _NodeText) -> _TypeName | None:
+        parent = node.parent
+        if parent is None:
+            return None
+        in_annotation = parent.type in _PYTHON_TYPE_NODE_TYPES
+        in_bases = parent.type == "argument_list" and self._field_name(parent) == _PYTHON_SUPERCLASS_FIELD
+        if not (in_annotation or in_bases):
+            return None
+        if node.type == "identifier":
+            return node, text(node), ""
+        if node.type == "attribute":
+            return self._script_member_name(node, "attribute", "object", text)
         return None
 
     @staticmethod

--- a/static_analyzer/engine/type_reference_builder.py
+++ b/static_analyzer/engine/type_reference_builder.py
@@ -16,7 +16,13 @@ from pathlib import Path
 
 from static_analyzer.cfg import CallGraph, EdgeKind, ReferenceEdge
 from static_analyzer.engine.models import ImportBinding, NamespaceContext, TypeReferenceSite, UsingDirective
-from static_analyzer.engine.source_inspector import SourceInspector, simple_type_name, split_type_name
+from static_analyzer.engine.source_inspector import (
+    _PYTHON_SUFFIXES,
+    _SCRIPT_SUFFIXES,
+    SourceInspector,
+    simple_type_name,
+    split_type_name,
+)
 from static_analyzer.internal_references import is_self_or_container_edge
 from static_analyzer.node import Node
 
@@ -76,12 +82,19 @@ class TypeIndex:
         return best
 
     def resolve(self, site: TypeReferenceSite) -> Node | None:
-        """The declaration ``site`` names, or ``None`` when unknown or not decidable."""
-        if site.file.lower().endswith(_SCRIPT_MODULE_SUFFIXES):
-            return self._resolve_script(site)
-        return self._resolve_csharp(site)
+        """The declaration ``site`` names, or ``None`` when unknown or not decidable.
 
-    def _resolve_csharp(self, site: TypeReferenceSite) -> Node | None:
+        Two families: a language that resolves a bare name against a declared scope and its
+        imports (C#, Java), and one that binds each name to a module (TypeScript, Python).
+        """
+        suffix = os.path.splitext(site.file)[1].lower()
+        if suffix in _SCRIPT_SUFFIXES:
+            return self._resolve_script(site)
+        if suffix in _PYTHON_SUFFIXES:
+            return self._resolve_python(site)
+        return self._resolve_by_namespace(site)
+
+    def _resolve_by_namespace(self, site: TypeReferenceSite) -> Node | None:
         written = f"{site.qualifier}.{site.name}" if site.qualifier else site.name
         alias_target = _expand_alias(written, self._usings_at(site.file, site.line))
         if alias_target:
@@ -98,15 +111,31 @@ class TypeIndex:
             return narrowed[0]
         return _closest(narrowed or candidates, site.file)
 
+    def _resolve_python(self, site: TypeReferenceSite) -> Node | None:
+        bindings = self._imports_of(site.file)
+        binding = bindings.get(site.qualifier or site.name)
+        if binding is None:
+            return self._only_local_candidate(site)
+        wanted = site.name if binding.imported_name == _NAMESPACE_IMPORT else binding.imported_name
+        module, anchored = _python_module(binding.source, site.file)
+        candidates = [
+            node for node in self._by_name.get(wanted, []) if _in_python_module(node.file_path, module, anchored)
+        ]
+        return candidates[0] if len(candidates) == 1 else None
+
+    def _only_local_candidate(self, site: TypeReferenceSite) -> Node | None:
+        """The name with no import behind it: this file's own, or the repository's only one."""
+        candidates = self._by_name.get(site.name, [])
+        same_file = [node for node in candidates if node.file_path == site.file]
+        if len(same_file) == 1:
+            return same_file[0]
+        return candidates[0] if len(candidates) == 1 else None
+
     def _resolve_script(self, site: TypeReferenceSite) -> Node | None:
         bindings = self._imports_of(site.file)
         binding = bindings.get(site.qualifier or site.name)
         if binding is None:
-            candidates = self._by_name.get(site.name, [])
-            same_file = [node for node in candidates if node.file_path == site.file]
-            if len(same_file) == 1:
-                return same_file[0]
-            return candidates[0] if len(candidates) == 1 else None
+            return self._only_local_candidate(site)
         if not binding.source.startswith("."):
             return None
         wanted = site.name if binding.imported_name in (_NAMESPACE_IMPORT, "default") else binding.imported_name
@@ -212,6 +241,31 @@ def _expand_alias(written: str, directives: Iterable[UsingDirective]) -> str:
         if directive.alias == head:
             return ".".join(part for part in (directive.target, rest) if part)
     return ""
+
+
+def _python_module(source: str, site_file: str) -> tuple[str, bool]:
+    """A Python import's module as a path, and whether it is anchored at a known directory.
+
+    A relative import resolves against the importing file and so is anchored; an absolute one
+    names a package whose root this layer does not know, and is matched as a path suffix.
+    """
+    if not source.startswith("."):
+        return source.replace(".", os.sep), False
+    depth = len(source) - len(source.lstrip("."))
+    base = os.path.dirname(site_file)
+    for _ in range(depth - 1):
+        base = os.path.dirname(base)
+    rest = source[depth:].replace(".", os.sep)
+    return (os.path.join(base, rest) if rest else base), True
+
+
+def _in_python_module(file_path: str, module: str, anchored: bool) -> bool:
+    """Whether ``file_path`` is the module, as a file or as a package's ``__init__``."""
+    stem = file_path[: -len(".py")] if file_path.endswith(".py") else file_path
+    package = os.sep + "__init__"
+    if stem.endswith(package):
+        stem = stem[: -len(package)]
+    return stem == module if anchored else stem == module or stem.endswith(os.sep + module)
 
 
 def _module_stem(path: str) -> str:

--- a/tests/static_analyzer/test_source_inspector.py
+++ b/tests/static_analyzer/test_source_inspector.py
@@ -786,15 +786,15 @@ class TestFindTypeReferenceSites:
         sites = SourceInspector().find_type_reference_sites(f)
         assert [site.name for site in sites] == ["B"]
 
-    def test_other_languages_have_no_type_sites(self, tmp_path: Path):
-        f = tmp_path / "a.py"
-        f.write_text("class A(B):\n    def m(self, x: C) -> D: ...\n")
+    def test_a_language_without_a_selector_has_no_type_sites(self, tmp_path: Path):
+        f = tmp_path / "a.rs"
+        f.write_text("struct A { b: B }\nimpl C for A { fn m(&self, x: D) -> E { }}\n")
         assert SourceInspector().find_type_reference_sites(f) == []
 
     def test_a_language_without_a_selector_is_never_parsed(self, tmp_path: Path):
         """Why: the pass runs over every source file, and a parse thrown away is the whole cost."""
-        f = tmp_path / "a.py"
-        f.write_text("class A(B): ...\n")
+        f = tmp_path / "a.rs"
+        f.write_text("struct A { b: B }\n")
         inspector = SourceInspector()
         assert inspector.find_type_reference_sites(f) == []
         assert inspector.cache_stats()["parsed_files"] == 0
@@ -821,6 +821,103 @@ class TestCSharpTypeNameNormalization:
     def test_a_plain_qualified_name_is_unchanged(self, tmp_path: Path):
         sites = self._sites(tmp_path, "class K { Lib.Domain.Order F; }\n")
         assert sites["Order"] == ("Order", "Lib.Domain")
+
+
+class TestJavaTypeSites:
+    def _sites(self, tmp_path: Path, body: str) -> set[tuple[str, str]]:
+        f = tmp_path / "S.java"
+        f.write_text(body)
+        return {(s.name, s.qualifier) for s in SourceInspector().find_type_reference_sites(f)}
+
+    def test_every_type_position_java_writes(self, tmp_path: Path):
+        sites = self._sites(
+            tmp_path,
+            "package com.example;\n"
+            "@Component\n"
+            "public class Service extends BaseService implements Runnable {\n"
+            "  private java.util.List<Widget> all;\n"
+            "  public Repo find(Query q) throws NotFound {\n"
+            "    Object o = (Widget) all; if (o instanceof Widget w) { }\n"
+            "    try { } catch (BadThing e) { }\n"
+            "    return null;\n"
+            "  }\n"
+            "}\n",
+        )
+        assert {("BaseService", ""), ("Runnable", ""), ("Component", "")} <= sites
+        assert ("List", "java.util") in sites and ("Widget", "") in sites
+        assert {("Repo", ""), ("Query", ""), ("NotFound", ""), ("BadThing", "")} <= sites
+        # The class names itself with a plain identifier, so a declaration is never a site.
+        assert not any(name == "Service" for name, _ in sites)
+
+    def test_a_created_type_is_left_to_the_constructor_call(self, tmp_path: Path):
+        sites = self._sites(tmp_path, "class S { void m() { Widget w = new Other(); } }\n")
+        assert ("Widget", "") in sites
+        assert ("Other", "") not in sites
+
+
+class TestPythonTypeSites:
+    def _sites(self, tmp_path: Path, body: str) -> set[tuple[str, str]]:
+        f = tmp_path / "a.py"
+        f.write_text(body)
+        return {(s.name, s.qualifier) for s in SourceInspector().find_type_reference_sites(f)}
+
+    def test_annotations_bases_and_nested_generics(self, tmp_path: Path):
+        sites = self._sites(
+            tmp_path,
+            "class Service(BaseService, Runnable):\n"
+            "    widget: Widget\n"
+            "    items: list[Nested]\n"
+            "    def find(self, q: Query, o: Optional[Deep]) -> Result: ...\n"
+            "    def use(self, x: mod.Thing): ...\n",
+        )
+        assert {("BaseService", ""), ("Runnable", ""), ("Widget", "")} <= sites
+        assert {("list", ""), ("Nested", ""), ("Optional", ""), ("Deep", "")} <= sites
+        assert {("Query", ""), ("Result", ""), ("Thing", "mod")} <= sites
+        assert not any(name == "Service" for name, _ in sites)
+
+    def test_a_call_is_not_a_type_position(self, tmp_path: Path):
+        assert self._sites(tmp_path, "def m():\n    return Widget()\n") == set()
+
+
+class TestJavaNamespaceContext:
+    def test_package_imports_wildcards_and_static(self, tmp_path: Path):
+        f = tmp_path / "S.java"
+        f.write_text(
+            "package com.example.app;\n"
+            "import com.example.core.Widget;\n"
+            "import com.example.util.*;\n"
+            "import static com.example.util.Helpers.check;\n"
+            "class S { }\n"
+        )
+        context = SourceInspector().find_namespace_context(f)
+        assert context.namespaces[0][0] == "com.example.app"
+        # A single-type import decides a name, exactly as a C# alias does; a wildcard offers a
+        # package; a static import offers members and not the type itself.
+        assert [(d.target, d.alias, d.static) for d in context.usings] == [
+            ("com.example.core.Widget", "Widget", False),
+            ("com.example.util", "", False),
+            ("com.example.util.Helpers.check", "", True),
+        ]
+
+
+class TestPythonImportBindings:
+    def test_absolute_relative_and_aliased_imports(self, tmp_path: Path):
+        f = tmp_path / "a.py"
+        f.write_text(
+            "from a.b import Widget, Other as Alias\n"
+            "from .mod import Nearby\n"
+            "from . import sibling\n"
+            "import pkg.sub\n"
+            "import pkg.sub as ps\n"
+        )
+        bindings = SourceInspector().find_import_bindings(f)
+        assert bindings["Widget"] == ImportBinding("a.b", "Widget")
+        assert bindings["Alias"] == ImportBinding("a.b", "Other")
+        assert bindings["Nearby"] == ImportBinding(".mod", "Nearby")
+        assert bindings["sibling"] == ImportBinding(".", "sibling")
+        # ``import a.b`` binds the dotted name, because that is what a type site writes.
+        assert bindings["pkg.sub"] == ImportBinding("pkg.sub", "*")
+        assert bindings["ps"] == ImportBinding("pkg.sub", "*")
 
 
 class TestFindNamespaceContext:

--- a/tests/static_analyzer/test_type_reference_builder.py
+++ b/tests/static_analyzer/test_type_reference_builder.py
@@ -159,6 +159,107 @@ class TestTypeIndexCSharpUsings:
         assert _resolved_name(index, _site(user, "X", line=3)) == "c.X"
 
 
+class TestTypeIndexJava:
+    """Java resolves a bare name the way C# does, so it shares the resolver and only the reader differs."""
+
+    def _repo(self, tmp_path: Path) -> tuple[Path, list]:
+        core = _write(
+            tmp_path / "com" / "example" / "core" / "Widget.java",
+            "package com.example.core;\npublic class Widget { }\n",
+        )
+        util = _write(
+            tmp_path / "com" / "example" / "util" / "Widget.java",
+            "package com.example.util;\npublic class Widget { }\n",
+        )
+        return tmp_path, [_class("com.example.core.Widget", core), _class("com.example.util.Widget", util)]
+
+    def test_a_single_type_import_decides_the_name(self, tmp_path: Path):
+        root, nodes = self._repo(tmp_path)
+        user = _write(
+            root / "com" / "example" / "util" / "Service.java",
+            "package com.example.util;\nimport com.example.core.Widget;\npublic class Service { Widget w; }\n",
+        )
+        index = TypeIndex(nodes, SourceInspector())
+        # Without the import the file's own package would win.
+        assert _resolved_name(index, _site(user, "Widget", line=3)) == "com.example.core.Widget"
+
+    def test_the_files_own_package_resolves_without_an_import(self, tmp_path: Path):
+        root, nodes = self._repo(tmp_path)
+        user = _write(
+            root / "com" / "example" / "util" / "Service.java",
+            "package com.example.util;\npublic class Service { Widget w; }\n",
+        )
+        index = TypeIndex(nodes, SourceInspector())
+        assert _resolved_name(index, _site(user, "Widget", line=2)) == "com.example.util.Widget"
+
+    def test_a_wildcard_import_makes_a_package_nameable(self, tmp_path: Path):
+        root, nodes = self._repo(tmp_path)
+        user = _write(
+            root / "com" / "app" / "Service.java",
+            "package com.app;\nimport com.example.core.*;\npublic class Service { Widget w; }\n",
+        )
+        index = TypeIndex(nodes, SourceInspector())
+        assert _resolved_name(index, _site(user, "Widget", line=3)) == "com.example.core.Widget"
+
+    def test_a_static_import_does_not_make_the_type_nameable(self, tmp_path: Path):
+        root, nodes = self._repo(tmp_path)
+        user = _write(
+            root / "com" / "example" / "util" / "Service.java",
+            "package com.example.util;\nimport static com.example.core.Widget.check;\n"
+            "public class Service { Widget w; }\n",
+        )
+        index = TypeIndex(nodes, SourceInspector())
+        # The static import brings in members, so the file's own package still decides.
+        assert _resolved_name(index, _site(user, "Widget", line=3)) == "com.example.util.Widget"
+
+
+class TestTypeIndexPython:
+    def test_an_absolute_import_resolves_to_its_module(self, tmp_path: Path):
+        widget = _write(tmp_path / "a" / "b.py", "class Widget: ...\n")
+        other = _write(tmp_path / "z" / "b.py", "class Widget: ...\n")
+        user = _write(tmp_path / "u.py", "from a.b import Widget\n")
+        index = TypeIndex([_class("a.b.Widget", widget), _class("z.b.Widget", other)], SourceInspector())
+        assert _resolved_name(index, _site(user, "Widget")) == "a.b.Widget"
+
+    def test_a_relative_import_resolves_against_the_importing_file(self, tmp_path: Path):
+        near = _write(tmp_path / "pkg" / "mod.py", "class Widget: ...\n")
+        far = _write(tmp_path / "other" / "mod.py", "class Widget: ...\n")
+        user = _write(tmp_path / "pkg" / "u.py", "from .mod import Widget\n")
+        index = TypeIndex([_class("pkg.mod.Widget", near), _class("other.mod.Widget", far)], SourceInspector())
+        assert _resolved_name(index, _site(user, "Widget")) == "pkg.mod.Widget"
+
+    def test_a_package_resolves_through_its_init(self, tmp_path: Path):
+        widget = _write(tmp_path / "a" / "b" / "__init__.py", "class Widget: ...\n")
+        user = _write(tmp_path / "u.py", "from a.b import Widget\n")
+        index = TypeIndex([_class("a.b.Widget", widget)], SourceInspector())
+        assert _resolved_name(index, _site(user, "Widget")) == "a.b.Widget"
+
+    def test_an_alias_resolves_to_the_exported_name(self, tmp_path: Path):
+        widget = _write(tmp_path / "a" / "b.py", "class Widget: ...\n")
+        user = _write(tmp_path / "u.py", "from a.b import Widget as W\n")
+        index = TypeIndex([_class("a.b.Widget", widget)], SourceInspector())
+        assert _resolved_name(index, _site(user, "W")) == "a.b.Widget"
+
+    def test_a_module_import_resolves_through_its_qualifier(self, tmp_path: Path):
+        widget = _write(tmp_path / "pkg" / "sub.py", "class Thing: ...\n")
+        user = _write(tmp_path / "u.py", "import pkg.sub\n")
+        index = TypeIndex([_class("pkg.sub.Thing", widget)], SourceInspector())
+        assert _resolved_name(index, _site(user, "Thing", qualifier="pkg.sub")) == "pkg.sub.Thing"
+
+    def test_a_third_party_import_is_external(self, tmp_path: Path):
+        """A name the repository also declares must not be claimed for an installed package."""
+        widget = _write(tmp_path / "mine" / "b.py", "class Widget: ...\n")
+        user = _write(tmp_path / "u.py", "from django.db import Widget\n")
+        index = TypeIndex([_class("mine.b.Widget", widget)], SourceInspector())
+        assert index.resolve(_site(user, "Widget")) is None
+
+    def test_a_name_with_no_import_falls_back_to_this_file(self, tmp_path: Path):
+        here = _write(tmp_path / "u.py", "class Widget: ...\n")
+        elsewhere = _write(tmp_path / "far" / "b.py", "class Widget: ...\n")
+        index = TypeIndex([_class("u.Widget", here), _class("far.b.Widget", elsewhere)], SourceInspector())
+        assert _resolved_name(index, _site(here, "Widget")) == "u.Widget"
+
+
 class TestTypeIndexScript:
     def test_resolves_through_a_relative_import(self, tmp_path: Path):
         svc = _write(tmp_path / "svc.ts", "export class Svc { }\n")


### PR DESCRIPTION
Stacked on [#570](https://github.com/CodeBoarding/CodeBoarding/pull/570) — **base is `feat/relation-edge-kind`**, which is itself stacked on [#568](https://github.com/CodeBoarding/CodeBoarding/pull/568).

## Why

#568 gave the type-reference layer to C# and TypeScript and returned nothing for the other six wired languages. Nothing about the defect was C#-specific — `_process_references_for_position` drops a reference to a class-like symbol that is not an invocation whatever the language, so `void m(Widget w)` and `def m(w: Widget)` were exactly as invisible as `[DependsOn(typeof(X))]`. A Java or Python repository kept the floating components the C# work exists to remove, and since `AFFINE_REFERENCE_KINDS` feeds TYPEREF into clustering, those repositories were also grouped worse — with nothing in the UI to explain why.

The original mandate for this work said all eight languages. This is two of the six that were missing.

## There are only two resolution rules

Adding a language needs a reader and a rule for what a bare name means. It turns out there are two families, and both already existed:

- **A declared scope plus imports** — C#, **Java**. Java reuses `_resolve_by_namespace` unchanged: a single-type import decides a name exactly as a C# alias does, a wildcard import offers a package as a plain `using` does, and a static import offers members rather than the type itself. The only new code is the reader that turns `package`/`import` into the `UsingDirective` records C# already produces.
- **A name bound to a module** — TypeScript, **Python**. Python reuses the import-binding shape, with a dotted module path in place of a relative specifier: relative imports anchor against the importing file, absolute ones match as a path suffix, and a package resolves through its `__init__`.

`_resolve_csharp` is renamed `_resolve_by_namespace` because it is no longer C#-specific, and the suffix→selector chain became a lookup so a language is one row rather than a branch.

## The readers are small because the grammars are explicit

**Java:** every `type_identifier` is a type position — a declaration names itself with a plain `identifier` — so the selector only excludes the segments of a dotted name and the type of a creation, which is already a constructor call. Annotations are included on purpose: in a Spring or Mockito codebase they *are* the wiring, and the ones that matter resolve in-repo while `@Override` and `@Test` resolve to nothing and cost nothing.

**Python:** every annotation is wrapped in a `type` node and base classes hang off the class's `superclasses` list. That is the whole rule; nested generics fall out of it, since `Optional[Deep]` puts `Deep` under another `type`.

## What these two languages actually discover

Real edges from the integration fixtures, absent before this branch. See [#568](https://github.com/CodeBoarding/CodeBoarding/pull/568) for the full framing; the short version is that a call is a runtime dependency and a type reference is a compile-time one, which is why the label is `uses`.

**Java** — 23 references on the fixture project:

| position | real example | edge |
|---|---|---|
| generic argument | `List<Animal> animals = new ArrayList<>();` | `main` uses `Animal` |
| `extends` | `public class Dog extends Animal` | `Dog` uses `Animal` |
| `implements` | `public class Duck extends Animal implements Swimmable` | `Duck` uses `Swimmable` |
| return type | `public static Animal create(String type, String name)` | `create` uses `Animal` |
| parameter type | `public static String getAnimalCity(Animal animal)` | `getAnimalCity` uses `Animal` |
| local type | `Animal factoryAnimal = AnimalFactory.create(...)` | `main` uses `Animal` |
| `instanceof` | `if (!(o instanceof Container c)) return false;` | `equals` uses `Container` |

**Annotations are included on purpose**, and they are the entry most worth arguing about. `@Override` and `@Test` resolve to nothing and cost nothing, because the annotation type is not in the repository. An in-repo `@Component` or `@Mock` does resolve, and in a Spring or Mockito codebase that annotation *is* the wiring — the same argument as C#'s `[DependsOn(typeof(X))]`. If you would rather not have them, it is one entry in `_JAVA_ANNOTATION_NODE_TYPES`.

**Python** — 16 references:

| position | real example | edge |
|---|---|---|
| base class | `class Cat(Animal):` | `Cat` uses `Animal` |
| parameter annotation | `def _handle_cat(animal: Animal) -> str:` | `_handle_cat` uses `Animal` |
| return annotation | `def create_dog(name: str) -> Dog:` | `create_dog` uses `Dog` |
| generic argument | `def animal_names(animals: list[Animal]) -> list[str]:` | `animal_names` uses `Animal` |

Python's are the cleanest of the six languages — an annotation is *only* ever a type, so there is no incidental category, and its import table means a name is either bound in this file or is not ours. That is why it resolves 1,407 of 1,870 sites where C# resolves 18%.

The honest weakness is coverage rather than precision: an unannotated codebase yields nothing. django has 894 analysed files and only 1,870 type positions in them. Nothing is wrong — there is simply less to read.

## Measured, over the files a real run analyses

| language | repo | files | class nodes | type references | pass | resolved / sites |
|---|---|---:|---:|---:|---:|---|
| Java | mockito | 990 | 1,823 | **3,425** | 1.3 s | 8,041 / 25,933 |
| Python | django | 894 | 1,920 | **1,405** | 2.2 s | 1,407 / 1,870 |
| Python | CodeBoarding | 168 | 1,638 | **816** | 0.6 s | 1,058 / 6,813 |

Python resolves a far higher share of its sites than Java or C# because its import table is explicit — a name is either bound or it is not ours. The edges are the ones a reader wants: `XFrameOptionsMiddleware` → `MiddlewareMixin` is a django relationship no call carries.

## Tests

Reader tests per language (every type position Java writes; a created type left to its constructor; annotations, bases and nested generics in Python; package/wildcard/static imports; absolute, relative, aliased and module imports) and resolver tests that discriminate rather than confirm — a single-type import beating the file's own package, a wildcard import reaching another package, a static import *not* making its type nameable, a relative import beating a same-named module elsewhere, and a third-party import refusing to claim a same-named local class.

The two tests that asserted "other languages have no type sites" now use Rust, which stays unsupported.

Full suite 2,151 passed; the 3 `test_cli_parser` failures are pre-existing and fail identically on `main` at `e38c07e3`. mypy and black clean.

## Still missing

Go and PHP follow in the next PR of this stack. Rust is deliberately last: `use` paths over a module tree plus trait impls and macro-generated types are a different order of difficulty, and I would rather land the four cheap ones first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Java and Python support for detecting type references in source code.
  - Improved handling of Java packages, imports, wildcard imports, and static imports.
  - Added Python import resolution for absolute, relative, aliased, and dotted imports.
  - Improved type resolution across local files, packages, modules, and imported names.
  - Preserved accurate behavior for unsupported languages and non-type expressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
