### PR TITLE
feat(cfg): type references for Go and PHP

### DIFF
--- a/static_analyzer/engine/models.py
+++ b/static_analyzer/engine/models.py
@@ -101,9 +101,14 @@ class NamespaceContext:
     namespaces: tuple[tuple[str, int, int], ...]
 
 
+#: ``imported_name`` for a binding that names a whole module rather than one of its exports:
+#: TypeScript's ``import * as NS``, Python's ``import a.b``, every Go import.
+NAMESPACE_IMPORT = "*"
+
+
 @dataclass(frozen=True)
 class ImportBinding:
-    """One local name a TS/JS file imports: the module specifier and the exported name."""
+    """One local name a file imports: the module specifier and the exported name."""
 
     source: str
     imported_name: str

--- a/static_analyzer/engine/source_inspector.py
+++ b/static_analyzer/engine/source_inspector.py
@@ -235,6 +235,7 @@ _PHP_SUFFIXES = frozenset(LANGUAGE_EXTENSIONS[Language.PHP])
 _GO_QUALIFIED_TYPE_NODE_TYPES = frozenset({"qualified_type"})
 _GO_TYPE_DECLARATION_NODE_TYPES = frozenset({"type_spec", "type_alias"})
 _GO_IMPORT_NODE_TYPES = frozenset({"import_declaration"})
+_GO_PARAMETER_LIST_NODE_TYPE = "parameter_list"
 # PHP: a type is written in a parameter, a property, a return, or a heritage clause.
 _PHP_TYPE_PARENT_NODE_TYPES = frozenset({"named_type", "base_clause", "class_interface_clause"})
 _PHP_QUALIFIED_NAME_NODE_TYPES = frozenset({"qualified_name"})
@@ -1293,7 +1294,22 @@ class SourceInspector:
             return None
         if parent.type in _GO_TYPE_DECLARATION_NODE_TYPES and self._field_name(node) == "name":
             return None
+        if self._inside_go_receiver(node):
+            return None
         return node, text(node), ""
+
+    def _inside_go_receiver(self, node: TreeSitterNode) -> bool:
+        """Whether the type sits in a method's receiver, which names the type the method is on.
+
+        Why: that is containment, already carried by a CONTAINS edge, and counting it as a type
+        reference makes every method depend on its own type — a third of fzf's references.
+        """
+        current: TreeSitterNode | None = node
+        while current is not None:
+            if current.type == _GO_PARAMETER_LIST_NODE_TYPE and self._field_name(current) == "receiver":
+                return True
+            current = current.parent
+        return False
 
     def _php_type_name(self, node: TreeSitterNode, text: _NodeText) -> _TypeName | None:
         parent = node.parent

--- a/static_analyzer/engine/source_inspector.py
+++ b/static_analyzer/engine/source_inspector.py
@@ -14,7 +14,14 @@ from tree_sitter import Node as TreeSitterNode
 from tree_sitter import Parser, Tree
 
 from static_analyzer.config import LANGUAGE_EXTENSIONS, Language
-from static_analyzer.engine.models import CallSite, ImportBinding, NamespaceContext, TypeReferenceSite, UsingDirective
+from static_analyzer.engine.models import (
+    CallSite,
+    ImportBinding,
+    NAMESPACE_IMPORT,
+    NamespaceContext,
+    TypeReferenceSite,
+    UsingDirective,
+)
 
 import tree_sitter_c_sharp
 import tree_sitter_go
@@ -221,6 +228,19 @@ _PYTHON_TYPE_NODE_TYPES = frozenset({"type", "generic_type"})
 _PYTHON_SUPERCLASS_FIELD = "superclasses"
 _PYTHON_IMPORT_NODE_TYPES = frozenset({"import_statement", "import_from_statement"})
 _PYTHON_RELATIVE_IMPORT_NODE_TYPES = frozenset({"relative_import"})
