### PR TITLE
fix(csharp): let csharp-ls find restore assets in UseArtifactsOutput solutions

### DIFF
--- a/static_analyzer/dotnet_solution.py
+++ b/static_analyzer/dotnet_solution.py
@@ -1,0 +1,29 @@
+"""The projects a .NET solution file lists."""
+
+from __future__ import annotations
+
+import re
+import xml.etree.ElementTree as ElementTree
+from pathlib import Path
+
+PROJECT_SUFFIXES = (".csproj", ".fsproj")
+# ``Project("{type guid}") = "Name", "relative\path.csproj", "{project guid}"``
+_SLN_PROJECT_LINE = re.compile(r'^Project\("\{[^}]*\}"\)\s*=\s*"[^"]*",\s*"([^"]+)"', re.MULTILINE)
+
+
+def solution_projects(solution: Path) -> list[Path]:
+    """The project files a ``.sln`` or ``.slnx`` lists, absolute, in listing order.
+
+    Solution folders and files that do not exist are left out; a ``.sln`` names
+    its solution folders with the same ``Project(...)`` syntax as its projects.
+    """
+    if solution.suffix.lower() == ".slnx":
+        listed = [element.get("Path") or "" for element in ElementTree.parse(solution).iter("Project")]
+    else:
+        listed = _SLN_PROJECT_LINE.findall(solution.read_text(encoding="utf-8-sig", errors="replace"))
+    projects: list[Path] = []
+    for raw in listed:
+        path = (solution.parent / raw.replace("\\", "/")).resolve()
+        if path.suffix.lower() in PROJECT_SUFFIXES and path.is_file() and path not in projects:
+            projects.append(path)
+    return projects

--- a/static_analyzer/engine/adapters/csharp_adapter.py
+++ b/static_analyzer/engine/adapters/csharp_adapter.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from repo_utils.ignore import RepoIgnoreManager
 from static_analyzer.config import Language, NodeType
 from static_analyzer.dotnet_sdk import DotnetSdkError, resolve_dotnet_sdk, system_dotnet_env
+from static_analyzer.dotnet_solution import solution_projects
 from static_analyzer.engine.language_adapter import LanguageAdapter
 from static_analyzer.engine.lsp_client import LSPClient
 from static_analyzer.engine.lsp_constants import EdgeStrategy
@@ -51,6 +52,7 @@ _SINGLE_TARGET_FRAMEWORK_TARGETS = r"""<Project>
 
 _WORKSPACE_TARGET_FRAMEWORK_PROPS = r"""<Project TreatAsLocalProperty="TargetFramework">
   <PropertyGroup>
+    <_DirectoryBuildPropsBasePath Condition="'$(_DirectoryBuildPropsBasePath)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove('$(MSBuildProjectDirectory)', 'Directory.Build.props'))</_DirectoryBuildPropsBasePath>
     <CodeBoardingWorkspaceTargetFramework>$(TargetFramework)</CodeBoardingWorkspaceTargetFramework>
     <CodeBoardingDirectoryBuildPropsPath Condition="'$(CodeBoardingOriginalDirectoryBuildPropsPath)' == ''">$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildProjectDirectory)'))</CodeBoardingDirectoryBuildPropsPath>
   </PropertyGroup>
@@ -91,6 +93,10 @@ def _single_target_framework_env(project_root: Path) -> dict[str, str]:
     solution load into unbounded growth. ``TreatAsLocalProperty`` demotes the
     property so each project sees its declared framework again. Roslyn retains
     its normal inner-build expansion for projects that genuinely multi-target.
+
+    Why the base path: ``UseArtifactsOutput`` derives its ``artifacts`` root from
+    ``_DirectoryBuildPropsBasePath``, which the SDK computes only when it found
+    ``Directory.Build.props`` itself rather than being handed a path.
 
     Folding a multi-target project down to a single framework stays behind
     ``_MULTI_TARGET_PROJECT_THRESHOLD``, because that fold discards frameworks a
