### PR TITLE
Update project version to 0.14.2 - prepare for release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "codeboarding"
-version = "0.14.1"
+version = "0.14.2"
 description = "Interactive Diagrams for Code"
 readme = "PYPI.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -288,7 +288,7 @@ wheels = [
 
 [[package]]
 name = "codeboarding"
-version = "0.14.1"
+version = "0.14.2"
 source = { editable = "." }
 dependencies = [
     { name = "docker" },


### PR DESCRIPTION
Version bump to `0.14.2` in preparation for release.

Note: `0.14.1` is already published on PyPI (it never landed on `main` and has no tag), so `0.14.2` is the next publishable version.

**Merge after** #577, so the release contains the telemetry `org` property.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the project version to 0.14.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->