### PR TITLE
Add run diagnostics to track analysis degradations

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,43 @@ for the actual depth. Existing baseline loading behavior is unchanged: prefer
 > doing a full run. Static-analysis caches are versioned but not migrated; after a cache-version
 > upgrade, run a full analysis once to reindex.
 
+### Run diagnostics
+
+Not every failure stops a run. A language server that never starts, a language nothing
+indexed under, an LLM that stopped answering during naming — each of these leaves the run
+able to finish and write an `analysis.json` that looks exactly like a good one. Those are
+recorded in `metadata.run_diagnostics`:
+
+```json
+"run_diagnostics": {
+  "version": 1,
+  "degraded": 1,
+  "notices": 0,
+  "entries": [
+    {
+      "code": "static.language_server_unavailable",
+      "severity": "degraded",
+      "title": "CSharp could not be analyzed",
+      "detail": "Its language server failed to start (csharp-ls not found), so no CSharp file contributed a component, a call or a relation to this diagram.",
+      "remedy": "Check the run log for the server's own error and confirm the CSharp toolchain is installed where the analysis ran, then run the analysis again.",
+      "subject": "CSharp",
+      "count": 1
+    }
+  ]
+}
+```
+
+`severity` is `degraded` when the diagram is missing structure a clean run would have had,
+and `notice` when it is whole but something about how it was produced is worth knowing. An
+empty `remedy` means nothing the reader does would have changed the outcome — consumers
+offer "report this" there rather than an instruction nobody can follow. The report describes
+the run that wrote the document and is never inherited from a previous one; an analysis
+written before the field existed simply has no `run_diagnostics` key.
+
+Every surface that renders an analysis is expected to say when `degraded` is non-zero —
+the GitHub Action annotates its run and its review comment, and the webview banners the
+diagram. Wording lives in `run_diagnostics/catalog.py`, one builder per code.
+
 ## Where to use it
 
 - [CLI](https://github.com/CodeBoarding/CodeBoarding) for local analysis, automation, and CI workflows.

--- a/diagram_analysis/analysis_json.py
+++ b/diagram_analysis/analysis_json.py
@@ -16,6 +16,7 @@ from agents.agent_responses import (
 from agents.file_index_models import FileEntry, FileMethodGroup, MethodEntry, MethodIndexEntry
 from agents.relation_edges import merge_relations_by_pair
 from repo_utils.path_utils import normalize_repo_path
+from run_diagnostics import RunDiagnosticsReport
 
 logger = logging.getLogger(__name__)
 
@@ -115,6 +116,12 @@ class AnalysisMetadata(BaseModel):
         "and words each component owns. Drafted on a full analysis; incremental and partial runs "
         "replay it, so the partition cannot move underneath unchanged code. Empty on an analysis "
         "written before it existed.",
+    )
+    run_diagnostics: RunDiagnosticsReport = Field(
+        default_factory=RunDiagnosticsReport,
+        description="What the run that produced this document had to leave out. Empty entries mean "
+        "the run completed clean; a degraded entry means the diagram is missing structure a clean "
+        "run would have had, and every surface that renders this document should say so.",
     )
 
 
@@ -459,6 +466,7 @@ def build_unified_analysis_json(
     sub_analyses: dict[str, tuple[AnalysisInsights, list[Component]]] | None = None,
     file_coverage_summary: FileCoverageSummary | None = None,
     tree_spec: dict | None = None,
+    run_diagnostics: RunDiagnosticsReport | None = None,
 ) -> str:
     """Build the full unified analysis JSON with metadata and nested sub-analyses.
 
@@ -495,6 +503,7 @@ def build_unified_analysis_json(
             depth_cap=depth_cap,
             file_coverage_summary=summary,
             tree_spec=tree_spec or {},
+            run_diagnostics=run_diagnostics or RunDiagnosticsReport(),
         ),
         description=analysis.description,
         files=_build_file_entry_json_from_files(files_index),

--- a/diagram_analysis/diagram_generator.py
+++ b/diagram_analysis/diagram_generator.py
@@ -67,6 +67,8 @@ from monitoring.mixin import MonitoringMixin
 from monitoring.paths import get_monitoring_run_dir
 from repo_utils.change_detector import ChangeSet
 from repo_utils.ignore import RepoIgnoreManager
+from run_diagnostics import RunDiagnostics
+from run_diagnostics.catalog import names_not_generated
 from static_analyzer import StaticAnalyzer, get_static_analysis
 from static_analyzer.analysis_cache import StaticAnalysisCache
 from static_analyzer.analysis_result import StaticAnalysisResults
@@ -620,6 +622,9 @@ class DiagramGenerator:
         self._naming_counts_lock = threading.Lock()
         self._scopes_enriched = 0
         self._scopes_unnamed = 0
+        # Everything this run had to leave out, from static analysis and from here.
+        # Written into the saved document so the surfaces that render it can say so.
+        self.run_diagnostics = RunDiagnostics()
         # Settled component names by id, so a child scope is told the names it sits inside.
         self._names_by_id: dict[str, str] = {}
         self.incremental_updater: IncrementalUpdater | None = None
@@ -664,6 +669,7 @@ class DiagramGenerator:
             static_analysis = self._get_static_with_new_analyzer()
 
         self.static_analysis = static_analysis
+        self.run_diagnostics.absorb(static_analysis.run_diagnostics)
         depth = hierarchy_depth if hierarchy_depth is not None else self.depth_cap
         if incremental:
             root_analysis = persisted_scopes.get(ROOT_SCOPE_ID)
@@ -1503,6 +1509,7 @@ class DiagramGenerator:
                 self._scopes_unnamed,
                 self._scopes_enriched,
             )
+            self.run_diagnostics.record(names_not_generated(self._scopes_unnamed, self._scopes_enriched))
         if persist_side_artifacts:
             source_tree_hash = self._source_tree_hash()
         else:
@@ -1526,6 +1533,7 @@ class DiagramGenerator:
             sub_expandable_ids=sub_expandable_ids,
             depth_cap=self.depth_cap,
             tree_spec=self._tree_spec_dict(),
+            run_diagnostics=self.run_diagnostics.report(),
         ).resolve()
         if persist_side_artifacts:
             self._write_file_coverage()

--- a/diagram_analysis/io_utils.py
+++ b/diagram_analysis/io_utils.py
@@ -31,6 +31,7 @@ from diagram_analysis.analysis_json import (
     parse_unified_analysis,
 )
 from diagram_analysis.run_context import DEFAULT_DEPTH_CAP
+from run_diagnostics import RunDiagnosticsReport
 from utils import ANALYSIS_FILENAME, FINGERPRINT_FILENAME
 
 logger = logging.getLogger(__name__)
@@ -102,13 +103,15 @@ class _AnalysisFileStore:
         sub_expandable_ids: dict[str, list[str]] | None = None,
         depth_cap: int | None = None,
         tree_spec: dict | None = None,
+        run_diagnostics: RunDiagnosticsReport | None = None,
     ) -> Path:
         """Write the full analysis to ``analysis.json`` with file locking.
 
         If *sub_analyses* is not provided, existing sub-analyses on disk are
         preserved. ``depth_cap`` is the run's configured depth ceiling; when
         omitted, the existing on-disk value is preserved (see
-        ``_write_with_lock_held``).
+        ``_write_with_lock_held``). ``run_diagnostics`` describes *this* run and
+        is never inherited from disk: an omitted report means "nothing to report".
         """
         with self._lock:
             return self._write_with_lock_held(
@@ -122,6 +125,7 @@ class _AnalysisFileStore:
                 sub_expandable_ids,
                 depth_cap,
                 tree_spec,
+                run_diagnostics,
             )
 
     def _write_with_lock_held(
@@ -136,6 +140,7 @@ class _AnalysisFileStore:
         sub_expandable_ids: dict[str, list[str]] | None = None,
         depth_cap: int | None = None,
         tree_spec: dict | None = None,
+        run_diagnostics: RunDiagnosticsReport | None = None,
     ) -> Path:
         """Write ``analysis.json`` — caller must already hold ``self._lock``."""
         # A caller-provided set is authoritative: it already reflects the run's expansion
@@ -229,6 +234,7 @@ class _AnalysisFileStore:
             sub_analyses=sub_analyses_tuples,
             file_coverage_summary=file_coverage_summary,
             tree_spec=tree_spec or {},
+            run_diagnostics=run_diagnostics,
         )
         write_text_atomic(self._analysis_path, payload)
         return self._analysis_path
@@ -352,6 +358,7 @@ def save_analysis(
     sub_expandable_ids: dict[str, list[str]] | None = None,
     depth_cap: int | None = None,
     tree_spec: dict | None = None,
+    run_diagnostics: RunDiagnosticsReport | None = None,
 ) -> Path:
     """Save the analysis to a unified analysis.json file with file locking.
 
