### PR TITLE
fix!: accept only depth-cap configuration; keep depth_level for results

### DIFF
--- a/PYPI.md
+++ b/PYPI.md
@@ -67,7 +67,7 @@ generated `.codeboarding/analysis.json` — it is parsed in your browser, nothin
 ```python
 import json
 from pathlib import Path
-from diagram_analysis import DiagramGenerator, configure_models
+from diagram_analysis import DiagramGenerator, RunContext, configure_models
 from diagram_analysis.analysis_json import parse_unified_analysis
 
 # Pass the key programmatically — shell env vars always take precedence if already set.
@@ -80,14 +80,17 @@ output_dir = repo_path / ".codeboarding"
 output_dir.mkdir(parents=True, exist_ok=True)
 
 # Generate the architectural diagram
+context = RunContext.resolve("my-project")
 generator = DiagramGenerator(
     repo_location=repo_path,
     temp_folder=output_dir,
     repo_name="my-project",
     output_dir=output_dir,
-    depth_level=3,  # safety-valve cap; a component that outgrows the leaf ceiling is flagged expandable and can be expanded on demand
+    depth_cap=3,  # Maximum hierarchy depth for automatic expansion, not a target.
+    run_id=context.run_id,
+    log_path=context.log_path,
 )
-[analysis_path] = generator.generate_analysis()
+analysis_path = generator.generate_analysis()
 
 # Read and inspect the results
 with open(analysis_path) as f:
@@ -148,7 +151,7 @@ codeboarding-render PATH/analysis.json --format FORMAT # render an existing anal
 |---|---|
 | `--local PATH` | Analyze a local repository (output: `PATH/.codeboarding/`) |
 | `--render {md,html,mdx,rst}` | Render overview and component files from the local `analysis.json` for full, incremental, or partial commands |
-| `--depth-cap INT` | Safety-valve depth cap (default: 3) on how deep auto-expansion goes; a component that outgrows the leaf ceiling is flagged expandable regardless, and can be expanded on demand. `--depth-level` remains a compatibility alias. Configures `metadata.depth_cap`, not `metadata.depth_level` (the depth actually reached) |
+| `--depth-cap INT` | Maximum allowed hierarchy depth for automatic expansion (default: 3), not a target. Components can still be expanded on demand. Configures `metadata.depth_cap`, not `metadata.depth_level` (the depth actually reached). No input alias is accepted. |
 | `--force` | (full only) Force full reanalysis, skip cached static analysis |
 | `--base-ref REF` / `--target-ref REF` | (incremental only) Git refs to diff |
 | `--component-id ID` | (partial only) ID of the component to update |

--- a/PYPI.md
+++ b/PYPI.md
@@ -148,7 +148,7 @@ codeboarding-render PATH/analysis.json --format FORMAT # render an existing anal
 |---|---|
 | `--local PATH` | Analyze a local repository (output: `PATH/.codeboarding/`) |
 | `--render {md,html,mdx,rst}` | Render overview and component files from the local `analysis.json` for full, incremental, or partial commands |
-| `--depth-level INT` | Safety-valve depth cap (default: 3) on how deep auto-expansion goes; a component that outgrows the leaf ceiling is flagged expandable regardless, and can be expanded on demand |
+| `--depth-cap INT` | Safety-valve depth cap (default: 3) on how deep auto-expansion goes; a component that outgrows the leaf ceiling is flagged expandable regardless, and can be expanded on demand. `--depth-level` remains a compatibility alias. Configures `metadata.depth_cap`, not `metadata.depth_level` (the depth actually reached) |
 | `--force` | (full only) Force full reanalysis, skip cached static analysis |
 | `--base-ref REF` / `--target-ref REF` | (incremental only) Git refs to diff |
 | `--component-id ID` | (partial only) ID of the component to update |

--- a/README.md
+++ b/README.md
@@ -169,7 +169,17 @@ python main.py full https://github.com/pytorch/pytorch
 ```
 
 `--depth-cap` configures `metadata.depth_cap`; `metadata.depth_level` records the
-depth actually reached. `--depth-level` remains a compatibility alias for `--depth-cap`.
+depth actually reached. The cap is a maximum, not a target depth. `--depth-level`
+is rejected; there is no compatibility alias.
+
+Python callers must use `run_full(..., depth_cap=...)`,
+`build_generator(..., depth_cap=...)`, and `DiagramGenerator(..., depth_cap=...)`.
+The generator attribute is `depth_cap` and the exported default is
+`diagram_analysis.DEFAULT_DEPTH_CAP` (3). The GitHub helper uses `DIAGRAM_DEPTH_CAP`
+and rejects `DIAGRAM_DEPTH_LEVEL`. Telemetry reports configured `depth_cap`, not
+`depth_level`. Readers of analysis results must keep reading `metadata.depth_level`
+for the actual depth. Baselines without `metadata.depth_cap` use the default cap,
+never their realized depth as configuration.
 
 > **Incremental needs a baseline.** `incremental` diffs the working tree against the previous
 > analysis in `.codeboarding/` (`analysis.json` + `fingerprint.json`). That baseline can live

--- a/README.md
+++ b/README.md
@@ -155,8 +155,8 @@ python main.py full --local ./my-project
 
 # Raise the depth ceiling to auto-expand deeper (rarely needed — a component that
 # outgrows the leaf ceiling is flagged expandable at whatever depth the run stops
-# and can be expanded on demand; --depth-level is a safety-valve cap, default 3)
-python main.py full --local ./my-project --depth-level 5
+# and can be expanded on demand; --depth-cap is a safety-valve cap, default 3)
+python main.py full --local ./my-project --depth-cap 5
 
 # Re-analyze only changed parts when possible
 python main.py incremental --local ./my-project
