### PR TITLE
fix(engine): finish call edges whose definition lies in another solution's project

### DIFF
--- a/static_analyzer/__init__.py
+++ b/static_analyzer/__init__.py
@@ -19,9 +19,11 @@ from static_analyzer.engine.call_graph_builder import CallGraphBuilder
 from static_analyzer.engine.language_adapter import LanguageAdapter
 from static_analyzer.engine.lsp_client import LSPClient
 from static_analyzer.engine.lsp_recycler import default_memory_budget, per_engine_memory_budget
+from static_analyzer.engine.models import ExternalCallSite
 from static_analyzer.engine.result_converter import convert_to_codeboarding_format
 from static_analyzer.engine.source_inspector import SourceInspector
 from static_analyzer.engine.utils import uri_to_path
+from static_analyzer.external_calls import link_external_call_sites
 from static_analyzer.incremental_orchestrator import update_cfg_for_changed_files
 from static_analyzer.java_config_scanner import JavaConfigScanner
 from static_analyzer.lsp_client.diagnostics import FileDiagnosticsMap
@@ -736,7 +738,7 @@ class StaticAnalyzer:
         # order. The merges replace on key collision, and overlapping configs
         # (nested solution roots) do collide, so completion order would let two
         # identical runs keep different nodes and produce different component IDs.
-        completed: dict[int, tuple[Language, dict]] = {}
+        completed: dict[int, tuple[LanguageAdapter, dict]] = {}
 
         def run_one(engine_config: EngineConfig, engine_client: LSPClient | None, order: int = 0) -> None:
             """Analyze one engine. Owns the client's lifetime when given none."""
@@ -760,7 +762,7 @@ class StaticAnalyzer:
                 duration_ms = round((time.monotonic() - t_lang_start) * 1000)
                 logger.info(f"Engine analysis for {adapter.language} completed in {duration_ms / 1000:.1f}s")
                 with absorb_lock:
-                    completed[order] = (language, analysis)
+                    completed[order] = (adapter, analysis)
                     self._collect_diagnostics_for(adapter, engine_client, analysis)
                     track_lsp_result(
                         language=adapter.language_enum.value,
@@ -817,9 +819,7 @@ class StaticAnalyzer:
                     f"(attempted: {', '.join(cfg.adapter.language for cfg in pending)}){details}"
                 )
 
-        for order in sorted(completed):
-            language, analysis = completed[order]
-            self._absorb_into_results(results, language, analysis)
+        self._absorb_and_link(results, [completed[order] for order in sorted(completed)])
 
         summaries = []
         for language in results.get_languages():
@@ -863,6 +863,8 @@ class StaticAnalyzer:
         # so a config that took its own copy of the cache would hand back the nodes another
         # config had just invalidated, and the merge would resurrect deleted files.
         carried: dict[Language, dict] = {}
+        carried_adapters: dict[Language, LanguageAdapter] = {}
+        rebuilt: list[tuple[LanguageAdapter, dict]] = []
         for engine_config, engine_client in self._live_clients("warm-start"):
             adapter, project_path = engine_config.adapter, engine_config.project_path
             language = adapter.results_language
@@ -871,7 +873,7 @@ class StaticAnalyzer:
 
             if changed_files is None:
                 analysis = self._run_full_analysis(engine_config, engine_client)
-                self._absorb_into_results(results, language, analysis)
+                rebuilt.append((adapter, analysis))
             else:
                 changed_files = {
                     path
@@ -884,6 +886,7 @@ class StaticAnalyzer:
                     cached_lang_dict, changed_files, adapter, project_path, engine_client, self.ignore_manager
                 )
                 carried[language] = analysis
+                carried_adapters[language] = adapter
 
             self._collect_diagnostics_for(adapter, engine_client, analysis)
             track_lsp_result(
@@ -894,8 +897,9 @@ class StaticAnalyzer:
                 analysis=analysis,
                 diagnostics=self.collected_diagnostics.get(adapter.results_language, {}),
             )
-        for language, analysis in carried.items():
-            self._absorb_into_results(results, language, analysis)
+        self._absorb_and_link(
+            results, rebuilt + [(carried_adapters[language], analysis) for language, analysis in carried.items()]
+        )
         results.incremental_base_results = cached_results
         return results
 
@@ -943,6 +947,24 @@ class StaticAnalyzer:
             "source_files": cached_source_files,
             "diagnostics": cached_results.diagnostics.get(language, {}),
         }
+
+    def _absorb_and_link(self, results: StaticAnalysisResults, analyses: list[tuple[LanguageAdapter, dict]]) -> None:
+        """Absorb every engine's analysis, then finish the calls whose definitions lie in another engine's files.
+
+        Why after all of them: only the merged graph holds every engine's nodes, so a call into
+        another solution's project can find its target, whichever engine ran first.
+        """
+        pending: dict[Language, tuple[LanguageAdapter, list[ExternalCallSite]]] = {}
+        for adapter, analysis in analyses:
+            language = adapter.results_language
+            self._absorb_into_results(results, language, analysis)
+            pending.setdefault(language, (adapter, []))[1].extend(analysis.get("external_call_sites", []))
+        inspector = SourceInspector()
+        for language, (adapter, sites) in pending.items():
+            if sites:
+                link_external_call_sites(
+                    results.get_cfg(language), sites, adapter, results.get_package_dependencies(language), inspector
+                )
 
     def _absorb_into_results(self, results: StaticAnalysisResults, language: Language, analysis: dict) -> None:
         """Stuff one language's analysis-dict into the shared ``StaticAnalysisResults``."""

--- a/static_analyzer/analysis_cache.py
+++ b/static_analyzer/analysis_cache.py
@@ -69,8 +69,9 @@ _LEGACY_CACHE_SUBDIR = "cache"
 # specification in analysis.json, replayed over the graph.
 # v8: a C# file compiled into several projects has symbols and callers, and a
 # nested solution's files are named by its own engine only.
+# v9: a call into a project of another solution root is an edge.
 # Older pickles are treated as cache misses and re-run.
-_TAG_VERSION = "v8"
+_TAG_VERSION = "v9"
 
 
 class StaticAnalysisCache:

--- a/static_analyzer/engine/call_graph_builder.py
+++ b/static_analyzer/engine/call_graph_builder.py
@@ -122,6 +122,7 @@ class CallGraphBuilder:
             cfg=cfg,
             package_dependencies=package_deps,
             source_files=abs_files,
+            external_call_sites=ctx.external_call_sites,
         )
 
     def _build_recycler(self, source_files: list[Path]) -> LSPRecycler | None:

--- a/static_analyzer/engine/edge_build_context.py
+++ b/static_analyzer/engine/edge_build_context.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from static_analyzer.engine.lsp_client import LSPClient
 from static_analyzer.engine.lsp_recycler import LSPRecycler
+from static_analyzer.engine.models import ExternalCallSite
 from static_analyzer.engine.source_inspector import SourceInspector
 from static_analyzer.engine.symbol_table import SymbolTable
 
@@ -20,3 +21,6 @@ class EdgeBuildContext:
     # Set only for servers that may be restarted mid-phase; None means the
     # strategy runs against a single server process for the whole phase.
     recycler: LSPRecycler | None = None
+    # Calls the server resolved into files this engine has no symbols for; the
+    # merged graph of every engine is where they can still become edges.
+    external_call_sites: list[ExternalCallSite] = field(default_factory=list)

