### PR TITLE
fix(csharp): name the members of a file compiled into several projects

### DIFF
--- a/static_analyzer/__init__.py
+++ b/static_analyzer/__init__.py
@@ -49,6 +49,8 @@ class EngineConfig:
     adapter: LanguageAdapter
     project_path: Path
     source_files: list[Path] = field(default_factory=list)
+    # Retain discovery exclusions for incremental edits, including deleted files.
+    excluded_roots: list[Path] = field(default_factory=list)
 
 
 class StaticAnalysisFatalError(RuntimeError):
@@ -231,7 +233,11 @@ def _create_engine_configs(
                                 f"Every C# file under {csharp_config.root} belongs to a nested solution; skipping"
                             )
                             continue
-                        configs.append(EngineConfig(adapter, csharp_config.root, source_files=source_files))
+                        configs.append(
+                            EngineConfig(
+                                adapter, csharp_config.root, source_files=source_files, excluded_roots=elsewhere
+                            )
+                        )
                 else:
                     logger.info("No C# projects detected")
 
@@ -867,6 +873,11 @@ class StaticAnalyzer:
                 analysis = self._run_full_analysis(engine_config, engine_client)
                 self._absorb_into_results(results, language, analysis)
             else:
+                changed_files = {
+                    path
+                    for path in changed_files
+                    if not any(path.is_relative_to(root) for root in engine_config.excluded_roots)
+                }
                 logger.info(f"warmstart {adapter.language}: re-LSPing {len(changed_files)} changed file(s)")
                 cached_lang_dict = carried.get(language) or self._extract_language_dict(cached_results, language)
                 analysis = update_cfg_for_changed_files(

--- a/static_analyzer/__init__.py
+++ b/static_analyzer/__init__.py
@@ -12,7 +12,8 @@ from static_analyzer.analysis_cache import StaticAnalysisCache
 from static_analyzer.analysis_result import StaticAnalysisResults
 from static_analyzer.cfg import CallGraph
 from static_analyzer.config import AdapterName, Language
-from static_analyzer.csharp_config_scanner import CSharpConfigScanner
+from static_analyzer.csharp_config_scanner import SOLUTION_GLOBS, CSharpConfigScanner, CSharpProjectConfig
+from static_analyzer.dotnet_solution import solution_projects
 from static_analyzer.engine.adapters import get_adapter
 from static_analyzer.engine.call_graph_builder import CallGraphBuilder
 from static_analyzer.engine.language_adapter import LanguageAdapter
@@ -39,8 +40,10 @@ class EngineConfig:
     """One adapter + project root the engine should run.
 
     ``source_files`` is non-empty only when a scanner has authoritatively
-    resolved file membership (currently TypeScript via ``tsc --showConfig``);
-    otherwise the adapter walks ``project_path`` itself in ``_run_full_analysis``.
+    resolved file membership (TypeScript via ``tsc --showConfig``, C# by what
+    each root's solution lists); otherwise the adapter walks ``project_path``
+    itself in ``_run_full_analysis``. A config whose membership resolved to no
+    file is not created at all.
     """
 
     adapter: LanguageAdapter
@@ -121,6 +124,15 @@ def _adapter_names_for(programming_languages: list[ProgrammingLanguage]) -> list
     return names
 
 
+def _csharp_solution_members(csharp_projects: list[CSharpProjectConfig]) -> dict[Path, list[Path]]:
+    """Per C# root, the project files its solution files list."""
+    members: dict[Path, list[Path]] = {}
+    for config in csharp_projects:
+        solutions = [path for pattern in SOLUTION_GLOBS for path in config.root.glob(pattern)]
+        members[config.root] = [project for solution in solutions for project in solution_projects(solution)]
+    return members
+
+
 def _create_engine_configs(
     programming_languages: list[ProgrammingLanguage],
     repository_path: Path,
@@ -198,12 +210,28 @@ def _create_engine_configs(
                 csharp_projects = csharp_scanner.scan()
 
                 if csharp_projects:
+                    members = _csharp_solution_members(csharp_projects)
                     for csharp_config in csharp_projects:
                         logger.info(
                             f"Creating engine config for CSharp ({csharp_config.project_type}) at: "
                             f"{csharp_config.root.relative_to(repository_path)}"
                         )
-                        configs.append(EngineConfig(adapter, csharp_config.root))
+                        # A project a nested root's solution lists, and this root's solutions do not,
+                        # is that engine's; naming it here as well would put it in the graph twice.
+                        elsewhere = [
+                            project.parent
+                            for root, projects in members.items()
+                            if root != csharp_config.root and root.is_relative_to(csharp_config.root)
+                            for project in projects
+                            if project not in members[csharp_config.root]
+                        ]
+                        source_files = adapter.discover_source_files(csharp_config.root, ignore_manager, elsewhere)
+                        if not source_files:
+                            logger.info(
+                                f"Every C# file under {csharp_config.root} belongs to a nested solution; skipping"
+                            )
+                            continue
+                        configs.append(EngineConfig(adapter, csharp_config.root, source_files=source_files))
                 else:
                     logger.info("No C# projects detected")
 

--- a/static_analyzer/analysis_cache.py
+++ b/static_analyzer/analysis_cache.py
@@ -67,8 +67,10 @@ _LEGACY_CACHE_SUBDIR = "cache"
 # named after.
 # v7: the pickle no longer carries cluster lineage; components come from the tree
 # specification in analysis.json, replayed over the graph.
+# v8: a C# file compiled into several projects has symbols and callers, and a
+# nested solution's files are named by its own engine only.
 # Older pickles are treated as cache misses and re-run.
-_TAG_VERSION = "v7"
+_TAG_VERSION = "v8"
 
 
 class StaticAnalysisCache:

--- a/static_analyzer/engine/adapters/csharp_adapter.py
+++ b/static_analyzer/engine/adapters/csharp_adapter.py
@@ -16,6 +16,7 @@ from static_analyzer.dotnet_solution import solution_projects
 from static_analyzer.engine.language_adapter import LanguageAdapter
 from static_analyzer.engine.lsp_client import LSPClient
 from static_analyzer.engine.lsp_constants import EdgeStrategy
+from static_analyzer.engine.source_inspector import SourceInspector
 from tool_registry import (
     TOOL_REGISTRY,
     ToolKind,
@@ -144,6 +145,24 @@ class CSharpAdapter(LanguageAdapter):
             self._files_with_sibling_types.add(key)
         else:
             self._files_with_sibling_types.discard(key)
+
+    def read_document_symbols(self, file_path: Path, inspector: SourceInspector, client: LSPClient) -> list[dict]:
+        """csharp-ls answers nothing for a file that is in more than one project (a
+        shared source linked into several); the parse tree names its members instead.
+
+        Why the workspace query: the server answers nothing for a file outside its
+        solution too, and that one it can still serve once opened. Only a file the
+        loaded solution declares types in is a linked file.
+        """
+        symbols = inspector.find_document_symbols(file_path)
+        declared = self._top_level_types(symbols)
+        if not declared:
+            return []
+        query = declared[0].split("<", 1)[0]
+        uri = file_path.resolve().as_uri()
+        if any(hit.get("location", {}).get("uri") == uri for hit in client.workspace_symbol(query)):
+            return symbols
+        return []
 
     @property
     def language(self) -> str:

--- a/static_analyzer/engine/adapters/go_adapter.py
+++ b/static_analyzer/engine/adapters/go_adapter.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import re
 import shutil
+from collections.abc import Sequence
 from pathlib import Path
 
 from repo_utils.ignore import RepoIgnoreManager, _ALWAYS_IGNORED_DIRS
@@ -210,14 +211,16 @@ class GoAdapter(LanguageAdapter):
         """Give each serialized gopls reference search a modest time budget."""
         return 10
 
-    def discover_source_files(self, project_root: Path, ignore_manager: RepoIgnoreManager) -> list[Path]:
+    def discover_source_files(
+        self, project_root: Path, ignore_manager: RepoIgnoreManager, nested_roots: Sequence[Path] = ()
+    ) -> list[Path]:
         """Discover Go source files, filtering out build-tag-constrained files.
 
         Files with ``//go:build`` or ``// +build`` directives containing
         negations (``!``) are excluded because gopls cannot resolve package
         metadata for them, which causes errors during cross-reference queries.
         """
-        files = super().discover_source_files(project_root, ignore_manager)
+        files = super().discover_source_files(project_root, ignore_manager, nested_roots)
         filtered = [f for f in files if not self._has_excluding_build_tag(f)]
         skipped = len(files) - len(filtered)
         if skipped:

--- a/static_analyzer/engine/call_graph_builder.py
+++ b/static_analyzer/engine/call_graph_builder.py
@@ -162,11 +162,20 @@ class CallGraphBuilder:
         probe_timeout = self._probe_timeout(total)
 
         interleave_open = self._adapter.interleave_did_open_with_symbols
+        owns_documents = self._adapter.workspace_owns_documents
 
         # Workspace-based servers can probe before didOpen. Some also need
         # request backpressure while creating overlays, so they interleave
         # each didOpen notification with the matching documentSymbol request.
-        if self._adapter.probe_before_open or interleave_open:
+        if owns_documents:
+            # Symbols first, then open: a file the server cannot map to one document (a
+            # source linked into several projects) answers nothing, and opening it makes
+            # the server add a second copy to the project on that path, after which every
+            # call into the file binds ambiguously. Such a file is read from source and
+            # stays closed; a file the server merely does not know yet is opened and asked
+            # again, as it always was.
+            probe_result = self._send_sync_probe(source_files, probe_timeout)
+        elif self._adapter.probe_before_open or interleave_open:
             probe_result = self._send_sync_probe(source_files, probe_timeout)
             if not interleave_open:
                 self._bulk_did_open(source_files)
@@ -175,6 +184,8 @@ class CallGraphBuilder:
             probe_result = self._send_sync_probe(source_files, probe_timeout)
 
         # Phase 1: extract symbols from each file
+        read_from_source: list[Path] = []
+        opened_early: list[Path] = []
         pbar = ProgressLogger("Phase 1 (symbols)", total, unit="file")
         for idx, file_path in enumerate(source_files, 1):
             if interleave_open:
@@ -190,11 +201,27 @@ class CallGraphBuilder:
                 symbols = self._lsp.document_symbol(file_path, timeout=probe_timeout)
             else:
                 symbols = self._lsp.document_symbol(file_path)
+            if not symbols and owns_documents:
+                symbols = self._adapter.read_document_symbols(file_path, self._source_inspector, self._lsp)
+                if symbols:
+                    read_from_source.append(file_path)
+                else:
+                    opened_early.append(file_path)
+                    self._lsp.did_open(file_path)
+                    symbols = self._lsp.document_symbol(file_path)
             self._adapter.record_document_symbols(file_path, symbols, self._root)
             self._symbol_table.register_symbols(file_path, symbols, parent_chain=[], project_root=self._root)
             pbar.set_postfix(symbols=len(self._symbol_table.symbols))
             pbar.update(1)
         pbar.finish()
+        if owns_documents:
+            already = set(read_from_source) | set(opened_early)
+            self._bulk_did_open([file_path for file_path in source_files if file_path not in already])
+        if read_from_source:
+            logger.info(
+                "Phase 1: %d file(s) compiled into more than one project were read from source",
+                len(read_from_source),
+            )
 
         logger.info("Discovered %d symbols across %d files", len(self._symbol_table.symbols), len(source_files))
 

--- a/static_analyzer/engine/language_adapter.py
+++ b/static_analyzer/engine/language_adapter.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 import logging
 from abc import ABC, abstractmethod
+from collections.abc import Collection, Iterator, Sequence
 from pathlib import Path
 
 from repo_utils.ignore import RepoIgnoreManager
 from static_analyzer.config import LANGUAGE_EXTENSIONS, Language, NodeType
 from static_analyzer.engine.lsp_client import LSPClient
+from static_analyzer.engine.source_inspector import SourceInspector
 from static_analyzer.engine.lsp_constants import (
     CALLABLE_KINDS,
     CLASS_LIKE_KINDS,
@@ -262,20 +264,24 @@ class LanguageAdapter(ABC):
         """
         return None
 
-    def discover_source_files(self, project_root: Path, ignore_manager: RepoIgnoreManager) -> list[Path]:
+    def discover_source_files(
+        self, project_root: Path, ignore_manager: RepoIgnoreManager, nested_roots: Sequence[Path] = ()
+    ) -> list[Path]:
         """Discover source files for this adapter under a project root.
 
         Walks the directory tree, skipping paths rejected by
         ``ignore_manager`` and files that don't match this adapter's
-        extensions.
+        extensions. ``nested_roots`` are directories another engine of the
+        same adapter owns; their files belong to that engine alone.
 
         Returns a sorted list of absolute paths.
         """
         project_root = project_root.resolve()
         extensions = set(self.file_extensions)
         files: list[Path] = []
+        skipped = {root.resolve() for root in nested_roots}
 
-        for path in self._walk(project_root, ignore_manager):
+        for path in self._walk(project_root, ignore_manager, skipped):
             if path.suffix in extensions:
                 files.append(path)
 
@@ -284,7 +290,7 @@ class LanguageAdapter(ABC):
             logger.info("Found %d %s files in %s", len(files), self.language, project_root)
         return files
 
-    def _walk(self, root: Path, ignore_manager: RepoIgnoreManager):
+    def _walk(self, root: Path, ignore_manager: RepoIgnoreManager, skipped: Collection[Path] = ()) -> Iterator[Path]:
         """Walk directory tree, skipping paths rejected by RepoIgnoreManager."""
         try:
             entries = sorted(root.iterdir())
@@ -295,7 +301,9 @@ class LanguageAdapter(ABC):
             if ignore_manager.should_ignore(entry):
                 continue
             if entry.is_dir():
-                yield from self._walk(entry, ignore_manager)
+                if entry.resolve() in skipped:
+                    continue
+                yield from self._walk(entry, ignore_manager, skipped)
             elif entry.is_file():
                 yield entry
 
@@ -363,6 +371,15 @@ class LanguageAdapter(ABC):
         by *project_root* as well, since one adapter instance serves every engine config and
         two of them can hold the same file with different symbols.
         """
+
+    def read_document_symbols(self, file_path: Path, inspector: SourceInspector, client: LSPClient) -> list[dict]:
+        """Symbols for a file the server answered nothing for; none by default.
+
+        Why: a server that owns the workspace can decline a file it cannot map to one
+        document, and calls into that file then resolve to positions no symbol covers.
+        An empty answer means the file is left to the server: it gets opened and asked again.
+        """
+        return []
 
     @property
     def expands_constructors(self) -> bool:

--- a/static_analyzer/engine/lsp_client.py
+++ b/static_analyzer/engine/lsp_client.py
@@ -438,6 +438,13 @@ class LSPClient:
         """
         return self._send_batch("textDocument/implementation", queries, self._position_params, timeout=timeout)
 
+    def workspace_symbol(self, query: str) -> list[dict]:
+        """Symbols declared anywhere in the loaded workspace whose name matches *query*."""
+        result = self._send_request("workspace/symbol", {"query": query})
+        if isinstance(result, list):
+            return result
+        return []
+
     def type_hierarchy_prepare(self, file_path: Path, line: int, character: int) -> list[dict] | None:
         """Prepare type hierarchy at the given position."""
         result = self._send_request(

--- a/static_analyzer/engine/source_inspector.py
+++ b/static_analyzer/engine/source_inspector.py
@@ -13,7 +13,7 @@ from tree_sitter import Language as TreeSitterLanguage
 from tree_sitter import Node as TreeSitterNode
 from tree_sitter import Parser, Tree
 
-from static_analyzer.config import LANGUAGE_EXTENSIONS, Language
+from static_analyzer.config import LANGUAGE_EXTENSIONS, Language, NodeType
 from static_analyzer.engine.models import CallSite
 
 import tree_sitter_c_sharp
@@ -106,6 +106,62 @@ _TYPE_DECLARATION_NODE_TYPES = frozenset(
     {"class_declaration", "interface_declaration", "record_declaration", "struct_declaration"}
 )
 _BASE_LIST_NODE_TYPES = frozenset({"base_list", "superclass", "super_interfaces", "extends_interfaces"})
+# C# declarations csharp-ls reports as document symbols, and the LSP kind it gives each.
+_CSHARP_NAMESPACE_NODE_TYPES = frozenset({"namespace_declaration", "file_scoped_namespace_declaration"})
+_CSHARP_SYMBOL_KINDS: dict[str, int] = {
+    "class_declaration": NodeType.CLASS,
+    "record_declaration": NodeType.CLASS,
+    "delegate_declaration": NodeType.CLASS,
+    "struct_declaration": NodeType.STRUCT,
+    "record_struct_declaration": NodeType.STRUCT,
+    "interface_declaration": NodeType.INTERFACE,
+    "enum_declaration": NodeType.ENUM,
+    "enum_member_declaration": NodeType.ENUM_MEMBER,
+    "method_declaration": NodeType.METHOD,
+    "destructor_declaration": NodeType.METHOD,
+    "constructor_declaration": NodeType.CONSTRUCTOR,
+    "property_declaration": NodeType.PROPERTY,
+    "indexer_declaration": NodeType.PROPERTY,
+    "field_declaration": NodeType.FIELD,
+    "event_field_declaration": NodeType.EVENT,
+    "event_declaration": NodeType.EVENT,
+    "operator_declaration": NodeType.OPERATOR,
+    "conversion_operator_declaration": NodeType.OPERATOR,
+}
+_CSHARP_PARAMETER_LIST_NODE_TYPES = frozenset({"parameter_list", "bracketed_parameter_list"})
+_CSHARP_TYPE_SYMBOL_NODE_TYPES = frozenset(
+    {
+        "class_declaration",
+        "record_declaration",
+        "delegate_declaration",
+        "struct_declaration",
+        "record_struct_declaration",
+        "interface_declaration",
+        "enum_declaration",
+    }
+)
+_CSHARP_CALLABLE_MEMBER_NODE_TYPES = frozenset(
+    {
+        "method_declaration",
+        "destructor_declaration",
+        "constructor_declaration",
+        "indexer_declaration",
+        "operator_declaration",
+        "conversion_operator_declaration",
+    }
+)
+_CSHARP_LITERAL_NODE_TYPES = frozenset(
+    {
+        "string_literal",
+        "verbatim_string_literal",
+        "raw_string_literal",
+        "character_literal",
+        "interpolated_string_expression",
+    }
+)
+_CSHARP_UNNAMED_MEMBER_NODE_TYPES = frozenset(
+    {"indexer_declaration", "operator_declaration", "conversion_operator_declaration"}
+)
 # Java groups several bases under one node; C# wraps a record's base in its
 # primary-constructor call, whose ``type`` field is the base itself.
 _BASE_GROUP_NODE_TYPES = frozenset({"type_list"})
@@ -646,6 +702,147 @@ class SourceInspector:
                     found.add("explicit")
                 modifiers[(type_name, text(member_name_node))] = frozenset(found)
         return modifiers
+
+    def find_document_symbols(self, file_path: Path) -> list[dict]:
+        """C# document symbols read from the parse tree, shaped like csharp-ls reports them.
+
+        Why: csharp-ls answers nothing for a file that belongs to more than one project
+        (a shared source file linked into several), so calls into it resolve to a
+        position no symbol covers. Names follow the server's display form --
+        ``Add<T>(this IList<T> items, int count = 0)`` -- so the two sources of a
+        symbol table agree on how a member is spelled.
+        """
+        if file_path.suffix.lower() != ".cs":
+            return []
+        parsed = self._parse(file_path)
+        if parsed is None:
+            return []
+
+        def text(node: TreeSitterNode) -> str:
+            raw = parsed.content[node.start_byte : node.end_byte].decode("utf8", "replace")
+            # Whitespace inside a literal is the literal; between tokens it is layout.
+            return raw if node.type in _CSHARP_LITERAL_NODE_TYPES else " ".join(raw.split())
+
+        def point(row_col: tuple[int, int]) -> dict[str, int]:
+            return {"line": row_col[0], "character": row_col[1]}
+
+        def symbol(node: TreeSitterNode, name: str, kind: int, selection: TreeSitterNode, children: list[dict]) -> dict:
+            return {
+                "name": name,
+                "kind": int(kind),
+                "range": {"start": point(node.start_point), "end": point(node.end_point)},
+                "selectionRange": {"start": point(selection.start_point), "end": point(selection.end_point)},
+                "children": children,
+            }
+
+        def parameters(node: TreeSitterNode) -> str:
+            rendered: list[str] = []
+            # The grammar leaves a ``params`` parameter as loose tokens between the commas.
+            loose: list[str] = []
+            for child in node.children:
+                if child.type in ("(", ")", "[", "]", ","):
+                    if loose:
+                        rendered.append(" ".join(loose))
+                        loose = []
+                    continue
+                if child.type != "parameter":
+                    loose.append(text(child))
+                    continue
+                parts = [
+                    text(part) for part in child.children if part.type not in ("attribute_list", "equals_value_clause")
+                ]
+                default = next((part for part in child.children if part.type == "equals_value_clause"), None)
+                if default is not None:
+                    parts.extend(["=", *(text(value) for value in default.named_children[:1])])
+                rendered.append(" ".join(parts))
+            if loose:
+                rendered.append(" ".join(loose))
+            # The server prints types without their ``pb::`` alias qualifiers.
+            return re.sub(r"\b\w+::", "", ", ".join(rendered))
+
+        def type_parameters(node: TreeSitterNode) -> str:
+            params = node.child_by_field_name("type_parameters")
+            if params is None:
+                return ""
+            names = [text(name) for param in params.named_children if (name := param.child_by_field_name("name"))]
+            return f"<{', '.join(names)}>"
+
+        def member_name(node: TreeSitterNode, name_node: TreeSitterNode | None) -> str:
+            base = text(name_node) if name_node is not None else ""
+            # ``void IFoo.M()`` and ``void IBar.M()`` are two members, as the server names them.
+            explicit = next((child for child in node.children if child.type == "explicit_interface_specifier"), None)
+            if explicit is not None:
+                base = text(explicit) + base
+            if node.type in ("method_declaration", "delegate_declaration"):
+                base += type_parameters(node)
+            params = next((child for child in node.children if child.type in _CSHARP_PARAMETER_LIST_NODE_TYPES), None)
+            if node.type == "indexer_declaration":
+                return f"{text(explicit) if explicit is not None else ''}this[{parameters(params) if params else ''}]"
+            if node.type in ("operator_declaration", "conversion_operator_declaration"):
+                # Everything between the ``operator`` keyword and the parameters names the
+                # operator: ``+``, ``checked +``, or a conversion's target type.
+                tokens = [child for child in node.children if child.type not in ("modifier", "attribute_list")]
+                keyword = next((i for i, child in enumerate(tokens) if child.type == "operator"), len(tokens))
+                after = tokens[keyword + 1 :]
+                until = next((i for i, token in enumerate(after) if token.type in _CSHARP_PARAMETER_LIST_NODE_TYPES), 0)
+                operator = " ".join(text(token) for token in after[:until])
+                return f"operator {operator}({parameters(params) if params is not None else ''})"
+            if node.type == "destructor_declaration":
+                base = "~" + base
+            if params is not None and node.type != "record_declaration":
+                base += f"({parameters(params)})"
+            return base
+
+        def declarations(nodes: list[TreeSitterNode], enclosing: str = "") -> list[dict]:
+            found: list[dict] = []
+            for index, node in enumerate(nodes):
+                if node.type in _CSHARP_NAMESPACE_NODE_TYPES:
+                    name_node = node.child_by_field_name("name")
+                    if name_node is None:
+                        continue
+                    body = node.child_by_field_name("body")
+                    # A file-scoped namespace has no body: everything after it is inside it.
+                    members = body.named_children if body is not None else nodes[index + 1 :]
+                    # The server names a namespace in full, ``A.B`` for ``namespace A { namespace B``.
+                    full_name = f"{enclosing}.{text(name_node)}" if enclosing else text(name_node)
+                    namespace = symbol(node, full_name, NodeType.NAMESPACE, name_node, declarations(members, full_name))
+                    namespace["detail"] = full_name
+                    found.append(namespace)
+                    if body is None:
+                        break
+                    continue
+                kind = _CSHARP_SYMBOL_KINDS.get(node.type)
+                if kind is None:
+                    continue
+                if node.type in ("field_declaration", "event_field_declaration"):
+                    declaration = next(
+                        (child for child in node.named_children if child.type == "variable_declaration"), None
+                    )
+                    for declarator in declaration.named_children if declaration is not None else []:
+                        name_node = declarator.child_by_field_name("name")
+                        if declarator.type == "variable_declarator" and name_node is not None:
+                            found.append(symbol(node, text(name_node), kind, name_node, []))
+                    continue
+                name_node = node.child_by_field_name("name")
+                if node.type in _CSHARP_CALLABLE_MEMBER_NODE_TYPES:
+                    if name_node is None and node.type not in _CSHARP_UNNAMED_MEMBER_NODE_TYPES:
+                        continue
+                    found.append(symbol(node, member_name(node, name_node), kind, name_node or node, []))
+                    continue
+                if name_node is None:
+                    continue
+                children: list[dict] = []
+                name = text(name_node)
+                if node.type in _CSHARP_TYPE_SYMBOL_NODE_TYPES:
+                    name += type_parameters(node)
+                    body = node.child_by_field_name("body")
+                    children = declarations(body.named_children) if body is not None else []
+                found.append(symbol(node, name, kind, name_node, children))
+            return found
+
+        root = parsed.tree.root_node
+        file_symbol = symbol(root, file_path.name, NodeType.FILE, root, declarations(root.named_children))
+        return [file_symbol] if file_symbol["children"] else []
 
     @staticmethod
     def _occupies_body_field(node: TreeSitterNode) -> bool:

--- a/tests/static_analyzer/test_call_graph_builder.py
+++ b/tests/static_analyzer/test_call_graph_builder.py
@@ -54,6 +54,8 @@ def _make_adapter() -> MagicMock:
     adapter.get_probe_timeout_minimum.return_value = 0
     adapter.probe_before_open = False
     adapter.interleave_did_open_with_symbols = False
+    adapter.workspace_owns_documents = False
+    adapter.read_document_symbols.return_value = []
     return adapter
 
 
@@ -187,6 +189,60 @@ class TestDiscoverSymbols:
             ("document_symbol", files[1]),
         ]
         assert [item.kwargs.get("timeout") for item in lsp.document_symbol.call_args_list[1:]] == [64, 64]
+
+    def test_a_workspace_owning_server_keeps_a_file_read_from_source_closed(self):
+        """csharp-ls adds a second copy of a file it cannot map to one document when that
+        file is opened, so symbols come first and such a file is never opened."""
+        lsp = _make_lsp()
+        adapter = _make_adapter()
+        adapter.probe_before_open = True
+        adapter.workspace_owns_documents = True
+        files = [Path("/project/a.cs"), Path("/project/shared.cs")]
+        served = {"name": "A", "kind": NodeType.CLASS, "range": _range(0, 3), "selectionRange": _range(0, 0)}
+        lsp.document_symbol.side_effect = lambda path, timeout=None: [served] if path == files[0] else []
+        read = {"name": "Shared", "kind": NodeType.CLASS, "range": _range(0, 3), "selectionRange": _range(0, 0)}
+        adapter.read_document_symbols.return_value = [read]
+        builder = CallGraphBuilder(lsp, adapter, Path("/project"))
+
+        builder._discover_symbols(files)
+
+        calls = [(item[0], item.args[0]) for item in lsp.method_calls if item[0] in {"did_open", "document_symbol"}]
+        assert calls == [("document_symbol", files[0]), ("document_symbol", files[1]), ("did_open", files[0])]
+        adapter.read_document_symbols.assert_called_once_with(files[1], builder._source_inspector, lsp)
+        assert {"a.A", "shared.Shared"} <= set(builder.symbol_table.symbols)
+
+    def test_a_file_the_server_does_not_know_yet_is_opened_and_asked_again(self):
+        """A file outside the loaded solution answers nothing until it is opened; that
+        is the server's to serve, not the parse tree's."""
+        lsp = _make_lsp()
+        adapter = _make_adapter()
+        adapter.probe_before_open = True
+        adapter.workspace_owns_documents = True
+        files = [Path("/project/a.cs"), Path("/project/loose.cs")]
+        served = {"name": "A", "kind": NodeType.CLASS, "range": _range(0, 3), "selectionRange": _range(0, 0)}
+        loose = {"name": "Loose", "kind": NodeType.CLASS, "range": _range(0, 3), "selectionRange": _range(0, 0)}
+        opened: list[Path] = []
+        lsp.did_open.side_effect = opened.append
+        lsp.document_symbol.side_effect = lambda path, timeout=None: (
+            [served] if path == files[0] else ([loose] if path in opened else [])
+        )
+        builder = CallGraphBuilder(lsp, adapter, Path("/project"))
+
+        builder._discover_symbols(files)
+
+        calls = [(item[0], item.args[0]) for item in lsp.method_calls if item[0] in {"did_open", "document_symbol"}]
+        assert calls == [
+            ("document_symbol", files[0]),
+            ("document_symbol", files[1]),
+            ("did_open", files[1]),
+            ("document_symbol", files[1]),
+            ("did_open", files[0]),
+        ]
+        assert {"a.A", "loose.Loose"} <= set(builder.symbol_table.symbols)
+
+
+def _range(start_line: int, end_line: int) -> dict:
+    return {"start": {"line": start_line, "character": 0}, "end": {"line": end_line, "character": 0}}
 
 
 class TestBuild:

--- a/tests/static_analyzer/test_csharp_adapter.py
+++ b/tests/static_analyzer/test_csharp_adapter.py
@@ -10,6 +10,7 @@ import pytest
 from static_analyzer.config import Language, NodeType
 from static_analyzer.dotnet_sdk import DotnetSdkError, DotnetSdkResolution
 from static_analyzer.engine.adapters.csharp_adapter import CSharpAdapter
+from static_analyzer.engine.source_inspector import SourceInspector
 
 
 def _dotnet_resolution(dotnet_path: str = "/usr/bin/dotnet", env: dict[str, str] | None = None) -> DotnetSdkResolution:
@@ -659,3 +660,39 @@ class TestPrepareProject:
         monkeypatch.setattr("static_analyzer.engine.adapters.csharp_adapter.subprocess.run", fake_run)
 
         CSharpAdapter().prepare_project(tmp_path)  # no exception
+
+
+class TestReadDocumentSymbols:
+    """The parse tree stands in only for a file the loaded solution declares types in (a
+    source compiled into several projects); a file the server does not know is left to it."""
+
+    def _client(self, hits: list[str]) -> MagicMock:
+        client = MagicMock()
+        client.workspace_symbol.return_value = [{"name": "Clock", "location": {"uri": uri}} for uri in hits]
+        return client
+
+    def test_a_file_the_solution_declares_is_read_from_source(self, tmp_path: Path):
+        shared = tmp_path / "Shared" / "Clock.cs"
+        shared.parent.mkdir()
+        shared.write_text('namespace Shared;\ninternal static class Clock { public static string Stamp() => ""; }\n')
+        client = self._client([shared.resolve().as_uri()])
+
+        symbols = CSharpAdapter().read_document_symbols(shared, SourceInspector(), client)
+
+        assert [child["name"] for child in symbols[0]["children"][0]["children"]] == ["Clock"]
+        client.workspace_symbol.assert_called_once_with("Clock")
+
+    def test_a_file_the_solution_does_not_declare_is_left_to_the_server(self, tmp_path: Path):
+        loose = tmp_path / "Loose.cs"
+        loose.write_text("class Clock { }\n")
+        client = self._client([(tmp_path / "Elsewhere" / "Clock.cs").as_uri()])
+
+        assert CSharpAdapter().read_document_symbols(loose, SourceInspector(), client) == []
+
+    def test_a_file_without_types_asks_nothing(self, tmp_path: Path):
+        usings = tmp_path / "GlobalUsings.cs"
+        usings.write_text("global using System;\n")
+        client = self._client([])
+
+        assert CSharpAdapter().read_document_symbols(usings, SourceInspector(), client) == []
+        client.workspace_symbol.assert_not_called()

--- a/tests/static_analyzer/test_engine_configs.py
+++ b/tests/static_analyzer/test_engine_configs.py
@@ -29,6 +29,7 @@ _SUFFIXES = {
     "JSX": [".jsx"],
     "Python": [".py"],
     "Java": [".java"],
+    "C#": [".cs"],
 }
 
 
@@ -93,6 +94,57 @@ class TestEngineConfigsPerFamily(unittest.TestCase):
         configs = self._configs([lang("Python")], {"a.py": "def a():\n    pass\n"})
         self.assertEqual(len(configs), 1)
         self.assertIs(configs[0].adapter.language_enum, Language.PYTHON)
+
+    def test_a_project_only_a_nested_solution_lists_belongs_to_that_engine(self) -> None:
+        """Two engines naming the same file from different roots would put it in the graph twice."""
+        configs = self._configs(
+            [lang("C#")],
+            {
+                "App.slnx": '<Solution><Project Path="App/App.csproj" /></Solution>',
+                "App/App.csproj": "<Project />",
+                "App/Program.cs": "class Program {}\n",
+                "Shared/Clock.cs": "class Clock {}\n",
+                "plugins/Plugins.slnx": '<Solution><Project Path="Host/Host.csproj" /></Solution>',
+                "plugins/Host/Host.csproj": "<Project />",
+                "plugins/Host/Host.cs": "class Host {}\n",
+            },
+        )
+        self.assertEqual(len(configs), 2)
+        outer = next(config for config in configs if config.project_path.name != "plugins")
+        inner = next(config for config in configs if config.project_path.name == "plugins")
+        # Shared/ is in no project directory; the root engine keeps it, as it always did.
+        self.assertEqual([f.name for f in outer.source_files], ["Program.cs", "Clock.cs"])
+        self.assertEqual([f.name for f in inner.source_files], ["Host.cs"])
+
+    def test_a_project_the_outer_solution_lists_stays_with_it_even_under_a_nested_solution(self) -> None:
+        """eShop's root solution lists src/ClientApp/ClientApp.csproj although that directory has
+        a solution of its own; the outer server loaded it, so the outer engine names it."""
+        configs = self._configs(
+            [lang("C#")],
+            {
+                "App.slnx": '<Solution><Project Path="App/App.csproj" /><Project Path="mobile/Client/Client.csproj" /></Solution>',
+                "App/App.csproj": "<Project />",
+                "App/Program.cs": "class Program {}\n",
+                "mobile/Client.slnx": '<Solution><Project Path="Client/Client.csproj" /></Solution>',
+                "mobile/Client/Client.csproj": "<Project />",
+                "mobile/Client/Client.cs": "class Client {}\n",
+            },
+        )
+        outer = next(config for config in configs if config.project_path.name != "mobile")
+        self.assertEqual([f.name for f in outer.source_files], ["Program.cs", "Client.cs"])
+
+    def test_a_root_whose_files_all_belong_to_nested_solutions_gets_no_engine(self) -> None:
+        configs = self._configs(
+            [lang("C#")],
+            {
+                "All.slnx": '<Solution><Project Path="Tools/Tools.csproj" /></Solution>',
+                "Tools/Tools.csproj": "<Project />",
+                "plugins/Plugins.slnx": '<Solution><Project Path="Host/Host.csproj" /></Solution>',
+                "plugins/Host/Host.csproj": "<Project />",
+                "plugins/Host/Host.cs": "class Host {}\n",
+            },
+        )
+        self.assertEqual([config.project_path.name for config in configs], ["plugins"])
 
     def _configs(self, languages, files: dict[str, str]):
         # Resolved: on macOS mkdtemp hands back /var/... while tsc reports /private/var/...

--- a/tests/static_analyzer/test_engine_configs.py
+++ b/tests/static_analyzer/test_engine_configs.py
@@ -115,6 +115,8 @@ class TestEngineConfigsPerFamily(unittest.TestCase):
         # Shared/ is in no project directory; the root engine keeps it, as it always did.
         self.assertEqual([f.name for f in outer.source_files], ["Program.cs", "Clock.cs"])
         self.assertEqual([f.name for f in inner.source_files], ["Host.cs"])
+        self.assertEqual(outer.excluded_roots, [inner.project_path / "Host"])
+        self.assertEqual(inner.excluded_roots, [])
 
     def test_a_project_the_outer_solution_lists_stays_with_it_even_under_a_nested_solution(self) -> None:
         """eShop's root solution lists src/ClientApp/ClientApp.csproj although that directory has
@@ -132,6 +134,7 @@ class TestEngineConfigsPerFamily(unittest.TestCase):
         )
         outer = next(config for config in configs if config.project_path.name != "mobile")
         self.assertEqual([f.name for f in outer.source_files], ["Program.cs", "Client.cs"])
+        self.assertEqual(outer.excluded_roots, [])
 
     def test_a_root_whose_files_all_belong_to_nested_solutions_gets_no_engine(self) -> None:
         configs = self._configs(

--- a/tests/static_analyzer/test_source_inspector.py
+++ b/tests/static_analyzer/test_source_inspector.py
@@ -684,3 +684,107 @@ class TestIteratedExpression:
         si = SourceInspector()
         positions = _positions(si.find_iterated_expression_sites(f))
         assert (1, 46) in positions  # `Items`, whose type is what gets enumerated
+
+
+class TestFindDocumentSymbols:
+    """The parse tree stands in for csharp-ls on a file it answers nothing for, so the
+    symbols must be spelled the way the server spells them."""
+
+    SOURCE = """using System;
+namespace Polly.Utils;
+internal static class Guard
+{
+    public static T NotNull<T>(T value, [CallerArgumentExpression("value")] string argumentName = "") where T : class => value;
+    private readonly int _count, _other;
+    public string Name { get; set; }
+    public event EventHandler Changed;
+    public Guard(int x) { }
+    public int this[int i] => i;
+    public static Guard operator +(Guard a, Guard b) => a;
+    public static implicit operator int(Guard g) => 1;
+    public void Run(pb::CodedOutputStream output, params string[] parts) { static int Local() => 1; }
+    private class Inner { public void M() { } }
+    public enum Kind { A, B }
+}
+"""
+
+    def _symbols(self, tmp_path: Path, source: str = SOURCE, name: str = "Guard.cs") -> list[dict]:
+        f = tmp_path / name
+        f.write_text(source)
+        return SourceInspector().find_document_symbols(f)
+
+    @staticmethod
+    def _flat(symbols: list[dict], depth: int = 0):
+        for sym in symbols:
+            yield depth, sym
+            yield from TestFindDocumentSymbols._flat(sym.get("children", []), depth + 1)
+
+    def test_nests_file_namespace_type_and_members(self, tmp_path: Path):
+        symbols = self._symbols(tmp_path)
+        shape = [(depth, sym["kind"], sym["name"]) for depth, sym in self._flat(symbols)]
+        assert shape[:3] == [(0, 1, "Guard.cs"), (1, 3, "Polly.Utils"), (2, 5, "Guard")]
+        assert symbols[0]["children"][0]["detail"] == "Polly.Utils"
+        members = [(kind, name) for depth, kind, name in shape if depth == 3]
+        assert members == [
+            (6, 'NotNull<T>(T value, string argumentName = "")'),
+            (8, "_count"),
+            (8, "_other"),
+            (7, "Name"),
+            (24, "Changed"),
+            (9, "Guard(int x)"),
+            (7, "this[int i]"),
+            (25, "operator +(Guard a, Guard b)"),
+            (25, "operator int(Guard g)"),
+            (6, "Run(CodedOutputStream output, params string[] parts)"),
+            (5, "Inner"),
+            (10, "Kind"),
+        ]
+        assert [(kind, name) for depth, kind, name in shape if depth == 4] == [(6, "M()"), (22, "A"), (22, "B")]
+
+    def test_local_functions_are_not_symbols(self, tmp_path: Path):
+        names = [sym["name"] for _, sym in self._flat(self._symbols(tmp_path))]
+        assert not any(name.startswith("Local") for name in names)
+
+    def test_selection_range_is_the_name(self, tmp_path: Path):
+        symbols = self._symbols(tmp_path)
+        method = next(sym for _, sym in self._flat(symbols) if sym["name"].startswith("NotNull"))
+        assert method["selectionRange"]["start"] == {"line": 4, "character": 20}
+        assert method["range"]["start"]["line"] == 4
+
+    def test_block_namespaces_and_generic_types(self, tmp_path: Path):
+        source = "namespace A.B { public interface IRepo<T> { T Get(int id); } public record Rec(int A); }\n"
+        symbols = self._symbols(tmp_path, source, "Repo.cs")
+        shape = [(depth, sym["kind"], sym["name"]) for depth, sym in self._flat(symbols)]
+        assert shape == [(0, 1, "Repo.cs"), (1, 3, "A.B"), (2, 11, "IRepo<T>"), (3, 6, "Get(int id)"), (2, 5, "Rec")]
+
+    def test_a_file_without_declarations_has_none(self, tmp_path: Path):
+        assert self._symbols(tmp_path, "using System;\n", "GlobalUsings.cs") == []
+
+    def test_only_csharp(self, tmp_path: Path):
+        assert self._symbols(tmp_path, "class A {}\n", "A.java") == []
+
+    def test_explicit_interface_members_keep_their_interface(self, tmp_path: Path):
+        source = "class Bag : IFoo, IBar { void IFoo.M() { } void IBar.M() { } int IFoo.this[int i] => i; }\n"
+        names = [
+            sym["name"] for _, sym in self._flat(self._symbols(tmp_path, source, "Bag.cs")) if sym["kind"] in (6, 7)
+        ]
+        assert names == ["IFoo.M()", "IBar.M()", "IFoo.this[int i]"]
+
+    def test_nested_block_namespaces_are_named_in_full(self, tmp_path: Path):
+        source = "namespace A { namespace Common { class C { } } }\nnamespace B { namespace Common { class D { } } }\n"
+        symbols = self._symbols(tmp_path, source, "N.cs")
+        namespaces = [(sym["name"], sym["detail"]) for _, sym in self._flat(symbols) if sym["kind"] == 3]
+        assert namespaces == [("A", "A"), ("A.Common", "A.Common"), ("B", "B"), ("B.Common", "B.Common")]
+
+    def test_whitespace_inside_a_default_literal_is_kept(self, tmp_path: Path):
+        source = 'class J { string Join(string separator = "  ", int\n    width = 2) => separator; }\n'
+        names = [sym["name"] for _, sym in self._flat(self._symbols(tmp_path, source, "J.cs")) if sym["kind"] == 6]
+        assert names == ['Join(string separator = "  ", int width = 2)']
+
+    def test_checked_operators_are_distinct(self, tmp_path: Path):
+        source = (
+            "class V { public static V operator +(V a, V b) => a; public static V operator checked +(V a, V b) => a;"
+            " public static explicit operator int(V v) => 1; }\n"
+        )
+        names = [sym["name"] for _, sym in self._flat(self._symbols(tmp_path, source, "V.cs")) if sym["kind"] == 25]
+        assert names == ["operator +(V a, V b)", "operator checked +(V a, V b)", "operator int(V v)"]

--- a/tests/static_analyzer/test_warmstart_changed_files.py
+++ b/tests/static_analyzer/test_warmstart_changed_files.py
@@ -100,6 +100,37 @@ class TestWarmStartChangedFiles(unittest.TestCase):
         absorb.assert_called_once()
         self.assertIs(absorb.call_args.args[2], second)
 
+    def test_discovery_exclusions_scope_supplied_and_git_changes_before_invalidation(self) -> None:
+        inner_root = self.project / "plugins"
+        excluded = inner_root / "Inner"
+        inner_changes = {excluded / name for name in ("modified.cs", "added.cs", "deleted.cs")}
+        outer_changes = {self.project / "Outer.cs", self.project / "plugins-extra" / "Other.cs"}
+        for use_git in (False, True):
+            with self.subTest(use_git=use_git):
+                analyzer = _analyzer_with_one_engine(
+                    self.project, changed_files=None if use_git else inner_changes | outer_changes
+                )
+                ((outer, client),) = analyzer._engine_clients
+                outer.excluded_roots = [excluded]
+                outer.source_files = [self.project / "Unchanged.cs"]
+                inner = EngineConfig(outer.adapter, inner_root, source_files=[excluded / "modified.cs"])
+                analyzer._engine_clients.append((inner, client))
+                with (
+                    patch(
+                        "static_analyzer.get_changed_files_since",
+                        side_effect=[inner_changes | outer_changes, inner_changes],
+                    ),
+                    patch("static_analyzer.update_cfg_for_changed_files", return_value={}) as update,
+                    patch.object(analyzer, "_extract_language_dict", return_value={}),
+                    patch.object(analyzer, "_absorb_into_results"),
+                    patch.object(analyzer, "_collect_diagnostics_for"),
+                    patch("static_analyzer.track_lsp_result"),
+                ):
+                    analyzer._update_cached_results(self.cached, cached_sha="baseline")
+                self.assertEqual(update.call_args_list[0].args[1], outer_changes)
+                # Added/deleted paths are absent from source_files but still belong to the inner engine.
+                self.assertEqual(update.call_args_list[1].args[1], inner_changes)
+
     @patch("static_analyzer.update_cfg_for_changed_files", return_value={})
     @patch("static_analyzer.get_changed_files_since", return_value={Path("/proj/x.py")})
     def test_none_falls_back_to_git(self, mock_git, mock_update) -> None:


### PR DESCRIPTION
Stacked on #581. Paired tests PR: https://github.com/CodeBoarding/CodeBoarding-tests/pull/39 (same branch name).

## Why

Second loss class from the same investigation as #581. csharp-ls answers **nothing** for a path that maps to more than one Roslyn document (`WorkspaceFolder.fs`: `| [ d ] -> Some d | _ -> None`, unchanged through 0.27 and master's unreleased fix, which only handles multi-TFM flavors and explicitly leaves linked files ambiguous). A source file linked into several projects is exactly that: Polly's `Guard.cs`, `ObjectPool.cs`, `ExceptionUtilities.cs`, `ResilienceValidationContext.cs` (Polly.Core's own files, also `<Compile Include>`d into Polly.Extensions and Polly.RateLimiting), eShop's `src/Shared/*.cs`.

Two effects, both logged at the LSP boundary:
- `documentSymbol` returns `[]` for the file, so every `textDocument/definition` that lands in it (the server still resolves *into* it fine) finds no symbol and the call is dropped. Polly: 196 call sites into four files. eShop: 11.
- Our `didOpen` of such a file makes csharp-ls add **one more** copy to the project whose directory holds it, after which every call into it is ambiguous. That is the source of Polly's 161 `CS0121: The call is ambiguous between 'Polly.Utils.Guard.NotNull<T>(T, string)' and 'Polly.Utils.Guard.NotNull<T>(T, string)'`.

## What changes

- `CallGraphBuilder._discover_symbols`: for a server that owns the workspace, symbols are queried before any file is opened, and only the files it answered for are opened afterwards.
- `LanguageAdapter.read_document_symbols` (default none); `CSharpAdapter` returns `SourceInspector.find_document_symbols`, a tree-sitter reading of the file shaped like csharp-ls's own `DocumentSymbol` tree (File → Namespace → types → members, names spelled the server's way: `NotNull<T>(T value, string argumentName = "")`, `this[int i]`, `operator +(Guard a, Guard b)`, no attributes, no `pb::` alias qualifiers). Checked against 213 symbols csharp-ls itself reported on eShop files: same position and spelling for all but nullable-reference `?` and generated protobuf properties.

Calls *from inside* such a file still get no answer from the server (no document to bind in); that half is an upstream csharp-ls change.

## Measured (zero-LLM, static only)

| | Polly before | after | eShop before | after |
|---|---|---|---|---|
| call edges | 5307 | 5544 | 1511 | 1523 |
| call sites resolved to an edge | 3477 | 3674 | 1336 | 1342 |
| files read from source | – | 15 | – | 2 |
| CS0121 errors | 161 | 0 | 0 | 0 |

## Second commit: a nested solution's files belong to its own engine

A solution root nested under another (Polly's `samples/`, eShop's `src/ClientApp`) already gets its own engine, but the outer engine walked the same files and asked its server about them. csharp-ls declines a file outside its solution, so those files silently had no symbols in the outer engine before; with the parse-tree fallback they would have had a second, differently named copy next to the nested engine's own (Polly: 73 duplicate symbols for the 20 sample files). `_create_engine_configs` now hands the outer engine its files minus every nested root.

## Tests

- Unit: `find_document_symbols` shape/spelling on a sample (`tests/static_analyzer/test_source_inspector.py`), discovery order and opened-file set for a workspace-owning server (`tests/static_analyzer/test_call_graph_builder.py`).
- Integration (paired PR): two sources of the hand-written C# edge-case solution are compiled into more than one project; its exact fixture moves from 94 to 102 edges and fails on the base engine with 8 missing edges. `tests/static_analyzer/test_engine_configs.py` covers the nested-root exclusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved C# symbol discovery for namespaces, types, fields, events, methods, and nested declarations.
  * Added source-based fallback symbol detection when language services provide no results.
  * Reduced unnecessary file opening during analysis.
  * Improved source-file attribution for nested C# projects, reducing duplicate analysis.
  * Improved handling of files shared across multiple C# projects.

* **Tests**
  * Added coverage for C# symbol extraction, workspace document handling, and nested project source separation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## After review

- **"Answered nothing" conflated two opposite states.** A file in two projects and a file in none both get `[]` from csharp-ls, but the first must stay closed (opening it duplicates the document) and the second must be opened (that is how the server serves it). The adapter now asks `workspace/symbol` for a type the file declares: a hit in that file means the loaded solution has it, so it is a linked file and is read from source; no hit means the server does not know it, so it is opened and asked again, exactly as before. A tree without any solution therefore keeps its symbols from the server, and a workspace that failed to load still trips `fail_on_empty_symbols`.
- **Engine ownership followed directory nesting; it now follows solution membership.** A project a nested solution lists, and the outer solution does not, belongs to the nested engine; a project the outer solution lists as well (eShop's `src/ClientApp/ClientApp.csproj`) stays with the outer engine; a root whose files all belong to nested solutions gets no engine, so the "empty means unresolved" sentinel never carries an authoritative empty list.
- Synthesized symbols: explicit interface members keep their interface (`IFoo.M()`), nested block namespaces are named in full (`A.Common`), whitespace inside a default-value literal is kept, `operator checked +` is distinct from `operator +`. `#if` regions are not an issue: the inspector blanks directive lines before parsing, so both branches are seen.
- `_walk` is annotated; cache tag v8 because the same source now yields more symbols and edges.

Re-measured on Polly: 5 files read from source (the genuinely linked ones; 10 others the server did not know are now opened and served), 0 CS0121, 5578 edges.