@@ -167,6 +167,9 @@ python main.py partial --local ./my-project --component-id "1.2"
 # Analyze a remote GitHub repository
 python main.py full https://github.com/pytorch/pytorch
 ```
+
+`--depth-cap` configures `metadata.depth_cap`; `metadata.depth_level` records the
+depth actually reached. `--depth-level` remains a compatibility alias for `--depth-cap`.
 
 > **Incremental needs a baseline.** `incremental` diffs the working tree against the previous
 > analysis in `.codeboarding/` (`analysis.json` + `fingerprint.json`). That baseline can live

--- a/README.md
+++ b/README.md
@@ -178,8 +178,9 @@ The generator attribute is `depth_cap` and the exported default is
 `diagram_analysis.DEFAULT_DEPTH_CAP` (3). The GitHub helper uses `DIAGRAM_DEPTH_CAP`
 and rejects `DIAGRAM_DEPTH_LEVEL`. Telemetry reports configured `depth_cap`, not
 `depth_level`. Readers of analysis results must keep reading `metadata.depth_level`
-for the actual depth. Baselines without `metadata.depth_cap` use the default cap,
-never their realized depth as configuration.
+for the actual depth. Existing baseline loading behavior is unchanged: prefer
+`metadata.depth_cap`, fall back to legacy `metadata.depth_level`, then use
+`DEFAULT_DEPTH_CAP` if neither exists. This metadata fallback is not a CLI alias.
 
 > **Incremental needs a baseline.** `incremental` diffs the working tree against the previous
 > analysis in `.codeboarding/` (`analysis.json` + `fingerprint.json`). That baseline can live

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -46,8 +46,8 @@ never personal data.
 
 | Event | When | Properties |
 |-------|------|------------|
-| `analysis_started` | An analysis run begins | `command`, `version`, `run_id`, `depth_level` |
-| `analysis_completed` | An analysis run ends (success or failure) | `command`, `version`, `run_id`, `depth_level`, `status`, `duration_ms`, `model_name`, `total_tokens`, `input_tokens`, `output_tokens` |
+| `analysis_started` | An analysis run begins | `command`, `version`, `run_id`, `depth_cap` |
+| `analysis_completed` | An analysis run ends (success or failure) | `command`, `version`, `run_id`, `depth_cap`, `status`, `duration_ms`, `model_name`, `total_tokens`, `input_tokens`, `output_tokens` |
 | `repo_scanned` | The repository is scanned (once per repo) | `version`, `run_id`, `total_loc`, `language_count`, `languages`, `stack` |
 | `$exception` | Any unhandled exception, via PostHog's built-in error tracking | `command`, `version`, `run_id` (plus the exception type, message, and stack trace captured automatically by the SDK) |
 
@@ -72,7 +72,7 @@ Property meanings:
   `generate_analysis_incremental`).
 - `version` — the installed CodeBoarding version.
 - `run_id` — the per-run correlation id described under Identity.
-- `depth_level` — the configured diagram depth (an integer).
+- `depth_cap` — the configured maximum hierarchy depth (an integer), not the depth reached.
 - `status` — `success` or `error`.
 - `duration_ms` — wall-clock duration of the run.
 - `model_name` — the LLM model used (e.g. `gpt-4o`), for cost analysis.

--- a/codeboarding_cli/commands/full_analysis.py
+++ b/codeboarding_cli/commands/full_analysis.py
@@ -11,7 +11,7 @@ from codeboarding_workflows.analysis import run_full
 from codeboarding_workflows.orchestration import run_analysis_pipeline
 from codeboarding_workflows.sources import SourceContext, local_source, remote_source
 from constants import CLI_ROOT_DOCUMENT_NAME
-from diagram_analysis import DEFAULT_DEPTH_LEVEL, RunContext, RunPaths
+from diagram_analysis import DEFAULT_DEPTH_CAP, RunContext, RunPaths
 from monitoring import monitor_execution
 from monitoring.paths import get_monitoring_run_dir
 from output_generators.rendering import render_docs
@@ -46,15 +46,14 @@ def add_arguments(subparsers: argparse._SubParsersAction, parents: list[argparse
     )
     parser.add_argument(
         "--depth-cap",
-        "--depth-level",
         dest="depth_cap",
         type=int,
-        default=DEFAULT_DEPTH_LEVEL,
+        default=DEFAULT_DEPTH_CAP,
         help=(
-            "Safety-valve ceiling on how deep components auto-expand (default: "
-            f"{DEFAULT_DEPTH_LEVEL}). A component that outgrows the leaf ceiling is flagged expandable "
+            "Maximum allowed hierarchy depth for automatic expansion (default: "
+            f"{DEFAULT_DEPTH_CAP}). A component that outgrows the leaf ceiling is flagged expandable "
             "regardless and can be expanded on demand; raise this only to auto-expand deeper up front. "
-            "--depth-level is a compatibility alias. This configures metadata.depth_cap, "
+            "This configures metadata.depth_cap, "
             "not metadata.depth_level (the depth actually reached)."
         ),
     )
@@ -107,7 +106,7 @@ def _run_local(args: argparse.Namespace) -> None:
         run_full(
             RunPaths(repo_path=src.repo_path, output_dir=src.artifact_dir, project_name=src.project_name),
             run_context,
-            depth_level=args.depth_cap,
+            depth_cap=args.depth_cap,
             monitoring_enabled=should_monitor,
             force_full=args.force,
             source_sha=get_current_commit(src.repo_path),
@@ -189,7 +188,7 @@ def _process_one_remote(
             analysis_path = run_full(
                 RunPaths(repo_path=src.repo_path, output_dir=src.artifact_dir, project_name=src.project_name),
                 run_context,
-                depth_level=depth_cap,
+                depth_cap=depth_cap,
                 monitoring_enabled=should_monitor,
                 source_sha=get_current_commit(src.repo_path),
             )

--- a/codeboarding_cli/commands/full_analysis.py
+++ b/codeboarding_cli/commands/full_analysis.py
@@ -45,13 +45,17 @@ def add_arguments(subparsers: argparse._SubParsersAction, parents: list[argparse
         help="Force full reanalysis, skipping cached static analysis",
     )
     parser.add_argument(
+        "--depth-cap",
         "--depth-level",
+        dest="depth_cap",
         type=int,
         default=DEFAULT_DEPTH_LEVEL,
         help=(
             "Safety-valve ceiling on how deep components auto-expand (default: "
             f"{DEFAULT_DEPTH_LEVEL}). A component that outgrows the leaf ceiling is flagged expandable "
-            "regardless and can be expanded on demand; raise this only to auto-expand deeper up front."
+            "regardless and can be expanded on demand; raise this only to auto-expand deeper up front. "
+            "--depth-level is a compatibility alias. This configures metadata.depth_cap, "
+            "not metadata.depth_level (the depth actually reached)."
         ),
     )
 
@@ -103,7 +107,7 @@ def _run_local(args: argparse.Namespace) -> None:
         run_full(
             RunPaths(repo_path=src.repo_path, output_dir=src.artifact_dir, project_name=src.project_name),
             run_context,
-            depth_level=args.depth_level,
+            depth_level=args.depth_cap,
             monitoring_enabled=should_monitor,
             force_full=args.force,
             source_sha=get_current_commit(src.repo_path),
@@ -152,7 +156,7 @@ def _run_remote(args: argparse.Namespace) -> None:
             _process_one_remote(
                 repo_url=repo_url,
                 workspace_root=workspace_root,
-                depth_level=args.depth_level,
+                depth_cap=args.depth_cap,
                 upload=args.upload,
                 should_monitor=should_monitor,
             )
@@ -166,7 +170,7 @@ def _run_remote(args: argparse.Namespace) -> None:
 def _process_one_remote(
     repo_url: str,
     workspace_root: Path,
-    depth_level: int,
+    depth_cap: int,
     upload: bool,
     should_monitor: bool,
 ) -> None:
@@ -185,7 +189,7 @@ def _process_one_remote(
             analysis_path = run_full(
                 RunPaths(repo_path=src.repo_path, output_dir=src.artifact_dir, project_name=src.project_name),
                 run_context,
-                depth_level=depth_level,
+                depth_level=depth_cap,
                 monitoring_enabled=should_monitor,
                 source_sha=get_current_commit(src.repo_path),
             )

--- a/codeboarding_workflows/analysis.py
+++ b/codeboarding_workflows/analysis.py
@@ -17,7 +17,7 @@ from agents.content_hash import compute_source_tree_hash
 from agents.scope_ids import ROOT_SCOPE_ID
 from diagram_analysis import DiagramGenerator
 from diagram_analysis.io_utils import load_analysis_metadata, load_expandable_component_ids, load_full_analysis
-from diagram_analysis.run_context import DEFAULT_DEPTH_LEVEL, RunContext, RunPaths
+from diagram_analysis.run_context import DEFAULT_DEPTH_CAP, RunContext, RunPaths
 from repo_utils.change_detector import ChangeSet
 from repo_utils.fingerprint_diff import BaselineUnavailableError, detect_changes_from_fingerprint
 from telemetry.events import track_analysis
@@ -30,7 +30,7 @@ __all__ = ["BaselineUnavailableError", "run_full", "run_partial", "run_increment
 def build_generator(
     run_paths: RunPaths,
     run_context: RunContext,
-    depth_level: int,
+    depth_cap: int,
     monitoring_enabled: bool = False,
     static_analyzer=None,
     changes=None,
@@ -40,7 +40,7 @@ def build_generator(
         temp_folder=run_paths.output_dir,
         repo_name=run_paths.project_name,
         output_dir=run_paths.output_dir,
-        depth_level=depth_level,
+        depth_cap=depth_cap,
         run_id=run_context.run_id,
         log_path=run_context.log_path,
         monitoring_enabled=monitoring_enabled,
@@ -52,7 +52,7 @@ def build_generator(
 def run_full(
     run_paths: RunPaths,
     run_context: RunContext,
-    depth_level: int = DEFAULT_DEPTH_LEVEL,
+    depth_cap: int = DEFAULT_DEPTH_CAP,
     monitoring_enabled: bool = False,
     force_full: bool = False,
     static_analyzer=None,
@@ -63,7 +63,7 @@ def run_full(
     generator = build_generator(
         run_paths,
         run_context,
-        depth_level=depth_level,
+        depth_cap=depth_cap,
         monitoring_enabled=monitoring_enabled,
         static_analyzer=static_analyzer,
     )
@@ -87,8 +87,7 @@ def run_partial(
         f"Running PARTIAL analysis workflow for project '{run_paths.project_name}', component '{component_id}'."
     )
 
-    # Depth is the baseline's configured cap (metadata.depth_cap), with a
-    # legacy depth_level fallback — not the realized depth.
+    # Only the configured cap controls expansion, never the realized depth.
     metadata = load_analysis_metadata(run_paths.output_dir)
     if metadata is None:
         raise BaselineUnavailableError(
@@ -107,7 +106,7 @@ def run_partial(
             "Partial analysis requires an up-to-date source baseline. Run incremental analysis before expanding a component."
         )
 
-    depth_level = int(metadata.get("depth_cap", metadata.get("depth_level", DEFAULT_DEPTH_LEVEL)))
+    depth_cap = int(metadata.get("depth_cap", DEFAULT_DEPTH_CAP))
     full_analysis = load_full_analysis(run_paths.output_dir)
     if full_analysis is None:
         # Metadata was present but the unified read failed — treat as a
@@ -139,11 +138,11 @@ def run_partial(
         logger.error(f"Component with ID '{component_id}' not found in analysis")
         return
 
-    generator = build_generator(run_paths, run_context, depth_level=depth_level, changes=ChangeSet(files=[]))
+    generator = build_generator(run_paths, run_context, depth_cap=depth_cap, changes=ChangeSet(files=[]))
     generator.source_sha = current_source_hash
     # A component at the persisted cap needs one additional level prepared for expansion.
     generator.prepare_analysis(
-        hierarchy_depth=depth_level + 1,
+        hierarchy_depth=depth_cap + 1,
         target_component=component_to_analyze,
         persisted_scopes={ROOT_SCOPE_ID: root_analysis, **sub_analyses},
     )
@@ -189,19 +188,13 @@ def run_incremental(
     should surface a "run full analysis" prompt rather than silently degrading to
     an unscoped run.
     """
-    # Depth comes from the existing analysis.json's configured cap
-    # (metadata.depth_cap, falling back to depth_level for legacy baselines
-    # that predate it) — not the realized depth_level, so a run that stopped
-    # short of its cap doesn't leave incremental permanently capped shallower
-    # than what was actually configured. Fail fast on cold-start:
-    # ``_generate_subcomponents`` requires the prior depth to re-detail
-    # changed components.
+    # Only the configured cap controls expansion, never the realized depth.
     metadata = load_analysis_metadata(run_paths.output_dir)
     if metadata is None:
         raise BaselineUnavailableError(
             f"No baseline analysis.json found in '{run_paths.output_dir}'. Run a full analysis first."
         )
-    depth_level = int(metadata.get("depth_cap", metadata.get("depth_level", DEFAULT_DEPTH_LEVEL)))
+    depth_cap = int(metadata.get("depth_cap", DEFAULT_DEPTH_CAP))
 
     changes = detect_changes_from_fingerprint(run_paths.repo_path, run_paths.output_dir)
     logger.info(
@@ -212,7 +205,7 @@ def run_incremental(
     generator = build_generator(
         run_paths,
         run_context,
-        depth_level=depth_level,
+        depth_cap=depth_cap,
         monitoring_enabled=monitoring_enabled,
         static_analyzer=static_analyzer,
         changes=changes,

--- a/codeboarding_workflows/analysis.py
+++ b/codeboarding_workflows/analysis.py
@@ -87,7 +87,7 @@ def run_partial(
         f"Running PARTIAL analysis workflow for project '{run_paths.project_name}', component '{component_id}'."
     )
 
-    # Only the configured cap controls expansion, never the realized depth.
+    # Prefer the configured cap; retain depth_level for legacy baselines.
     metadata = load_analysis_metadata(run_paths.output_dir)
     if metadata is None:
         raise BaselineUnavailableError(
@@ -106,7 +106,7 @@ def run_partial(
             "Partial analysis requires an up-to-date source baseline. Run incremental analysis before expanding a component."
         )
 
-    depth_cap = int(metadata.get("depth_cap", DEFAULT_DEPTH_CAP))
+    depth_cap = int(metadata.get("depth_cap", metadata.get("depth_level", DEFAULT_DEPTH_CAP)))
     full_analysis = load_full_analysis(run_paths.output_dir)
     if full_analysis is None:
         # Metadata was present but the unified read failed — treat as a
@@ -188,13 +188,13 @@ def run_incremental(
     should surface a "run full analysis" prompt rather than silently degrading to
     an unscoped run.
     """
-    # Only the configured cap controls expansion, never the realized depth.
+    # Prefer the configured cap; retain depth_level for legacy baselines.
     metadata = load_analysis_metadata(run_paths.output_dir)
     if metadata is None:
         raise BaselineUnavailableError(
             f"No baseline analysis.json found in '{run_paths.output_dir}'. Run a full analysis first."
         )
-    depth_cap = int(metadata.get("depth_cap", DEFAULT_DEPTH_CAP))
+    depth_cap = int(metadata.get("depth_cap", metadata.get("depth_level", DEFAULT_DEPTH_CAP)))
 
     changes = detect_changes_from_fingerprint(run_paths.repo_path, run_paths.output_dir)
     logger.info(

--- a/diagram_analysis/__init__.py
+++ b/diagram_analysis/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-__all__ = ["DiagramGenerator", "RunContext", "RunPaths", "DEFAULT_DEPTH_LEVEL", "configure_models"]
+__all__ = ["DiagramGenerator", "RunContext", "RunPaths", "DEFAULT_DEPTH_CAP", "configure_models"]
 
 
 def __getattr__(name: str):
@@ -19,10 +19,10 @@ def __getattr__(name: str):
         from .run_context import RunPaths
 
         return RunPaths
-    if name == "DEFAULT_DEPTH_LEVEL":
-        from .run_context import DEFAULT_DEPTH_LEVEL
+    if name == "DEFAULT_DEPTH_CAP":
+        from .run_context import DEFAULT_DEPTH_CAP
 
-        return DEFAULT_DEPTH_LEVEL
+        return DEFAULT_DEPTH_CAP
     if name == "configure_models":
         from agents.llm_config import configure_models
 

--- a/diagram_analysis/analysis_json.py
+++ b/diagram_analysis/analysis_json.py
@@ -99,7 +99,7 @@ class AnalysisMetadata(BaseModel):
     repo_name: str = Field(description="Name of the analyzed repository.")
     depth_level: int = Field(description="Maximum depth level actually reached by this analysis.")
     depth_cap: int = Field(
-        description="Safety-valve depth ceiling the run was configured with (see --depth-level); "
+        description="Safety-valve depth ceiling the run was configured with (see --depth-cap); "
         "may exceed depth_level when separability stopped expansion before the cap. "
         "The value future incremental/partial runs reuse as their own cap."
     )

--- a/diagram_analysis/diagram_generator.py
+++ b/diagram_analysis/diagram_generator.py
@@ -555,7 +555,7 @@ class DiagramGenerator:
         temp_folder: Path,
         repo_name: str,
         output_dir: Path,
-        depth_level: int,
+        depth_cap: int,
         run_id: str,
         log_path: str,
         project_name: str | None = None,
@@ -567,7 +567,7 @@ class DiagramGenerator:
         self.temp_folder = temp_folder
         self.repo_name = repo_name
         self.output_dir = output_dir
-        self.depth_level = depth_level
+        self.depth_cap = depth_cap
         self.project_name = project_name
         self.run_id = run_id
         self.log_path = log_path
@@ -664,7 +664,7 @@ class DiagramGenerator:
             static_analysis = self._get_static_with_new_analyzer()
 
         self.static_analysis = static_analysis
-        depth = hierarchy_depth if hierarchy_depth is not None else self.depth_level
+        depth = hierarchy_depth if hierarchy_depth is not None else self.depth_cap
         if incremental:
             root_analysis = persisted_scopes.get(ROOT_SCOPE_ID)
             if root_analysis is None:
@@ -1295,7 +1295,7 @@ class DiagramGenerator:
                 logger.debug("Submitted component='%s' at level=%d", comp.name, lvl)
 
             # 1. Initial Seeding
-            for component, level in _component_expansion_seeds(root_components, self.depth_level):
+            for component, level in _component_expansion_seeds(root_components, self.depth_cap):
                 submit_component(component, level)
 
             logger.info(
@@ -1340,11 +1340,11 @@ class DiagramGenerator:
                             source_tree_hash=self._source_tree_hash(),
                             expandable_component_ids=expandable_ids,
                             sub_expandable_ids=sub_expandable_ids,
-                            depth_cap=self.depth_level,
+                            depth_cap=self.depth_cap,
                             tree_spec=self._tree_spec_dict(),
                         )
 
-                    if new_components and level + 1 < self.depth_level:
+                    if new_components and level + 1 < self.depth_cap:
                         for child in new_components:
                             submit_component(child, level + 1)
 
@@ -1524,7 +1524,7 @@ class DiagramGenerator:
             source_tree_hash=source_tree_hash,
             expandable_component_ids=expandable_component_ids,
             sub_expandable_ids=sub_expandable_ids,
-            depth_cap=self.depth_level,
+            depth_cap=self.depth_cap,
             tree_spec=self._tree_spec_dict(),
         ).resolve()
         if persist_side_artifacts:
@@ -1633,7 +1633,7 @@ class DiagramGenerator:
             self._incremental_preparation = self._prepare_incremental_clustering(
                 root_analysis,
                 sub_analyses,
-                self.depth_level,
+                self.depth_cap,
             )
             if self.incremental_updater is None:
                 self.agent_init()
@@ -1698,7 +1698,7 @@ class DiagramGenerator:
                 component
                 for component in created_components
                 if component.component_id in hierarchy.preclustered_scopes
-                and _component_depth(component.component_id) < self.depth_level
+                and _component_depth(component.component_id) < self.depth_cap
             ]
             generated_scope_ids: frozenset[str] = frozenset()
             if new_components:

--- a/diagram_analysis/io_utils.py
+++ b/diagram_analysis/io_utils.py
@@ -191,7 +191,7 @@ class _AnalysisFileStore:
                         if depth_cap is not None:
                             logger.warning(
                                 "Baseline has no depth_cap; using its realized depth_level=%s as the cap. "
-                                "Run a full analysis with --depth-level to widen it.",
+                                "Run a full analysis with --depth-cap to widen it.",
                                 depth_cap,
                             )
         if depth_cap is None:

--- a/diagram_analysis/io_utils.py
+++ b/diagram_analysis/io_utils.py
@@ -30,7 +30,7 @@ from diagram_analysis.analysis_json import (
     build_unified_analysis_json,
     parse_unified_analysis,
 )
-from diagram_analysis.run_context import DEFAULT_DEPTH_LEVEL
+from diagram_analysis.run_context import DEFAULT_DEPTH_CAP
 from utils import ANALYSIS_FILENAME, FINGERPRINT_FILENAME
 
 logger = logging.getLogger(__name__)
@@ -182,20 +182,8 @@ class _AnalysisFileStore:
                         )
                 if depth_cap is None:
                     depth_cap = metadata.get("depth_cap")
-                    if depth_cap is None:
-                        # Legacy baselines predate depth_cap and only recorded depth_level,
-                        # which is the depth the run *realized* — often short of the cap it
-                        # was configured with. Reusing it as a cap can pin the tree shallower
-                        # than its owner asked for, so say so rather than silently narrowing.
-                        depth_cap = metadata.get("depth_level")
-                        if depth_cap is not None:
-                            logger.warning(
-                                "Baseline has no depth_cap; using its realized depth_level=%s as the cap. "
-                                "Run a full analysis with --depth-cap to widen it.",
-                                depth_cap,
-                            )
         if depth_cap is None:
-            depth_cap = DEFAULT_DEPTH_LEVEL
+            depth_cap = DEFAULT_DEPTH_CAP
 
         # Convert sub_analyses dict to the format expected by build_unified_analysis_json
         sub_analyses_tuples: dict[str, tuple[AnalysisInsights, list[Component]]] | None = None

--- a/diagram_analysis/io_utils.py
+++ b/diagram_analysis/io_utils.py
@@ -182,6 +182,14 @@ class _AnalysisFileStore:
                         )
                 if depth_cap is None:
                     depth_cap = metadata.get("depth_cap")
+                    if depth_cap is None:
+                        depth_cap = metadata.get("depth_level")
+                        if depth_cap is not None:
+                            logger.warning(
+                                "Baseline has no depth_cap; using its realized depth_level=%s as the cap. "
+                                "Run a full analysis with --depth-cap to widen it.",
+                                depth_cap,
+                            )
         if depth_cap is None:
             depth_cap = DEFAULT_DEPTH_CAP
 

--- a/diagram_analysis/run_context.py
+++ b/diagram_analysis/run_context.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from monitoring.paths import generate_log_path
 from utils import generate_run_id
 
-# Safety-valve depth cap, not a target — see --depth-level help / README for why.
+# Safety-valve depth cap, not a target — see --depth-cap help / README for why.
 # A component that outgrows the leaf ceiling is flagged expandable at whatever depth
 # the run stops, so this cap bounds how much gets expanded up front, not whether a
 # large component *can* be expanded (on demand, via the partial-analysis API). Raise

--- a/diagram_analysis/run_context.py
+++ b/diagram_analysis/run_context.py
@@ -9,7 +9,7 @@ from utils import generate_run_id
 # the run stops, so this cap bounds how much gets expanded up front, not whether a
 # large component *can* be expanded (on demand, via the partial-analysis API). Raise
 # it to auto-expand deeper.
-DEFAULT_DEPTH_LEVEL = 3
+DEFAULT_DEPTH_CAP = 3
 
 
 @dataclass(frozen=True, slots=True)

--- a/docs/design/name-tree.md
+++ b/docs/design/name-tree.md
@@ -241,7 +241,7 @@ baseline. The cluster lineage in the pickle is no longer read.
 scope is absent, draft it from the component's units. A leaf by decision stays a leaf: the
 API reports it as not expandable with its reason.
 
-**Depth.** `--depth-level` is the cap on how many scopes are materialised up front, never a
+**Depth.** `--depth-cap` is the cap on how many scopes are materialised up front, never a
 target. The spec is drafted one level deeper than the tree is materialised, so `expandable`
 on a group is a recorded decision: its child scope has rules. The modularity expansion gate
 and the size-based `scope_load` are retired.

--- a/github_action.py
+++ b/github_action.py
@@ -4,7 +4,7 @@ import shutil
 from pathlib import Path
 
 from codeboarding_workflows.analysis import run_incremental_workflow
-from diagram_analysis import DEFAULT_DEPTH_LEVEL, DiagramGenerator, RunContext
+from diagram_analysis import DEFAULT_DEPTH_CAP, DiagramGenerator, RunContext
 from diagram_analysis.io_utils import load_analysis_metadata
 from output_generators.rendering import render_docs
 from repo_utils import checkout_repo, clone_repository
@@ -85,15 +85,17 @@ def _seed_existing_analysis(existing_analysis_dir: Path, temp_repo_folder: Path)
             logger.info(f"Seeded existing {filename} for incremental analysis")
 
 
-def _resolve_depth_level(temp_repo_folder: Path) -> int:
+def _resolve_depth_cap(temp_repo_folder: Path) -> int:
     """Depth cap: explicit env var, else the seeded baseline's own depth_cap, else the default."""
-    env_depth = os.getenv("DIAGRAM_DEPTH_LEVEL")
+    if "DIAGRAM_DEPTH_LEVEL" in os.environ:
+        raise ValueError("DIAGRAM_DEPTH_LEVEL is no longer supported; use DIAGRAM_DEPTH_CAP")
+    env_depth = os.getenv("DIAGRAM_DEPTH_CAP")
     if env_depth is not None:
         return int(env_depth)
     metadata = load_analysis_metadata(temp_repo_folder)
     if metadata is not None:
-        return int(metadata.get("depth_cap", metadata.get("depth_level", DEFAULT_DEPTH_LEVEL)))
-    return DEFAULT_DEPTH_LEVEL
+        return int(metadata.get("depth_cap", DEFAULT_DEPTH_CAP))
+    return DEFAULT_DEPTH_CAP
 
 
 def generate_analysis(
@@ -121,7 +123,7 @@ def generate_analysis(
         temp_folder=temp_repo_folder,
         repo_name=repo_name,
         output_dir=temp_repo_folder,
-        depth_level=_resolve_depth_level(temp_repo_folder),
+        depth_cap=_resolve_depth_cap(temp_repo_folder),
         run_id=run_context.run_id,
         log_path=run_context.log_path,
     )

--- a/llms.txt
+++ b/llms.txt
@@ -1,3 +1,7 @@
+Historical source snapshot. For current APIs, consult README.md and PYPI.md.
+Configured depth is depth_cap (CLI --depth-cap), a maximum rather than a target.
+Only output metadata.depth_level means actual generated depth; no legacy input alias is accepted.
+
 ================================================
 FILE: duckdb_crud.py
 ================================================
@@ -257,7 +261,7 @@ def generate_analysis(
         temp_folder=temp_repo_folder,
         repo_name=repo_name,
         output_dir=temp_repo_folder,
-        depth_level=int(os.environ["DIAGRAM_DEPTH_LEVEL"]),
+        depth_cap=int(os.environ["DIAGRAM_DEPTH_CAP"]),
     )
 
     analysis_files = generator.generate_analysis()
@@ -781,7 +785,7 @@ OLLAMA_BASE_URL=http://localhost:11434
 REPO_ROOT={project_root}/repos
 STATIC_ANALYSIS_CONFIG={project_root}/static_analysis_config.yml
 PROJECT_ROOT={project_root}
-DIAGRAM_DEPTH_LEVEL=1
+DIAGRAM_DEPTH_CAP=1
 CACHING_DOCUMENTATION=false
 
 # Monitoring Configuration
@@ -1561,7 +1565,7 @@ def generate_analysis(
     repo_name: str,
     repo_path: Path,
     output_dir: Path,
-    depth_level: int = 1,
+    depth_cap: int = 1,
     run_id: str | None = None,
     monitoring_enabled: bool = False,
 ) -> list[Path]:
@@ -1570,7 +1574,7 @@ def generate_analysis(
         temp_folder=output_dir,
         repo_name=repo_name,
         output_dir=output_dir,
-        depth_level=depth_level,
+        depth_cap=depth_cap,
         run_id=run_id,
         monitoring_enabled=monitoring_enabled,
     )
@@ -1613,7 +1617,7 @@ def partial_update(
     project_name: str,
     component_name: str,
     analysis_name: str,
-    depth_level: int = 1,
+    depth_cap: int = 1,
 ):
     """
     Update a specific component in an existing analysis.
@@ -1623,7 +1627,7 @@ def partial_update(
         temp_folder=output_dir,
         repo_name=project_name,
         output_dir=output_dir,
-        depth_level=depth_level,
+        depth_cap=depth_cap,
     )
     generator.pre_analysis()
 
@@ -1667,7 +1671,7 @@ def generate_docs_remote(
     process_remote_repository(
         repo_url=repo_url,
         output_dir=temp_repo_folder,
-        depth_level=int(os.getenv("DIAGRAM_DEPTH_LEVEL", "1")),
+        depth_cap=int(os.getenv("DIAGRAM_DEPTH_CAP", "1")),
         upload=not local_dev,  # Only upload if not in local dev mode
         cache_check=True,
         run_id=run_id,
@@ -1678,7 +1682,7 @@ def generate_docs_remote(
 def process_remote_repository(
     repo_url: str,
     output_dir: Path | None = None,
-    depth_level: int = 1,
+    depth_cap: int = 1,
     upload: bool = False,
     cache_check: bool = True,
     run_id: str | None = None,
@@ -1708,7 +1712,7 @@ def process_remote_repository(
             repo_name=repo_name,
             repo_path=repo_path,
             output_dir=temp_folder,
-            depth_level=depth_level,
+            depth_cap=depth_cap,
             run_id=run_id,
             monitoring_enabled=monitoring_enabled,
         )
@@ -1740,7 +1744,7 @@ def process_local_repository(
     repo_path: Path,
     output_dir: Path,
     project_name: str,
-    depth_level: int = 1,
+    depth_cap: int = 1,
     component_name: str | None = None,
     analysis_name: str | None = None,
     monitoring_enabled: bool = False,
@@ -1753,7 +1757,7 @@ def process_local_repository(
             project_name=project_name,
             component_name=component_name,
             analysis_name=analysis_name,
-            depth_level=depth_level,
+            depth_cap=depth_cap,
         )
     else:
         # Full analysis (local repo - no markdown generation)
@@ -1761,7 +1765,7 @@ def process_local_repository(
             repo_name=project_name,
             repo_path=repo_path,
             output_dir=output_dir,
-            depth_level=depth_level,
+            depth_cap=depth_cap,
             monitoring_enabled=monitoring_enabled,
         )
 
@@ -1832,7 +1836,7 @@ def define_cli_arguments(parser: argparse.ArgumentParser):
         help="Load the .env file for environment variables",
     )
     parser.add_argument("--binary-location", type=Path, help="Path to the binary directory for language servers")
-    parser.add_argument("--depth-level", type=int, default=1, help="Depth level for diagram generation (default: 1)")
+    parser.add_argument("--depth-cap", type=int, default=3, help="Maximum hierarchy depth (default: 3)")
     parser.add_argument(
         "--upload",
         action="store_true",
@@ -1907,7 +1911,7 @@ Examples:
             repo_path=args.local,
             output_dir=output_dir,
             project_name=args.project_name,
-            depth_level=args.depth_level,
+            depth_cap=args.depth_cap,
             component_name=args.partial_component,
             analysis_name=args.partial_analysis,
             monitoring_enabled=should_monitor,
@@ -1935,7 +1939,7 @@ Examples:
                         process_remote_repository(
                             repo_url=repo,
                             output_dir=output_dir,
-                            depth_level=args.depth_level,
+                            depth_cap=args.depth_cap,
                             upload=args.upload,
                             cache_check=not args.no_cache_check,
                             run_id=run_id,
@@ -6930,7 +6934,7 @@ class DiagramGenerator:
         temp_folder: Path,
         repo_name: str,
         output_dir: Path,
-        depth_level: int,
+        depth_cap: int,
         project_name: str | None = None,
         run_id: str | None = None,
         monitoring_enabled: bool = False,
@@ -6939,7 +6943,7 @@ class DiagramGenerator:
         self.temp_folder = temp_folder
         self.repo_name = repo_name
         self.output_dir = output_dir
-        self.depth_level = depth_level
+        self.depth_cap = depth_cap
         self.project_name = project_name
         self.run_id = run_id
         self.monitoring_enabled = monitoring_enabled
@@ -7107,7 +7111,7 @@ class DiagramGenerator:
             # Process each level of components in parallel
             while current_level_components:
                 level += 1
-                if level == self.depth_level:
+                if level == self.depth_cap:
                     break
                 logger.info(f"Processing level {level} with {len(current_level_components)} components")
                 next_level_components = []
@@ -7512,19 +7516,19 @@ PROJECTS_SCALING = [
         name="markitdown-depth-1",
         url="https://github.com/microsoft/markitdown",
         expected_language="Python",
-        env_vars={"DIAGRAM_DEPTH_LEVEL": "1"},
+        env_vars={"DIAGRAM_DEPTH_CAP": "1"},
     ),
     ProjectSpec(
         name="bertopic-depth-1",
         url="https://github.com/MaartenGr/BERTopic",
         expected_language="Python",
-        env_vars={"DIAGRAM_DEPTH_LEVEL": "1"},
+        env_vars={"DIAGRAM_DEPTH_CAP": "1"},
     ),
     # ProjectSpec(
     #     name="markitdown-depth-2",
     #     url="https://github.com/microsoft/markitdown",
     #     expected_language="Python",
-    #     env_vars={"DIAGRAM_DEPTH_LEVEL": "2"},
+    #     env_vars={"DIAGRAM_DEPTH_CAP": "2"},
     # ),
 ]
 
@@ -7976,7 +7980,7 @@ class ScalabilityEval(BaseEval):
             tool_usage = agent_data.get("tool_usage", {}).get("counts", {})
             agent_tool_usage[agent_name] = tool_usage
 
-        depth = int(project.env_vars.get("DIAGRAM_DEPTH_LEVEL") or 0)
+        depth = int(project.env_vars.get("DIAGRAM_DEPTH_CAP") or 0)
 
         return ScalabilityMetrics(
             loc=total_loc,
@@ -15478,7 +15482,7 @@ class TestGenerateAnalysis(unittest.TestCase):
     @patch("github_action.create_temp_repo_folder")
     @patch("github_action.checkout_repo")
     @patch("github_action.clone_repository")
-    @patch.dict(os.environ, {"REPO_ROOT": "/tmp/repos", "DIAGRAM_DEPTH_LEVEL": "2"})
+    @patch.dict(os.environ, {"REPO_ROOT": "/tmp/repos", "DIAGRAM_DEPTH_CAP": "2"})
     def test_generate_analysis_markdown(
         self,
         mock_clone,
@@ -15517,7 +15521,7 @@ class TestGenerateAnalysis(unittest.TestCase):
             # Check that generator was created with correct params
             mock_generator_class.assert_called_once()
             args = mock_generator_class.call_args
-            self.assertEqual(args[1]["depth_level"], 2)
+            self.assertEqual(args[1]["depth_cap"], 2)
 
             # Check that markdown generation was called
             mock_generate_markdown.assert_called_once()
@@ -15530,7 +15534,7 @@ class TestGenerateAnalysis(unittest.TestCase):
     @patch("github_action.create_temp_repo_folder")
     @patch("github_action.checkout_repo")
     @patch("github_action.clone_repository")
-    @patch.dict(os.environ, {"REPO_ROOT": "/tmp/repos", "DIAGRAM_DEPTH_LEVEL": "1"})
+    @patch.dict(os.environ, {"REPO_ROOT": "/tmp/repos", "DIAGRAM_DEPTH_CAP": "1"})
     def test_generate_analysis_html(
         self,
         mock_clone,
@@ -15565,7 +15569,7 @@ class TestGenerateAnalysis(unittest.TestCase):
     @patch("github_action.create_temp_repo_folder")
     @patch("github_action.checkout_repo")
     @patch("github_action.clone_repository")
-    @patch.dict(os.environ, {"REPO_ROOT": "/tmp/repos", "DIAGRAM_DEPTH_LEVEL": "1"})
+    @patch.dict(os.environ, {"REPO_ROOT": "/tmp/repos", "DIAGRAM_DEPTH_CAP": "1"})
     def test_generate_analysis_mdx(
         self,
         mock_clone,
@@ -15600,7 +15604,7 @@ class TestGenerateAnalysis(unittest.TestCase):
     @patch("github_action.create_temp_repo_folder")
     @patch("github_action.checkout_repo")
     @patch("github_action.clone_repository")
-    @patch.dict(os.environ, {"REPO_ROOT": "/tmp/repos", "DIAGRAM_DEPTH_LEVEL": "1"})
+    @patch.dict(os.environ, {"REPO_ROOT": "/tmp/repos", "DIAGRAM_DEPTH_CAP": "1"})
     def test_generate_analysis_rst(
         self,
         mock_clone,
@@ -15634,7 +15638,7 @@ class TestGenerateAnalysis(unittest.TestCase):
     @patch("github_action.create_temp_repo_folder")
     @patch("github_action.checkout_repo")
     @patch("github_action.clone_repository")
-    @patch.dict(os.environ, {"REPO_ROOT": "/tmp/repos", "DIAGRAM_DEPTH_LEVEL": "1"})
+    @patch.dict(os.environ, {"REPO_ROOT": "/tmp/repos", "DIAGRAM_DEPTH_CAP": "1"})
     def test_generate_analysis_unsupported_extension(
         self,
         mock_clone,
@@ -15667,7 +15671,7 @@ class TestGenerateAnalysis(unittest.TestCase):
     @patch("github_action.create_temp_repo_folder")
     @patch("github_action.checkout_repo")
     @patch("github_action.clone_repository")
-    @patch.dict(os.environ, {"REPO_ROOT": "/tmp/repos", "DIAGRAM_DEPTH_LEVEL": "1"})
+    @patch.dict(os.environ, {"REPO_ROOT": "/tmp/repos", "DIAGRAM_DEPTH_CAP": "1"})
     def test_generate_analysis_branch_checkout(
         self,
         mock_clone,
@@ -16540,7 +16544,7 @@ class TestGenerateAnalysis(unittest.TestCase):
                 repo_name="test_repo",
                 repo_path=repo_path,
                 output_dir=output_dir,
-                depth_level=2,
+                depth_cap=2,
             )
 
             self.assertEqual(len(result), 2)
@@ -16549,7 +16553,7 @@ class TestGenerateAnalysis(unittest.TestCase):
                 temp_folder=output_dir,
                 repo_name="test_repo",
                 output_dir=output_dir,
-                depth_level=2,
+                depth_cap=2,
                 run_id=None,
                 monitoring_enabled=False,
             )
@@ -16636,7 +16640,7 @@ class TestPartialUpdate(unittest.TestCase):
                 project_name="test_project",
                 component_name="TestComponent",
                 analysis_name="test_analysis",
-                depth_level=1,
+                depth_cap=1,
             )
 
             mock_generator.pre_analysis.assert_called_once()
@@ -16661,7 +16665,7 @@ class TestPartialUpdate(unittest.TestCase):
                 project_name="test_project",
                 component_name="TestComponent",
                 analysis_name="nonexistent",
-                depth_level=1,
+                depth_cap=1,
             )
 
             # pre_analysis should be called, but process_component should not
@@ -16770,14 +16774,14 @@ class TestProcessLocalRepository(unittest.TestCase):
                 repo_path=repo_path,
                 output_dir=output_dir,
                 project_name="test_project",
-                depth_level=1,
+                depth_cap=1,
             )
 
             mock_generate_analysis.assert_called_once_with(
                 repo_name="test_project",
                 repo_path=repo_path,
                 output_dir=output_dir,
-                depth_level=1,
+                depth_cap=1,
                 monitoring_enabled=False,
             )
             self.assertTrue(output_dir.exists())
@@ -16794,7 +16798,7 @@ class TestProcessLocalRepository(unittest.TestCase):
                 repo_path=repo_path,
                 output_dir=output_dir,
                 project_name="test_project",
-                depth_level=2,
+                depth_cap=2,
                 component_name="TestComponent",
                 analysis_name="test_analysis",
             )
@@ -16805,7 +16809,7 @@ class TestProcessLocalRepository(unittest.TestCase):
                 project_name="test_project",
                 component_name="TestComponent",
                 analysis_name="test_analysis",
-                depth_level=2,
+                depth_cap=2,
             )
 
 
@@ -20766,13 +20770,13 @@ class TestDiagramGenerator(unittest.TestCase):
             temp_folder=self.temp_folder,
             repo_name="test_repo",
             output_dir=self.output_dir,
-            depth_level=2,
+            depth_cap=2,
         )
 
         self.assertEqual(gen.repo_location, self.repo_location)
         self.assertEqual(gen.repo_name, "test_repo")
         self.assertEqual(gen.output_dir, self.output_dir)
-        self.assertEqual(gen.depth_level, 2)
+        self.assertEqual(gen.depth_cap, 2)
         self.assertIsNone(gen.details_agent)
         self.assertIsNone(gen.abstraction_agent)
 
@@ -20813,7 +20817,7 @@ class TestDiagramGenerator(unittest.TestCase):
             temp_folder=self.temp_folder,
             repo_name="test_repo",
             output_dir=self.output_dir,
-            depth_level=2,
+            depth_cap=2,
         )
 
         gen.pre_analysis()
@@ -20835,7 +20839,7 @@ class TestDiagramGenerator(unittest.TestCase):
             temp_folder=self.temp_folder,
             repo_name="test_repo",
             output_dir=self.output_dir,
-            depth_level=2,
+            depth_cap=2,
         )
 
         # Setup agents

--- a/main.py
+++ b/main.py
@@ -46,7 +46,7 @@ Examples:
 
   # Local full analysis with a higher depth ceiling (rarely needed — expansion
   # is driven by structural separability, this only raises the safety-valve cap)
-  codeboarding --local /path/to/repo --depth-level 5
+  codeboarding --local /path/to/repo --depth-cap 5
 
   # Incremental update on a local repository (explicit subcommand required)
   codeboarding incremental --local /path/to/repo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "codeboarding"
-version = "0.14.0"
+version = "0.14.1"
 description = "Interactive Diagrams for Code"
 readme = "PYPI.md"
 license = "MIT"

--- a/telemetry/events.py
+++ b/telemetry/events.py
@@ -171,11 +171,11 @@ def track_analysis(func):
         instance = args[0] if args else None
         command = func.__name__
         run_id = os.getenv("CODEBOARDING_RUN_ID") or kwargs.get("run_id") or getattr(instance, "run_id", None)
-        depth_level = kwargs.get("depth_level") or getattr(instance, "depth_level", None)
+        depth_cap = kwargs.get("depth_cap") or getattr(instance, "depth_cap", None)
 
         telemetry.capture(
             "analysis_started",
-            AnalysisStarted(command=command, version=_app_version(), run_id=run_id, depth_level=depth_level).model_dump(
+            AnalysisStarted(command=command, version=_app_version(), run_id=run_id, depth_cap=depth_cap).model_dump(
                 exclude_none=True
             ),
         )
@@ -208,7 +208,7 @@ def track_analysis(func):
                     input_tokens=after.input_tokens - before.input_tokens,
                     output_tokens=after.output_tokens - before.output_tokens,
                     run_id=run_id,
-                    depth_level=depth_level,
+                    depth_cap=depth_cap,
                 ).model_dump(exclude_none=True),
             )
             if exc is not None:

--- a/telemetry/schemas.py
+++ b/telemetry/schemas.py
@@ -44,7 +44,7 @@ class AnalysisStarted(BaseModel):
     command: str
     version: str
     run_id: str | None = None
-    depth_level: int | None = None
+    depth_cap: int | None = None
 
 
 class AnalysisCompleted(BaseModel):
@@ -57,7 +57,7 @@ class AnalysisCompleted(BaseModel):
     input_tokens: int = 0
     output_tokens: int = 0
     run_id: str | None = None
-    depth_level: int | None = None
+    depth_cap: int | None = None
 
 
 class TokenSnapshot(BaseModel):

--- a/tests/diagram_analysis/test_diagram_analysis.py
+++ b/tests/diagram_analysis/test_diagram_analysis.py
@@ -844,6 +844,32 @@ class TestDepthCapPersistence(unittest.TestCase):
         self.assertEqual(metadata["depth_level"], 1)
         self.assertEqual(metadata["depth_cap"], 3)
 
+    def test_save_does_not_treat_legacy_result_depth_as_configuration(self):
+        save_analysis(
+            analysis=self._make_root(),
+            output_dir=self.output_dir,
+            repo_dir=self.repo_dir,
+            source_tree_hash="hash1",
+            repo_name="test",
+            depth_cap=5,
+        )
+        path = self.output_dir / "analysis.json"
+        baseline = json.loads(path.read_text())
+        del baseline["metadata"]["depth_cap"]
+        baseline["metadata"]["depth_level"] = 5
+        path.write_text(json.dumps(baseline))
+
+        save_analysis(
+            analysis=self._make_root(),
+            output_dir=self.output_dir,
+            repo_dir=self.repo_dir,
+            source_tree_hash="hash2",
+            repo_name="test",
+        )
+        metadata = json.loads(path.read_text())["metadata"]
+        self.assertEqual(metadata["depth_level"], 1)
+        self.assertEqual(metadata["depth_cap"], 3)
+
 
 class TestDiagramGenerator(unittest.TestCase):
     def setUp(self):
@@ -870,7 +896,7 @@ class TestDiagramGenerator(unittest.TestCase):
             temp_folder=self.temp_folder,
             repo_name="test_repo",
             output_dir=self.output_dir,
-            depth_level=2,
+            depth_cap=2,
             run_id="test-run-id",
             log_path="test_repo/test-run-log",
         )
@@ -878,7 +904,8 @@ class TestDiagramGenerator(unittest.TestCase):
         self.assertEqual(gen.repo_location, self.repo_location)
         self.assertEqual(gen.repo_name, "test_repo")
         self.assertEqual(gen.output_dir, self.output_dir)
-        self.assertEqual(gen.depth_level, 2)
+        self.assertEqual(gen.depth_cap, 2)
+        self.assertFalse(hasattr(gen, "depth_level"))
         self.assertIsNotNone(gen.scope_assembler)
         self.assertIsNone(gen.incremental_updater)
 
@@ -888,7 +915,7 @@ class TestDiagramGenerator(unittest.TestCase):
             temp_folder=self.temp_folder,
             repo_name="test_repo",
             output_dir=self.output_dir,
-            depth_level=2,
+            depth_cap=2,
             run_id="test-run-id",
             log_path="test_repo/test-run-log",
         )
@@ -909,7 +936,7 @@ class TestDiagramGenerator(unittest.TestCase):
             temp_folder=self.temp_folder,
             repo_name="test_repo",
             output_dir=self.output_dir,
-            depth_level=2,
+            depth_cap=2,
             run_id="test-run-id",
             log_path="test_repo/test-run-log",
         )
@@ -937,7 +964,7 @@ class TestDiagramGenerator(unittest.TestCase):
             temp_folder=self.temp_folder,
             repo_name="test_repo",
             output_dir=self.output_dir,
-            depth_level=2,
+            depth_cap=2,
             run_id="test-run-id",
             log_path="test_repo/test-run-log",
         )
@@ -962,7 +989,7 @@ class TestDiagramGenerator(unittest.TestCase):
             temp_folder=self.temp_folder,
             repo_name="test_repo",
             output_dir=self.output_dir,
-            depth_level=3,
+            depth_cap=3,
             run_id="test-run-id",
             log_path="test_repo/test-run-log",
         )
@@ -1002,7 +1029,7 @@ class TestDiagramGenerator(unittest.TestCase):
             temp_folder=self.temp_folder,
             repo_name="test_repo",
             output_dir=self.output_dir,
-            depth_level=2,
+            depth_cap=2,
             run_id="test-run-id",
             log_path="test_repo/test-run-log",
         )
@@ -1034,7 +1061,7 @@ class TestDiagramGenerator(unittest.TestCase):
             temp_folder=self.temp_folder,
             repo_name="test_repo",
             output_dir=self.output_dir,
-            depth_level=2,
+            depth_cap=2,
             run_id="test-run-id",
             log_path="test_repo/test-run-log",
         )
@@ -1059,7 +1086,7 @@ class TestDiagramGenerator(unittest.TestCase):
             temp_folder=self.temp_folder,
             repo_name="test_repo",
             output_dir=self.output_dir,
-            depth_level=2,
+            depth_cap=2,
             run_id="test-run-id",
             log_path="test_repo/test-run-log",
         )
@@ -1082,7 +1109,7 @@ class TestDiagramGenerator(unittest.TestCase):
             temp_folder=self.temp_folder,
             repo_name="test_repo",
             output_dir=self.output_dir,
-            depth_level=2,
+            depth_cap=2,
             run_id="test-run-id",
             log_path="test_repo/test-run-log",
         )
@@ -1106,7 +1133,7 @@ class TestDiagramGenerator(unittest.TestCase):
             temp_folder=self.temp_folder,
             repo_name="test_repo",
             output_dir=self.output_dir,
-            depth_level=2,
+            depth_cap=2,
             run_id="test-run-id",
             log_path="test_repo/test-run-log",
         )
@@ -1128,7 +1155,7 @@ class TestDiagramGenerator(unittest.TestCase):
             temp_folder=self.temp_folder,
             repo_name="test_repo",
             output_dir=self.output_dir,
-            depth_level=2,
+            depth_cap=2,
             run_id="test-run-id",
             log_path="test_repo/test-run-log",
         )
@@ -1152,7 +1179,7 @@ class TestDiagramGenerator(unittest.TestCase):
             temp_folder=self.temp_folder,
             repo_name="test_repo",
             output_dir=self.output_dir,
-            depth_level=2,
+            depth_cap=2,
             run_id="test-run-id",
             log_path="test_repo/test-run-log",
         )
@@ -1181,7 +1208,7 @@ class TestDiagramGenerator(unittest.TestCase):
             temp_folder=self.temp_folder,
             repo_name="test_repo",
             output_dir=self.output_dir,
-            depth_level=2,
+            depth_cap=2,
             run_id="test-run-id",
             log_path="test_repo/test-run-log",
         )
@@ -1197,7 +1224,7 @@ class TestDiagramGenerator(unittest.TestCase):
             temp_folder=self.temp_folder,
             repo_name="test_repo",
             output_dir=self.output_dir,
-            depth_level=2,
+            depth_cap=2,
             run_id="test-run-id",
             log_path="test_repo/test-run-log",
         )
@@ -1213,7 +1240,7 @@ class TestDiagramGenerator(unittest.TestCase):
             temp_folder=self.temp_folder,
             repo_name="test_repo",
             output_dir=self.output_dir,
-            depth_level=3,
+            depth_cap=3,
             run_id="test-run-id",
             log_path="test_repo/test-run-log",
         )
@@ -1246,7 +1273,7 @@ class TestDiagramGenerator(unittest.TestCase):
             temp_folder=self.temp_folder,
             repo_name="test_repo",
             output_dir=self.output_dir,
-            depth_level=3,
+            depth_cap=3,
             run_id="test-run-id",
             log_path="test_repo/test-run-log",
         )
@@ -1296,7 +1323,7 @@ class TestDiagramGenerator(unittest.TestCase):
             temp_folder=self.temp_folder,
             repo_name="test_repo",
             output_dir=self.output_dir,
-            depth_level=3,
+            depth_cap=3,
             run_id="test-run-id",
             log_path="test_repo/test-run-log",
         )
@@ -1329,7 +1356,7 @@ class TestDiagramGenerator(unittest.TestCase):
             temp_folder=self.temp_folder,
             repo_name="test_repo",
             output_dir=self.output_dir,
-            depth_level=2,
+            depth_cap=2,
             run_id="test-run-id",
             log_path="test_repo/test-run-log",
         )
@@ -1367,7 +1394,7 @@ class TestDiagramGenerator(unittest.TestCase):
             temp_folder=self.temp_folder,
             repo_name="test_repo",
             output_dir=self.output_dir,
-            depth_level=2,
+            depth_cap=2,
             run_id="test-run-id",
             log_path="test_repo/test-run-log",
         )
@@ -1395,7 +1422,7 @@ class TestDiagramGenerator(unittest.TestCase):
             temp_folder=self.temp_folder,
             repo_name="test_repo",
             output_dir=self.output_dir,
-            depth_level=2,
+            depth_cap=2,
             run_id="test-run-id",
             log_path="test_repo/test-run-log",
         )
@@ -1482,7 +1509,7 @@ class TestDiagramGenerator(unittest.TestCase):
             temp_folder=self.temp_folder,
             repo_name="test_repo",
             output_dir=self.output_dir,
-            depth_level=2,
+            depth_cap=2,
             run_id="test-run-id",
             log_path="test_repo/test-run-log",
         )
@@ -1516,7 +1543,7 @@ class TestDiagramGenerator(unittest.TestCase):
             temp_folder=self.temp_folder,
             repo_name="test_repo",
             output_dir=self.output_dir,
-            depth_level=3,
+            depth_cap=3,
             run_id="test-run-id",
             log_path="test_repo/test-run-log",
         )
@@ -1587,7 +1614,7 @@ class TestDiagramGenerator(unittest.TestCase):
             temp_folder=self.temp_folder,
             repo_name="test_repo",
             output_dir=self.output_dir,
-            depth_level=1,
+            depth_cap=1,
             run_id="test-run-id",
             log_path="test_repo/test-run-log",
         )
@@ -1713,7 +1740,7 @@ class TestDiagramGenerator(unittest.TestCase):
             temp_folder=self.temp_folder,
             repo_name="test_repo",
             output_dir=self.output_dir,
-            depth_level=1,
+            depth_cap=1,
             run_id="test-run-id",
             log_path="test_repo/test-run-log",
         )
@@ -1740,7 +1767,7 @@ class TestDiagramGenerator(unittest.TestCase):
             temp_folder=self.temp_folder,
             repo_name="test_repo",
             output_dir=self.output_dir,
-            depth_level=2,
+            depth_cap=2,
             run_id="test-run-id",
             log_path="test_repo/test-run-log",
         )
@@ -1783,7 +1810,7 @@ class TestDiagramGenerator(unittest.TestCase):
             temp_folder=self.temp_folder,
             repo_name="test_repo",
             output_dir=self.output_dir,
-            depth_level=3,
+            depth_cap=3,
             run_id="test-run-id",
             log_path="test_repo/test-run-log",
         )
@@ -1818,7 +1845,7 @@ class TestDiagramGenerator(unittest.TestCase):
             temp_folder=self.temp_folder,
             repo_name="test_repo",
             output_dir=self.output_dir,
-            depth_level=2,
+            depth_cap=2,
             run_id="test-run-id",
             log_path="test_repo/test-run-log",
         )
@@ -1844,7 +1871,7 @@ class TestDiagramGenerator(unittest.TestCase):
             temp_folder=self.temp_folder,
             repo_name="test_repo",
             output_dir=self.output_dir,
-            depth_level=3,
+            depth_cap=3,
             run_id="test-run-id",
             log_path="test_repo/test-run-log",
         )
@@ -1887,7 +1914,7 @@ class TestDiagramGenerator(unittest.TestCase):
             temp_folder=self.temp_folder,
             repo_name="test_repo",
             output_dir=self.output_dir,
-            depth_level=2,
+            depth_cap=2,
             run_id="test-run-id",
             log_path="test_repo/test-run-log",
         )
@@ -1965,7 +1992,7 @@ class TestDiagramGenerator(unittest.TestCase):
             temp_folder=self.temp_folder,
             repo_name="test_repo",
             output_dir=self.output_dir,
-            depth_level=2,
+            depth_cap=2,
             run_id="test-run-id",
             log_path="test_repo/test-run-log",
         )
@@ -2010,7 +2037,7 @@ class TestDiagramGenerator(unittest.TestCase):
             temp_folder=self.temp_folder,
             repo_name="test_repo",
             output_dir=self.output_dir,
-            depth_level=2,
+            depth_cap=2,
             run_id="test-run-id",
             log_path="test_repo/test-run-log",
         )
@@ -2072,7 +2099,7 @@ class TestDiagramGenerator(unittest.TestCase):
             temp_folder=self.temp_folder,
             repo_name="test_repo",
             output_dir=self.output_dir,
-            depth_level=3,
+            depth_cap=3,
             run_id="test-run-id",
             log_path="test_repo/test-run-log",
         )
@@ -2126,7 +2153,7 @@ class TestDiagramGenerator(unittest.TestCase):
             temp_folder=self.temp_folder,
             repo_name="test_repo",
             output_dir=self.output_dir,
-            depth_level=2,
+            depth_cap=2,
             run_id="test-run-id",
             log_path="test_repo/test-run-log",
         )
@@ -2166,7 +2193,7 @@ class TestDiagramGenerator(unittest.TestCase):
             temp_folder=self.temp_folder,
             repo_name="test_repo",
             output_dir=self.output_dir,
-            depth_level=2,
+            depth_cap=2,
             run_id="test-run-id",
             log_path="test_repo/test-run-log",
         )
@@ -2281,7 +2308,7 @@ class TestDiagramGenerator(unittest.TestCase):
             temp_folder=self.temp_folder,
             repo_name="test_repo",
             output_dir=self.output_dir,
-            depth_level=2,
+            depth_cap=2,
             run_id="test-run-id",
             log_path="test_repo/test-run-log",
         )
@@ -2320,7 +2347,7 @@ class TestDiagramGenerator(unittest.TestCase):
             temp_folder=self.temp_folder,
             repo_name="test_repo",
             output_dir=self.output_dir,
-            depth_level=1,
+            depth_cap=1,
             run_id="test-run-id",
             log_path="test_repo/test-run-log",
         )
@@ -2357,7 +2384,7 @@ class TestDiagramGenerator(unittest.TestCase):
             temp_folder=self.temp_folder,
             repo_name="test_repo",
             output_dir=self.output_dir,
-            depth_level=1,
+            depth_cap=1,
             run_id="test-run-id",
             log_path="test_repo/test-run-log",
         )

--- a/tests/diagram_analysis/test_diagram_analysis.py
+++ b/tests/diagram_analysis/test_diagram_analysis.py
@@ -844,7 +844,7 @@ class TestDepthCapPersistence(unittest.TestCase):
         self.assertEqual(metadata["depth_level"], 1)
         self.assertEqual(metadata["depth_cap"], 3)
 
-    def test_save_does_not_treat_legacy_result_depth_as_configuration(self):
+    def test_save_preserves_legacy_depth_fallback(self):
         save_analysis(
             analysis=self._make_root(),
             output_dir=self.output_dir,
@@ -868,7 +868,7 @@ class TestDepthCapPersistence(unittest.TestCase):
         )
         metadata = json.loads(path.read_text())["metadata"]
         self.assertEqual(metadata["depth_level"], 1)
-        self.assertEqual(metadata["depth_cap"], 3)
+        self.assertEqual(metadata["depth_cap"], 5)
 
 
 class TestDiagramGenerator(unittest.TestCase):

--- a/tests/diagram_analysis/test_incremental_copy_forward.py
+++ b/tests/diagram_analysis/test_incremental_copy_forward.py
@@ -560,7 +560,7 @@ class TestProgressSaveNeverTruncates(unittest.TestCase):
                 temp_folder=Path(tmp),
                 repo_name="test_repo",
                 output_dir=Path(tmp),
-                depth_level=2,
+                depth_cap=2,
                 run_id="test-run-id",
                 log_path="test_repo/test-run-log",
             )
@@ -577,7 +577,7 @@ class TestProgressSaveNeverTruncates(unittest.TestCase):
                 temp_folder=Path(tmp),
                 repo_name="test_repo",
                 output_dir=Path(tmp),
-                depth_level=2,
+                depth_cap=2,
                 run_id="test-run-id",
                 log_path="test_repo/test-run-log",
             )
@@ -596,7 +596,7 @@ class TestAnalysedSubtreeSurvivesTheSaveTimeVerdict(unittest.TestCase):
             temp_folder=Path(tmp),
             repo_name="test_repo",
             output_dir=Path(tmp),
-            depth_level=3,
+            depth_cap=3,
             run_id="test-run-id",
             log_path="test_repo/test-run-log",
         )

--- a/tests/diagram_analysis/test_tree_spec_persistence.py
+++ b/tests/diagram_analysis/test_tree_spec_persistence.py
@@ -61,7 +61,7 @@ class TestTreeSpecPersistence(unittest.TestCase):
             temp_folder=self.temp_dir,
             repo_name="repo",
             output_dir=self.temp_dir,
-            depth_level=1,
+            depth_cap=1,
             run_id="run",
             log_path="log",
         )

--- a/tests/test_cli_parser.py
+++ b/tests/test_cli_parser.py
@@ -1,10 +1,13 @@
 import json
+from contextlib import nullcontext
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
 from codeboarding_cli.render import main as render_main
+from codeboarding_workflows.sources import SourceContext
+from diagram_analysis import DEFAULT_DEPTH_LEVEL
 from main import build_parser, main
 from output_generators import SUPPORTED_FORMATS
 
@@ -74,6 +77,62 @@ def test_force_flag_registered_and_defaults_false() -> None:
 def test_force_flag_sets_true_when_passed() -> None:
     args = build_parser().parse_args(["full", "--local", "/tmp/repo", "--force"])
     assert args.force is True
+
+
+def test_depth_cap_default_is_unchanged() -> None:
+    args = build_parser().parse_args(["full", "--local", "/tmp/repo"])
+    assert args.depth_cap == DEFAULT_DEPTH_LEVEL == 3
+    assert not hasattr(args, "depth_level")
+
+
+@pytest.mark.parametrize("command", [[], ["full"]])
+@pytest.mark.parametrize("flag", ["--depth-cap", "--depth-level"])
+def test_depth_cap_spellings_share_canonical_destination(command: list[str], flag: str) -> None:
+    with patch("main.full_analysis.run_from_args") as run_full:
+        main([*command, "--local", "/tmp/repo", flag, "5"])
+
+    args = run_full.call_args.args[0]
+    assert args.depth_cap == 5
+    assert not hasattr(args, "depth_level")
+
+
+@pytest.mark.parametrize("flag", ["--depth-cap", "--depth-level"])
+def test_depth_cap_requires_integer(flag: str) -> None:
+    with pytest.raises(SystemExit) as exc:
+        build_parser().parse_args(["full", "--local", "/tmp/repo", flag, "invalid"])
+    assert exc.value.code == 2
+
+
+def test_full_help_names_cap_and_distinguishes_realized_depth(capsys) -> None:
+    with pytest.raises(SystemExit) as exc:
+        main(["full", "--help"])
+    assert exc.value.code == 0
+    help_text = capsys.readouterr().out
+    assert "--depth-cap DEPTH_CAP, --depth-level DEPTH_CAP" in help_text
+    assert "metadata.depth_cap" in help_text
+    assert "metadata.depth_level" in help_text
+
+
+@pytest.mark.parametrize("remote", [False, True])
+@pytest.mark.parametrize("flag", ["--depth-cap", "--depth-level"])
+def test_depth_cap_maps_to_existing_workflow_parameter(tmp_path: Path, monkeypatch, remote: bool, flag: str) -> None:
+    monkeypatch.chdir(tmp_path)
+    source = SourceContext(repo_path=tmp_path, artifact_dir=tmp_path, project_name="repo")
+    target = ["https://github.com/user/repo"] if remote else ["--local", str(tmp_path)]
+    with (
+        patch("codeboarding_cli.commands.full_analysis.bootstrap_environment"),
+        patch("codeboarding_workflows.orchestration.RunContext.resolve"),
+        patch("codeboarding_cli.commands.full_analysis.remote_source", return_value=nullcontext(source)),
+        patch("codeboarding_cli.commands.full_analysis.monitor_execution"),
+        patch("codeboarding_cli.commands.full_analysis.render_docs"),
+        patch("codeboarding_cli.commands.full_analysis.get_branch", return_value="main"),
+        patch("codeboarding_cli.commands.full_analysis.get_current_commit", return_value="sha"),
+        patch("codeboarding_cli.commands.full_analysis.run_full") as run_full,
+    ):
+        main(["full", *target, flag, "5"])
+
+    run_full.assert_called_once()
+    assert run_full.call_args.kwargs["depth_level"] == 5
 
 
 def test_render_flag_registered_and_defaults_none() -> None:

--- a/tests/test_cli_parser.py
+++ b/tests/test_cli_parser.py
@@ -5,9 +5,11 @@ from unittest.mock import patch
 
 import pytest
 
+import diagram_analysis
 from codeboarding_cli.render import main as render_main
+from codeboarding_workflows.analysis import build_generator, run_full
 from codeboarding_workflows.sources import SourceContext
-from diagram_analysis import DEFAULT_DEPTH_LEVEL
+from diagram_analysis import DEFAULT_DEPTH_CAP, DiagramGenerator, RunContext, RunPaths
 from main import build_parser, main
 from output_generators import SUPPORTED_FORMATS
 
@@ -81,25 +83,48 @@ def test_force_flag_sets_true_when_passed() -> None:
 
 def test_depth_cap_default_is_unchanged() -> None:
     args = build_parser().parse_args(["full", "--local", "/tmp/repo"])
-    assert args.depth_cap == DEFAULT_DEPTH_LEVEL == 3
+    assert args.depth_cap == DEFAULT_DEPTH_CAP == 3
     assert not hasattr(args, "depth_level")
+    assert not hasattr(diagram_analysis, "DEFAULT_DEPTH_LEVEL")
 
 
 @pytest.mark.parametrize("command", [[], ["full"]])
-@pytest.mark.parametrize("flag", ["--depth-cap", "--depth-level"])
-def test_depth_cap_spellings_share_canonical_destination(command: list[str], flag: str) -> None:
+def test_depth_cap_has_canonical_destination(command: list[str]) -> None:
     with patch("main.full_analysis.run_from_args") as run_full:
-        main([*command, "--local", "/tmp/repo", flag, "5"])
+        main([*command, "--local", "/tmp/repo", "--depth-cap", "5"])
 
     args = run_full.call_args.args[0]
     assert args.depth_cap == 5
     assert not hasattr(args, "depth_level")
 
 
-@pytest.mark.parametrize("flag", ["--depth-cap", "--depth-level"])
-def test_depth_cap_requires_integer(flag: str) -> None:
+@pytest.mark.parametrize("command", [[], ["full"]])
+@pytest.mark.parametrize("remote", [False, True])
+@pytest.mark.parametrize("extra", [[], ["--depth-cap", "4"]])
+def test_old_depth_input_is_rejected(command, remote, extra, capsys) -> None:
+    target = ["https://github.com/user/repo"] if remote else ["--local", "/tmp/repo"]
+    with patch("main.full_analysis.run_from_args") as run_full:
+        with pytest.raises(SystemExit) as exc:
+            main([*command, *target, "--depth-level", "5", *extra])
+    assert exc.value.code == 2
+    assert "unrecognized arguments: --depth-level" in capsys.readouterr().err
+    run_full.assert_not_called()
+
+
+@pytest.mark.parametrize("factory", [run_full, build_generator])
+def test_workflow_rejects_old_python_keyword(factory, tmp_path) -> None:
+    with pytest.raises(TypeError, match="depth_level"):
+        factory(RunPaths(tmp_path, tmp_path, "repo"), RunContext("run", "log"), **{"depth_level": 3})
+
+
+def test_generator_rejects_old_python_keyword(tmp_path) -> None:
+    with pytest.raises(TypeError, match="depth_level"):
+        DiagramGenerator(tmp_path, tmp_path, "repo", tmp_path, run_id="run", log_path="log", **{"depth_level": 3})
+
+
+def test_depth_cap_requires_integer() -> None:
     with pytest.raises(SystemExit) as exc:
-        build_parser().parse_args(["full", "--local", "/tmp/repo", flag, "invalid"])
+        build_parser().parse_args(["full", "--local", "/tmp/repo", "--depth-cap", "invalid"])
     assert exc.value.code == 2
 
 
@@ -108,14 +133,14 @@ def test_full_help_names_cap_and_distinguishes_realized_depth(capsys) -> None:
         main(["full", "--help"])
     assert exc.value.code == 0
     help_text = capsys.readouterr().out
-    assert "--depth-cap DEPTH_CAP, --depth-level DEPTH_CAP" in help_text
+    assert "--depth-cap DEPTH_CAP" in help_text
+    assert "--depth-level" not in help_text
     assert "metadata.depth_cap" in help_text
     assert "metadata.depth_level" in help_text
 
 
 @pytest.mark.parametrize("remote", [False, True])
-@pytest.mark.parametrize("flag", ["--depth-cap", "--depth-level"])
-def test_depth_cap_maps_to_existing_workflow_parameter(tmp_path: Path, monkeypatch, remote: bool, flag: str) -> None:
+def test_depth_cap_maps_to_workflow_parameter(tmp_path: Path, monkeypatch, remote: bool) -> None:
     monkeypatch.chdir(tmp_path)
     source = SourceContext(repo_path=tmp_path, artifact_dir=tmp_path, project_name="repo")
     target = ["https://github.com/user/repo"] if remote else ["--local", str(tmp_path)]
@@ -129,10 +154,11 @@ def test_depth_cap_maps_to_existing_workflow_parameter(tmp_path: Path, monkeypat
         patch("codeboarding_cli.commands.full_analysis.get_current_commit", return_value="sha"),
         patch("codeboarding_cli.commands.full_analysis.run_full") as run_full,
     ):
-        main(["full", *target, flag, "5"])
+        main(["full", *target, "--depth-cap", "5"])
 
     run_full.assert_called_once()
-    assert run_full.call_args.kwargs["depth_level"] == 5
+    assert run_full.call_args.kwargs["depth_cap"] == 5
+    assert "depth_level" not in run_full.call_args.kwargs
 
 
 def test_render_flag_registered_and_defaults_none() -> None:

--- a/tests/test_github_action.py
+++ b/tests/test_github_action.py
@@ -5,9 +5,9 @@ import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from diagram_analysis import DEFAULT_DEPTH_LEVEL
+from diagram_analysis import DEFAULT_DEPTH_CAP
 from github_action import (
-    _resolve_depth_level,
+    _resolve_depth_cap,
     generate_analysis,
     generate_html,
     generate_markdown,
@@ -189,7 +189,7 @@ class TestGenerateAnalysis(unittest.TestCase):
     @patch("github_action.create_temp_repo_folder")
     @patch("github_action.checkout_repo")
     @patch("github_action.clone_repository")
-    @patch.dict(os.environ, {"REPO_ROOT": "/tmp/repos", "DIAGRAM_DEPTH_LEVEL": "2"})
+    @patch.dict(os.environ, {"REPO_ROOT": "/tmp/repos", "DIAGRAM_DEPTH_CAP": "2"})
     def test_generate_analysis_markdown(
         self,
         mock_clone,
@@ -229,7 +229,7 @@ class TestGenerateAnalysis(unittest.TestCase):
             # Check that generator was created with correct params
             mock_generator_class.assert_called_once()
             args = mock_generator_class.call_args
-            self.assertEqual(args[1]["depth_level"], 2)
+            self.assertEqual(args[1]["depth_cap"], 2)
 
             # Check that markdown generation was called with a Path
             mock_generate_markdown.assert_called_once()
@@ -247,7 +247,7 @@ class TestGenerateAnalysis(unittest.TestCase):
     @patch("github_action.create_temp_repo_folder")
     @patch("github_action.checkout_repo")
     @patch("github_action.clone_repository")
-    @patch.dict(os.environ, {"REPO_ROOT": "/tmp/repos", "DIAGRAM_DEPTH_LEVEL": "1"})
+    @patch.dict(os.environ, {"REPO_ROOT": "/tmp/repos", "DIAGRAM_DEPTH_CAP": "1"})
     def test_generate_analysis_html(
         self,
         mock_clone,
@@ -284,7 +284,7 @@ class TestGenerateAnalysis(unittest.TestCase):
     @patch("github_action.create_temp_repo_folder")
     @patch("github_action.checkout_repo")
     @patch("github_action.clone_repository")
-    @patch.dict(os.environ, {"REPO_ROOT": "/tmp/repos", "DIAGRAM_DEPTH_LEVEL": "1"})
+    @patch.dict(os.environ, {"REPO_ROOT": "/tmp/repos", "DIAGRAM_DEPTH_CAP": "1"})
     def test_generate_analysis_mdx(
         self,
         mock_clone,
@@ -321,7 +321,7 @@ class TestGenerateAnalysis(unittest.TestCase):
     @patch("github_action.create_temp_repo_folder")
     @patch("github_action.checkout_repo")
     @patch("github_action.clone_repository")
-    @patch.dict(os.environ, {"REPO_ROOT": "/tmp/repos", "DIAGRAM_DEPTH_LEVEL": "1"})
+    @patch.dict(os.environ, {"REPO_ROOT": "/tmp/repos", "DIAGRAM_DEPTH_CAP": "1"})
     def test_generate_analysis_rst(
         self,
         mock_clone,
@@ -357,7 +357,7 @@ class TestGenerateAnalysis(unittest.TestCase):
     @patch("github_action.create_temp_repo_folder")
     @patch("github_action.checkout_repo")
     @patch("github_action.clone_repository")
-    @patch.dict(os.environ, {"REPO_ROOT": "/tmp/repos", "DIAGRAM_DEPTH_LEVEL": "1"})
+    @patch.dict(os.environ, {"REPO_ROOT": "/tmp/repos", "DIAGRAM_DEPTH_CAP": "1"})
     def test_generate_analysis_unsupported_extension(
         self,
         mock_clone,
@@ -393,7 +393,7 @@ class TestGenerateAnalysis(unittest.TestCase):
     @patch("github_action.create_temp_repo_folder")
     @patch("github_action.checkout_repo")
     @patch("github_action.clone_repository")
-    @patch.dict(os.environ, {"REPO_ROOT": "/tmp/repos", "DIAGRAM_DEPTH_LEVEL": "1"})
+    @patch.dict(os.environ, {"REPO_ROOT": "/tmp/repos", "DIAGRAM_DEPTH_CAP": "1"})
     def test_generate_analysis_branch_checkout(
         self,
         mock_clone,
@@ -428,16 +428,16 @@ class TestGenerateAnalysis(unittest.TestCase):
             self.assertEqual(args[1], "feature-branch")
 
 
-class TestResolveDepthLevel(unittest.TestCase):
+class TestResolveDepthCap(unittest.TestCase):
     """An action incremental over a seeded baseline must reuse the baseline's
     own configured cap, not silently re-cap it at the current default."""
 
-    @patch.dict(os.environ, {"DIAGRAM_DEPTH_LEVEL": "5"}, clear=True)
+    @patch.dict(os.environ, {"DIAGRAM_DEPTH_CAP": "5"}, clear=True)
     def test_env_var_takes_priority_over_seeded_baseline(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_path = Path(temp_dir)
             _write_analysis_file(temp_path / "analysis.json")
-            self.assertEqual(_resolve_depth_level(temp_path), 5)
+            self.assertEqual(_resolve_depth_cap(temp_path), 5)
 
     @patch.dict(os.environ, {}, clear=True)
     def test_seeded_baseline_depth_cap_used_when_env_var_unset(self):
@@ -453,20 +453,24 @@ class TestResolveDepthLevel(unittest.TestCase):
             with open(temp_path / "analysis.json", "w") as f:
                 json.dump(analysis, f)
 
-            self.assertEqual(_resolve_depth_level(temp_path), 4)
+            self.assertEqual(_resolve_depth_cap(temp_path), 4)
 
     @patch.dict(os.environ, {}, clear=True)
-    def test_legacy_baseline_falls_back_to_depth_level(self):
-        """Baselines written before depth_cap existed only have depth_level."""
+    def test_realized_depth_is_not_a_configuration_fallback(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_path = Path(temp_dir)
             _write_analysis_file(temp_path / "analysis.json")  # depth_level=1, no depth_cap
-            self.assertEqual(_resolve_depth_level(temp_path), 1)
+            self.assertEqual(_resolve_depth_cap(temp_path), DEFAULT_DEPTH_CAP)
+
+    @patch.dict(os.environ, {"DIAGRAM_DEPTH_LEVEL": "5"}, clear=True)
+    def test_old_environment_input_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "use DIAGRAM_DEPTH_CAP"):
+            _resolve_depth_cap(Path("unused"))
 
     @patch.dict(os.environ, {}, clear=True)
     def test_no_baseline_falls_back_to_default(self):
         with tempfile.TemporaryDirectory() as temp_dir:
-            self.assertEqual(_resolve_depth_level(Path(temp_dir)), DEFAULT_DEPTH_LEVEL)
+            self.assertEqual(_resolve_depth_cap(Path(temp_dir)), DEFAULT_DEPTH_CAP)
 
 
 if __name__ == "__main__":

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -93,7 +93,7 @@ class TestPartialUpdate(unittest.TestCase):
     @patch("codeboarding_workflows.analysis.load_analysis_metadata")
     @patch("codeboarding_workflows.analysis.DiagramGenerator")
     def test_partial_update_success(self, mock_generator_class, mock_load_metadata, mock_load_full):
-        mock_load_metadata.return_value = {"depth_level": 1, "depth_cap": 1, "source_tree_hash": "source-hash"}
+        mock_load_metadata.return_value = {"depth_level": 1, "source_tree_hash": "source-hash"}
         from agents.agent_responses import AnalysisInsights, Component
 
         mock_generator = MagicMock()
@@ -303,7 +303,6 @@ class TestIncrementalDepthSource(unittest.TestCase):
     @patch("codeboarding_workflows.analysis.DiagramGenerator")
     @patch("codeboarding_workflows.analysis.load_analysis_metadata")
     def test_depth_cap_taken_from_metadata(self, mock_load_metadata, mock_generator_class, mock_detect, mock_workflow):
-        mock_load_metadata.return_value = {"depth_level": 1, "depth_cap": 4}
         mock_detect.return_value = MagicMock(files=[])
         mock_workflow.return_value = Path("analysis.json")
 
@@ -313,12 +312,18 @@ class TestIncrementalDepthSource(unittest.TestCase):
             output_dir = Path(temp_dir) / "output"
             output_dir.mkdir()
 
-            run_incremental(
-                RunPaths(repo_path=repo_path, output_dir=output_dir, project_name="test_project"),
-                RunContext(run_id="r", log_path="l"),
-            )
-
-        self.assertEqual(mock_generator_class.call_args.kwargs["depth_cap"], 4)
+            for metadata, expected_cap in (
+                ({"depth_level": 1, "depth_cap": 4}, 4),
+                ({"depth_level": 1}, 1),
+                ({}, 3),
+            ):
+                with self.subTest(metadata=metadata):
+                    mock_load_metadata.return_value = metadata
+                    run_incremental(
+                        RunPaths(repo_path=repo_path, output_dir=output_dir, project_name="test_project"),
+                        RunContext(run_id="r", log_path="l"),
+                    )
+                    self.assertEqual(mock_generator_class.call_args.kwargs["depth_cap"], expected_cap)
 
 
 class TestRemoteSource(unittest.TestCase):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -434,7 +434,7 @@ class TestFullCliLocal(unittest.TestCase):
         args.output_dir = None
         args.project_name = None
         args.binary_location = None
-        args.depth_level = 1
+        args.depth_cap = 1
         args.upload = False
         args.enable_monitoring = False
         args.force = False
@@ -458,6 +458,7 @@ class TestFullCliLocal(unittest.TestCase):
         mock_run_full.assert_called_once()
         run_paths = mock_run_full.call_args.args[0]
         self.assertEqual(run_paths.repo_path, repo_path.resolve())
+        self.assertEqual(mock_run_full.call_args.kwargs["depth_level"], 1)
         self.assertFalse(mock_run_full.call_args.kwargs["force_full"])
 
     @patch("codeboarding_cli.commands.full_analysis.run_full")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -49,7 +49,7 @@ class TestGenerateAnalysis(unittest.TestCase):
             result = run_full(
                 RunPaths(repo_path=repo_path, output_dir=output_dir, project_name="test_repo"),
                 RunContext(run_id="test-run-id", log_path="test_repo/test-run-log"),
-                depth_level=2,
+                depth_cap=2,
             )
 
             self.assertEqual(result, Path("analysis.json"))
@@ -58,7 +58,7 @@ class TestGenerateAnalysis(unittest.TestCase):
                 temp_folder=output_dir,
                 repo_name="test_repo",
                 output_dir=output_dir,
-                depth_level=2,
+                depth_cap=2,
                 run_id="test-run-id",
                 log_path="test_repo/test-run-log",
                 monitoring_enabled=False,
@@ -93,7 +93,7 @@ class TestPartialUpdate(unittest.TestCase):
     @patch("codeboarding_workflows.analysis.load_analysis_metadata")
     @patch("codeboarding_workflows.analysis.DiagramGenerator")
     def test_partial_update_success(self, mock_generator_class, mock_load_metadata, mock_load_full):
-        mock_load_metadata.return_value = {"depth_level": 1, "source_tree_hash": "source-hash"}
+        mock_load_metadata.return_value = {"depth_level": 1, "depth_cap": 1, "source_tree_hash": "source-hash"}
         from agents.agent_responses import AnalysisInsights, Component
 
         mock_generator = MagicMock()
@@ -163,7 +163,7 @@ class TestPartialUpdate(unittest.TestCase):
     @patch("codeboarding_workflows.analysis.load_analysis_metadata")
     @patch("codeboarding_workflows.analysis.DiagramGenerator")
     def test_partial_update_nested_component_success(self, mock_generator_class, mock_load_metadata, mock_load_full):
-        mock_load_metadata.return_value = {"depth_level": 2, "source_tree_hash": "source-hash"}
+        mock_load_metadata.return_value = {"depth_level": 1, "depth_cap": 2, "source_tree_hash": "source-hash"}
         from agents.agent_responses import AnalysisInsights, Component
 
         mock_generator = MagicMock()
@@ -217,7 +217,7 @@ class TestPartialUpdate(unittest.TestCase):
                 persisted_scopes={"root": root_analysis, "root_comp_id": sub_analysis_of_root},
             )
             mock_generator.process_component.assert_called_once_with(nested_component)
-            self.assertEqual(mock_generator_class.call_args.kwargs["depth_level"], 2)
+            self.assertEqual(mock_generator_class.call_args.kwargs["depth_cap"], 2)
             mock_generator.finalize_and_save.assert_called_once()
             mock_generator._persist_static_analysis_artifact.assert_called_once_with()
 
@@ -280,7 +280,7 @@ class TestPartialUpdate(unittest.TestCase):
 
 
 class TestIncrementalDepthSource(unittest.TestCase):
-    """``run_incremental`` reads depth_level from analysis.json metadata."""
+    """Incremental reuses the configured cap, not the realized depth."""
 
     @patch("codeboarding_workflows.analysis.load_analysis_metadata")
     def test_cold_start_raises_incremental_unavailable(self, mock_load_metadata):
@@ -302,10 +302,8 @@ class TestIncrementalDepthSource(unittest.TestCase):
     @patch("codeboarding_workflows.analysis.detect_changes_from_fingerprint")
     @patch("codeboarding_workflows.analysis.DiagramGenerator")
     @patch("codeboarding_workflows.analysis.load_analysis_metadata")
-    def test_depth_level_taken_from_metadata(
-        self, mock_load_metadata, mock_generator_class, mock_detect, mock_workflow
-    ):
-        mock_load_metadata.return_value = {"depth_level": 3}
+    def test_depth_cap_taken_from_metadata(self, mock_load_metadata, mock_generator_class, mock_detect, mock_workflow):
+        mock_load_metadata.return_value = {"depth_level": 1, "depth_cap": 4}
         mock_detect.return_value = MagicMock(files=[])
         mock_workflow.return_value = Path("analysis.json")
 
@@ -320,7 +318,7 @@ class TestIncrementalDepthSource(unittest.TestCase):
                 RunContext(run_id="r", log_path="l"),
             )
 
-        self.assertEqual(mock_generator_class.call_args.kwargs["depth_level"], 3)
+        self.assertEqual(mock_generator_class.call_args.kwargs["depth_cap"], 4)
 
 
 class TestRemoteSource(unittest.TestCase):
@@ -398,7 +396,7 @@ class TestLocalSource(unittest.TestCase):
             description="",
             key_entities=[],
         )
-        mock_load_metadata.return_value = {"depth_level": 1, "source_tree_hash": "source-hash"}
+        mock_load_metadata.return_value = {"depth_level": 1, "depth_cap": 1, "source_tree_hash": "source-hash"}
         root_analysis = AnalysisInsights(description="root", components=[component], components_relations=[])
         mock_load_full.return_value = (root_analysis, {})
         mock_generator_class.return_value.process_component.return_value = ("target", None, [])
@@ -458,7 +456,7 @@ class TestFullCliLocal(unittest.TestCase):
         mock_run_full.assert_called_once()
         run_paths = mock_run_full.call_args.args[0]
         self.assertEqual(run_paths.repo_path, repo_path.resolve())
-        self.assertEqual(mock_run_full.call_args.kwargs["depth_level"], 1)
+        self.assertEqual(mock_run_full.call_args.kwargs["depth_cap"], 1)
         self.assertFalse(mock_run_full.call_args.kwargs["force_full"])
 
     @patch("codeboarding_cli.commands.full_analysis.run_full")

--- a/tests/test_telemetry_events.py
+++ b/tests/test_telemetry_events.py
@@ -26,11 +26,11 @@ def props_for(cap, name):
 
 def test_track_analysis_on_error_marks_status_and_forwards_exception(captured):
     @track_analysis
-    def run_full(repo_name, run_id=None, depth_level=1):
+    def run_full(repo_name, run_id=None, depth_cap=1):
         raise RuntimeError("git fetch failed: bad object")
 
     with pytest.raises(RuntimeError):
-        run_full("x", run_id="r1", depth_level=2)
+        run_full("x", run_id="r1", depth_cap=2)
 
     completed = props_for(captured, "analysis_completed")
     assert completed["status"] == "error"
@@ -100,7 +100,7 @@ def test_track_analysis_reads_run_id_from_self_for_generator_methods(captured):
 
     class Generator:
         run_id = "from-self"
-        depth_level = 3
+        depth_cap = 3
 
         @track_analysis
         def generate_analysis(self):
@@ -111,7 +111,10 @@ def test_track_analysis_reads_run_id_from_self_for_generator_methods(captured):
     started = props_for(captured, "analysis_started")
     assert started["command"] == "generate_analysis"
     assert started["run_id"] == "from-self"
-    assert started["depth_level"] == 3
+    assert started["depth_cap"] == 3
+    assert "depth_level" not in started
+    assert props_for(captured, "analysis_completed")["depth_cap"] == 3
+    assert "depth_level" not in props_for(captured, "analysis_completed")
     assert props_for(captured, "analysis_completed")["run_id"] == "from-self"
 
 
@@ -120,7 +123,7 @@ def test_track_analysis_propagates_run_id_to_nested_repo_scanned(captured):
 
     class Generator:
         run_id = "nested-id"
-        depth_level = 1
+        depth_cap = 1
 
         @track_analysis
         def generate_analysis(self):
@@ -184,7 +187,7 @@ def test_track_analysis_env_run_id_overrides_self(captured, monkeypatch):
 
     class Generator:
         run_id = "internal-id"
-        depth_level = 1
+        depth_cap = 1
 
         @track_analysis
         def generate_analysis(self):

--- a/uv.lock
+++ b/uv.lock
@@ -229,14 +229,12 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser", marker = "implementation_name != 'PyPy' and sys_platform != 'win32'" },
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
     { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
     { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
     { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
     { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
@@ -290,7 +288,7 @@ wheels = [
 
 [[package]]
 name = "codeboarding"
-version = "0.14.0"
+version = "0.14.1"
 source = { editable = "." }
 dependencies = [
     { name = "docker" },
@@ -493,29 +491,25 @@ name = "cryptography"
 version = "46.0.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'win32'" },
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/60/04/ee2a9e8542e4fa2773b81771ff8349ff19cdd56b7258a0cc442639052edb/cryptography-46.0.5.tar.gz", hash = "sha256:abace499247268e3757271b2f1e244b36b06f8515cf27c4d49468fc9eb16e93d", size = 750064, upload-time = "2026-02-10T19:18:38.255Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ff/9e/6b4397a3e3d15123de3b1806ef342522393d50736c13b20ec4c9ea6693a6/cryptography-46.0.5-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c18ff11e86df2e28854939acde2d003f7984f721eba450b56a200ad90eeb0e6b", size = 4275637, upload-time = "2026-02-10T19:17:10.53Z" },
     { url = "https://files.pythonhosted.org/packages/63/e7/471ab61099a3920b0c77852ea3f0ea611c9702f651600397ac567848b897/cryptography-46.0.5-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d7e3d356b8cd4ea5aff04f129d5f66ebdc7b6f8eae802b93739ed520c47c79b", size = 4424742, upload-time = "2026-02-10T19:17:12.388Z" },
     { url = "https://files.pythonhosted.org/packages/37/53/a18500f270342d66bf7e4d9f091114e31e5ee9e7375a5aba2e85a91e0044/cryptography-46.0.5-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:50bfb6925eff619c9c023b967d5b77a54e04256c4281b0e21336a130cd7fc263", size = 4277528, upload-time = "2026-02-10T19:17:13.853Z" },
-    { url = "https://files.pythonhosted.org/packages/22/29/c2e812ebc38c57b40e7c583895e73c8c5adb4d1e4a0cc4c5a4fdab2b1acc/cryptography-46.0.5-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:803812e111e75d1aa73690d2facc295eaefd4439be1023fefc4995eaea2af90d", size = 4947993, upload-time = "2026-02-10T19:17:15.618Z" },
     { url = "https://files.pythonhosted.org/packages/6b/e7/237155ae19a9023de7e30ec64e5d99a9431a567407ac21170a046d22a5a3/cryptography-46.0.5-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3ee190460e2fbe447175cda91b88b84ae8322a104fc27766ad09428754a618ed", size = 4456855, upload-time = "2026-02-10T19:17:17.221Z" },
     { url = "https://files.pythonhosted.org/packages/2d/87/fc628a7ad85b81206738abbd213b07702bcbdada1dd43f72236ef3cffbb5/cryptography-46.0.5-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:f145bba11b878005c496e93e257c1e88f154d278d2638e6450d17e0f31e558d2", size = 3984635, upload-time = "2026-02-10T19:17:18.792Z" },
     { url = "https://files.pythonhosted.org/packages/84/29/65b55622bde135aedf4565dc509d99b560ee4095e56989e815f8fd2aa910/cryptography-46.0.5-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:e9251e3be159d1020c4030bd2e5f84d6a43fe54b6c19c12f51cde9542a2817b2", size = 4277038, upload-time = "2026-02-10T19:17:20.256Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/36/45e76c68d7311432741faf1fbf7fac8a196a0a735ca21f504c75d37e2558/cryptography-46.0.5-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:47fb8a66058b80e509c47118ef8a75d14c455e81ac369050f20ba0d23e77fee0", size = 4912181, upload-time = "2026-02-10T19:17:21.825Z" },
     { url = "https://files.pythonhosted.org/packages/6d/1a/c1ba8fead184d6e3d5afcf03d569acac5ad063f3ac9fb7258af158f7e378/cryptography-46.0.5-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:4c3341037c136030cb46e4b1e17b7418ea4cbd9dd207e4a6f3b2b24e0d4ac731", size = 4456482, upload-time = "2026-02-10T19:17:25.133Z" },
     { url = "https://files.pythonhosted.org/packages/f9/e5/3fb22e37f66827ced3b902cf895e6a6bc1d095b5b26be26bd13c441fdf19/cryptography-46.0.5-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:890bcb4abd5a2d3f852196437129eb3667d62630333aacc13dfd470fad3aaa82", size = 4405497, upload-time = "2026-02-10T19:17:26.66Z" },
     { url = "https://files.pythonhosted.org/packages/1a/df/9d58bb32b1121a8a2f27383fabae4d63080c7ca60b9b5c88be742be04ee7/cryptography-46.0.5-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:80a8d7bfdf38f87ca30a5391c0c9ce4ed2926918e017c29ddf643d0ed2778ea1", size = 4667819, upload-time = "2026-02-10T19:17:28.569Z" },
     { url = "https://files.pythonhosted.org/packages/0f/04/c85bdeab78c8bc77b701bf0d9bdcf514c044e18a46dcff330df5448631b0/cryptography-46.0.5-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7d1f30a86d2757199cb2d56e48cce14deddf1f9c95f1ef1b64ee91ea43fe2e18", size = 4275349, upload-time = "2026-02-10T19:17:58.419Z" },
     { url = "https://files.pythonhosted.org/packages/5c/32/9b87132a2f91ee7f5223b091dc963055503e9b442c98fc0b8a5ca765fab0/cryptography-46.0.5-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:039917b0dc418bb9f6edce8a906572d69e74bd330b0b3fea4f79dab7f8ddd235", size = 4420667, upload-time = "2026-02-10T19:18:00.619Z" },
     { url = "https://files.pythonhosted.org/packages/a1/a6/a7cb7010bec4b7c5692ca6f024150371b295ee1c108bdc1c400e4c44562b/cryptography-46.0.5-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:ba2a27ff02f48193fc4daeadf8ad2590516fa3d0adeeb34336b96f7fa64c1e3a", size = 4276980, upload-time = "2026-02-10T19:18:02.379Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/7c/c4f45e0eeff9b91e3f12dbd0e165fcf2a38847288fcfd889deea99fb7b6d/cryptography-46.0.5-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:61aa400dce22cb001a98014f647dc21cda08f7915ceb95df0c9eaf84b4b6af76", size = 4939143, upload-time = "2026-02-10T19:18:03.964Z" },
     { url = "https://files.pythonhosted.org/packages/37/19/e1b8f964a834eddb44fa1b9a9976f4e414cbb7aa62809b6760c8803d22d1/cryptography-46.0.5-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3ce58ba46e1bc2aac4f7d9290223cead56743fa6ab94a5d53292ffaac6a91614", size = 4453674, upload-time = "2026-02-10T19:18:05.588Z" },
     { url = "https://files.pythonhosted.org/packages/db/ed/db15d3956f65264ca204625597c410d420e26530c4e2943e05a0d2f24d51/cryptography-46.0.5-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:420d0e909050490d04359e7fdb5ed7e667ca5c3c402b809ae2563d7e66a92229", size = 3978801, upload-time = "2026-02-10T19:18:07.167Z" },
     { url = "https://files.pythonhosted.org/packages/41/e2/df40a31d82df0a70a0daf69791f91dbb70e47644c58581d654879b382d11/cryptography-46.0.5-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:582f5fcd2afa31622f317f80426a027f30dc792e9c80ffee87b993200ea115f1", size = 4276755, upload-time = "2026-02-10T19:18:09.813Z" },
-    { url = "https://files.pythonhosted.org/packages/33/45/726809d1176959f4a896b86907b98ff4391a8aa29c0aaaf9450a8a10630e/cryptography-46.0.5-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:bfd56bb4b37ed4f330b82402f6f435845a5f5648edf1ad497da51a8452d5d62d", size = 4901539, upload-time = "2026-02-10T19:18:11.263Z" },
     { url = "https://files.pythonhosted.org/packages/99/0f/a3076874e9c88ecb2ecc31382f6e7c21b428ede6f55aafa1aa272613e3cd/cryptography-46.0.5-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:a3d507bb6a513ca96ba84443226af944b0f7f47dcc9a399d110cd6146481d24c", size = 4452794, upload-time = "2026-02-10T19:18:12.914Z" },
     { url = "https://files.pythonhosted.org/packages/02/ef/ffeb542d3683d24194a38f66ca17c0a4b8bf10631feef44a7ef64e631b1a/cryptography-46.0.5-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9f16fbdf4da055efb21c22d81b89f155f02ba420558db21288b3d0035bafd5f4", size = 4404160, upload-time = "2026-02-10T19:18:14.375Z" },
     { url = "https://files.pythonhosted.org/packages/96/93/682d2b43c1d5f1406ed048f377c0fc9fc8f7b0447a478d5c65ab3d3a66eb/cryptography-46.0.5-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:ced80795227d70549a411a4ab66e8ce307899fad2220ce5ab2f296e687eacde9", size = 4667123, upload-time = "2026-02-10T19:18:15.886Z" },
@@ -783,7 +777,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/0a/a3871375c7b9727edaeeea994bfff7c63ff7804c9829c19309ba2e058807/greenlet-3.3.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:b01548f6e0b9e9784a2c99c5651e5dc89ffcbe870bc5fb2e5ef864e9cc6b5dcb", size = 276379, upload-time = "2025-12-04T14:23:30.498Z" },
     { url = "https://files.pythonhosted.org/packages/43/ab/7ebfe34dce8b87be0d11dae91acbf76f7b8246bf9d6b319c741f99fa59c6/greenlet-3.3.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:349345b770dc88f81506c6861d22a6ccd422207829d2c854ae2af8025af303e3", size = 597294, upload-time = "2025-12-04T14:50:06.847Z" },
     { url = "https://files.pythonhosted.org/packages/a4/39/f1c8da50024feecd0793dbd5e08f526809b8ab5609224a2da40aad3a7641/greenlet-3.3.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e8e18ed6995e9e2c0b4ed264d2cf89260ab3ac7e13555b8032b25a74c6d18655", size = 607742, upload-time = "2025-12-04T14:57:42.349Z" },
-    { url = "https://files.pythonhosted.org/packages/77/cb/43692bcd5f7a0da6ec0ec6d58ee7cddb606d055ce94a62ac9b1aa481e969/greenlet-3.3.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c024b1e5696626890038e34f76140ed1daf858e37496d33f2af57f06189e70d7", size = 622297, upload-time = "2025-12-04T15:07:13.552Z" },
     { url = "https://files.pythonhosted.org/packages/75/b0/6bde0b1011a60782108c01de5913c588cf51a839174538d266de15e4bf4d/greenlet-3.3.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:047ab3df20ede6a57c35c14bf5200fcf04039d50f908270d3f9a7a82064f543b", size = 609885, upload-time = "2025-12-04T14:26:02.368Z" },
     { url = "https://files.pythonhosted.org/packages/49/0e/49b46ac39f931f59f987b7cd9f34bfec8ef81d2a1e6e00682f55be5de9f4/greenlet-3.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2d9ad37fc657b1102ec880e637cccf20191581f75c64087a549e66c57e1ceb53", size = 1567424, upload-time = "2025-12-04T15:04:23.757Z" },
     { url = "https://files.pythonhosted.org/packages/05/f5/49a9ac2dff7f10091935def9165c90236d8f175afb27cbed38fb1d61ab6b/greenlet-3.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:83cd0e36932e0e7f36a64b732a6f60c2fc2df28c351bae79fbaf4f8092fe7614", size = 1636017, upload-time = "2025-12-04T14:27:29.688Z" },
@@ -1336,7 +1329,7 @@ name = "macholib"
 version = "1.16.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "altgraph", marker = "sys_platform != 'win32'" },
+    { name = "altgraph" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/10/2f/97589876ea967487978071c9042518d28b958d87b17dceb7cdc1d881f963/macholib-1.16.4.tar.gz", hash = "sha256:f408c93ab2e995cd2c46e34fe328b130404be143469e41bc366c807448979362", size = 59427, upload-time = "2025-11-22T08:28:38.373Z" }
 wheels = [
@@ -2258,8 +2251,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "sys_platform != 'win32'" },
-    { name = "jeepney", marker = "sys_platform != 'win32'" },
+    { name = "cryptography" },
+    { name = "jeepney" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [


### PR DESCRIPTION
## 0.14.1 release preparation
Project version and uv.lock are now **0.14.1**. uv lock and uv lock --check passed; 73 CLI/main tests passed. Changes are pushed; no release has been published by this thread.

## Product decision (breaking; no aliases)

The final product decision supersedes the earlier compatibility proposal: **`--depth-cap` is the only CLI depth input. `--depth-level` is rejected**, including when both flags are supplied. The configured ceiling is `depth_cap`; `depth_level` is reserved for actual generated/reached depth in analysis results. There is no legacy Python keyword, attribute, or constant alias.

Related: [action #120](https://github.com/CodeBoarding/CodeBoarding-action/pull/120), Wrapper #102.

## Behavior

- `codeboarding [full] --local PATH --depth-cap INT` and remote repository invocation use the same canonical `args.depth_cap`. Default **3** and integer parsing are unchanged. The cap is a maximum for automatic hierarchy expansion, not a target that analysis must reach.
- Local/remote CLI entry points and the full workflow pass `depth_cap` to the generator. Expansion checks and persistence consume `generator.depth_cap`.
- **Output stays distinct:** `metadata.depth_level` is computed from the generated hierarchy; `metadata.depth_cap` is the configured ceiling. The output schema and actual-depth computation are not renamed.
- Baseline loading behavior is preserved, not redesigned: `depth_cap = int(metadata.get("depth_cap", metadata.get("depth_level", DEFAULT_DEPTH_CAP)))`. Prefer the configured cap; retain the existing legacy metadata fallback; use default 3 only when neither field exists. Persistence retains the same fallback and warning. Missing `depth_cap` alone does not newly invalidate a baseline. This metadata fallback is not a configurable input alias.
- GitHub helper input is `DIAGRAM_DEPTH_CAP`; presence of `DIAGRAM_DEPTH_LEVEL` raises an explicit migration error.
- Lifecycle telemetry now emits configured `depth_cap` rather than calling the configured value `depth_level`.
- Help, README, package guide/Python example, telemetry/design docs, and depth references in the historical `llms.txt` snapshot are updated.
- Scope note: existing explicit on-demand partial expansion and save-time widening of the persisted cap to encompass an expanded tree are unchanged. This change names and enforces the sole configuration input; it does not introduce a new prohibition on explicitly requested future partial expansion.

## Python API migration required by Wrapper and evals

| Old configured API | Required replacement |
| --- | --- |
| `codeboarding_workflows.analysis.run_full(..., depth_level=...)` | `run_full(..., depth_cap=...)` |
| `codeboarding_workflows.analysis.build_generator(..., depth_level=...)` | `build_generator(..., depth_cap=...)` |
| `DiagramGenerator(..., depth_level=...)` | `DiagramGenerator(..., depth_cap=...)` |
| `generator.depth_level` | `generator.depth_cap` |
| `diagram_analysis.DEFAULT_DEPTH_LEVEL` / `diagram_analysis.run_context.DEFAULT_DEPTH_LEVEL` | `DEFAULT_DEPTH_CAP` in the same modules |
| `DIAGRAM_DEPTH_LEVEL` | `DIAGRAM_DEPTH_CAP` in the GitHub helper and invoking harnesses |
| Configured lifecycle telemetry `depth_level` | `depth_cap` in `AnalysisStarted`, `AnalysisCompleted`, and consumers |

`github_action._resolve_depth_level` is also renamed `_resolve_depth_cap`. **Do not rename readers of result `metadata.depth_level`: they must continue to mean actual reached depth.** Wrapper/eval config models, keyword construction, fixtures and telemetry mappings must follow the configured-name changes before adopting this Core build.

## Validation

- After restoring the existing metadata fallback in [18eec9c6](https://github.com/CodeBoarding/CodeBoarding/commit/18eec9c62d44c5fc2c380693e273c854902b6ee0): `uv run pytest tests/test_main.py tests/test_cli_parser.py tests/diagram_analysis -q` → **301 passed**; targeted Black check passed; `uv run mypy .` → **303 source files passed**; `git diff --check` passed. Regression cases distinguish configured cap from reached depth and cover legacy-only and absent metadata fields. The broader results below predate this follow-up.
- Focused CLI, workflows, GitHub helper, telemetry and diagram-analysis suites: **332 passed**.
- Full `uv run pytest --cov=. --cov-report=term --cov-fail-under=80`: **2092 passed, 6 skipped, 1 failed**, **85.21% coverage**; the 80% coverage gate passes.
- The sole full-suite failure is the pre-existing environment-sensitive `tests/test_registry_coverage.py::TestHasRequiredToolsCoversEveryKind::test_missing_artifact_is_detected_for_every_kind`. This orb lacks dotnet; registry validation logs that csharp is unavailable and skips its artifact check. The registry test and implementation are unchanged from fetched `origin/main` (`e38c07e31b615ff5cb479b8d117d741d247e6b60`); the earlier PR validation also reproduced this on untouched main. No tests were weakened or skipped to work around it; no protected tests were changed.
- `uv run black .`: **303 files unchanged**. `uv run mypy .`: **success, 303 source files**. `uv run pre-commit run --all-files`: **Black passed**. `git diff --check`: **passed**.
- Added rejection coverage for the old CLI flag (local/remote, explicit/implied full, alone/alongside the new flag), old workflow/generator Python keywords, old exported constant, and old environment input. Tests distinguish cap from reached depth in workflow forwarding, telemetry, persistence and legacy-result handling.
- Private integration suite and live LLM analysis were not run. No sibling repositories were edited.

## Downstream/release blockers

1. A Core release containing this PR is required before downstream callers send `--depth-cap` or new Python keywords to an installed release; current Core **0.14.0** does not provide these names.
2. Action #120 now pins 0.14.1, including its provider-table mirror. Wrapper #102 now pins ==0.14.1; its lock must be refreshed after Core is published.
3. Wrapper #102 and eval/private integration callers must migrate the configured Python API names and environment input above, preserve result-depth readers, and validate against the same Core version. This is a coordinated breaking adoption, not a dual-input transition.
4. Telemetry consumers of the former configured `depth_level` property must migrate to `depth_cap`. Older baselines retain their existing metadata fallback; regenerate with an explicit cap when a different ceiling is desired.
5. Full-suite green verification still needs a dotnet-capable runner; private integration/live analysis remain unverified here.

Pushed to the existing `fix/cli-depth-cap` branch. **No merge or release performed.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Renamed the analysis depth setting to `--depth-cap`; the former `--depth-level` option and `DIAGRAM_DEPTH_LEVEL` variable are rejected.
  * Depth is treated as a maximum expansion limit, while the depth actually reached is reported separately.
  * Updated Python APIs, GitHub integration, telemetry, and metadata terminology.
  * The default depth cap is now 3.

* **Documentation**
  * Updated CLI help, README, package documentation, and design guidance.

* **Tests**
  * Added coverage for validation, defaults, metadata handling, integrations, and telemetry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