+_GO_SUFFIXES = frozenset(LANGUAGE_EXTENSIONS[Language.GO])
+_PHP_SUFFIXES = frozenset(LANGUAGE_EXTENSIONS[Language.PHP])
+# Go writes a foreign type as ``pkg.Type`` and its own without a qualifier; a declaration is the
+# ``name`` of its own spec, which is the only ``type_identifier`` that is not a type position.
+_GO_QUALIFIED_TYPE_NODE_TYPES = frozenset({"qualified_type"})
+_GO_TYPE_DECLARATION_NODE_TYPES = frozenset({"type_spec", "type_alias"})
+_GO_IMPORT_NODE_TYPES = frozenset({"import_declaration"})
+# PHP: a type is written in a parameter, a property, a return, or a heritage clause.
+_PHP_TYPE_PARENT_NODE_TYPES = frozenset({"named_type", "base_clause", "class_interface_clause"})
+_PHP_QUALIFIED_NAME_NODE_TYPES = frozenset({"qualified_name"})
+_PHP_NAMESPACE_NODE_TYPES = frozenset({"namespace_definition"})
+_PHP_USE_NODE_TYPES = frozenset({"namespace_use_declaration"})
+_PHP_SEPARATOR = "\\"
 
 # Ceiling on retained tree-sitter nodes. Trees are by far the largest thing this
 # class touches — retaining one per file cost 2.2GB on a 5k-file C# repo — and
@@ -717,6 +737,8 @@ class SourceInspector:
                     (_SCRIPT_SUFFIXES, self._script_type_name),
                     (_JAVA_SUFFIXES, self._java_type_name),
                     (_PYTHON_SUFFIXES, self._python_type_name),
+                    (_GO_SUFFIXES, self._go_type_name),
+                    (_PHP_SUFFIXES, self._php_type_name),
                 )
                 if suffix in suffixes
             ),