@@ -327,6 +333,9 @@ class CSharpAdapter(LanguageAdapter):
         emits a flood of bogus ``CS0518: Predefined type System.X is not
         defined`` diagnostics for every file. Restore is idempotent and
         only writes under ``obj/`` (which we already gitignore).
+
+        Restore runs under the MSBuild environment csharp-ls gets, so the two
+        evaluate every path the same way and the server finds what restore wrote.
         """
         # Find solution or csproj/fsproj at the project_root level
         target = next(iter(project_root.glob("*.sln")), None)
@@ -346,29 +355,17 @@ class CSharpAdapter(LanguageAdapter):
             raise RuntimeError(str(exc)) from exc
 
         env = os.environ.copy()
-        env.update(resolution.env)
-        try:
-            result = subprocess.run(
-                [resolution.dotnet_path, "restore", str(target.name), "--nologo", "--verbosity", "minimal"],
-                cwd=str(project_root),
-                env=env,
-                capture_output=True,
-                text=True,
-                timeout=600,
-            )
-            if result.returncode != 0:
-                logger.warning(
-                    "dotnet restore failed for %s (exit %d): %s",
-                    target.name,
-                    result.returncode,
-                    (result.stderr or result.stdout)[-500:],
-                )
-            else:
-                logger.info("dotnet restore completed for %s", target.name)
-        except subprocess.TimeoutExpired:
-            logger.warning("dotnet restore timed out after 600s for %s", target.name)
-        except OSError as exc:
-            logger.warning("dotnet restore could not be invoked: %s", exc)
+        env.update(self.get_lsp_env(project_root))
+        if self._restore(resolution.dotnet_path, target, project_root, env) or target.suffix not in (".sln", ".slnx"):
+            return
+        # A solution restore evaluates every project before writing any assets, so one
+        # project it cannot evaluate (a missing workload, a broken import) leaves the
+        # rest without ``project.assets.json`` -- and csharp-ls then resolves no package
+        # or transitive project reference anywhere. Each member on its own only fails
+        # for itself.
+        projects = solution_projects(target)
+        restored = sum(self._restore(resolution.dotnet_path, project, project_root, env) for project in projects)
+        logger.info("dotnet restore per project: %d of %d restored", restored, len(projects))
 
     def get_lsp_env(self, project_root: Path | None = None) -> dict[str, str]:
         """Return the .NET environment needed by csharp-ls.
@@ -412,3 +409,30 @@ class CSharpAdapter(LanguageAdapter):
             elif self.is_class_like(kind):
                 found.append(sym.get("name", ""))
         return found
+
+    def _restore(self, dotnet_path: str, target: Path, project_root: Path, env: dict[str, str]) -> bool:
+        try:
+            result = subprocess.run(
+                [dotnet_path, "restore", os.path.relpath(target, project_root), "--nologo", "--verbosity", "minimal"],
+                cwd=str(project_root),
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=600,
+            )
+        except subprocess.TimeoutExpired:
+            logger.warning("dotnet restore timed out after 600s for %s", target.name)
+            return False
+        except OSError as exc:
+            logger.warning("dotnet restore could not be invoked: %s", exc)
+            return False
+        if result.returncode != 0:
+            logger.warning(
+                "dotnet restore failed for %s (exit %d): %s",
+                target.name,
+                result.returncode,
+                (result.stderr or result.stdout)[-500:],
+            )
+            return False
+        logger.info("dotnet restore completed for %s", target.name)
+        return True

--- a/tests/static_analyzer/test_csharp_adapter.py
+++ b/tests/static_analyzer/test_csharp_adapter.py
@@ -478,6 +478,10 @@ class TestLspEnv:
         assert (
             "<CodeBoardingWorkspaceTargetFramework>$(TargetFramework)</CodeBoardingWorkspaceTargetFramework>" in props
         )
+        # UseArtifactsOutput derives the artifacts root from this; the SDK skips it when
+        # DirectoryBuildPropsPath arrives from outside.
+        assert "<_DirectoryBuildPropsBasePath Condition=\"'$(_DirectoryBuildPropsBasePath)' == ''\">" in props
+        assert props.index("<_DirectoryBuildPropsBasePath") < props.index("<Import")
         targets = Path(env["DirectoryBuildTargetsPath"]).read_text()
         assert "<TargetFramework Condition=" not in targets
         assert "<TargetFramework>$(TargetFrameworks)</TargetFramework>" not in targets