@@ -359,6 +366,8 @@ def save_analysis(
     whole-tree version key (reproducible by consumers that fingerprint the tree).
     ``depth_cap`` is the run's configured depth ceiling; omit to preserve the
     existing on-disk value (e.g. for an intermediate save mid-run).
+    ``run_diagnostics`` is what this run had to leave out; an intermediate save
+    omits it, and the run's own authoritative save supplies the finished report.
     """
     return _get_store(output_dir).write(
         analysis,
@@ -371,4 +380,5 @@ def save_analysis(
         sub_expandable_ids,
         depth_cap,
         tree_spec,
+        run_diagnostics,
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ packages = [
     "monitoring",
     "output_generators",
     "repo_utils",
+    "run_diagnostics",
     "static_analyzer",
     "static_analyzer.cfg",
     "static_analyzer.clustering",

--- a/run_diagnostics/__init__.py
+++ b/run_diagnostics/__init__.py
@@ -1,0 +1,22 @@
+"""Run diagnostics: what a completed analysis has to admit about itself.
+
+``models`` holds the wire types and the collector; ``catalog`` holds one
+builder per known degradation, wording included. Recorded during a run, read
+back from ``metadata.run_diagnostics`` in ``analysis.json``.
+"""
+
+from run_diagnostics.models import (
+    SCHEMA_VERSION,
+    Diagnostic,
+    DiagnosticSeverity,
+    RunDiagnostics,
+    RunDiagnosticsReport,
+)
+
+__all__ = [
+    "SCHEMA_VERSION",
+    "Diagnostic",
+    "DiagnosticSeverity",
+    "RunDiagnostics",
+    "RunDiagnosticsReport",
+]

--- a/run_diagnostics/catalog.py
+++ b/run_diagnostics/catalog.py
@@ -1,0 +1,103 @@
+"""The known ways a run finishes with less than it should have.
+
+One builder per code, each owning its own wording. Consumers (the CLI, the
+GitHub Action, the webview) render ``title``/``detail``/``remedy`` verbatim, so
+this module is the single place the user-facing phrasing lives.
+
+A ``remedy`` is written only where the reader could actually change the outcome.
+Where the cause is ours, it stays empty and the surfaces offer "report this"
+instead of an instruction nobody can follow.
+"""
+
+from run_diagnostics.models import Diagnostic, DiagnosticSeverity
+
+# Below this share of a repository's code, an unanalyzable language is a stray
+# script rather than a hole in the diagram, and saying so every run is noise.
+UNANALYZED_LANGUAGE_MIN_SHARE = 5.0
+
+
+def language_server_unavailable(language: str, reason: str) -> Diagnostic:
+    """A configured language server never came up; that language is absent entirely."""
+    return Diagnostic(
+        code="static.language_server_unavailable",
+        severity=DiagnosticSeverity.DEGRADED,
+        title=f"{language} could not be analyzed",
+        detail=(
+            f"Its language server failed to start ({reason}), so no {language} file contributed a "
+            "component, a call or a relation to this diagram."
+        ),
+        remedy=(
+            f"Check the run log for the server's own error and confirm the {language} toolchain is "
+            "installed where the analysis ran, then run the analysis again."
+        ),
+        subject=language,
+    )
+
+
+def language_engine_failed(language: str, reason: str) -> Diagnostic:
+    """The server started but indexing raised; the language's symbols are missing."""
+    return Diagnostic(
+        code="static.language_engine_failed",
+        severity=DiagnosticSeverity.DEGRADED,
+        title=f"{language} analysis did not finish",
+        detail=(
+            f"The {language} language server errored while indexing ({reason}). Components that own "
+            f"{language} code look smaller than they are, and calls in or out of it are missing."
+        ),
+        remedy=(
+            "Confirm the project builds and its dependencies are installed where the analysis ran, "
+            "then run the analysis again."
+        ),
+        subject=language,
+    )
+
+
+def language_not_supported(language: str, share_percent: float) -> Diagnostic:
+    """A material part of the repository is written in a language we cannot read."""
+    return Diagnostic(
+        code="static.language_not_supported",
+        severity=DiagnosticSeverity.DEGRADED,
+        title=f"{language} is not analyzed",
+        detail=(
+            f"{share_percent:.0f}% of this repository's code is {language}, which CodeBoarding has no "
+            "language server for. Those files are absent from the diagram, and so is anything that "
+            "only they reach."
+        ),
+        subject=language,
+    )
+
+
+def no_source_files(language: str) -> Diagnostic:
+    """The scan found the language, the pass found no files — almost always a filter."""
+    return Diagnostic(
+        code="static.no_source_files",
+        severity=DiagnosticSeverity.DEGRADED,
+        title=f"No {language} files were indexed",
+        detail=(
+            f"The scan detected {language} in this repository, but no {language} file survived the "
+            "analysis filters. Everything written in it is missing from the diagram."
+        ),
+        remedy=(
+            "Check .codeboardingignore and the project's own configuration (for example the include "
+            "patterns in tsconfig.json) for a rule that excludes them."
+        ),
+        subject=language,
+    )
+
+
+def names_not_generated(unnamed: int, total: int) -> Diagnostic:
+    """Semantic naming did not answer, so components kept their deterministic names."""
+    return Diagnostic(
+        code="semantics.names_not_generated",
+        severity=DiagnosticSeverity.DEGRADED,
+        title="Some components kept their fallback names",
+        detail=(
+            f"Naming did not complete for {unnamed} of {total} scopes, so those components are named "
+            "after the folders they were drawn from rather than what they do. Their grouping, members "
+            "and relations are unaffected."
+        ),
+        remedy=(
+            "This is usually a provider timeout or a rate limit. Run the analysis again to name them; "
+            "check the run log for the provider's own error if it repeats."
+        ),
+    )

--- a/run_diagnostics/models.py
+++ b/run_diagnostics/models.py
@@ -1,0 +1,101 @@
+"""What a finished run has to admit about itself.
+
+A run that raises never reaches a consumer with a half-truth: the CLI exits
+non-zero and nothing is written. The dangerous case is the run that *finishes*
+with less than it should have — a language server that never came up, an LLM
+that stopped answering — and hands over an ``analysis.json`` that looks exactly
+like a good one. These are the records of that, carried in the document itself
+so every surface downstream can say so.
+"""
+
+from collections import deque
+from enum import Enum
+
+from pydantic import BaseModel, Field
+
+SCHEMA_VERSION = 1
+
+
+class DiagnosticSeverity(str, Enum):
+    """How much of the diagram the reader should distrust."""
+
+    # Structure is missing: components, relations or names that a clean run would have had.
+    DEGRADED = "degraded"
+    # The diagram is whole; something about how it was produced is still worth knowing.
+    NOTICE = "notice"
+
+
+class Diagnostic(BaseModel):
+    """One thing that went wrong without stopping the run.
+
+    ``remedy`` empty means nothing the reader does would have changed the
+    outcome; consumers offer "report this" instead of an instruction.
+    """
+
+    code: str = Field(description="Stable identifier, e.g. 'static.language_engine_failed'.")
+    severity: DiagnosticSeverity
+    title: str = Field(description="One line, in the reader's terms.")
+    detail: str = Field(description="What is missing from the diagram because of it.")
+    remedy: str = Field(default="", description="What the reader can do about it; empty when nothing would.")
+    subject: str = Field(default="", description="What it is about (a language, a scope) — dedupes repeats.")
+    count: int = Field(default=1, description="How many times this code/subject pair was recorded.")
+
+
+class RunDiagnosticsReport(BaseModel):
+    """The serialized form: what ``metadata.run_diagnostics`` holds."""
+
+    version: int = Field(default=SCHEMA_VERSION)
+    degraded: int = Field(default=0, description="Number of degraded entries.")
+    notices: int = Field(default=0, description="Number of notice entries.")
+    entries: list[Diagnostic] = Field(default_factory=list, description="Degraded first, then notices.")
+
+
+class RunDiagnostics:
+    """Collector for one analysis run.
+
+    A ``deque`` rather than a lock: engines record from a thread pool, and
+    ``append`` is thread-safe by contract, which keeps this picklable and
+    deep-copyable — it rides on ``StaticAnalysisResults``, which is both.
+    Aggregation happens on read so recording stays cheap and non-blocking.
+    """
+
+    def __init__(self) -> None:
+        self._recorded: deque[Diagnostic] = deque()
+
+    def __bool__(self) -> bool:
+        return bool(self._recorded)
+
+    def record(self, diagnostic: Diagnostic) -> None:
+        self._recorded.append(diagnostic)
+
+    def absorb(self, other: "RunDiagnostics") -> None:
+        """Take over another collector's records (e.g. the static analyzer's)."""
+        self._recorded.extend(other._recorded)
+
+    def entries(self) -> list[Diagnostic]:
+        """Deduplicated by ``(code, subject)`` with counts summed, degraded first.
+
+        Why dedupe: a server that fails on every file would otherwise bury the
+        one entry that explains why half the diagram is missing.
+        """
+        merged: dict[tuple[str, str], Diagnostic] = {}
+        for diagnostic in list(self._recorded):
+            key = (diagnostic.code, diagnostic.subject)
+            seen = merged.get(key)
+            if seen is None:
+                merged[key] = diagnostic.model_copy(deep=True)
+            else:
+                seen.count += diagnostic.count
+        return sorted(
+            merged.values(),
+            key=lambda d: (d.severity != DiagnosticSeverity.DEGRADED, d.code, d.subject),
+        )
+
+    def report(self) -> RunDiagnosticsReport:
+        entries = self.entries()
+        return RunDiagnosticsReport(
+            version=SCHEMA_VERSION,
+            degraded=sum(1 for e in entries if e.severity == DiagnosticSeverity.DEGRADED),
+            notices=sum(1 for e in entries if e.severity == DiagnosticSeverity.NOTICE),
+            entries=entries,
+        )

--- a/static_analyzer/__init__.py
+++ b/static_analyzer/__init__.py
@@ -8,6 +8,14 @@ from pathlib import Path
 
 from repo_utils.git_ops import get_changed_files_since
 from repo_utils.ignore import RepoIgnoreManager
+from run_diagnostics import RunDiagnostics
+from run_diagnostics.catalog import (
+    UNANALYZED_LANGUAGE_MIN_SHARE,
+    language_engine_failed,
+    language_not_supported,
+    language_server_unavailable,
+    no_source_files,
+)
 from static_analyzer.analysis_cache import StaticAnalysisCache
 from static_analyzer.analysis_result import StaticAnalysisResults
 from static_analyzer.cfg import CallGraph
@@ -241,7 +249,14 @@ class StaticAnalyzer:
     def __init__(self, repository_path: Path, changed_files: set[Path] | None = None):
         self.repository_path = repository_path.resolve()
         self.ignore_manager = RepoIgnoreManager(self.repository_path)
-        self.programming_langs = ProjectScanner(self.repository_path).scan()
+        # What this run had to leave out. Rides on the results so every surface
+        # downstream can say the diagram is short of what a clean run produces.
+        self.run_diagnostics = RunDiagnostics()
+        scanner = ProjectScanner(self.repository_path)
+        self.programming_langs = scanner.scan()
+        for language in scanner.unsupported_code_languages:
+            if language.percentage >= UNANALYZED_LANGUAGE_MIN_SHARE:
+                self.run_diagnostics.record(language_not_supported(language.language, language.percentage))
         self._engine_configs = _create_engine_configs(self.programming_langs, self.repository_path, self.ignore_manager)
         self._engine_clients: list[tuple[EngineConfig, LSPClient]] = []
         # (language, project) -> the failure preparation raised, or None.
@@ -284,6 +299,7 @@ class StaticAnalyzer:
         started: list[tuple[EngineConfig, LSPClient]] = []
         attempted: list[str] = []
         failed_languages: list[str] = []
+        failed_reasons: list[str] = []
         failed_details: list[str] = []
 
         for engine_config in self._engine_configs:
@@ -312,7 +328,10 @@ class StaticAnalyzer:
                     f"skipping this language and continuing"
                 )
                 failed_languages.append(adapter.language)