--- a/static_analyzer/engine/edge_builder.py
+++ b/static_analyzer/engine/edge_builder.py
@@ -18,10 +18,11 @@ from static_analyzer.engine.lsp_constants import (
     CALLABLE_KINDS,
     CLASS_LIKE_KINDS,
 )
-from static_analyzer.engine.models import CallSite, SymbolInfo
+from static_analyzer.engine.models import CallSite, ExternalCallSite, SymbolInfo
 from static_analyzer.engine.protocols import EdgeBuildAdapter
 from static_analyzer.engine.symbol_table import SymbolTable
 from static_analyzer.engine.utils import definition_location, uri_to_path
+from static_analyzer.graph_definitions import CALL, COLLECTION_INITIALIZER, ITERATED, METHOD_GROUP
 from static_analyzer.internal_references import is_self_or_container_edge, parent_qualified_name
 
 logger = logging.getLogger(__name__)
@@ -382,7 +383,10 @@ def _resolve_iterated_types(
                     continue
                 for result in results[index] if index < len(results) else []:
                     target = _resolve_definition_to_symbol(result, pos_to_sym, line_to_syms)
-                    if target is None or not _is_valid_edge(caller, target):
+                    if target is None:
+                        _record_external_call_site(ctx, st.attribution_symbol(caller), result, site, ITERATED)
+                        continue
+                    if not _is_valid_edge(caller, target):
                         continue
                     resolved += 1
                     attributed = st.attribution_symbol(caller)
@@ -481,9 +485,16 @@ def _resolve_definitions(
                 if not caller:
                     continue
 
+                position = (call_site.lsp_line, call_site.lsp_column)
+                kind = CALL
+                if position in method_group_positions:
+                    kind = METHOD_GROUP
+                elif position in collection_positions:
+                    kind = COLLECTION_INITIALIZER
                 for def_result in defs:
                     target = _resolve_definition_to_symbol(def_result, pos_to_sym, line_to_syms)
                     if not target:
+                        _record_external_call_site(ctx, st.attribution_symbol(caller), def_result, call_site, kind)
                         continue
                     total_resolved += 1
 
@@ -618,6 +629,25 @@ def _resolve_implementations(
 # ---------------------------------------------------------------------------
 # Shared helpers
 # ---------------------------------------------------------------------------
+
+
+def _record_external_call_site(
+    ctx: EdgeBuildContext, caller: SymbolInfo, def_result: dict, call_site: CallSite, kind: str
+) -> None:
+    """Keep a definition that landed in a file this engine never named, for the merged graph."""
+    location = definition_location(def_result)
+    if location is None or str(location[0]) in ctx.symbol_table.file_symbols:
+        return
+    ctx.external_call_sites.append(
+        ExternalCallSite(
+            caller=caller.qualified_name,
+            file=str(location[0]),
+            line=location[1],
+            character=location[2],
+            call_site=call_site,
+            kind=kind,
+        )
+    )
 
 
 def _call_site(file_path: Path, line: int, column: int) -> CallSite:

--- a/static_analyzer/engine/models.py
+++ b/static_analyzer/engine/models.py
@@ -94,6 +94,26 @@ class CallFlowGraph:
 
 
 @dataclass
+@dataclass(frozen=True)
+class ExternalCallSite:
+    """A call whose definition the server placed in a file this engine holds no symbols for.
+
+    Why: a repository with several solutions runs one engine per solution, and a call
+    into another solution's project resolves to a file only that other engine named.
+    The position is kept so the merged graph can finish the edge, and how the site
+    was found (a call, a method-group probe, a collection initializer, a ``foreach``)
+    so it is finished the way the engine would have.
+    """
+
+    caller: str
+    file: str
+    line: int
+    character: int
+    call_site: CallSite
+    kind: str = "call"
+
+
+@dataclass
 class LanguageAnalysisResult:
     """Analysis result for a single language."""
 
@@ -102,6 +122,7 @@ class LanguageAnalysisResult:
     cfg: CallFlowGraph = field(default_factory=CallFlowGraph)
     package_dependencies: dict[str, dict] = field(default_factory=dict)
     source_files: list[str] = field(default_factory=list)
+    external_call_sites: list[ExternalCallSite] = field(default_factory=list)
     # Non-call relationship edges completing the graph for clustering. Each entry
     # is (source_qname, target_qname). type_references: code names a type (param,
     # return, annotation, cast); import_edges: module A imports symbol/module B.

--- a/static_analyzer/engine/result_converter.py
+++ b/static_analyzer/engine/result_converter.py
@@ -161,6 +161,7 @@ def convert_to_codeboarding_format(
         "references": references,
         "source_files": result.source_files,
         "diagnostics": {},
+        "external_call_sites": [site for site in result.external_call_sites if call_graph.has_node(site.caller)],
     }
 
 

--- a/static_analyzer/external_calls.py
+++ b/static_analyzer/external_calls.py
@@ -1,0 +1,86 @@
+"""Finish the call edges one engine could not: definitions in another engine's files.
+
+A repository with several solutions runs one engine per solution root, and a call
+into a project outside the caller's solution resolves to a file only the other
+engine named. Each engine keeps those positions; once every graph is merged, the
+positions are resolved here the way the engine resolves its own.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from static_analyzer.cfg import CallGraph
+from static_analyzer.engine.language_adapter import LanguageAdapter
+from static_analyzer.engine.models import ExternalCallSite
+from static_analyzer.engine.source_inspector import SourceInspector
+from static_analyzer.graph_definitions import CALL, GraphIndex, targets_for
+from static_analyzer.internal_references import is_self_or_container_edge
+
+logger = logging.getLogger(__name__)
+
+
+def link_external_call_sites(
+    call_graph: CallGraph,
+    sites: list[ExternalCallSite],
+    adapter: LanguageAdapter,
+    package_dependencies: dict[str, dict],
+    inspector: SourceInspector,
+) -> int:
+    """Add the edges whose targets the merged graph now holds; return how many were added.
+
+    A new edge across packages is recorded in *package_dependencies* too: each engine
+    derived those from its own edges before the merge, and the health checks read them.
+    """
+    if not sites:
+        return 0
+    index = GraphIndex(call_graph)
+    added = 0
+    unresolved = 0
+    for site in sites:
+        caller = call_graph.nodes.get(site.caller)
+        if caller is None:
+            continue
+        constructing = (
+            site.kind == CALL and adapter.expands_constructors and inspector.is_construction_site(site.call_site)
+        )
+        targets = targets_for(index, site.file, site.line, site.character, site.kind, adapter, constructing)
+        if not targets:
+            unresolved += 1
+            continue
+        call_site = {"file": site.call_site.file, "line": site.call_site.line, "column": site.call_site.column}
+        for destination in targets:
+            if is_self_or_container_edge(caller.fully_qualified_name, destination.fully_qualified_name):
+                continue
+            if (destination.file_path, destination.line_start) == (caller.file_path, caller.line_start):
+                continue
+            before = len(call_graph.edges)
+            call_graph.add_edge(caller.fully_qualified_name, destination.fully_qualified_name, call_sites=[call_site])
+            if len(call_graph.edges) > before:
+                added += 1
+                _record_package_import(
+                    package_dependencies, adapter, caller.fully_qualified_name, destination.fully_qualified_name
+                )
+    logger.info(
+        "Cross-engine call sites: %d linked into %d new edges, %d point outside every engine's files",
+        len(sites) - unresolved,
+        added,
+        unresolved,
+    )
+    return added
+
+
+def _record_package_import(
+    package_dependencies: dict[str, dict], adapter: LanguageAdapter, source: str, destination: str
+) -> None:
+    src_pkg, dst_pkg = adapter.extract_package(source), adapter.extract_package(destination)
+    if src_pkg == dst_pkg:
+        return
+    src_info = package_dependencies.get(src_pkg)
+    dst_info = package_dependencies.get(dst_pkg)
+    if src_info is not None and dst_pkg not in src_info.setdefault("imports", []):
+        src_info["imports"].append(dst_pkg)
+        src_info["imports"].sort()
+    if dst_info is not None and src_pkg not in dst_info.setdefault("imported_by", []):
+        dst_info["imported_by"].append(src_pkg)
+        dst_info["imported_by"].sort()

--- a/static_analyzer/graph_definitions.py
+++ b/static_analyzer/graph_definitions.py
@@ -1,0 +1,179 @@
+"""Resolve a definition position against a merged call graph, expanded the way the engine expands it.
+
+Shared by the warm-start updater (definitions of changed files, against the cached
+graph) and the cross-engine linker (definitions one engine could not name, against
+every engine's graph), so the two cannot disagree on which nodes a call site reaches.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+
+from static_analyzer.cfg import CallGraph, EdgeKind
+from static_analyzer.engine.language_adapter import LanguageAdapter
+from static_analyzer.engine.lsp_constants import EdgeStrategy
+from static_analyzer.engine.utils import definition_location
+from static_analyzer.internal_references import parent_qualified_name
+from static_analyzer.node import Node
+
+# How a call site was found in source; it decides what a resolved definition may become.
+CALL = "call"
+METHOD_GROUP = "method_group"
+COLLECTION_INITIALIZER = "collection"
+ITERATED = "iterated"
+
+
+class GraphIndex:
+    """A graph's nodes by file, so a position lookup does not scan every node."""
+
+    def __init__(self, call_graph: CallGraph) -> None:
+        self.call_graph = call_graph
+        self._by_file: dict[str, list[Node]] = defaultdict(list)
+        for node in call_graph.nodes.values():
+            self._by_file[node.file_path].append(node)
+
+    def nodes_in(self, file_path: str) -> list[Node]:
+        return self._by_file.get(file_path, [])
+
+
+def position_inside_node(node: Node, zero_based_line: int, character: int) -> bool:
+    line = zero_based_line + 1
+    if line < node.line_start or line > node.line_end:
+        return False
+    if line == node.line_start and character < node.col_start:
+        return False
+    return True
+
+
+def most_specific_node_at_position(
+    index: GraphIndex, file_path: str, line: int, char: int, callable_only: bool = False
+) -> Node | None:
+    matches = [
+        node
+        for node in index.nodes_in(file_path)
+        if (not callable_only or node.is_callable()) and position_inside_node(node, line, char)
+    ]
+    if not matches:
+        return None
+    return max(
+        matches,
+        key=lambda node: (node.line_start, node.col_start, -node.line_end, len(node.fully_qualified_name)),
+    )
+
+
+def containing_source_node(index: GraphIndex, file_path: str, line: int, char: int) -> Node | None:
+    """The node an edge from this position belongs to, callable or otherwise.
+
+    A field initializer -- ``private readonly Store _store = new Store();`` -- calls
+    a constructor from outside any method, so a callable-only lookup finds nothing
+    and the edge is dropped. The full rebuild attributes it to the enclosing class,
+    and every later pass has to agree or it loses the edge on every edit to that file.
+    """
+    callable_node = most_specific_node_at_position(index, file_path, line, char, callable_only=True)
+    if callable_node is not None:
+        return callable_node
+    return most_specific_node_at_position(index, file_path, line, char)
+
+
+def nodes_at_location(
+    index: GraphIndex, file_path: str, line: int, character: int, include_callable_parent: bool = False
+) -> list[Node]:
+    """The node declared at an LSP position, plus the class a callable or constructor belongs to."""
+    target = most_specific_node_at_position(index, file_path, line, character)
+    if target is None:
+        same_line = [node for node in index.nodes_in(file_path) if node.line_start == line + 1]
+        if same_line:
+            target = max(
+                same_line, key=lambda node: (node.is_class(), node.is_callable(), len(node.fully_qualified_name))
+            )
+    if target is None:
+        return []
+    targets = [target]
+    if (include_callable_parent and target.is_callable()) or target.type.name == "CONSTRUCTOR":
+        parent = index.call_graph.nodes.get(parent_qualified_name(target.fully_qualified_name))
+        if parent is not None and parent.is_class():
+            targets.append(parent)
+    return targets
+
+
+def definition_nodes(index: GraphIndex, definition: dict, include_callable_parent: bool = False) -> list[Node]:
+    location = definition_location(definition)
+    if location is None:
+        return []
+    file_path, line, character = location
+    return nodes_at_location(index, str(file_path), line, character, include_callable_parent)
+
+
+def members_named(call_graph: CallGraph, owner: Node, name: str) -> list[Node]:
+    """Nodes for ``owner``'s members called *name*, by qualified-name prefix.
+
+    The full rebuild reads these off the symbol table; on a merged graph only the
+    qualified names remain, so the owning type's members are found by name.
+    """
+    prefix = f"{owner.fully_qualified_name}.{name}"
+    return [node for qname, node in call_graph.nodes.items() if qname == prefix or qname.startswith(f"{prefix}(")]
+
+
+def override_nodes(call_graph: CallGraph, target: Node) -> list[Node]:
+    """Same-named members on types that inherit the target's owner.
+
+    A call through a base-typed reference resolves to the base declaration; the
+    INHERITS edges already in the merged graph carry the relation the full rebuild
+    reads from source.
+    """
+    if not target.is_callable():
+        return []
+    owner_qname = parent_qualified_name(target.fully_qualified_name)
+    owner = call_graph.nodes.get(owner_qname)
+    if owner is None:
+        return []
+    member = target.fully_qualified_name[len(owner_qname) + 1 :].split("(")[0]
+    overrides: list[Node] = []
+    for ref in call_graph.reference_edges:
+        if ref.kind is EdgeKind.INHERITS and ref.dst == owner_qname:
+            derived = call_graph.nodes.get(ref.src)
+            if derived is not None:
+                overrides.extend(members_named(call_graph, derived, member))
+    return overrides
+
+
+def targets_for(
+    index: GraphIndex,
+    file_path: str,
+    line: int,
+    character: int,
+    kind: str,
+    adapter: LanguageAdapter,
+    constructing: bool = False,
+) -> list[Node]:
+    """Every node a call site of *kind* reaches when its definition is at this position.
+
+    Mirrors the engine's own definition strategy: an argument position is a method
+    group only when it resolves to something callable; a ``foreach`` calls the
+    enumerated type's ``GetEnumerator``; a collection initializer calls ``Add``; a
+    base member dispatches to its overrides; a construction reaches the constructors.
+    """
+    call_graph = index.call_graph
+    include_parent = adapter.edge_strategy == EdgeStrategy.DEFINITIONS and kind != ITERATED
+    resolved = nodes_at_location(index, file_path, line, character, include_parent)
+    if kind == METHOD_GROUP and resolved:
+        # A probe resolves to whatever declaration the name denotes; only a callable or a type
+        # declared exactly there is a method group. An enum member or property is not a node,
+        # and the type that encloses it must not stand in for it.
+        primary = resolved[0]
+        declared_here = (primary.line_start, primary.col_start) == (line + 1, character)
+        if not declared_here or not (primary.is_callable() or primary.is_class()):
+            return []
+    targets: list[Node] = []
+    for node in resolved:
+        targets.append(node)
+        if kind == ITERATED:
+            targets.extend(members_named(call_graph, node, "GetEnumerator"))
+            continue
+        if adapter.expands_virtual_dispatch:
+            targets.extend(override_nodes(call_graph, node))
+        if kind == COLLECTION_INITIALIZER:
+            targets.extend(members_named(call_graph, node, "Add"))
+        if constructing and adapter.expands_constructors and node.is_class():
+            targets.extend(members_named(call_graph, node, node.fully_qualified_name.split(".")[-1].split("<")[0]))
+    return targets

--- a/static_analyzer/incremental_orchestrator.py
+++ b/static_analyzer/incremental_orchestrator.py
@@ -25,9 +25,22 @@ from static_analyzer.engine.lsp_client import LSPClient
 from static_analyzer.engine.lsp_constants import EdgeStrategy
 from static_analyzer.engine.result_converter import convert_to_codeboarding_format
 from static_analyzer.engine.source_inspector import SourceInspector
+from static_analyzer.engine.models import CallSite, ExternalCallSite
 from static_analyzer.engine.utils import definition_location, uri_to_path
-from static_analyzer.cfg import CallGraph, EdgeKind
-from static_analyzer.internal_references import is_self_or_container_edge, parent_qualified_name
+from static_analyzer.graph_definitions import (
+    CALL,
+    COLLECTION_INITIALIZER,
+    ITERATED,
+    METHOD_GROUP,
+    GraphIndex,
+    containing_source_node,
+    definition_nodes,
+    override_nodes,
+    position_inside_node,
+    targets_for,
+)
+from static_analyzer.cfg import CallGraph
+from static_analyzer.internal_references import is_self_or_container_edge
 from static_analyzer.node import Node
 
 logger = logging.getLogger(__name__)
@@ -99,7 +112,7 @@ def update_cfg_for_changed_files(
         new_analysis["diagnostics"] = fresh_diagnostics
 
     merged_analysis = merge_results(updated_cache.analysis, new_analysis)
-    _rebuild_changed_file_edges(
+    external = _rebuild_changed_file_edges(
         merged_analysis,
         updated_cache.invalidated_edges,
         updated_cache.invalidated_files,
@@ -107,7 +120,9 @@ def update_cfg_for_changed_files(
         adapter,
         engine_client,
     )
-    return _filter_to_live_files(merged_analysis).to_dict()
+    updated = _filter_to_live_files(merged_analysis).to_dict()
+    updated["external_call_sites"] = external
+    return updated
 
 
 def _rebuild_changed_file_edges(
@@ -117,13 +132,18 @@ def _rebuild_changed_file_edges(
     changed_source_files: list[Path],
     adapter: LanguageAdapter,
     engine_client: LSPClient,
-) -> None:
+) -> list[ExternalCallSite]:
+    """Restore and re-resolve the edges an edit touched; return the definitions this graph cannot name yet.
+
+    Why return them: a changed caller in one solution and its new destination in another are
+    updated by different engines, in either order, so a definition with no node here is only
+    finished once every engine's graph is merged.
+    """
     source_inspector = SourceInspector()
-    _restore_cross_boundary_edges(
-        merged_analysis.call_graph, invalidated_edges, changed_file_strs, adapter, engine_client, source_inspector
-    )
-    _add_outbound_edges_from_changed_files(
-        merged_analysis.call_graph,
+    index = GraphIndex(merged_analysis.call_graph)
+    _restore_cross_boundary_edges(index, invalidated_edges, changed_file_strs, adapter, engine_client, source_inspector)
+    return _add_outbound_edges_from_changed_files(
+        index,
         changed_source_files,
         engine_client,
         source_inspector,
@@ -132,19 +152,20 @@ def _rebuild_changed_file_edges(
 
 
 def _restore_cross_boundary_edges(
-    call_graph: CallGraph,
+    index: GraphIndex,
     invalidated_edges: list[InvalidatedEdge],
     changed_file_strs: set[str],
     adapter: LanguageAdapter,
     engine_client: LSPClient,
     source_inspector: SourceInspector,
 ) -> None:
+    call_graph = index.call_graph
     if not invalidated_edges:
         return
 
     if adapter.edge_strategy == EdgeStrategy.DEFINITIONS:
         _restore_inbound_edges_via_definitions(
-            call_graph,
+            index,
             invalidated_edges,
             changed_file_strs,
             adapter,
@@ -201,13 +222,14 @@ def _restore_cross_boundary_edges(
 
 
 def _restore_inbound_edges_via_definitions(
-    call_graph: CallGraph,
+    index: GraphIndex,
     invalidated_edges: list[InvalidatedEdge],
     changed_file_strs: set[str],
     adapter: LanguageAdapter,
     engine_client: LSPClient,
     include_callable_parent: bool,
 ) -> None:
+    call_graph = index.call_graph
     """Re-resolve invalidated edges whose source file is unchanged, from their cached call sites.
 
     Why not references: an adapter on the definitions strategy is there because
@@ -261,12 +283,12 @@ def _restore_inbound_edges_via_definitions(
             resolved = [
                 dst_node
                 for definition in definitions
-                for dst_node in _definition_nodes(call_graph, definition, include_callable_parent)
+                for dst_node in definition_nodes(index, definition, include_callable_parent)
             ]
             reachable = {node.fully_qualified_name for node in resolved}
             if adapter.expands_virtual_dispatch:
                 for node in resolved:
-                    reachable.update(o.fully_qualified_name for o in _override_nodes(call_graph, node))
+                    reachable.update(o.fully_qualified_name for o in override_nodes(call_graph, node))
             if edge[1] in reachable:
                 confirmed.setdefault(edge, []).append(site)
 
@@ -300,7 +322,7 @@ def _edge_reference_call_sites(
         ref_line = ref_start.get("line", -1)
         ref_char = ref_start.get("character", -1)
         ref_end_char = ref_end.get("character", -1)
-        if not _position_inside_node(src_node, ref_line, ref_char):
+        if not position_inside_node(src_node, ref_line, ref_char):
             continue
         if not _reference_matches_edge_kind(
             dst_node, ref_file, ref_line, ref_char, ref_end_char, adapter, source_inspector
@@ -310,54 +332,19 @@ def _edge_reference_call_sites(
     return call_sites
 
 
-def _members_named(call_graph: CallGraph, owner: Node, name: str) -> list[Node]:
-    """Nodes for ``owner``'s members called *name*, by qualified-name prefix.
-
-    The full rebuild reads these off the symbol table; incrementally only the
-    merged graph is available, so the owning type's members are found by name.
-    """
-    prefix = f"{owner.fully_qualified_name}.{name}"
-    return [node for qname, node in call_graph.nodes.items() if qname == prefix or qname.startswith(f"{prefix}(")]
-
-
-def _override_nodes(call_graph: CallGraph, target: Node) -> list[Node]:
-    """Same-named members on types that inherit the target's owner.
-
-    A call through a base-typed reference resolves to the base declaration, so
-    without this the incremental graph stops where the full rebuild continues.
-    The full rebuild builds a subclass index from source; here the INHERITS
-    edges already in the merged graph carry the same relation.
-    """
-    if not target.is_callable():
-        return []
-    owner_qname = parent_qualified_name(target.fully_qualified_name)
-    owner = call_graph.nodes.get(owner_qname)
-    if owner is None:
-        return []
-    member = target.fully_qualified_name[len(owner_qname) + 1 :].split("(")[0]
-    overrides: list[Node] = []
-    for ref in call_graph.reference_edges:
-        if ref.kind is EdgeKind.INHERITS and ref.dst == owner_qname:
-            derived = call_graph.nodes.get(ref.src)
-            if derived is not None:
-                overrides.extend(_members_named(call_graph, derived, member))
-    return overrides
-
-
 def _add_outbound_edges_from_changed_files(
-    call_graph: CallGraph,
+    index: GraphIndex,
     changed_source_files: list[Path],
     engine_client: LSPClient,
     source_inspector: SourceInspector,
     adapter: LanguageAdapter,
-) -> None:
+) -> list[ExternalCallSite]:
+    call_graph = index.call_graph
+    external: list[ExternalCallSite] = []
     if not changed_source_files:
-        return
-
-    include_callable_parent = adapter.edge_strategy == EdgeStrategy.DEFINITIONS
+        return external
     added = 0
     changed_file_strs = {str(file_path) for file_path in changed_source_files}
-
     for file_path in changed_source_files:
         call_sites = source_inspector.find_call_sites(file_path)
         method_group_positions: set[tuple[int, int]] = set()
@@ -374,14 +361,7 @@ def _add_outbound_edges_from_changed_files(
                 (site.lsp_line, site.lsp_column)
                 for site in source_inspector.find_collection_initializer_sites(file_path)
             }
-        added += _add_iterated_type_edges(
-            call_graph,
-            file_path,
-            engine_client,
-            source_inspector,
-            adapter,
-            changed_file_strs,
-        )
+        added += _add_iterated_type_edges(index, file_path, engine_client, source_inspector, adapter, external)
         if not call_sites:
             continue
         queries = [(file_path, site.lsp_line, site.lsp_column) for site in call_sites]
@@ -390,59 +370,42 @@ def _add_outbound_edges_from_changed_files(
         except Exception:
             logger.debug("Failed to resolve outbound definitions for %s", file_path, exc_info=True)
             continue
-
         for site, definitions in zip(call_sites, definition_results):
-            line = site.lsp_line
-            char = site.lsp_column
-            src_node = _containing_source_node(call_graph, file_path, line, char)
+            position = (site.lsp_line, site.lsp_column)
+            src_node = containing_source_node(index, str(file_path), site.lsp_line, site.lsp_column)
             if src_node is None:
                 continue
-            is_method_group = (line, char) in method_group_positions
+            kind = CALL
+            if position in method_group_positions:
+                kind = METHOD_GROUP
+            elif position in collection_positions:
+                kind = COLLECTION_INITIALIZER
+            constructing = kind == CALL and adapter.expands_constructors and source_inspector.is_construction_site(site)
             for definition in definitions:
-                for resolved in _definition_nodes(call_graph, definition, include_callable_parent):
-                    # Same rule as the full rebuild: an argument position is a
-                    # method group only when it resolves to something callable.
-                    if is_method_group and not (resolved.is_callable() or resolved.is_class()):
-                        continue
-                    targets = [resolved]
-                    if adapter.expands_virtual_dispatch:
-                        targets += _override_nodes(call_graph, resolved)
-                    if (line, char) in collection_positions:
-                        targets += _members_named(call_graph, resolved, "Add")
-                    for dst_node in targets:
-                        # The fresh partial analysis already owns changed-to-changed edges.
-                        if dst_node.file_path in changed_file_strs:
-                            continue
-                        if is_self_or_container_edge(src_node.fully_qualified_name, dst_node.fully_qualified_name):
-                            continue
-                        try:
-                            before = len(call_graph.edges)
-                            call_graph.add_edge(
-                                src_node.fully_qualified_name,
-                                dst_node.fully_qualified_name,
-                                call_sites=[{"file": site.file, "line": site.line, "column": site.column}],
-                            )
-                            if len(call_graph.edges) > before:
-                                added += 1
-                        except ValueError:
-                            logger.debug(
-                                "Failed to add outbound edge %s -> %s",
-                                src_node.fully_qualified_name,
-                                dst_node.fully_qualified_name,
-                                exc_info=True,
-                            )
-
+                location = definition_location(definition)
+                if location is None:
+                    continue
+                targets = targets_for(index, str(location[0]), location[1], location[2], kind, adapter, constructing)
+                if not targets:
+                    external.append(
+                        ExternalCallSite(
+                            src_node.fully_qualified_name, str(location[0]), location[1], location[2], site, kind
+                        )
+                    )
+                    continue
+                added += _add_edges(call_graph, src_node, targets, site, changed_file_strs)
     if added:
         logger.info("Added %d new outbound edge(s) from changed files", added)
+    return external
 
 
 def _add_iterated_type_edges(
-    call_graph: CallGraph,
+    index: GraphIndex,
     file_path: Path,
     engine_client: LSPClient,
     source_inspector: SourceInspector,
     adapter: LanguageAdapter,
-    changed_file_strs: set[str],
+    external: list[ExternalCallSite],
 ) -> int:
     """``foreach (var x in bag)`` calls ``bag.GetEnumerator()`` with no call written.
 
@@ -462,118 +425,49 @@ def _add_iterated_type_edges(
     except Exception:
         logger.warning("Failed to resolve iterated types for %s", file_path, exc_info=True)
         return 0
-
     added = 0
     for site, definitions in zip(sites, results):
-        src_node = _containing_source_node(call_graph, file_path, site.lsp_line, site.lsp_column)
+        src_node = containing_source_node(index, str(file_path), site.lsp_line, site.lsp_column)
         if src_node is None:
             continue
         for definition in definitions:
-            for type_node in _definition_nodes(call_graph, definition, include_callable_parent=False):
-                for dst_node in [type_node] + _members_named(call_graph, type_node, "GetEnumerator"):
-                    if dst_node.file_path in changed_file_strs:
-                        continue
-                    if is_self_or_container_edge(src_node.fully_qualified_name, dst_node.fully_qualified_name):
-                        continue
-                    try:
-                        before = len(call_graph.edges)
-                        call_graph.add_edge(
-                            src_node.fully_qualified_name,
-                            dst_node.fully_qualified_name,
-                            call_sites=[{"file": site.file, "line": site.line, "column": site.column}],
-                        )
-                        if len(call_graph.edges) > before:
-                            added += 1
-                    except ValueError:
-                        logger.debug("Failed to add iterated-type edge", exc_info=True)
+            location = definition_location(definition)
+            if location is None:
+                continue
+            targets = targets_for(index, str(location[0]), location[1], location[2], ITERATED, adapter)
+            if not targets:
+                external.append(
+                    ExternalCallSite(
+                        src_node.fully_qualified_name, str(location[0]), location[1], location[2], site, ITERATED
+                    )
+                )
+                continue
+            added += _add_edges(index.call_graph, src_node, targets, site, {str(file_path)})
     return added
 
 
-def _containing_source_node(call_graph: CallGraph, file_path: Path, line: int, char: int) -> Node | None:
-    """The node an edge from this position belongs to, callable or otherwise.
-
-    A field initializer -- ``private readonly Store _store = new Store();`` -- calls
-    a constructor from outside any method, so a callable-only lookup finds nothing
-    and the edge is dropped. The full rebuild attributes it to the enclosing class,
-    and an incremental run has to agree or it loses the edge on every edit to that
-    file, including edits that change nothing.
-    """
-    callable_node = _most_specific_node_at_position(call_graph, file_path, line, char, callable_only=True)
-    if callable_node is not None:
-        return callable_node
-    return _most_specific_node_at_position(call_graph, file_path, line, char)
-
-
-def _most_specific_node_at_position(
-    call_graph: CallGraph,
-    file_path: Path,
-    line: int,
-    char: int,
-    callable_only: bool = False,
-) -> Node | None:
-    matches = [
-        node
-        for node in call_graph.nodes.values()
-        if node.file_path == str(file_path)
-        and (not callable_only or node.is_callable())
-        and _position_inside_node(node, line, char)
-    ]
-    if not matches:
-        return None
-    return max(
-        matches,
-        key=lambda node: (
-            node.line_start,
-            node.col_start,
-            -node.line_end,
-            len(node.fully_qualified_name),
-        ),
-    )
-
-
-def _definition_nodes(
-    call_graph: CallGraph,
-    definition: dict[str, Any],
-    include_callable_parent: bool = False,
-) -> list[Node]:
-    location = definition_location(definition)
-    if location is None:
-        return []
-    file_path, line, character = location
-    target = _most_specific_node_at_position(call_graph, file_path, line, character)
-    if target is None:
-        same_line = [
-            node
-            for node in call_graph.nodes.values()
-            if node.file_path == str(file_path) and node.line_start == line + 1
-        ]
-        if same_line:
-            target = max(
-                same_line,
-                key=lambda node: (
-                    node.is_class(),
-                    node.is_callable(),
-                    len(node.fully_qualified_name),
-                ),
+def _add_edges(
+    call_graph: CallGraph, src_node: Node, targets: list[Node], site: CallSite, changed_file_strs: set[str]
+) -> int:
+    """Edges from *src_node* to *targets* with *site*; the fresh partial analysis already owns changed-to-changed ones."""
+    added = 0
+    for dst_node in targets:
+        if dst_node.file_path in changed_file_strs:
+            continue
+        if is_self_or_container_edge(src_node.fully_qualified_name, dst_node.fully_qualified_name):
+            continue
+        try:
+            before = len(call_graph.edges)
+            call_graph.add_edge(
+                src_node.fully_qualified_name,
+                dst_node.fully_qualified_name,
+                call_sites=[{"file": site.file, "line": site.line, "column": site.column}],
             )
-    if target is None:
-        return []
-
-    targets = [target]
-    if (include_callable_parent and target.is_callable()) or target.type == NodeType.CONSTRUCTOR:
-        parent = call_graph.nodes.get(parent_qualified_name(target.fully_qualified_name))
-        if parent is not None and parent.is_class():
-            targets.append(parent)
-    return targets
-
-
-def _position_inside_node(node: Node, zero_based_line: int, character: int) -> bool:
-    line = zero_based_line + 1
-    if line < node.line_start or line > node.line_end:
-        return False
-    if line == node.line_start and character < node.col_start:
-        return False
-    return True
+            if len(call_graph.edges) > before:
+                added += 1
+        except ValueError:
+            logger.debug("Failed to add edge %s -> %s", src_node.fully_qualified_name, dst_node.fully_qualified_name)
+    return added
 
 
 def _reference_matches_edge_kind(

--- a/tests/static_analyzer/test_analysis_cache_inmem.py
+++ b/tests/static_analyzer/test_analysis_cache_inmem.py
@@ -16,11 +16,13 @@ from static_analyzer.analysis_result import AnalysisData, StaticAnalysisResults
 from static_analyzer.config import Language, NodeType
 from static_analyzer.cfg import CallGraph
 from static_analyzer.node import Node
+from static_analyzer.graph_definitions import GraphIndex, definition_nodes
 from static_analyzer.incremental_orchestrator import (
-    _definition_nodes,
+    _add_outbound_edges_from_changed_files,
     _restore_cross_boundary_edges,
     update_cfg_for_changed_files,
 )
+from static_analyzer.engine.adapters.csharp_adapter import CSharpAdapter
 from static_analyzer.engine.source_inspector import SourceInspector
 from utils import CODEBOARDING_DIR_NAME
 
@@ -244,7 +246,7 @@ class TestWarmStartOutboundEdges(unittest.TestCase):
             "range": {"start": {"line": 2, "character": 0}, "end": {"line": 2, "character": 66}},
         }
 
-        matches = _definition_nodes(call_graph, definition)
+        matches = definition_nodes(GraphIndex(call_graph), definition)
 
         self.assertEqual([node.fully_qualified_name for node in matches], ["unchanged.unchanged_target"])
 
@@ -275,7 +277,7 @@ class TestWarmStartOutboundEdges(unittest.TestCase):
             "range": {"start": {"line": 9, "character": 8}, "end": {"line": 9, "character": 15}},
         }
 
-        matches = _definition_nodes(call_graph, definition, include_callable_parent=True)
+        matches = definition_nodes(GraphIndex(call_graph), definition, include_callable_parent=True)
 
         self.assertEqual(
             [node.fully_qualified_name for node in matches],
@@ -313,7 +315,7 @@ class TestWarmStartOutboundEdges(unittest.TestCase):
             "range": {"start": {"line": 0, "character": 0}, "end": {"line": 0, "character": 6}},
         }
 
-        matches = _definition_nodes(call_graph, definition)
+        matches = definition_nodes(GraphIndex(call_graph), definition)
 
         self.assertEqual([node.fully_qualified_name for node in matches], ["pkg.target.Target"])
 
@@ -344,7 +346,7 @@ class TestWarmStartOutboundEdges(unittest.TestCase):
             "range": {"start": {"line": 1, "character": 5}, "end": {"line": 1, "character": 16}},
         }
 
-        matches = _definition_nodes(call_graph, definition)
+        matches = definition_nodes(GraphIndex(call_graph), definition)
 
         self.assertEqual(
             [node.fully_qualified_name for node in matches],
@@ -390,7 +392,7 @@ class TestWarmStartOutboundEdges(unittest.TestCase):
             adapter.is_class_like.return_value = False
 
             _restore_cross_boundary_edges(
-                call_graph,
+                GraphIndex(call_graph),
                 [(source.fully_qualified_name, target.fully_qualified_name, source, target, [])],
                 {str(changed_file)},
                 adapter,
@@ -407,3 +409,29 @@ class TestWarmStartOutboundEdges(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestWarmStartKeepsDefinitionsAnotherEngineOwns:
+    def test_a_changed_caller_whose_definition_has_no_node_yet_is_handed_back(self, tmp_path: Path) -> None:
+        """Solution A's changed file calls something solution B adds in the same edit; B's node is
+        not in the graph when A is processed, so the site must survive until every engine merged."""
+        changed = tmp_path / "Host.cs"
+        changed.write_text("class Host\n{\n    void Configure() { Builder.UseAuditing(); }\n}\n")
+        graph = CallGraph(language="csharp")
+        graph.add_node(Node("Host", NodeType.CLASS, str(changed), line_start=1, line_end=4, col_start=0))
+        graph.add_node(Node("Host.Configure()", NodeType.METHOD, str(changed), line_start=3, line_end=3, col_start=9))
+        elsewhere = tmp_path / "framework" / "Builder.cs"
+        client = MagicMock()
+        client.send_definition_batch.side_effect = lambda queries: (
+            [[{"uri": elsewhere.as_uri(), "range": {"start": {"line": 20, "character": 4}}}] for _ in queries],
+            set(),
+        )
+
+        external = _add_outbound_edges_from_changed_files(
+            GraphIndex(graph), [changed], client, SourceInspector(), CSharpAdapter()
+        )
+
+        assert graph.edges == []
+        assert [(s.caller, s.file, s.line, s.character, s.kind) for s in external] == [
+            ("Host.Configure()", str(elsewhere), 20, 4, "call")
+        ]

--- a/tests/static_analyzer/test_edge_builder.py
+++ b/tests/static_analyzer/test_edge_builder.py
@@ -490,6 +490,38 @@ class TestBuildEdgesViaDefinitions:
         edges = build_edges_via_definitions(adapter, ctx, [src])
         assert ("app.main", "app.helper") in edges
 
+    def test_a_definition_in_a_file_this_engine_never_named_is_kept_for_the_merge(self, tmp_path: Path):
+        lsp = _make_lsp()
+        ctx, adapter = _make_ctx(lsp)
+        st = ctx.symbol_table
+
+        src = tmp_path / "modules" / "app.py"
+        src.parent.mkdir()
+        src.write_text("def main():\n    helper()\n")
+        other = tmp_path / "framework" / "lib.py"
+
+        caller = _sym("main", "app.main", NodeType.FUNCTION, str(src), 0, 4, 1)
+        st._symbols["app.main"] = caller
+        st._file_symbols[str(src)] = [caller]
+        st._primary_file_symbols[str(src)] = [caller]
+        st.build_indices()
+
+        lsp.send_definition_batch.side_effect = lambda queries: (
+            [
+                [{"uri": other.as_uri(), "range": {"start": {"line": 7, "character": 4}}}] if line == 1 else []
+                for _, line, _ in queries
+            ],
+            set(),
+        )
+
+        edges = build_edges_via_definitions(adapter, ctx, [src])
+
+        assert edges == {}
+        assert [(s.caller, s.file, s.line, s.character, s.kind) for s in ctx.external_call_sites] == [
+            ("app.main", str(other), 7, 4, "call")
+        ]
+        assert (ctx.external_call_sites[0].call_site.line, ctx.external_call_sites[0].call_site.column) == (2, 5)
+
     def test_no_call_sites_produces_empty(self, tmp_path: Path):
         """File with no call sites produces no edges."""
         lsp = _make_lsp()

--- a/tests/static_analyzer/test_external_calls.py
+++ b/tests/static_analyzer/test_external_calls.py
@@ -1,0 +1,158 @@
+from static_analyzer.cfg import CallGraph, EdgeKind, ReferenceEdge
+from static_analyzer.config import NodeType
+from static_analyzer.engine.adapters.csharp_adapter import CSharpAdapter
+from static_analyzer.engine.models import CallSite, ExternalCallSite
+from static_analyzer.engine.source_inspector import SourceInspector
+from static_analyzer.external_calls import link_external_call_sites
+from static_analyzer.graph_definitions import COLLECTION_INITIALIZER, ITERATED, METHOD_GROUP
+from static_analyzer.node import Node
+
+CALLER = "Modules.Host.Configure(App app)"
+BUILDER = "/repo/framework/Builder.cs"
+
+
+def _node(qname: str, kind: NodeType, file: str, line: int, col: int = 4, end: int = 0) -> Node:
+    return Node(qname, kind, file, line_start=line, line_end=end or line + 3, col_start=col)
+
+
+def _graph() -> CallGraph:
+    """Two engines' worth of nodes after the merge: a module and the framework it calls."""
+    graph = CallGraph(language="csharp")
+    graph.add_node(_node(CALLER, NodeType.METHOD, "/repo/modules/Host.cs", 10))
+    graph.add_node(_node("Modules.Host", NodeType.CLASS, "/repo/modules/Host.cs", 3, 0, 40))
+    graph.add_node(_node("Framework.Builder", NodeType.CLASS, BUILDER, 3, 0, 60))
+    graph.add_node(_node("Framework.Builder.UseAuditing(App app)", NodeType.METHOD, BUILDER, 20))
+    graph.add_node(_node("Framework.Builder.UseAuditing(App app, int depth)", NodeType.METHOD, BUILDER, 30))
+    graph.add_node(_node("Framework.Builder.Status", NodeType.ENUM, BUILDER, 40, 4, 40))
+    graph.add_node(_node("Framework.Bag", NodeType.CLASS, "/repo/framework/Bag.cs", 3, 0, 30))
+    graph.add_node(_node("Framework.Bag.Add(int item)", NodeType.METHOD, "/repo/framework/Bag.cs", 8))
+    graph.add_node(_node("Framework.Bag.GetEnumerator()", NodeType.METHOD, "/repo/framework/Bag.cs", 14))
+    graph.add_node(_node("Framework.Loud", NodeType.CLASS, "/repo/framework/Loud.cs", 3, 0, 30))
+    graph.add_node(_node("Framework.Loud.UseAuditing(App app)", NodeType.METHOD, "/repo/framework/Loud.cs", 8))
+    graph.add_reference_edge(ReferenceEdge("Framework.Loud", "Framework.Builder", EdgeKind.INHERITS))
+    return graph
+
+
+def _site(file: str, line: int, character: int, kind: str = "call", at_line: int = 12) -> ExternalCallSite:
+    return ExternalCallSite(CALLER, file, line, character, CallSite("/repo/modules/Host.cs", at_line, 9), kind)
+
+
+def _link(graph: CallGraph, sites: list[ExternalCallSite], packages: dict | None = None) -> int:
+    return link_external_call_sites(
+        graph, sites, CSharpAdapter(), packages if packages is not None else {}, SourceInspector()
+    )
+
+
+def _destinations(graph: CallGraph) -> set[str]:
+    return {edge.get_destination() for edge in graph.edges}
+
+
+def test_a_definition_in_another_engines_file_becomes_an_edge_with_its_call_site():
+    graph = _graph()
+
+    added = _link(graph, [_site(BUILDER, 19, 4)])
+
+    # The method, its class, and the override the INHERITS edge names: what the engine itself adds.
+    assert added == 3
+    edges = {(e.get_source(), e.get_destination()): e for e in graph.edges}
+    edge = edges[(CALLER, "Framework.Builder.UseAuditing(App app)")]
+    assert [(s["file"], s["line"], s["column"]) for s in edge.call_sites] == [("/repo/modules/Host.cs", 12, 9)]
+    assert (CALLER, "Framework.Builder") in edges
+    assert (CALLER, "Framework.Loud.UseAuditing(App app)") in edges
+
+
+def test_exact_position_beats_a_neighbouring_line():
+    """Two overloads a few lines apart: the selection start decides."""
+    graph = _graph()
+
+    _link(graph, [_site(BUILDER, 29, 4)])
+
+    assert "Framework.Builder.UseAuditing(App app, int depth)" in _destinations(graph)
+    assert "Framework.Builder.UseAuditing(App app)" not in _destinations(graph)
+
+
+def test_a_position_inside_a_declaration_resolves_to_it():
+    graph = _graph()
+
+    _link(graph, [_site(BUILDER, 21, 8)])
+
+    assert "Framework.Builder.UseAuditing(App app)" in _destinations(graph)
+
+
+def test_a_method_group_probe_that_is_a_value_adds_nothing():
+    """``Use(Status.Open)`` probes ``Open`` as a possible method group. The member is no node,
+    and the one-line enum around it must not stand in for it."""
+    graph = _graph()
+
+    assert _link(graph, [_site(BUILDER, 39, 20, METHOD_GROUP)]) == 0
+
+
+def test_a_method_group_probe_that_is_a_method_is_an_edge():
+    graph = _graph()
+
+    _link(graph, [_site(BUILDER, 19, 4, METHOD_GROUP)])
+
+    assert {"Framework.Builder.UseAuditing(App app)", "Framework.Builder"} <= _destinations(graph)
+
+
+def test_a_collection_initializer_reaches_add():
+    graph = _graph()
+
+    _link(graph, [_site("/repo/framework/Bag.cs", 2, 0, COLLECTION_INITIALIZER)])
+
+    assert {"Framework.Bag", "Framework.Bag.Add(int item)"} <= _destinations(graph)
+
+
+def test_a_foreach_reaches_the_enumerator():
+    graph = _graph()
+
+    _link(graph, [_site("/repo/framework/Bag.cs", 2, 0, ITERATED)])
+
+    assert {"Framework.Bag", "Framework.Bag.GetEnumerator()"} <= _destinations(graph)
+
+
+def test_a_position_no_engine_named_adds_nothing():
+    graph = _graph()
+
+    assert _link(graph, [_site("/repo/vendor/Lib.cs", 5, 0)]) == 0
+    assert graph.edges == []
+
+
+def test_a_call_into_the_callers_own_class_is_not_an_edge():
+    graph = _graph()
+
+    assert _link(graph, [_site("/repo/modules/Host.cs", 2, 0)]) == 0
+
+
+def test_a_repeated_site_adds_no_second_edge():
+    graph = _graph()
+    site = _site(BUILDER, 19, 4)
+
+    _link(graph, [site, site])
+
+    edge = next(e for e in graph.edges if e.get_destination().endswith("Builder.UseAuditing(App app)"))
+    assert len(edge.call_sites) == 1
+
+
+def test_a_linked_edge_across_packages_is_a_package_import():
+    """Each engine derived its package relations before the merge; the health checks read them."""
+    graph = _graph()
+    packages: dict[str, dict] = {
+        "Modules": {"imports": [], "imported_by": []},
+        "Framework": {"imports": [], "imported_by": []},
+    }
+
+    _link(graph, [_site(BUILDER, 19, 4)], packages)
+
+    assert packages["Modules"]["imports"] == ["Framework"]
+    assert packages["Framework"]["imported_by"] == ["Modules"]
+
+
+def test_call_sites_are_one_based_like_the_engines():
+    site = ExternalCallSite(CALLER, BUILDER, 19, 4, CallSite.from_lsp_position("/repo/modules/Host.cs", 11, 8))
+    graph = _graph()
+
+    _link(graph, [site])
+
+    edge = next(e for e in graph.edges if e.get_destination().endswith("Builder.UseAuditing(App app)"))
+    assert (edge.call_sites[0]["line"], edge.call_sites[0]["column"]) == (12, 9)


### PR DESCRIPTION
Stacked on #582 (which is stacked on #581). Paired tests PR: https://github.com/CodeBoarding/CodeBoarding-tests/pull/40 (same branch name).

## Why

Third loss class from the same investigation. A repository with several solutions runs **one engine per solution root**, each with its own symbol table. abp has 30 solution roots; a module's `app.UseAuditing()` resolves at the LSP boundary to `framework/src/Volo.Abp.AspNetCore/.../AbpApplicationBuilderExtensions.cs` (csharp-ls follows the `ProjectReference` outside the module solution), but that file belongs to the framework engine, so `_resolve_definition_to_symbol` finds nothing and the call is dropped. On abp, 357 of the 594 callerless extension-method call sites (by a regex count) were cross-solution.

## What changes

- `_resolve_definitions` records an `ExternalCallSite` (caller, definition file/line/char, call site) whenever the definition lands in a file this engine holds **no** symbols for. Definitions in files it does hold symbols for but cannot match keep their current fate; framework and NuGet definitions carry no file location at all, so nothing is recorded for them.
- The sites travel on `LanguageAnalysisResult` → the converter dict → `_run_full_lsp_pass`, which after absorbing every engine calls `link_external_call_sites` (new module `static_analyzer/external_calls.py`) on the merged graph: exact selection-start match first, then same line, then ±2 lines, callables over classes, longest name; the same self/container and same-line guards as the engine; the class of a callable target gets its edge too, as the engine does. The incremental path already resolves definitions against the merged cached graph and needs nothing.

## Tests

- `tests/static_analyzer/test_external_calls.py`: edge + call site, overload picked by exact position, ±1 line tolerance, unknown file, own class, repeated site.
- `tests/static_analyzer/test_edge_builder.py`: the engine records a definition in a file it never named and builds no edge for it.
- Integration (paired PR): a second solution nested under the hand-written C# edge-case solution, whose project references a project outside it; the exact fixture moves from 102 to 107 edges and fails on the base engine with the 4 cross-solution edges missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved static analysis by linking calls across separately analyzed projects and languages.
  * Cross-project call targets are now included in full and incremental analysis results.
  * Unresolved external call sites are preserved with source locations and call-type details.
  * Improved resolution of constructors, overrides, method groups, collection initializers, and iterated calls.

* **Bug Fixes**
  * Prevented duplicate, self-referential, and invalid call edges.

* **Tests**
  * Added coverage for cross-project linking, incremental analysis, position matching, and unresolved targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## After review

The linker was a second, weaker implementation of something the warm-start updater already had. Reworked:

- **A recorded site keeps how it was found** (`ExternalCallSite.kind`: call, method-group probe, collection initializer, `foreach`), from both the definition loop and the iterated-type pass. A method-group probe that lands on a value (an enum member has no node; the enum around it must not stand in) adds nothing; a collection initializer reaches `Add`; a `foreach` reaches `GetEnumerator`; a base member reaches its overrides through the merged graph's INHERITS edges; a construction reaches the constructors where the adapter expands them.
- **One resolver for both paths.** The graph-level helpers the incremental orchestrator had (`_definition_nodes`, `_override_nodes`, `_members_named`, ...) move to `static_analyzer/graph_definitions.py` with a per-file index, and both the warm-start updater and the linker resolve through `targets_for`, so they cannot disagree.
- **Linking runs on every path**: the cold pass and both warm-start branches share `_absorb_and_link`; the updater hands back the definitions of changed files it could not resolve, so a caller changed in solution A and a destination added in solution B link after every engine merged, whichever ran first.
- A linked edge across packages is recorded in the package relations (health's cycle check reads them). Cache tag v9.

Not done, on purpose: a delegate-valued field in another engine that takes part in no local edge is not a node of the merged graph and cannot be linked; that is the converter's node filter, not the linker's.