@@ -537,115 +541,121 @@ class TestPrepareProject:
     """``prepare_project`` runs ``dotnet restore`` so csharp-ls sees framework
     references; without it diagnostics are flooded with bogus CS0518."""
 
-    def test_runs_dotnet_restore_when_csproj_present(self, tmp_path, monkeypatch):
-        (tmp_path / "Foo.csproj").write_text("<Project />")
-
-        called = {}
+    @pytest.fixture(autouse=True)
+    def _fake_toolchain(self, tmp_path, monkeypatch):
+        self.commands: list[list[str]] = []
+        self.envs: list[dict[str, str]] = []
+        self.failing: set[str] = set()
 
         def fake_run(cmd, **kwargs):
-            called["cmd"] = cmd
-            called["cwd"] = kwargs.get("cwd")
-            called["env"] = kwargs.get("env")
-            return MagicMock(returncode=0, stdout="", stderr="")
+            self.commands.append(cmd)
+            self.envs.append(kwargs.get("env", {}))
+            self.cwd = kwargs.get("cwd")
+            failed = cmd[2] in self.failing
+            return MagicMock(returncode=1 if failed else 0, stdout="", stderr="NETSDK1147 workload missing")
 
-        monkeypatch.setattr(
-            "static_analyzer.engine.adapters.csharp_adapter.subprocess.run",
-            fake_run,
-        )
+        monkeypatch.setattr("static_analyzer.engine.adapters.csharp_adapter.subprocess.run", fake_run)
         monkeypatch.setattr(
             "static_analyzer.engine.adapters.csharp_adapter.resolve_dotnet_sdk",
             lambda _root: _dotnet_resolution("/opt/dotnet/dotnet", {"DOTNET_ROOT": "/opt/dotnet"}),
         )
-        CSharpAdapter().prepare_project(tmp_path)
-        assert called["cmd"][:2] == ["/opt/dotnet/dotnet", "restore"]
-        assert called["cmd"][2] == "Foo.csproj"
-        assert called["cwd"] == str(tmp_path)
-        assert called["env"]["DOTNET_ROOT"] == "/opt/dotnet"
+        monkeypatch.setattr("static_analyzer.engine.adapters.csharp_adapter.get_servers_dir", lambda: tmp_path)
 
-    def test_prefers_solution_over_csproj(self, tmp_path, monkeypatch):
-        (tmp_path / "Foo.sln").write_text("")
-        (tmp_path / "Foo.csproj").write_text("<Project />")
+    @staticmethod
+    def _project(root: Path, relative: str) -> None:
+        (root / relative).parent.mkdir(parents=True, exist_ok=True)
+        (root / relative).write_text("<Project />")
 