+                failed_reasons.append(str(exc))
                 failed_details.append(f"{adapter.language}: {exc}")
+
+        self._record_languages_without_sources()
 
         if not attempted:
             logger.info(f"No source files for any detected language in {self.repository_path}; no LSP clients started.")
@@ -352,9 +371,22 @@ class StaticAnalyzer:
                 f"Started: {', '.join(s.adapter.language for s, _ in started)}."
                 f"{details}"
             )
+            for language, reason in zip(failed_languages, failed_reasons):
+                self.run_diagnostics.record(language_server_unavailable(language, reason))
 
         self._engine_clients = started
         self._clients_started = True
+
+    def _record_languages_without_sources(self) -> None:
+        """Report a detected language whose every project resolved to zero files.
+
+        Per language, not per project: one empty sub-project in a monorepo is
+        ordinary, while a language with nothing to index anywhere is a hole the
+        reader can usually close by fixing an ignore rule.
+        """
+        with_sources = {config.adapter.language for config in self._engine_configs if config.source_files}
+        for language in sorted({config.adapter.language for config in self._engine_configs} - with_sources):
+            self.run_diagnostics.record(no_source_files(language))
 
     def _prepare_project_once(self, engine_config: EngineConfig) -> None:
         """Let the adapter prepare a project exactly once (e.g. ``dotnet restore``).
@@ -684,6 +716,7 @@ class StaticAnalyzer:
 
         self._validate_analysis_results(results)
         results.diagnostics = self.collected_diagnostics
+        results.run_diagnostics = self.run_diagnostics
         self._cached_results = results
         return results
 
@@ -740,6 +773,7 @@ class StaticAnalyzer:
                 raise
             except Exception as e:
                 logger.error(f"Error during engine analysis for {adapter.language}: {e}")
+                self.run_diagnostics.record(language_engine_failed(adapter.language, str(e)))
                 with absorb_lock:
                     track_lsp_result(
                         language=adapter.language_enum.value,

--- a/static_analyzer/analysis_cache.py
+++ b/static_analyzer/analysis_cache.py
@@ -31,6 +31,7 @@ from filelock import FileLock
 
 from constants import STATIC_ANALYSIS_PKL, STATIC_ANALYSIS_SHA
 from repo_utils.path_utils import to_absolute_path, to_relative_path
+from run_diagnostics import RunDiagnostics
 from static_analyzer.analysis_result import AnalysisData, InvalidatedAnalysis, InvalidatedEdge, StaticAnalysisResults
 from static_analyzer.cfg import CallGraph, EdgeKind, ReferenceEdge
 from static_analyzer.lsp_client.diagnostics import FileDiagnosticsMap
@@ -93,8 +94,10 @@ class StaticAnalysisCache:
     def _relativize(self, result: StaticAnalysisResults) -> StaticAnalysisResults:
         """Return a copy of result with all file paths made repo-relative."""
         portable = copy.copy(result)
-        # Drop runtime-only warm-start context before deep-copying/pickling the cache artifact.
+        # Drop runtime-only context before deep-copying/pickling the cache artifact. A warm
+        # start must not resurrect the previous run's diagnostics as if they were this run's.
         portable.incremental_base_results = None
+        portable.run_diagnostics = RunDiagnostics()
         portable = copy.deepcopy(portable)
         for lang_data in portable.results.values():
             lang_data.visit_paths(self._to_relative)

--- a/static_analyzer/analysis_result.py
+++ b/static_analyzer/analysis_result.py
@@ -11,6 +11,7 @@ from static_analyzer.config import FAMILY_OWNER, SOURCE_EXTENSION_TO_LANGUAGE, L
 from static_analyzer.language_results import LanguageResults
 from static_analyzer.lsp_client.diagnostics import FileDiagnosticsMap
 from static_analyzer.node import Node
+from run_diagnostics import RunDiagnostics
 
 logger = logging.getLogger(__name__)
 
@@ -181,6 +182,9 @@ class StaticAnalysisResults:
 
     results: dict[Language, LanguageResults] = field(default_factory=dict)
     diagnostics: dict[Language, FileDiagnosticsMap] = field(default_factory=dict)
+    # What this run had to leave out (a server that never started, a language with
+    # nothing to index). Belongs to the run, not the cache, so the pickle drops it.
+    run_diagnostics: RunDiagnostics = field(default_factory=RunDiagnostics)
     # Runtime-only warm-start base; never persisted into the static-analysis cache.
     incremental_base_results: "StaticAnalysisResults | None" = None
 

--- a/static_analyzer/scanner.py
+++ b/static_analyzer/scanner.py
@@ -12,6 +12,43 @@ from utils import get_config
 
 logger = logging.getLogger(__name__)
 
+# Tokei counts data formats and markup as "languages" too, so a repository that is
+# mostly JSON would otherwise be reported as unanalyzed code. Only names on this
+# list are program code a reader would expect to see in an architecture diagram;
+# an unrecognised name is left alone rather than guessed at.
+UNSUPPORTED_CODE_LANGUAGES = frozenset(
+    {
+        "C",
+        "C Header",
+        "C++",
+        "C++ Header",
+        "Clojure",
+        "Dart",
+        "Elixir",
+        "Elm",
+        "Erlang",
+        "F#",
+        "Fortran",
+        "Groovy",
+        "Haskell",
+        "Julia",
+        "Kotlin",
+        "Lua",
+        "Nim",
+        "OCaml",
+        "Objective-C",
+        "Objective-C++",
+        "Perl",
+        "R",
+        "Ruby",
+        "Scala",
+        "Solidity",
+        "Swift",
+        "Visual Basic",
+        "Zig",
+    }
+)
+
 
 def _format_command(command: object) -> str:
     if isinstance(command, str):
@@ -65,6 +102,9 @@ class ProjectScanner:
     def __init__(self, repo_location: Path):
         self.repo_location = repo_location
         self.all_text_files: list[str] = []
+        # Program code no language server serves, so ``scan`` drops it. Kept so
+        # the run can report the hole rather than silently omitting it.
+        self.unsupported_code_languages: list[ProgrammingLanguage] = []
 
     def scan(self) -> list[ProgrammingLanguage]:
         """