@@ -760,13 +782,15 @@ class SourceInspector:
         declares plus what it imports — so they share one record and one resolver.
         """
         suffix = file_path.suffix.lower()
-        if suffix not in _PREPROCESSOR_SUFFIXES and suffix not in _JAVA_SUFFIXES:
+        if suffix not in _PREPROCESSOR_SUFFIXES | _JAVA_SUFFIXES | _PHP_SUFFIXES:
             return NamespaceContext((), ())
         parsed = self._parse(file_path)
         if parsed is None:
             return NamespaceContext((), ())
         if suffix in _JAVA_SUFFIXES:
             return self._java_namespace_context(parsed)
+        if suffix in _PHP_SUFFIXES:
+            return self._php_namespace_context(parsed)
 
         def text(node: TreeSitterNode) -> str:
             return parsed.content[node.start_byte : node.end_byte].decode("utf8", "replace")
@@ -844,13 +868,15 @@ class SourceInspector:
     def find_import_bindings(self, file_path: Path) -> dict[str, ImportBinding]:
         """Local name -> the module and export a TS/JS or Python file bound it from."""
         suffix = file_path.suffix.lower()
-        if suffix not in _SCRIPT_SUFFIXES and suffix not in _PYTHON_SUFFIXES:
+        if suffix not in _SCRIPT_SUFFIXES | _PYTHON_SUFFIXES | _GO_SUFFIXES:
             return {}
         parsed = self._parse(file_path)
         if parsed is None:
             return {}
         if suffix in _PYTHON_SUFFIXES:
             return self._python_import_bindings(parsed)
+        if suffix in _GO_SUFFIXES:
+            return self._go_import_bindings(parsed)
 
         def text(node: TreeSitterNode) -> str:
             return parsed.content[node.start_byte : node.end_byte].decode("utf8", "replace")
@@ -871,7 +897,7 @@ class SourceInspector:
                         bindings[text(part)] = ImportBinding(source, "default")
                     elif part.type == "namespace_import":
                         for alias in part.named_children:
-                            bindings[text(alias)] = ImportBinding(source, "*")
+                            bindings[text(alias)] = ImportBinding(source, NAMESPACE_IMPORT)
                     elif part.type == "named_imports":
                         for specifier in part.named_children:
                             name_node = specifier.child_by_field_name("name")
@@ -913,11 +939,69 @@ class SourceInspector:
                     if name_node is None or alias_node is None:
                         continue
                     written = text(name_node)
-                    bindings[text(alias_node)] = ImportBinding(module or written, "*" if not module else written)
+                    bindings[text(alias_node)] = ImportBinding(
+                        module or written, NAMESPACE_IMPORT if not module else written
+                    )
                 elif imported.type == "dotted_name":
                     written = text(imported)
                     # ``import a.b`` has no module of its own; the dotted name is the module.
-                    bindings[written] = ImportBinding(module or written, written if module else "*")
+                    bindings[written] = ImportBinding(module or written, written if module else NAMESPACE_IMPORT)
+        return bindings
+
+    def _php_namespace_context(self, parsed: ParsedSource) -> NamespaceContext:
+        """``namespace`` as the declared scope; each ``use`` binds one name, as an alias does."""
+
+        def text(node: TreeSitterNode) -> str:
+            return parsed.content[node.start_byte : node.end_byte].decode("utf8", "replace")
+
+        def dotted(node: TreeSitterNode) -> str:
+            return text(node).strip(_PHP_SEPARATOR).replace(_PHP_SEPARATOR, ".")
+
+        last_line = parsed.tree.root_node.end_point.row + 1
+        usings: list[UsingDirective] = []
+        namespaces: list[tuple[str, int, int]] = []
+        for child in parsed.tree.root_node.named_children:
+            if child.type in _PHP_NAMESPACE_NODE_TYPES:
+                name = child.child_by_field_name("name")
+                if name is not None:
+                    namespaces.append((dotted(name), 1, last_line))
+            elif child.type in _PHP_USE_NODE_TYPES:
+                for clause in child.named_children:
+                    if clause.type != "namespace_use_clause":
+                        continue
+                    target = next((c for c in clause.named_children if c.type in ("qualified_name", "name")), None)
+                    if target is None:
+                        continue
+                    alias = clause.child_by_field_name("alias")
+                    written = dotted(target)
+                    usings.append(
+                        UsingDirective(
+                            target=written,
+                            first_line=1,
+                            last_line=last_line,
+                            alias=text(alias) if alias is not None else written.rpartition(".")[2],
+                        )
+                    )
+        return NamespaceContext(tuple(usings), tuple(namespaces))
+
+    def _go_import_bindings(self, parsed: ParsedSource) -> dict[str, ImportBinding]:
+        """Local package name -> its import path. Unaliased, the name is the path's last segment."""
+
+        def text(node: TreeSitterNode) -> str:
+            return parsed.content[node.start_byte : node.end_byte].decode("utf8", "replace")
+
+        bindings: dict[str, ImportBinding] = {}
+        for node in self._walk(parsed.tree.root_node):
+            if node.type != "import_spec":
+                continue
+            path_node = node.child_by_field_name("path")
+            if path_node is None:
+                continue
+            path = text(path_node).strip('"`')
+            alias = node.child_by_field_name("name")
+            local = text(alias) if alias is not None else path.rpartition("/")[2]
+            if local and local not in (".", "_"):
+                bindings[local] = ImportBinding(path, NAMESPACE_IMPORT)
         return bindings
 
     def find_type_bases(self, file_path: Path) -> list[tuple[str, list[str]]]:
@@ -1196,6 +1280,36 @@ class SourceInspector:
         if node.type == "attribute":
             return self._script_member_name(node, "attribute", "object", text)
         return None