-        called = {}
-
-        def fake_run(cmd, **kwargs):
-            called["cmd"] = cmd
-            return MagicMock(returncode=0, stdout="", stderr="")
-
-        monkeypatch.setattr(
-            "static_analyzer.engine.adapters.csharp_adapter.subprocess.run",
-            fake_run,
+    @staticmethod
+    def _solution(root: Path, name: str, *projects: str) -> None:
+        (root / name).write_text(
+            "<Solution>" + "".join(f'<Project Path="{project}" />' for project in projects) + "</Solution>"
         )
-        monkeypatch.setattr(
-            "static_analyzer.engine.adapters.csharp_adapter.resolve_dotnet_sdk",
-            lambda _root: _dotnet_resolution(),
-        )
+
+    def test_runs_dotnet_restore_when_csproj_present(self, tmp_path):
+        self._project(tmp_path, "Foo.csproj")
+
         CSharpAdapter().prepare_project(tmp_path)
-        assert called["cmd"][2] == "Foo.sln"
+
+        assert self.commands == [["/opt/dotnet/dotnet", "restore", "Foo.csproj", "--nologo", "--verbosity", "minimal"]]
+        assert self.cwd == str(tmp_path)
+        assert self.envs[0]["DOTNET_ROOT"] == "/opt/dotnet"
+
+    def test_restore_runs_under_the_environment_csharp_ls_gets(self, tmp_path):
+        """The two evaluate every path the same way, so the server finds what restore wrote."""
+        self._project(tmp_path, "Foo.csproj")
+
+        CSharpAdapter().prepare_project(tmp_path)
+
+        expected = CSharpAdapter().get_lsp_env(tmp_path)
+        assert {key: self.envs[0][key] for key in expected} == expected
+        assert Path(self.envs[0]["DirectoryBuildPropsPath"]).is_file()
+
+    def test_prefers_solution_over_csproj(self, tmp_path):
+        self._solution(tmp_path, "Foo.slnx", "Foo.csproj")
+        self._project(tmp_path, "Foo.csproj")
+
+        CSharpAdapter().prepare_project(tmp_path)
+
+        assert [cmd[2] for cmd in self.commands] == ["Foo.slnx"]
 
     def test_skips_when_no_project_file(self, tmp_path, monkeypatch):
-        def fake_run(*_args, **_kwargs):
-            raise AssertionError("subprocess.run should not be called")
-
         def fake_resolve(*_args, **_kwargs):
             raise AssertionError("resolve_dotnet_sdk should not be called")
 
-        monkeypatch.setattr(
-            "static_analyzer.engine.adapters.csharp_adapter.subprocess.run",
-            fake_run,
-        )
-        monkeypatch.setattr(
-            "static_analyzer.engine.adapters.csharp_adapter.resolve_dotnet_sdk",
-            fake_resolve,
-        )
-        CSharpAdapter().prepare_project(tmp_path)  # no exception
+        monkeypatch.setattr("static_analyzer.engine.adapters.csharp_adapter.resolve_dotnet_sdk", fake_resolve)
+
+        CSharpAdapter().prepare_project(tmp_path)
+
+        assert self.commands == []
 
     def test_raises_when_sdk_unavailable(self, tmp_path, monkeypatch):
-        (tmp_path / "Foo.csproj").write_text("<Project />")
-
-        def fake_run(*_args, **_kwargs):
-            raise AssertionError("subprocess.run should not be called")
-
-        monkeypatch.setattr(
-            "static_analyzer.engine.adapters.csharp_adapter.subprocess.run",
-            fake_run,
-        )
+        self._project(tmp_path, "Foo.csproj")
         monkeypatch.setattr(
             "static_analyzer.engine.adapters.csharp_adapter.resolve_dotnet_sdk",
             lambda _root: (_ for _ in ()).throw(DotnetSdkError("compatible .NET SDK was not found")),
         )
+
         with pytest.raises(RuntimeError, match="compatible .NET SDK"):
             CSharpAdapter().prepare_project(tmp_path)
+        assert self.commands == []
 
-    def test_swallows_restore_failure(self, tmp_path, monkeypatch):
-        (tmp_path / "Foo.csproj").write_text("<Project />")
+    def test_a_failed_project_restore_is_not_retried(self, tmp_path):
+        self._project(tmp_path, "Foo.csproj")
+        self.failing = {"Foo.csproj"}
 
-        def fake_run(cmd, **kwargs):
-            return MagicMock(returncode=1, stdout="", stderr="boom")
+        CSharpAdapter().prepare_project(tmp_path)  # a warning, not an abort
 
-        monkeypatch.setattr(
-            "static_analyzer.engine.adapters.csharp_adapter.subprocess.run",
-            fake_run,
-        )
-        monkeypatch.setattr(
-            "static_analyzer.engine.adapters.csharp_adapter.resolve_dotnet_sdk",
-            lambda _root: _dotnet_resolution(),
-        )
-        # Should not raise — restore failures are warnings, not aborts.
+        assert [cmd[2] for cmd in self.commands] == ["Foo.csproj"]
+
+    def test_restores_each_member_when_the_solution_restore_fails(self, tmp_path):
+        """One project a solution restore cannot evaluate leaves every other project
+        without assets; the fallback restores the solution's members on their own,
+        and only them."""
+        self._solution(tmp_path, "App.slnx", "src/Lib/Lib.csproj", "src/Mobile/Mobile.csproj")
+        self._project(tmp_path, "src/Lib/Lib.csproj")
+        self._project(tmp_path, "src/Mobile/Mobile.csproj")
+        self._project(tmp_path, "samples/Demo/Demo.csproj")
+        self.failing = {"App.slnx", "src/Mobile/Mobile.csproj"}
+
         CSharpAdapter().prepare_project(tmp_path)
 
+        assert [cmd[2] for cmd in self.commands] == ["App.slnx", "src/Lib/Lib.csproj", "src/Mobile/Mobile.csproj"]
+
+    def test_no_per_project_fallback_after_a_successful_solution_restore(self, tmp_path):
+        self._solution(tmp_path, "App.slnx", "Lib.csproj")
+        self._project(tmp_path, "Lib.csproj")
+
+        CSharpAdapter().prepare_project(tmp_path)
+
+        assert [cmd[2] for cmd in self.commands] == ["App.slnx"]
+
     def test_handles_subprocess_timeout(self, tmp_path, monkeypatch):
-        (tmp_path / "Foo.csproj").write_text("<Project />")
+        self._project(tmp_path, "Foo.csproj")
 
         def fake_run(cmd, **kwargs):
             raise subprocess.TimeoutExpired(cmd=cmd, timeout=1)
 
-        monkeypatch.setattr(
-            "static_analyzer.engine.adapters.csharp_adapter.subprocess.run",
-            fake_run,
-        )
-        monkeypatch.setattr(
-            "static_analyzer.engine.adapters.csharp_adapter.resolve_dotnet_sdk",
-            lambda _root: _dotnet_resolution(),
-        )
+        monkeypatch.setattr("static_analyzer.engine.adapters.csharp_adapter.subprocess.run", fake_run)
+
         CSharpAdapter().prepare_project(tmp_path)  # no exception

--- a/tests/static_analyzer/test_dotnet_solution.py
+++ b/tests/static_analyzer/test_dotnet_solution.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+
+from static_analyzer.dotnet_solution import solution_projects
+
+
+def _touch(path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("<Project />")
+    return path
+
+
+def test_a_sln_lists_its_projects_and_not_its_solution_folders(tmp_path: Path) -> None:
+    core = _touch(tmp_path / "src" / "Core" / "Core.csproj")
+    tests = _touch(tmp_path / "test" / "Core.Tests" / "Core.Tests.fsproj")
+    (tmp_path / "App.sln").write_text(
+        "\ufeffMicrosoft Visual Studio Solution File, Format Version 12.00\n"
+        'Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{79FE9DBE}"\n'
+        'Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Core", "src\\Core\\Core.csproj", "{E273E6D8}"\n'
+        'Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Core.Tests", "test\\Core.Tests\\Core.Tests.fsproj", "{F771DF22}"\n'
+        'Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Gone", "src\\Gone\\Gone.csproj", "{BED2624C}"\n'
+    )
+
+    assert solution_projects(tmp_path / "App.sln") == [core, tests]
+
+
+def test_a_slnx_lists_its_projects_including_those_in_folders(tmp_path: Path) -> None:
+    app = _touch(tmp_path / "App" / "App.csproj")
+    lib = _touch(tmp_path / "src" / "Lib" / "Lib.csproj")
+    (tmp_path / "App.slnx").write_text(
+        "<Solution>\n"
+        '  <Project Path="App/App.csproj" />\n'
+        '  <Folder Name="/src/">\n'
+        '    <Project Path="src/Lib/Lib.csproj" />\n'
+        '    <Project Path="src/Missing/Missing.csproj" />\n'
+        "  </Folder>\n"
+        "</Solution>\n"
+    )
+
+    assert solution_projects(tmp_path / "App.slnx") == [app, lib]
+
+
+def test_a_project_listed_twice_appears_once(tmp_path: Path) -> None:
+    app = _touch(tmp_path / "App" / "App.csproj")
+    (tmp_path / "App.slnx").write_text(
+        '<Solution><Project Path="App/App.csproj" /><Project Path="App\\App.csproj" /></Solution>'
+    )
+
+    assert solution_projects(tmp_path / "App.slnx") == [app]


### PR DESCRIPTION
## Why

eShop's `AddSubscription<T, TH>(this IEventBusBuilder)` is called 18 times across 6 functions and had **zero** incoming call edges. Logged at the LSP boundary: csharp-ls answered every `textDocument/definition` with `[]`, no error. Not a generic/extension-method problem: the design-time build had no `project.assets.json`, so every package type and every *transitive* project reference was unresolved (`CS0012: IEventBusBuilder is defined in an assembly that is not referenced`), and the call could not bind.

Two independent causes, both in `CSharpAdapter`:

1. **The injected Directory.Build.props moved the artifacts root.** The SDK derives `ArtifactsPath` from `_DirectoryBuildPropsBasePath` (`Microsoft.NET.DefaultArtifactsPath.props`), which `Microsoft.Common.props` only computes when `DirectoryBuildPropsPath` was not supplied from outside. Ours is, so a `UseArtifactsOutput` repo evaluated `ProjectAssetsFile` as `src/WebApp/artifacts/obj/project.assets.json` while `dotnet restore` wrote `artifacts/obj/WebApp/`. The injected props now set the base path the way the SDK would have.
2. **One project killed the solution restore.** `dotnet restore eShop.slnx` fails on the MAUI test project (NETSDK1147, `maui-tizen` workload) and writes assets for nobody. On failure, each project is now restored on its own (17 of 19 succeed on eShop, ~15s).

## Measured on eShop (zero-LLM, static only)

| | before | after |
|---|---|---|
| called extension methods with no caller | 21 / 48 | 3 / 48 |
| call sites lost | 46 / 135 | 11 / 135 |
| call edges | 1376 | 1511 |
| INHERITS edges | 82 | 131 |
| error diagnostics | 2217 | 1077 (MAUI projects only) |

The residual 3 are `src/Shared/*.cs` files linked into several projects; csharp-ls serves no document symbols for those. Separate defect, next PR.

abp is not this class: its restore works and csharp-ls resolves cross-solution calls; its callerless methods are dropped later because each solution root is its own engine. Also next.

## Tests

- Unit: per-project fallback + no fallback after success + the base-path line in the props (`tests/static_analyzer/test_csharp_adapter.py`).
- Integration (paired PR https://github.com/CodeBoarding/CodeBoarding-tests/pull/38, same branch name): fixture `csharp_artifacts_output_project` (UseArtifactsOutput, App → Transport → Contracts, plus a project whose restore fails deterministically) and three tests that fail on main and pass here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for discovering existing C# and F# projects listed in `.sln` and `.slnx` solution files, including projects nested in solution folders.

* **Bug Fixes**
  * Improved project restoration when a solution-level restore fails, allowing other projects to remain analyzable.
  * Preserved artifact and intermediate output locations during restoration for artifact-based builds.
  * Avoided unnecessary per-project restoration when the solution restore succeeds.
  * Direct project restore failures now stop without triggering additional retries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## After review

The review comments pointed at two design gaps rather than local slips, so the fix changed shape:

- **Restore and csharp-ls ran under different MSBuild environments.** The base-path prop only papered over one consequence of that (and a user-exported `DirectoryBuildPropsPath` would have broken it again). Restore now runs under the exact environment csharp-ls gets (`get_lsp_env`), so the two cannot disagree on a path by construction; the base-path prop stays so both also match a plain `dotnet build`.
- **The fallback was unscoped.** It ran after any failed restore, including a plain `.csproj`, and re-restored every project under the root. It now runs only after a failed *solution* restore and restores that solution's own members, read from the `.sln`/`.slnx` (`static_analyzer/dotnet_solution.py`, also used by #582 for engine ownership). A failed project restore is not retried.
- `_restore` moved below the public API; the props docstring is a two-line Why.

Re-measured: eShop still resolves all 18 `AddSubscription` sites; assets land in `artifacts/obj/<Project>/` for `src/` and `obj/` for `tests/` (its own `Directory.Build.props`), matching the plain layout.