@@ -124,6 +164,7 @@ class ProjectScanner:
             return []
 
         programming_languages: list[ProgrammingLanguage] = []
+        unsupported_code: list[ProgrammingLanguage] = []
         all_files: list[str] = []
         for technology, stats in tokei_data.items():
             if technology == "Total":
@@ -155,8 +196,11 @@ class ProjectScanner:
             logger.debug(f"Found: {pl}")
             if pl.is_supported_lang():
                 programming_languages.append(pl)
+            elif technology in UNSUPPORTED_CODE_LANGUAGES:
+                unsupported_code.append(pl)
 
         self.all_text_files = all_files
+        self.unsupported_code_languages = unsupported_code
         track_tech_stack(self.repo_location, total_code, programming_languages)
         return programming_languages
 

--- a/tests/diagram_analysis/test_diagram_analysis.py
+++ b/tests/diagram_analysis/test_diagram_analysis.py
@@ -1683,6 +1683,7 @@ class TestDiagramGenerator(unittest.TestCase):
             sub_analyses,
             file_coverage_summary,
             tree_spec,
+            run_diagnostics,
         ):
             captured["expandable_components"] = expandable_components
             return "{}"

--- a/tests/diagram_analysis/test_run_diagnostics_persistence.py
+++ b/tests/diagram_analysis/test_run_diagnostics_persistence.py
@@ -1,0 +1,89 @@
+"""A run's diagnostics ride in analysis.json metadata, and never outlive the run."""
+
+import json
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+from agents.agent_responses import AnalysisInsights, Component
+from diagram_analysis.io_utils import load_analysis_metadata, save_analysis
+from run_diagnostics import RunDiagnostics
+from run_diagnostics.catalog import language_engine_failed
+
+
+class TestRunDiagnosticsPersistence(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = Path(tempfile.mkdtemp())
+        self.analysis = AnalysisInsights(
+            description="root",
+            components=[Component(name="A", description="", key_entities=[], component_id="1")],
+            components_relations=[],
+        )
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def _save(self, run_diagnostics):
+        return save_analysis(
+            analysis=self.analysis,
+            output_dir=self.temp_dir,
+            sub_analyses={},
+            repo_name="repo",
+            repo_dir=self.temp_dir,
+            source_tree_hash="abc",
+            depth_cap=2,
+            run_diagnostics=run_diagnostics,
+        )
+
+    def _metadata(self) -> dict:
+        metadata = load_analysis_metadata(self.temp_dir)
+        assert metadata is not None
+        return metadata
+
+    def test_a_clean_run_writes_an_empty_report(self):
+        self._save(RunDiagnostics().report())
+        report = self._metadata()["run_diagnostics"]
+        self.assertEqual((report["degraded"], report["notices"], report["entries"]), (0, 0, []))
+
+    def test_a_degradation_reaches_the_document_with_its_wording(self):
+        collector = RunDiagnostics()
+        collector.record(language_engine_failed("TypeScript", "tsserver exited"))
+
+        self._save(collector.report())
+
+        report = self._metadata()["run_diagnostics"]
+        self.assertEqual(report["degraded"], 1)
+        entry = report["entries"][0]
+        self.assertEqual(entry["code"], "static.language_engine_failed")
+        self.assertEqual(entry["subject"], "TypeScript")
+        self.assertIn("tsserver exited", entry["detail"])
+        self.assertTrue(entry["remedy"])
+
+    def test_a_later_clean_save_clears_the_previous_run_report(self):
+        """Unlike the tree spec, diagnostics describe one run: inheriting them would lie."""
+        collector = RunDiagnostics()
+        collector.record(language_engine_failed("TypeScript", "tsserver exited"))
+        self._save(collector.report())
+
+        self._save(RunDiagnostics().report())
+
+        self.assertEqual(self._metadata()["run_diagnostics"]["entries"], [])
+
+    def test_an_intermediate_save_that_omits_the_report_writes_an_empty_one(self):
+        self._save(None)
+        self.assertEqual(self._metadata()["run_diagnostics"]["entries"], [])
+
+    def test_an_analysis_written_before_the_field_existed_still_parses(self):
+        self._save(RunDiagnostics().report())
+        path = self.temp_dir / "analysis.json"
+        data = json.loads(path.read_text())
+        del data["metadata"]["run_diagnostics"]
+        path.write_text(json.dumps(data))
+
+        # Reading through the store must not raise on the missing key.
+        self.assertNotIn("run_diagnostics", self._metadata())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/run_diagnostics/test_run_diagnostics.py
+++ b/tests/run_diagnostics/test_run_diagnostics.py
@@ -1,0 +1,84 @@
+"""The collector that decides what a finished run admits to."""
+
+import unittest
+
+from run_diagnostics import Diagnostic, DiagnosticSeverity, RunDiagnostics
+from run_diagnostics.catalog import (
+    language_engine_failed,
+    language_not_supported,
+    names_not_generated,
+)
+
+
+def _notice(code: str, subject: str = "") -> Diagnostic:
+    return Diagnostic(
+        code=code,
+        severity=DiagnosticSeverity.NOTICE,
+        title="t",
+        detail="d",
+        subject=subject,
+    )
+
+
+class TestRunDiagnostics(unittest.TestCase):
+    def test_an_empty_collector_is_falsy(self):
+        self.assertFalse(RunDiagnostics())
+
+    def test_repeats_of_one_code_and_subject_collapse_into_a_count(self):
+        collector = RunDiagnostics()
+        collector.record(language_engine_failed("TypeScript", "boom"))
+        collector.record(language_engine_failed("TypeScript", "boom again"))
+
+        entries = collector.entries()
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0].count, 2)
+        # The first recording's wording wins, so the count never contradicts the detail.
+        self.assertIn("boom)", entries[0].detail)
+
+    def test_the_same_code_for_two_subjects_stays_two_entries(self):
+        collector = RunDiagnostics()
+        collector.record(language_engine_failed("TypeScript", "boom"))
+        collector.record(language_engine_failed("Go", "boom"))
+
+        self.assertEqual([e.subject for e in collector.entries()], ["Go", "TypeScript"])
+
+    def test_degraded_entries_sort_ahead_of_notices(self):
+        collector = RunDiagnostics()
+        collector.record(_notice("a.notice"))
+        collector.record(names_not_generated(1, 4))
+
+        self.assertEqual(
+            [e.severity for e in collector.entries()],
+            [DiagnosticSeverity.DEGRADED, DiagnosticSeverity.NOTICE],
+        )
+
+    def test_the_report_counts_each_severity(self):
+        collector = RunDiagnostics()
+        collector.record(language_engine_failed("Go", "boom"))
+        collector.record(names_not_generated(1, 4))
+        collector.record(_notice("a.notice"))
+
+        report = collector.report()
+        self.assertEqual((report.degraded, report.notices), (2, 1))
+        self.assertEqual(len(report.entries), 3)
+
+    def test_absorbing_another_collector_takes_its_records(self):
+        static_analysis = RunDiagnostics()
+        static_analysis.record(language_engine_failed("Go", "boom"))
+        run = RunDiagnostics()
+        run.record(names_not_generated(1, 4))
+
+        run.absorb(static_analysis)
+
+        self.assertEqual(
+            {e.code for e in run.entries()}, {"static.language_engine_failed", "semantics.names_not_generated"}
+        )
+
+    def test_a_cause_the_reader_cannot_fix_carries_no_remedy(self):
+        """Consumers branch on an empty remedy to offer "report this" instead of an instruction."""
+        self.assertEqual(language_not_supported("Kotlin", 30.0).remedy, "")
+        self.assertNotEqual(language_engine_failed("Go", "boom").remedy, "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/static_analyzer/test_max_concurrent_engines.py
+++ b/tests/static_analyzer/test_max_concurrent_engines.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from run_diagnostics import RunDiagnostics
 from static_analyzer.config import Language
 from static_analyzer import (
     MAX_CONCURRENT_ENGINES_ENV_VAR,
@@ -158,6 +159,7 @@ class TestBoundedFullPass:
         analyzer = StaticAnalyzer.__new__(StaticAnalyzer)
         analyzer.repository_path = tmp_path
         analyzer.collected_diagnostics = {}
+        analyzer.run_diagnostics = RunDiagnostics()
         analyzer._engine_clients = []
         analyzer._engine_configs = []
         for i in range(engines):

--- a/tests/static_analyzer/test_run_diagnostics_collection.py
+++ b/tests/static_analyzer/test_run_diagnostics_collection.py
@@ -1,0 +1,114 @@
+"""What the static-analysis pass records when a language does not make it into the graph."""
+
+import shutil
+import tempfile
+import threading
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from run_diagnostics import RunDiagnostics
+from run_diagnostics.catalog import language_engine_failed
+from static_analyzer import EngineConfig, StaticAnalyzer
+from static_analyzer.analysis_cache import StaticAnalysisCache
+from static_analyzer.analysis_result import StaticAnalysisResults
+from static_analyzer.scanner import UNSUPPORTED_CODE_LANGUAGES
+from utils import CODEBOARDING_DIR_NAME
+
+
+def _engine_config(language: str, project_path: Path, source_files: list[Path]) -> EngineConfig:
+    adapter = MagicMock()
+    adapter.language = language
+    adapter.discover_source_files = MagicMock(return_value=source_files)
+    return EngineConfig(adapter, project_path, source_files=list(source_files))
+
+
+class TestStartClientsDiagnostics(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = Path(tempfile.mkdtemp())
+        self.analyzer = StaticAnalyzer.__new__(StaticAnalyzer)
+        self.analyzer.repository_path = self.temp_dir
+        self.analyzer.ignore_manager = MagicMock()
+        self.analyzer.run_diagnostics = RunDiagnostics()
+        self.analyzer._prepared_projects = {}
+        self.analyzer._prepared_lock = threading.Lock()
+        self.analyzer._clients_started = False
+        self.analyzer._engine_clients = []
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def _codes(self) -> dict[str, str]:
+        return {entry.code: entry.subject for entry in self.analyzer.run_diagnostics.entries()}
+
+    def test_a_server_that_never_starts_is_reported_against_its_language(self):
+        self.analyzer._engine_configs = [
+            _engine_config("CSharp", self.temp_dir, [self.temp_dir / "A.cs"]),
+            _engine_config("Python", self.temp_dir, [self.temp_dir / "a.py"]),
+        ]
+        self.analyzer._spawn_engine_client = MagicMock(side_effect=[RuntimeError("csharp-ls missing"), MagicMock()])
+
+        self.analyzer.start_clients()
+
+        entries = self.analyzer.run_diagnostics.entries()
+        self.assertEqual([e.code for e in entries], ["static.language_server_unavailable"])
+        self.assertEqual(entries[0].subject, "CSharp")
+        self.assertIn("csharp-ls missing", entries[0].detail)
+
+    def test_a_language_with_nothing_to_index_anywhere_is_reported_once(self):
+        self.analyzer._engine_configs = [
+            _engine_config("TypeScript", self.temp_dir / "a", []),
+            _engine_config("TypeScript", self.temp_dir / "b", []),
+            _engine_config("Python", self.temp_dir, [self.temp_dir / "a.py"]),
+        ]
+        self.analyzer._spawn_engine_client = MagicMock(return_value=MagicMock())
+
+        self.analyzer.start_clients()
+
+        self.assertEqual(self._codes(), {"static.no_source_files": "TypeScript"})
+
+    def test_one_empty_project_in_a_monorepo_is_not_a_hole(self):
+        """A language that indexed somewhere is in the graph; saying otherwise is noise."""
+        self.analyzer._engine_configs = [
+            _engine_config("CSharp", self.temp_dir / "a", []),
+            _engine_config("CSharp", self.temp_dir / "b", [self.temp_dir / "b" / "A.cs"]),
+        ]
+        self.analyzer._spawn_engine_client = MagicMock(return_value=MagicMock())
+
+        self.analyzer.start_clients()
+
+        self.assertEqual(self._codes(), {})
+
+
+class TestUnsupportedCodeLanguages(unittest.TestCase):
+    def test_data_formats_are_not_treated_as_unanalyzed_code(self):
+        """Tokei counts JSON and Markdown as languages; reporting them would be nonsense."""
+        for technology in ("JSON", "YAML", "Markdown", "Plain Text", "Shell", "TOML", "HTML", "CSS"):
+            self.assertNotIn(technology, UNSUPPORTED_CODE_LANGUAGES)
+
+    def test_real_languages_without_a_server_are_reportable(self):
+        for technology in ("Kotlin", "Ruby", "Swift", "C++"):
+            self.assertIn(technology, UNSUPPORTED_CODE_LANGUAGES)
+
+
+class TestDiagnosticsAreNotCached(unittest.TestCase):
+    def test_the_pickle_never_carries_a_previous_run_report(self):
+        temp_dir = Path(tempfile.mkdtemp())
+        try:
+            cache = StaticAnalysisCache(temp_dir / CODEBOARDING_DIR_NAME, temp_dir)
+            results = StaticAnalysisResults()
+            results.run_diagnostics.record(language_engine_failed("Go", "boom"))
+
+            cache.save(results, source_sha="sha")
+            loaded = cache.get()
+
+            assert loaded is not None
+            self.assertEqual(loaded.run_diagnostics.entries(), [])
+            # The live object keeps its own; only the artifact is stripped.
+            self.assertEqual(len(results.run_diagnostics.entries()), 1)
+        finally:
+            shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Introduces a comprehensive run diagnostics system that tracks and reports degradations that occur during analysis without stopping the run. This allows the system to transparently communicate when a diagram is incomplete due to language server failures, unsupported languages, missing source files, or other issues.

## Why this exists

A run that raises never reaches a consumer with a half-truth: the CLI exits non-zero and nothing is written. The dangerous case is the run that *finishes* with less than it should have and hands over an `analysis.json` that parses, renders, and looks exactly like a good one. Read as complete, an absent language reads as a repository that does not contain it, which is a claim the run never made. Today those cases are log lines nobody downstream ever sees.

The degradations this closes over, all previously silent:

| Site | What the reader loses |
|---|---|
| `static_analyzer/__init__.py` partial LSP coverage | A whole language contributes no component, call or relation |
| Per-language engine failure during indexing | That language's symbols never enter the CFG |
| A detected language with nothing left to index | Usually an ignore rule or a `tsconfig` include, and fixable |
| A material share of the repo in an unsupported language | Those files, and anything only they reach |
| Semantic naming falling back | Components named after folders rather than what they do |

Terminal errors are deliberately untouched: `LLMAuthError`, `LLMConfigError`, `PlannerUnavailableError`, `StaticAnalysisFatalError`, `BaselineUnavailableError` and the scope invariants already stop the run and already surface. This is only about what survives.

## Key Changes

- **New `run_diagnostics` module** with:
  - `models.py`: Core types (`Diagnostic`, `DiagnosticSeverity`, `RunDiagnostics`, `RunDiagnosticsReport`) for collecting and reporting degradations
  - `catalog.py`: Builders for known degradation types with user-facing wording (language server unavailable, engine failed, language not supported, no source files, naming incomplete)

- **Static analyzer integration**:
  - `StaticAnalyzer` now tracks a `run_diagnostics` collector throughout the analysis
  - Records unsupported languages that exceed a 5% threshold of the codebase
  - Records language servers that fail to start with specific error reasons
  - Records languages with no indexable source files (deduped to avoid noise)
  - New `_record_languages_without_sources()` method to identify and report languages with empty projects

- **Scanner enhancement**:
  - `ProjectScanner` now tracks `unsupported_code_languages` separately from supported ones
  - Added `UNSUPPORTED_CODE_LANGUAGES` constant to distinguish real programming languages from data formats (JSON, YAML, Markdown, etc.)

- **Persistence**:
  - Diagnostics are serialized in `analysis.json` metadata under `run_diagnostics`
  - Diagnostics are intentionally NOT cached: each run's report is independent and never inherited
  - `StaticAnalysisCache` strips diagnostics before pickling to prevent stale reports

- **Diagram generation**:
  - `DiagramGenerator` absorbs static analyzer diagnostics and records semantic naming failures
  - Reports are passed through to final analysis output

## Notable Implementation Details

- **Thread-safe recording**: Uses a `deque` for thread-safe appends from the engine thread pool without requiring locks. That is also what keeps the collector picklable and deep-copyable, which it has to be to ride on `StaticAnalysisResults`
- **Deduplication**: Identical `(code, subject)` pairs are merged with counts summed to avoid burying important messages
- **Severity levels**: `degraded` (missing structure) vs `notice` (whole but worth knowing)
- **Remedy field**: Empty when the reader cannot fix the issue; consumers offer "report this" instead of instructions
- **Backward compatibility**: Missing `run_diagnostics` key in older analysis files is handled gracefully

## Two judgment calls worth a reviewer's attention

- **The unsupported-language allow-list.** Tokei counts JSON, YAML and Markdown as languages, so an inverted (deny-list) rule would eventually report "JSON is not analyzed", which is nonsense. `UNSUPPORTED_CODE_LANGUAGES` therefore names program-code languages explicitly and stays silent on anything it does not recognise. It needs a line when a language gains or loses a server.
- **A partial run overwrites the report.** `finalize_and_save` writes this run's report unconditionally, so a `partial` run replaces a full run's. Language-level entries stay accurate (partial re-runs static analysis over the whole repo); the naming count covers only the regenerated scope. The alternative, merging into a previous run's report, would claim things about code this run never looked at.

## Tests

Comprehensive test coverage includes:
- Collector behavior and deduplication
- Server startup failures and language-specific reporting
- Empty project detection in monorepos
- Unsupported language classification
- Cache behavior (diagnostics not persisted)
- Persistence in analysis.json and metadata handling

Locally: 2110 passed, `mypy` clean over 310 files, `black` clean. One pre-existing failure in `tests/test_registry_coverage.py::test_missing_artifact_is_detected_for_every_kind`, which fails on `main` too and is unrelated to this change.

## Companion changes

This is one change across three repositories, all on the branch `claude/codeboarding-webview-errors-x3e0sw`:

- This PR writes `metadata.run_diagnostics`.
- CodeBoarding/CodeBoarding-action#124 reads it back into annotations, the job summary and the review comment.
- `CodeBoarding-webview` #127 banners it above the diagram.

Merge order does not matter and nothing breaks if the others never land: both consumers treat a missing field as silence. Note that the action only picks this up once its `codeboarding==` pin is bumped to a release containing this change.

https://claude.ai/code/session_01BSnQMqJKj7zbdfjy7KHF9x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added run diagnostics to analysis results, identifying issues such as unavailable language services, unsupported languages, missing source files, and incomplete naming.
  * Diagnostics include severity, details, counts, and suggested remedies where applicable.
  * Reports are scoped to the current run and persist in analysis output without carrying over from previous runs.

* **Documentation**
  * Added guidance for interpreting run diagnostics and displaying degraded-run warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->