+
+    def _go_type_name(self, node: TreeSitterNode, text: _NodeText) -> _TypeName | None:
+        parent = node.parent
+        if parent is None:
+            return None
+        if node.type in _GO_QUALIFIED_TYPE_NODE_TYPES:
+            return self._script_member_name(node, "name", "package", text)
+        if node.type != "type_identifier":
+            return None
+        if parent.type in _GO_QUALIFIED_TYPE_NODE_TYPES:
+            return None
+        if parent.type in _GO_TYPE_DECLARATION_NODE_TYPES and self._field_name(node) == "name":
+            return None
+        return node, text(node), ""
+
+    def _php_type_name(self, node: TreeSitterNode, text: _NodeText) -> _TypeName | None:
+        parent = node.parent
+        if parent is None or parent.type not in _PHP_TYPE_PARENT_NODE_TYPES:
+            return None
+        if node.type in _PHP_QUALIFIED_NAME_NODE_TYPES:
+            # Not the ``prefix`` field: on a fully qualified ``\App\Deep`` it is the leading
+            # separator token, and the namespace is a plain named child either way.
+            prefix = next((c for c in node.named_children if c.type == "namespace_name"), None)
+            name = next((c for c in node.named_children if c.type == "name"), None)
+            if name is None:
+                return None
+            return node, text(name), text(prefix).replace(_PHP_SEPARATOR, ".") if prefix is not None else ""
+        if node.type != "name":
+            return None
+        return node, text(node), ""
 
     @staticmethod
     def _script_member_name(

--- a/static_analyzer/engine/type_reference_builder.py
+++ b/static_analyzer/engine/type_reference_builder.py
@@ -15,8 +15,15 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from static_analyzer.cfg import CallGraph, EdgeKind, ReferenceEdge
-from static_analyzer.engine.models import ImportBinding, NamespaceContext, TypeReferenceSite, UsingDirective
+from static_analyzer.engine.models import (
+    ImportBinding,
+    NAMESPACE_IMPORT,
+    NamespaceContext,
+    TypeReferenceSite,
+    UsingDirective,
+)
 from static_analyzer.engine.source_inspector import (
+    _GO_SUFFIXES,
     _PYTHON_SUFFIXES,
     _SCRIPT_SUFFIXES,
     SourceInspector,
@@ -28,7 +35,6 @@ from static_analyzer.node import Node
 
 logger = logging.getLogger(__name__)
 
-_NAMESPACE_IMPORT = "*"
 _SCRIPT_MODULE_SUFFIXES = (".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs")
 
 
@@ -92,6 +98,8 @@ class TypeIndex:
             return self._resolve_script(site)
         if suffix in _PYTHON_SUFFIXES:
             return self._resolve_python(site)
+        if suffix in _GO_SUFFIXES:
+            return self._resolve_go(site)
         return self._resolve_by_namespace(site)
 
     def _resolve_by_namespace(self, site: TypeReferenceSite) -> Node | None:
@@ -116,12 +124,32 @@ class TypeIndex:
         binding = bindings.get(site.qualifier or site.name)
         if binding is None:
             return self._only_local_candidate(site)
-        wanted = site.name if binding.imported_name == _NAMESPACE_IMPORT else binding.imported_name
+        wanted = site.name if binding.imported_name == NAMESPACE_IMPORT else binding.imported_name
         module, anchored = _python_module(binding.source, site.file)
         candidates = [
             node for node in self._by_name.get(wanted, []) if _in_python_module(node.file_path, module, anchored)
         ]
         return candidates[0] if len(candidates) == 1 else None
+
+    def _resolve_go(self, site: TypeReferenceSite) -> Node | None:
+        """A package is a directory: an unqualified name is this file's, ``pkg.T`` is an import's."""
+        named = self._by_name.get(site.name, [])
+        if not site.qualifier:
+            here = os.path.dirname(site.file)
+            candidates = [node for node in named if os.path.dirname(node.file_path) == here]
+            return candidates[0] if len(candidates) == 1 else None
+        binding = self._imports_of(site.file).get(site.qualifier)
+        if binding is None:
+            return None
+        # The import path carries a module prefix this layer does not know, so the longest tail
+        # that matches a directory wins; a shorter one would match any package of that name.
+        parts = binding.source.split("/")
+        for start in range(len(parts)):
+            tail = os.sep.join(parts[start:])
+            candidates = [node for node in named if _in_directory(node.file_path, tail)]
+            if candidates:
+                return candidates[0] if len(candidates) == 1 else None
+        return None
 
     def _only_local_candidate(self, site: TypeReferenceSite) -> Node | None:
         """The name with no import behind it: this file's own, or the repository's only one."""
@@ -138,7 +166,7 @@ class TypeIndex:
             return self._only_local_candidate(site)
         if not binding.source.startswith("."):
             return None
-        wanted = site.name if binding.imported_name in (_NAMESPACE_IMPORT, "default") else binding.imported_name
+        wanted = site.name if binding.imported_name in (NAMESPACE_IMPORT, "default") else binding.imported_name
         module = _module_stem(os.path.normpath(os.path.join(os.path.dirname(site.file), binding.source)))
         candidates = [
             node
@@ -241,6 +269,11 @@ def _expand_alias(written: str, directives: Iterable[UsingDirective]) -> str:
         if directive.alias == head:
             return ".".join(part for part in (directive.target, rest) if part)
     return ""
+
+
+def _in_directory(file_path: str, directory: str) -> bool:
+    parent = os.path.dirname(file_path)
+    return parent == directory or parent.endswith(os.sep + directory)
 
 
 def _python_module(source: str, site_file: str) -> tuple[str, bool]:

--- a/tests/static_analyzer/test_source_inspector.py
+++ b/tests/static_analyzer/test_source_inspector.py
@@ -879,6 +879,73 @@ class TestPythonTypeSites:
         assert self._sites(tmp_path, "def m():\n    return Widget()\n") == set()
 
 
+class TestGoTypeSites:
+    def _sites(self, tmp_path: Path, body: str) -> set[tuple[str, str]]:
+        f = tmp_path / "s.go"
+        f.write_text(body)
+        return {(s.name, s.qualifier) for s in SourceInspector().find_type_reference_sites(f)}
+
+    def test_qualified_and_bare_types(self, tmp_path: Path):
+        sites = self._sites(
+            tmp_path,
+            "package app\n"
+            'import core "example.com/x/core"\n'
+            "type Service struct { widget core.Widget; items []core.Thing; local Helper }\n"
+            "func (s *Service) Find(q *core.Query) (Result, error) { return nil, nil }\n",
+        )
+        assert {("Widget", "core"), ("Thing", "core"), ("Query", "core")} <= sites
+        assert {("Helper", ""), ("Result", "")} <= sites
+        # The type being declared is the ``name`` of its own spec, never a reference to itself.
+        assert ("Service", "") in sites  # the method receiver does name it
+        assert not any(name == "app" for name, _ in sites)
+
+    def test_a_declaration_is_not_a_site(self, tmp_path: Path):
+        assert self._sites(tmp_path, "package app\ntype Widget struct { }\n") == set()
+
+
+class TestGoImportBindings:
+    def test_aliased_and_bare_imports(self, tmp_path: Path):
+        f = tmp_path / "s.go"
+        f.write_text(
+            'package app\nimport (\n  core "example.com/x/core"\n  "example.com/x/util"\n  _ "side/effect"\n)\n'
+        )
+        bindings = SourceInspector().find_import_bindings(f)
+        assert bindings["core"] == ImportBinding("example.com/x/core", "*")
+        # Unaliased, a package is named by the last segment of its path.
+        assert bindings["util"] == ImportBinding("example.com/x/util", "*")
+        assert "_" not in bindings
+
+
+class TestPhpTypeSites:
+    def test_heritage_properties_parameters_and_returns(self, tmp_path: Path):
+        f = tmp_path / "s.php"
+        f.write_text(
+            "<?php\n"
+            "namespace App\\Models;\n"
+            "class Service extends BaseService implements Runnable {\n"
+            "  private Widget $widget;\n"
+            "  public function find(Alias $a, \\App\\Other\\Deep $d): Result { }\n"
+            "}\n"
+        )
+        sites = {(s.name, s.qualifier) for s in SourceInspector().find_type_reference_sites(f)}
+        assert {("BaseService", ""), ("Runnable", ""), ("Widget", ""), ("Alias", ""), ("Result", "")} <= sites
+        # A fully qualified name keeps its namespace, whose separator is normalised to a dot.
+        assert ("Deep", "App.Other") in sites
+
+
+class TestPhpNamespaceContext:
+    def test_namespace_and_use_clauses(self, tmp_path: Path):
+        f = tmp_path / "s.php"
+        f.write_text("<?php\nnamespace App\\Models;\nuse App\\Core\\Widget;\nuse App\\Util\\Thing as Alias;\n")
+        context = SourceInspector().find_namespace_context(f)
+        assert context.namespaces[0][0] == "App.Models"
+        # Every ``use`` binds one name, so each is recorded the way an alias is.
+        assert [(d.target, d.alias) for d in context.usings] == [
+            ("App.Core.Widget", "Widget"),
+            ("App.Util.Thing", "Alias"),
+        ]
+
+
 class TestJavaNamespaceContext:
     def test_package_imports_wildcards_and_static(self, tmp_path: Path):
         f = tmp_path / "S.java"

--- a/tests/static_analyzer/test_source_inspector.py
+++ b/tests/static_analyzer/test_source_inspector.py
@@ -895,12 +895,25 @@ class TestGoTypeSites:
         )
         assert {("Widget", "core"), ("Thing", "core"), ("Query", "core")} <= sites
         assert {("Helper", ""), ("Result", "")} <= sites
-        # The type being declared is the ``name`` of its own spec, never a reference to itself.
-        assert ("Service", "") in sites  # the method receiver does name it
+        # Neither the type being declared nor the receiver of its own method is a reference to it.
+        assert ("Service", "") not in sites
         assert not any(name == "app" for name, _ in sites)
 
     def test_a_declaration_is_not_a_site(self, tmp_path: Path):
         assert self._sites(tmp_path, "package app\ntype Widget struct { }\n") == set()
+
+    def test_a_method_does_not_depend_on_its_own_receiver(self, tmp_path: Path):
+        """The receiver names the type the method is on: containment, which CONTAINS already carries."""
+        sites = self._sites(
+            tmp_path,
+            "package app\n"
+            "func (e *Entity) Set(t string) { }\n"
+            'func (c Cat) Name() string { return "" }\n'
+            "func Free(x *Widget) *Result { return nil }\n",
+        )
+        assert ("Entity", "") not in sites and ("Cat", "") not in sites
+        # A genuine parameter and return type are still references.
+        assert {("Widget", ""), ("Result", "")} <= sites
 
 
 class TestGoImportBindings:

--- a/tests/static_analyzer/test_type_reference_builder.py
+++ b/tests/static_analyzer/test_type_reference_builder.py
@@ -213,6 +213,75 @@ class TestTypeIndexJava:
         assert _resolved_name(index, _site(user, "Widget", line=3)) == "com.example.util.Widget"
 
 
+class TestTypeIndexGo:
+    def test_an_unqualified_name_is_this_files_package(self, tmp_path: Path):
+        here = _write(tmp_path / "app" / "widget.go", "package app\ntype Widget struct { }\n")
+        other = _write(tmp_path / "other" / "widget.go", "package other\ntype Widget struct { }\n")
+        user = _write(tmp_path / "app" / "s.go", "package app\ntype S struct { w Widget }\n")
+        index = TypeIndex([_class("app.widget.Widget", here), _class("other.widget.Widget", other)], SourceInspector())
+        assert _resolved_name(index, _site(user, "Widget", line=2)) == "app.widget.Widget"
+
+    def test_a_qualified_name_resolves_through_its_import(self, tmp_path: Path):
+        core = _write(tmp_path / "x" / "core" / "widget.go", "package core\ntype Widget struct { }\n")
+        other = _write(tmp_path / "x" / "util" / "widget.go", "package util\ntype Widget struct { }\n")
+        user = _write(
+            tmp_path / "app" / "s.go", 'package app\nimport "example.com/x/core"\ntype S struct { w core.Widget }\n'
+        )
+        index = TypeIndex(
+            [_class("x.core.widget.Widget", core), _class("x.util.widget.Widget", other)], SourceInspector()
+        )
+        assert _resolved_name(index, _site(user, "Widget", line=3, qualifier="core")) == "x.core.widget.Widget"
+
+    def test_an_aliased_import_resolves_through_its_local_name(self, tmp_path: Path):
+        core = _write(tmp_path / "x" / "core" / "widget.go", "package core\ntype Widget struct { }\n")
+        user = _write(
+            tmp_path / "app" / "s.go", 'package app\nimport c "example.com/x/core"\ntype S struct { w c.Widget }\n'
+        )
+        index = TypeIndex([_class("x.core.widget.Widget", core)], SourceInspector())
+        assert _resolved_name(index, _site(user, "Widget", line=3, qualifier="c")) == "x.core.widget.Widget"
+
+    def test_an_unimported_qualifier_resolves_to_nothing(self, tmp_path: Path):
+        core = _write(tmp_path / "x" / "core" / "widget.go", "package core\ntype Widget struct { }\n")
+        user = _write(tmp_path / "app" / "s.go", "package app\ntype S struct { }\n")
+        index = TypeIndex([_class("x.core.widget.Widget", core)], SourceInspector())
+        assert index.resolve(_site(user, "Widget", line=2, qualifier="core")) is None
+
+
+class TestTypeIndexPhp:
+    def _repo(self, tmp_path: Path):
+        core = _write(tmp_path / "core" / "Widget.php", "<?php\nnamespace App\\Core;\nclass Widget { }\n")
+        models = _write(tmp_path / "models" / "Widget.php", "<?php\nnamespace App\\Models;\nclass Widget { }\n")
+        return [_class("core.Widget.Widget", core), _class("models.Widget.Widget", models)]
+
+    def test_a_use_clause_decides_the_name(self, tmp_path: Path):
+        nodes = self._repo(tmp_path)
+        user = _write(
+            tmp_path / "models" / "Service.php",
+            "<?php\nnamespace App\\Models;\nuse App\\Core\\Widget;\nclass Service { private Widget $w; }\n",
+        )
+        index = TypeIndex(nodes, SourceInspector())
+        # Without the use clause the file's own namespace would win.
+        assert _resolved_name(index, _site(user, "Widget", line=4)) == "core.Widget.Widget"
+
+    def test_the_files_own_namespace_resolves_without_a_use(self, tmp_path: Path):
+        nodes = self._repo(tmp_path)
+        user = _write(
+            tmp_path / "models" / "Service.php",
+            "<?php\nnamespace App\\Models;\nclass Service { private Widget $w; }\n",
+        )
+        index = TypeIndex(nodes, SourceInspector())
+        assert _resolved_name(index, _site(user, "Widget", line=3)) == "models.Widget.Widget"
+
+    def test_an_aliased_use_resolves_to_its_target(self, tmp_path: Path):
+        nodes = self._repo(tmp_path)
+        user = _write(
+            tmp_path / "models" / "Service.php",
+            "<?php\nnamespace App\\Models;\nuse App\\Core\\Widget as W;\nclass Service { private W $w; }\n",
+        )
+        index = TypeIndex(nodes, SourceInspector())
+        assert _resolved_name(index, _site(user, "W", line=4)) == "core.Widget.Widget"
+
+
 class TestTypeIndexPython:
     def test_an_absolute_import_resolves_to_its_module(self, tmp_path: Path):
         widget = _write(tmp_path / "a" / "b.py", "class Widget: ...\n")


### PR DESCRIPTION
Stacked on [#573](https://github.com/CodeBoarding/CodeBoarding/pull/573) — **base is `feat/typeref-java-python`**. The stack is #568 → #570 → #573 → this.

The last two of the six languages the type-reference layer was missing, and the smaller half of the pair: Go and PHP matter less to us than Java and Python, which is why they are here rather than in #573.

## Neither needed a new idea

By this point there are two resolution rules and both languages fit one:

- **PHP** resolves a bare name against the namespace its file declares plus what it `use`s — the rule C# and Java already share. It contributes a **reader only**; `_resolve_by_namespace` is untouched. Each `use` binds exactly one name, so every clause is recorded the way an alias is and decides outright, and a fully qualified `\App\Other\Deep` keeps its namespace with the separator normalised to a dot so one comparison serves the whole family.
- **Go** binds a package name to an import path — the rule TypeScript and Python already share — but needs its own resolver because a Go package is a *directory* rather than a declared name.

## The two things worth reviewing

**Go's package matching.** An unqualified type is this file's own package, which is its directory. `pkg.Type` is the import whose local name is `pkg` — but the import path carries a module prefix (`example.com/x/core`) that this layer cannot know, so the **longest tail of the path that matches a directory wins**. A shorter tail would match any package of that name anywhere in the repo. Blank and dot imports (`_`, `.`) bind nothing and are skipped.

**PHP's `prefix` field is a trap.** On a fully qualified name it is the leading separator token, not the namespace — `\App\Other\Deep` gives `prefix == "\"` and would have produced a qualifier of `"."`. The namespace is read as a plain named child instead, which is correct for both spellings. There is a test for exactly this.

Also here: the `*` sentinel meaning "this binding names a module rather than one of its exports" moved to `models` beside `ImportBinding`, because three languages now write it and the reader cannot import it from the resolver.

## What these two languages discover, and one thing they should not have

Real edges from the integration fixtures. Framing is in [#568](https://github.com/CodeBoarding/CodeBoarding/pull/568): a call is a runtime dependency, a type reference is a compile-time one, hence the `uses` label.

**Go** — 36 references on the fixture project:

| position | real example | edge |
|---|---|---|
| package-qualified type | `Priority utils.Priority` | `Task` uses `Priority` |
| struct field | `Entity` (embedded) | `Cat` uses `Entity` |
| parameter type | `func ProcessTaskChain(tasks []*models.Task) []string` | `ProcessTaskChain` uses `Task` |
| result type | `func BuildQuery() string` → in-repo results | the function uses the returned type |
| slice element | `conditions []Condition` | the struct uses `Condition` |

Go's embedded struct field is worth calling out as a *good* case: `Entity` written bare inside `type Cat struct` is Go's composition, the nearest thing it has to inheritance, and it was invisible to a call graph.

**PHP** — 21 references:

| position | real example | edge |
|---|---|---|
| `extends` | `class Cat extends Entity implements Speakable` | `Cat` uses `Entity` |
| `implements` | same line | `Cat` uses `Speakable` |
| declared type (property, parameter, return) | `fn(Task $t): string => 'Active: ' . $t->taskName` | the closure uses `Task` |

### The one that was wrong, and is fixed in the last commit

Classifying these is what caught it. `func (e *Entity) SetType(...)` was being read as `SetType` depending on `Entity` — but that is the type the method is **defined on**, which the graph already carries as a `CONTAINS` edge. Every Go method depended on its own type.

It was **26 of 62 references on the fixture project, 42%**. The receiver is a `parameter_list` whose field is `receiver`, so it is now skipped outright; a genuine parameter or result of the same type still counts. 62 → 36.

This is the clearest argument for asking the question at all: it looked exactly like a dependency, and it was containment wearing a dependency's clothes. It is also the reason to be suspicious of the remaining categories in the other PRs — I would rather a reviewer disagree with one of them now than discover it on a customer's diagram.

## Measured

| language | source | files | type nodes | type references | pass |
|---|---|---:|---:|---:|---:|
| Go | fzf | 53 | 112 | **165** | 0.60 s |
| PHP | `php_edge_cases_project` | 8 | 16 | **11** | 0.01 s |

PHP is measured on the integration fixture because no PHP repository is checked out here; it is small but it exercises both shapes (`Dog` → `Entity` by `extends`, `Dog` → `Speakable` by `implements`). Go's are the relationships a reader wants: `itemLine` → `Result`, `labelPrinter` → `tui.Window`.

## Tests

Reader and resolver tests per language, written to discriminate: a Go declaration is *not* a site while a method receiver is; an aliased import resolves through its local name; an unimported qualifier resolves to nothing rather than guessing; a PHP `use` beats the file's own namespace while the file's own namespace wins without one; an aliased `use` resolves to its target.

Full suite 2,163 passed; the 3 `test_cli_parser` failures are pre-existing and fail identically on `main` at `e38c07e3`. mypy and black clean.

## What is left

**Rust is now the only wired language without type references**, and the only one whose rule is genuinely different — `use` paths over a module tree, plus trait impls and macro-generated types that no tree-sitter walk will see. It deserves its own PR and its own thinking, not a fifth repetition of these two rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added static analysis support for Go and PHP source files.
  - Go analysis recognizes imports, aliases, packages, declarations, and qualified or local type references.
  - PHP analysis recognizes namespaces, `use` statements, inheritance, properties, parameters, return types, and fully qualified names.
  - Improved namespace-import handling across supported languages for more consistent type and import detection.

- **Bug Fixes**
  - Go analysis no longer reports a method’s receiver type as its own reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
