### PR TITLE
feat(clustering): directories are the structure, small ones placed by their role; 9 the target and 15 the limit at every depth

### DIFF
--- a/diagram_analysis/diagram_generator.py
+++ b/diagram_analysis/diagram_generator.py
@@ -675,7 +675,7 @@ class DiagramGenerator:
             self.tree_spec = self._stored_tree_spec()
             self._incremental_preparation = self._prepare_incremental_clustering(root_analysis, sub_analyses, depth)
         elif target_component is None:
-            service = ClusteringService(self._grouper())
+            service = ClusteringService(self._grouper(), self.repo_location)
             self.clustering_hierarchy = service.build_full_hierarchy(static_analysis, depth)
             self.tree_spec = service.spec
         else:
@@ -1031,7 +1031,7 @@ class DiagramGenerator:
         assert self.tree_spec is not None
         persisted = {ROOT_SCOPE_ID: root_analysis, **sub_analyses}
         # Scopes the specification never reached are drafted deterministically here.
-        service = ClusteringService()
+        service = ClusteringService(repo_dir=self.repo_location)
         self.clustering_hierarchy = service.build_incremental_hierarchy(
             self.static_analysis,
             hierarchy_depth,
@@ -1252,7 +1252,7 @@ class DiagramGenerator:
             raise ClusteringScopeUnavailableError(component.component_id, "no owned CFG nodes")
         remaining_depth = max(1, hierarchy_depth - _component_depth(component.component_id))
         assert self.tree_spec is not None
-        service = ClusteringService(self._grouper())
+        service = ClusteringService(self._grouper(), self.repo_location)
         # The service replays the specification from the root down to this component, so the
         # scope holds the units a full run placed in it, data-only files included.
         scope = service.build_scope_hierarchy(graphs, remaining_depth, component.component_id, self.tree_spec)

--- a/docs/design/name-tree.md
+++ b/docs/design/name-tree.md
@@ -49,14 +49,17 @@ per scope, from the same names, writes them down once, and replays them everywhe
 
 ### 3.1 Units and the trie (`inventory.py`)
 
-A **unit** is a file: the set of qualified names declared in it. Its **position** is the
-longest prefix its names share, less a trailing symbol (a file declaring one class shares
-that class across every member). The engine emits no module node, so this is how the
-module of a Python file, the package of a Java type and the directory of a C# type are read
-off the names alone. The **trie** is the prefix tree of positions; a dotted directory name
-(`Ordering.API`) nests as two segments, which is what lets `Ordering.API`, `Ordering.Domain`
-and `Ordering.Infrastructure` sit under one `Ordering` node that is never split along its
-role-named children.
+A **unit** is a file: the set of qualified names declared in it. Its **position** is its
+directory under the repository root, and its **key** the position plus the file's name, so a
+file and a directory of one name stay apart. The names are never read for structure: the
+engine root a nested solution was analysed from, a dotted project directory (`Ordering.API`,
+`BTCPayServer.Client`) and the spelling each adapter chose all used to leak into the trie,
+and each was measured to scatter a root (abp's `framework/` invisible, btcpayserver's
+controllers transposed into 75 word boxes, eShop's two JavaScript files a box of their
+own). The **trie** is the prefix tree of positions: the repository's directory tree, the
+same for every language. A unit also records the nearest directory above it holding a
+project manifest (`package.json`, `pyproject.toml`, a `.csproj`, …), which the grouper reads
+as "a reader separated this on purpose".
 
 ### 3.2 The frontier walk (`frontier.py`)
 
@@ -65,13 +68,15 @@ Per node, in order:
 | node | rule |
 |---|---|
 | one child, no units | pass through |
-| child is a layout word (`src`, `packages`, `pkg`, …) or holds ≥ 80% of the parent | step through, whatever it is called; this is decided before the layered test below |
+| child holds ≥ 80% of the parent | step through, whatever it is called (`src`, `src/main/java`, the one package of a library); this is decided before the layered test below |
 | children mostly (≥ 60%) role-named, ≥ 3 of them | **layered**: if a feature name recurs under ≥ 2 distinct layer children, **transpose** onto those features (at the root and above the leaf cap; below it the node is one box, because a transposition leaves a residual per layer); else the layers are the boxes, the only structure there is |
-| child is role-named | a box, never a way in |
-| feature-named child holding ≥ 50% of the scope, with mostly feature-named children | open it: half the scope is the scope's structure, less is one of its parts |
-| feature-named child holding ≥ 50% of the scope, with ≥ 3 mostly role-named children | layered, as above |
-| anything else | a box; a one-unit child is a loose unit of its parent |
+| anything else | a box, and its inside is the next depth; a one-unit child is a loose unit of its parent |
 | a node the walk entered that has only units and one-unit children | one box (a flat scope) |
+
+There is no opening of a child that holds "enough" of the scope and no list of layout words:
+both were measured to scatter a directory's contents across its parent (Polly's strategies,
+AutoMapper's test folders, LMCache's `v1`, abp's twenty modules at the root). A directory is
+its scope's structure; what it holds is the next depth's.
 
 Role words are a fixed closed class (`ROLE_WORDS`, ~95 stems: Api, Domain, Models,
 Services, Handlers, …) plus a per-repo tail the planner may add; measured, this list cannot
@@ -96,21 +101,37 @@ implementations behind one protocol, switchable by configuration (`CODEBOARDING_
 - `KinshipGrouper`: merge candidates sharing their distinctive word (`Ordering` +
   `OrderProcessor`, `Webhooks` + `WebhookClient`, `EventBus` + `EventBusRabbitMQ`).
   Recovers eShop's depth-1 drawing at 1.000 with no model.
-- `AffinityGrouper` (default): kinship, then fold the rung along the call graph. The
-  context hands every grouper, per candidate, its size and the graph links (call edges plus
-  `INHERITS`/`TYPEREF` reference edges, cross-file only) it exchanges with each sibling;
-  the service computes them once per run and they never reach `replay`. A candidate below
-  the scope's floor, and then the smallest candidate while the scope holds more than nine,
-  joins the sibling with the highest *observed over expected* link count
-  (`links × total / (degree × degree)`, at least two links, never past 60% of the scope).
-  Why that ratio and not the raw count: a hub (`utils`, `core`) talks to everyone, so raw
-  counts fold every small box into it; against its degree it is nobody's closest sibling.
-  Measured on django it recovers what the LLM planner folded (`http` → `views`,
-  `templatetags` → `template`, `conf`/`apps` → `core`, `urls`/`middleware` together) and
-  agrees with the planner's root grouping at 0.96 pair-F1, with no model and byte-identical
-  across runs. A candidate with no affine sibling stays its own box; the fold only ever
-  merges. The persisted rules are still prefixes and words: a fold is one rule with the
-  members' prefixes and the union of their words, so replay stays graph-free.
+- `AffinityGrouper` (default): kinship, then the graph, in four steps that read the same at
+  every depth. The context hands every grouper, per candidate, its size, the links it
+  exchanges with each sibling (call edges plus `INHERITS`/`TYPEREF` reference edges,
+  cross-file only) **with their direction**, the stems its units' names are made of, and
+  whether its directory is a project; the service computes them once per run and they
+  never reach `replay`.
+  1. *Placement by role*, for every candidate under the scope's floor (5%). Read off the
+     direction of the calls: a **hub** (called by 40% of its siblings, three at least) stays;
+     an **application** (calls others, called by none) stays; a **project root** stays; one
+     **shared** by three siblings stays; a **helper**, called by one sibling only, goes inside
+     it; shared by exactly two, into the larger; linked to nothing, into the loose files; a
+     hub under three files, into the loose files. Loose files, residues, tests, samples,
+     benches, docs and hubs own no helper: the bus dispatching to a service's handlers does
+     not make the service its helper. Why direction: size cannot tell `core/` (3 files, a
+     helper of the CLI) from `PaymentProcessor` (6 files, a service); who calls whom can.
+  2. *Budget*: while the scope holds more than nine, the smallest candidate joins the
+     sibling it exchanges the most links with, never a hub, never a consumer, never past 60%
+     of the scope, and only a sibling carrying at least half of the candidate's links, so a
+     real component is never folded on the two links a helper brought along. Why raw counts
+     and not observed-over-expected: the ratio was measured to send `WebAppComponents` to
+     `HybridApp` on three links over `WebApp` on fifteen, and to fold every service into the
+     event bus once the recovered call sites made the bus everyone's busiest partner; the
+     hub exclusion does what the ratio was meant to do, and does it by name.
+  3. *Limit*: while the scope holds more than fifteen, the two non-hub candidates whose
+     identifier vocabulary (TF-IDF over stems) is closest merge, under the cap.
+  4. *Pool*: still over fifteen, the smallest are one box, "Other files".
+  Measured on fifteen repositories at depth 3: no scope above fifteen anywhere (before: abp
+  31, nopCommerce 51, btcpayserver 27 at the root); eShop 9 of 9 published boxes from 5 of 9;
+  serilog and mermaid no longer forced from 13 to 9. A candidate with no home stays its own
+  box; the fold only ever merges. The persisted rules are still prefixes and words: a fold is
+  one rule with the members' prefixes and the union of their words, so replay stays graph-free.
 - `TreePlannerAgent` (LLM): runs kinship first and, only when a scope is left with more
   than nine groups, shows the model those groups with their sizes and a few identifiers and
   lets it fold them into components toward the budget. It may merge across words
@@ -154,10 +175,16 @@ numbering cannot move a unit.
 
 | scope | rungs, in order |
 |---|---|
-| root | frontier of the trie (layers transposed or drawn) → words of the units (only if the frontier gave one box) |
-| component ≤ 7 units | un-merge: the candidates the grouper folded into it → leaf ("small") |
+| root | un-merge → frontier of the trie (layers transposed) → layers → files → roles → island; never refused: a root nothing splits is the one box the frontier gave it |
+| component ≤ 7 units | un-merge: the candidates the grouper folded into it, offered to the grouper again → leaf ("small") |
 | component 8–135 units | un-merge → frontier of its own sub-trie, a layered grid kept whole → the same frontier with the grid drawn layer by layer → files → roles → island → leaf ("cohesive") |
-| component > 135 units | un-merge → frontier of its sub-trie, transposed where a grid recurs → words of its units → layers → files → roles → island → leaf ("exhausted") |
+| component > 135 units | the same, the frontier transposed where a grid recurs → leaf ("exhausted") |
+
+The ladder is the same at every depth. The un-merge rung hands a fold's parts back to the
+grouper inside their own scope (kinship skipped, since the parts are already one word apart),
+so a box the root folded out of seventy candidates opens onto nine, not seventy. The
+vocabulary rung (one candidate per word of the units' names) is gone: it produced the 51- and
+60-child scopes and nothing could fold its candidates, which share no links.
 
 The two rungs below the trie read the files themselves, since below a leaf the trie is
 flat. **Files**: every file is a candidate labelled by its own name (its key: the position
@@ -364,11 +391,10 @@ perfect grouping) is the planner's to reach.
 
 - Kubernetes-scale repos over-produce root boxes (44–53 against 16 sigs); grouping them
   is the planner's job and its variance must be measured across draws before it ships.
-- The vocabulary rung without a model collapses onto the commonest word (markitdown 88%,
-  serilog 69% in the grouper study). After the layered root draws its layers no repository
-  in the set reaches the rung, so the co-occurrence grouping of its words the study proposed
-  is unmeasured and not attempted; the affinity fold applies to word candidates as to any
-  other, which is all the rung has today.
+- Inside a wide flat scope (abp's `framework`, a hundred packages) the rules give package
+  families by kinship and vocabulary, not the eight themes a reader would draw. That gap is
+  semantic; a dependency-fingerprint proxy (packages that depend on the same hubs) and, failing
+  that, the planner on such scopes only, are the candidates.
 - The fold is measured on repositories of at most 635 units; kubernetes-scale roots (44–53
   candidates) need links the synthesised ruler harness does not carry.
 - A unit the parent placed by a word has no home among the un-merged parts and lands in

--- a/docs/design/name-tree.md
+++ b/docs/design/name-tree.md
@@ -57,7 +57,10 @@ engine root a nested solution was analysed from, a dotted project directory (`Or
 and each was measured to scatter a root (abp's `framework/` invisible, btcpayserver's
 controllers transposed into 75 word boxes, eShop's two JavaScript files a box of their
 own). The **trie** is the prefix tree of positions: the repository's directory tree, the
-same for every language. A unit also records the nearest directory above it holding a
+same for every language. The names themselves follow the same rule since the engine spells
+every one from the repository root, segment for segment as the path is on disk (no adapter
+drops `src` or `src/main/java`, no nested solution spells its files relative to itself), so a
+name and a position agree. A unit also records the nearest directory above it holding a
 project manifest (`package.json`, `pyproject.toml`, a `.csproj`, …), which the grouper reads
 as "a reader separated this on purpose".
 
@@ -179,6 +182,11 @@ numbering cannot move a unit.
 | component ≤ 7 units | un-merge: the candidates the grouper folded into it, offered to the grouper again → leaf ("small") |
 | component 8–135 units | un-merge → frontier of its own sub-trie, a layered grid kept whole → the same frontier with the grid drawn layer by layer → files → roles → island → leaf ("cohesive") |
 | component > 135 units | the same, the frontier transposed where a grid recurs → leaf ("exhausted") |
+
+What no rule of a settled scope claims goes to a fallback-only "Loose files" rule on the
+scope's own prefix, drafted on the spot; there is no separate "Unassigned" bucket, so a reader
+meets one name for the files a scope holds directly, whether the walk found them or a later
+run added them.
 
 The ladder is the same at every depth. The un-merge rung hands a fold's parts back to the
 grouper inside their own scope (kinship skipped, since the parts are already one word apart),

--- a/static_analyzer/__init__.py
+++ b/static_analyzer/__init__.py
@@ -883,7 +883,13 @@ class StaticAnalyzer:
                 logger.info(f"warmstart {adapter.language}: re-LSPing {len(changed_files)} changed file(s)")
                 cached_lang_dict = carried.get(language) or self._extract_language_dict(cached_results, language)
                 analysis = update_cfg_for_changed_files(
-                    cached_lang_dict, changed_files, adapter, project_path, engine_client, self.ignore_manager
+                    cached_lang_dict,
+                    changed_files,
+                    adapter,
+                    project_path,
+                    self.repository_path,
+                    engine_client,
+                    self.ignore_manager,
                 )
                 carried[language] = analysis
                 carried_adapters[language] = adapter
@@ -1049,6 +1055,7 @@ class StaticAnalyzer:
             engine_client,
             adapter,
             project_path,
+            self.repository_path,
             memory_budget_bytes=per_engine_memory_budget(max(max_concurrent_engines(), 1)),
         )
         engine_result = builder.build(source_files)

--- a/static_analyzer/analysis_cache.py
+++ b/static_analyzer/analysis_cache.py
@@ -70,8 +70,9 @@ _LEGACY_CACHE_SUBDIR = "cache"
 # v8: a C# file compiled into several projects has symbols and callers, and a
 # nested solution's files are named by its own engine only.
 # v9: a call into a project of another solution root is an edge.
+# v10: every name is spelled from the repository root; C# keeps ``src`` and Java its source root.
 # Older pickles are treated as cache misses and re-run.
-_TAG_VERSION = "v9"
+_TAG_VERSION = "v10"
 
 
 class StaticAnalysisCache:

--- a/static_analyzer/clustering/names/__init__.py
+++ b/static_analyzer/clustering/names/__init__.py
@@ -17,17 +17,14 @@ from static_analyzer.clustering.names.frontier import Candidate, Frontier, walk
 from static_analyzer.clustering.names.inventory import (
     Trie,
     Unit,
-    unit_key,
-    unit_position,
     units_from_graph,
     units_from_graphs,
 )
 from static_analyzer.clustering.names.replay import Partition, replay
 from static_analyzer.clustering.names.spec import ComponentRule, ScopeSpec, TreeSpec
-from static_analyzer.clustering.names.tokens import LAYOUT_WORDS, ROLE_WORDS, stem, tokenize
+from static_analyzer.clustering.names.tokens import ROLE_WORDS, stem, tokenize
 
 __all__ = [
-    "LAYOUT_WORDS",
     "ROLE_WORDS",
     "AffinityGrouper",
     "Candidate",
@@ -48,8 +45,6 @@ __all__ = [
     "role_words_for",
     "stem",
     "tokenize",
-    "unit_key",
-    "unit_position",
     "units_from_graph",
     "units_from_graphs",
     "walk",

--- a/static_analyzer/clustering/names/draft.py
+++ b/static_analyzer/clustering/names/draft.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
+import math
 from collections import Counter
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass, field, replace
 from typing import Protocol
 
 from clustering_ids import ROOT_SCOPE_ID, ScopeId
-from static_analyzer.clustering.names.frontier import BOX, FILE, HEAD, LOOSE, RESIDUAL, SHARE, WORD, Candidate, walk
+from static_analyzer.clustering.names.frontier import BOX, FILE, HEAD, LOOSE, RESIDUAL, WORD, Candidate, walk
 from static_analyzer.clustering.names.inventory import Trie, Unit
 from static_analyzer.clustering.names.replay import Partition, replay
 from static_analyzer.clustering.names.spec import (
@@ -21,7 +22,6 @@ from static_analyzer.clustering.names.spec import (
     SEGMENT,
     UNMERGE,
     UNPLACED,
-    VOCABULARY,
     ComponentRule,
     Prefix,
     ScopeSpec,
@@ -44,22 +44,39 @@ GUARD_SHARE = 0.05
 LEAF_UNITS = 7
 """Units at or under which a component is a leaf: a box a reader takes in at a glance."""
 LEAF_CAP = 135
-"""Units above which a component transposes a layered sub-tree and reads its words."""
+"""Units above which a component transposes a layered sub-tree."""
 BUDGET = 9
-"""Components a rung is folded toward; the guard, not the budget, is what a rung must clear."""
+"""Components a scope is folded toward along its links, and only along links that carry
+at least half of what the folded candidate exchanges; the guard, not the budget, is what
+a rung must clear."""
+LIMIT = 15
+"""Components a scope never exceeds: past the budget nothing folds into a hub, past the
+limit the names' vocabulary and, last, a pool of the smallest bring it down."""
 MIN_LINKS = 2
 """Graph links two candidates must exchange before they count as affine: one is noise."""
+HUB_SHARE = 0.4
+"""Share of its siblings that must call a candidate for it to be shared infrastructure: a
+hub neither absorbs a sibling nor folds into one, whatever the counts say."""
+MIN_HUB_PARTNERS = 3
+"""Siblings a hub is called by at the least, so a scope of three cannot hold one."""
+MIN_HUB_UNITS = 3
+"""Units a hub needs to be drawn on its own; a smaller one is a loose file everybody calls."""
 CAP_SHARE = 0.6
 """No fold may grow a component past this share of its scope."""
 UNPLACED_NAME = "Unassigned"
 LOOSE_NAME = "Loose files"
+OTHER_NAME = "Other files"
 ISLAND_SHARE = 1 / 3
 """Share of a scope one family must hold to be drawn on its own against the rest."""
 ISLAND_STRAYS = 1
 """Links a family may exchange with the rest and still count as an island: one is noise."""
+CONSUMER_WORDS = frozenset(
+    {"test", "spec", "e2e", "sample", "example", "doc", "bench", "benchmark", "snippet", "demo", "script", "cypress"}
+)
+"""Stems naming code that calls the scope without being part of it: it owns no helper."""
 
 Links = Mapping[tuple[str, str], int]
-"""Weight of the graph edges between two units, keyed by the unit ids in sorted order."""
+"""Weight of the graph edges from one unit to another, keyed ``(calling unit, called unit)``."""
 
 
 @dataclass(frozen=True)
@@ -76,6 +93,12 @@ class GroupingContext:
     samples: dict[str, tuple[str, ...]] = field(default_factory=dict)
     links: dict[tuple[str, str], int] = field(default_factory=dict)
     """Graph edges between two candidates' units, keyed by their keys in sorted order."""
+    calls: dict[tuple[str, str], int] = field(default_factory=dict)
+    """The same edges with their direction kept: ``(calling candidate, called candidate)``."""
+    vocabulary: dict[str, Counter[str]] = field(default_factory=dict)
+    """Per candidate, the stems its units' names are made of, counted once per unit."""
+    projects: frozenset[str] = frozenset()
+    """Candidates whose directory is a project of its own (a manifest sits in it)."""
     floor: int = MIN_UNITS
     """Units a candidate must hold to stand on its own in this scope."""
 
@@ -128,77 +151,235 @@ class KinshipGrouper:
 
 
 class AffinityGrouper:
-    """Kinship, then fold the rung along the graph: a candidate below the floor, and the
-    smallest candidate while the rung is over budget, joins the sibling it exchanges the most
-    links with against what their sizes predict.
+    """Kinship, then the graph, in four steps that read the same at every depth.
 
-    Why observed over expected: a hub (``utils``, ``core``) talks to everyone, so raw counts
-    would fold every small box into it; against its degree it is nobody's closest sibling.
+    1. Every small candidate is placed by its role: a hub or an application stays, a helper
+       (called by one sibling only) goes inside that sibling, one shared by exactly two goes
+       into the larger of them, one nobody links to goes to the loose files.
+    2. Over the budget, the smallest candidate joins the sibling it exchanges the most links
+       with, never a hub, until nothing affine is left.
+    3. Over the limit still, the two candidates whose names share the most vocabulary merge.
+    4. Over the limit still, the smallest are pooled into one box, named for what they are.
+
+    Why hubs are out of every fold: shared infrastructure (an event bus, a ``core`` package)
+    is what every small sibling links to most, so by counts every service belongs to it; a
+    reader wants the infrastructure drawn as one box and the services that use it as theirs.
     """
 
     name = "affinity"
 
     def group(self, candidates: Sequence[Candidate], context: GroupingContext) -> list[CandidateGroup]:
-        groups = KinshipGrouper().group(candidates, context)
-        members = [list(group.keys) for group in groups]
-        terms = [group.terms for group in groups]
-        sizes = [sum(context.sizes.get(key, 0) for key in group.keys) for group in groups]
-        links = [
-            [sum(context.links.get((min(a, b), max(a, b)), 0) for a in left for b in right) for right in members]
-            for left in members
+        fold = _Fold(KinshipGrouper().group(candidates, context), candidates, context)
+        fold.place()
+        fold.toward_budget()
+        fold.by_vocabulary()
+        fold.pool()
+        return fold.groups()
+
+
+class _Fold:
+    """The merges of one rung, over the candidates' sizes, links and calls."""
+
+    def __init__(self, groups: list[CandidateGroup], candidates: Sequence[Candidate], context: GroupingContext):
+        self.context = context
+        self.by_key = {candidate.key: candidate for candidate in candidates}
+        self.members = [list(group.keys) for group in groups]
+        self.terms = [group.terms for group in groups]
+        self.sizes = [sum(context.sizes.get(key, 0) for key in group.keys) for group in groups]
+        count = len(groups)
+        self.links = [
+            [self._between(left, right, context.links, ordered=False) for right in self.members]
+            for left in self.members
         ]
-        for index in range(len(members)):
-            links[index][index] = 0
-        while True:
-            live = sorted((index for index in range(len(members)) if sizes[index]), key=lambda i: (sizes[i], i))
-            sources = [index for index in live if sizes[index] < context.floor]
-            if len(live) > BUDGET:
-                sources = live
-            chosen = self._fold(sources, live, sizes, links, context)
-            if chosen is None:
-                break
-            source, target = chosen
-            members[target].extend(members[source])
-            terms[target] = _dedupe(terms[target] + terms[source])
-            sizes[target] += sizes[source]
-            sizes[source] = 0
-            for other in range(len(members)):
-                links[target][other] += links[source][other]
-                links[other][target] += links[other][source]
-                links[source][other] = links[other][source] = 0
-            links[target][target] = 0
-            members[source] = []
-        by_key = {candidate.key: candidate for candidate in candidates}
-        groups = []
-        for index, keys in enumerate(members):
-            if not keys:
-                continue
-            # The biggest member names a fold: the box a reader already recognises.
-            biggest = max(context.sizes.get(key, 0) for key in keys)
-            name = _plainest([by_key[key] for key in keys if context.sizes.get(key, 0) == biggest])
-            groups.append(CandidateGroup(name, tuple(keys), terms[index]))
-        return groups
+        self.calls = [
+            [self._between(left, right, context.calls, ordered=True) for right in self.members] for left in self.members
+        ]
+        for index in range(count):
+            self.links[index][index] = self.calls[index][index] = 0
+        self.vocabulary = [
+            sum((context.vocabulary.get(key, Counter()) for key in group.keys), Counter()) for group in groups
+        ]
+        self.floor = context.floor
+        live = self.live()
+        threshold = max(MIN_HUB_PARTNERS, HUB_SHARE * (len(live) - 1))
+        self.hubs = {i for i in live if sum(1 for j in live if self.calls[j][i] >= MIN_LINKS) >= threshold}
+        self.projects = {i for i, keys in enumerate(self.members) if any(key in context.projects for key in keys)}
+        self.consumers = {i for i in live if self._is_consumer(i)}
+        self.kept: set[int] = set()
+        self.loose = next(
+            (i for i, keys in enumerate(self.members) if any(self.by_key[k].kind == LOOSE for k in keys)), None
+        )
 
     @staticmethod
-    def _fold(
-        sources: list[int], live: list[int], sizes: list[int], links: list[list[int]], context: GroupingContext
-    ) -> tuple[int, int] | None:
-        """The smallest source with an affine sibling, and that sibling: ``(source, target)``."""
-        degree = [sum(row) for row in links]
-        total = sum(degree) / 2 or 1.0
-        cap = CAP_SHARE * context.unit_count
-        for source in sources:
-            best: tuple[float, int, int] | None = None
-            for target in live:
-                count = links[source][target]
-                if target == source or count < MIN_LINKS or sizes[source] + sizes[target] > cap:
+    def _between(left: list[str], right: list[str], weights: Mapping[tuple[str, str], int], *, ordered: bool) -> int:
+        if ordered:
+            return sum(weights.get((a, b), 0) for a in left for b in right)
+        return sum(weights.get((min(a, b), max(a, b)), 0) for a in left for b in right)
+
+    def _is_consumer(self, index: int) -> bool:
+        """Loose files, tests, samples, benches and docs call the scope without being part of it."""
+        if any(self.by_key[key].kind == LOOSE for key in self.members[index]):
+            return True
+        labels = (self.by_key[key].label for key in self.members[index])
+        return any(set(stems(label)) & CONSUMER_WORDS for label in labels)
+
+    def live(self) -> list[int]:
+        return sorted((i for i in range(len(self.members)) if self.sizes[i]), key=lambda i: (self.sizes[i], i))
+
+    def merge(self, source: int, target: int) -> None:
+        self.members[target].extend(self.members[source])
+        self.terms[target] = _dedupe(self.terms[target] + self.terms[source])
+        self.sizes[target] += self.sizes[source]
+        self.sizes[source] = 0
+        self.vocabulary[target].update(self.vocabulary[source])
+        for other in range(len(self.members)):
+            self.links[target][other] += self.links[source][other]
+            self.links[other][target] += self.links[other][source]
+            self.calls[target][other] += self.calls[source][other]
+            self.calls[other][target] += self.calls[other][source]
+            self.links[source][other] = self.links[other][source] = 0
+            self.calls[source][other] = self.calls[other][source] = 0
+        self.links[target][target] = self.calls[target][target] = 0
+        self.members[source] = []
+        if source in self.hubs:
+            self.hubs.add(target)
+        if source in self.projects:
+            self.projects.add(target)
+
+    def place(self) -> None:
+        """Every candidate under the floor, by its role in the calls."""
+        for index in self.live():
+            if self.sizes[index] >= self.floor:
+                continue
+            # A hub calling a small sibling makes it a subscriber, not a helper: the bus owns no service.
+            callers = {
+                j: self.calls[j][index]
+                for j in self.live()
+                if j != index and j not in self.consumers and j not in self.hubs and self.calls[j][index]
+            }
+            incoming = sum(callers.values())
+            outgoing = sum(self.calls[index][j] for j in self.live() if j != index)
+            if index in self.hubs:
+                if self.sizes[index] < MIN_HUB_UNITS and self.loose is not None and self.loose != index:
+                    self.merge(index, self.loose)
+                else:
+                    self.kept.add(index)
+            elif index in self.projects or len(callers) >= 3:
+                self.kept.add(index)
+            elif incoming >= MIN_LINKS and len(callers) == 1:
+                self.merge(index, next(iter(callers)))
+            elif incoming >= MIN_LINKS and len(callers) == 2:
+                # The larger caller, unless taking the helper would grow it past the cap.
+                cap = CAP_SHARE * self.context.unit_count
+                fitting = [j for j in callers if self.sizes[j] + self.sizes[index] <= cap] or list(callers)
+                self.merge(index, max(fitting, key=lambda j: (self.sizes[j], -j)))
+            elif incoming or outgoing >= MIN_LINKS:
+                self.kept.add(index)
+            elif self.loose is not None and self.loose != index:
+                self.merge(index, self.loose)
+            else:
+                self.kept.add(index)
+
+    def toward_budget(self) -> None:
+        """The smallest candidate joins the sibling it exchanges the most links with, never a hub.
+
+        Below the floor a candidate the placement left standing joins whoever it links to;
+        over the budget a candidate joins only a sibling carrying at least half of its links,
+        so a real component is never folded on the two links a helper brought along.
+        """
+        cap = CAP_SHARE * self.context.unit_count
+        while True:
+            live = self.live()
+            over_budget = len(live) > BUDGET
+            sources = live if over_budget else [i for i in live if self.sizes[i] < self.floor and i not in self.kept]
+            chosen = None
+            for source in sources:
+                if source in self.hubs:
                     continue
-                affinity = count * total / (degree[source] * degree[target])
-                if best is None or (affinity, -sizes[target], -target) > best:
-                    best = (affinity, -sizes[target], -target)
-            if best is not None:
-                return source, -best[2]
-        return None
+                degree = sum(self.links[source][other] for other in live)
+                best: tuple[int, int, int] | None = None
+                for target in live:
+                    count = self.links[source][target]
+                    if target == source or target in self.hubs or count < MIN_LINKS:
+                        continue
+                    if self.sizes[source] + self.sizes[target] > cap:
+                        continue
+                    if over_budget and self.sizes[source] >= self.floor and count * 2 < degree:
+                        continue
+                    if best is None or (count, -self.sizes[target], -target) > best:
+                        best = (count, -self.sizes[target], -target)
+                if best is not None:
+                    chosen = (source, -best[2])
+                    break
+            if chosen is None:
+                return
+            self.merge(*chosen)
+
+    def by_vocabulary(self) -> None:
+        """Over the limit, the two non-hub candidates whose names share the most vocabulary merge."""
+        while len(self.live()) > LIMIT:
+            live = [i for i in self.live() if i not in self.hubs]
+            vectors = self._tfidf(live)
+            best: tuple[float, int, int] | None = None
+            for a in range(len(live)):
+                for b in range(a + 1, len(live)):
+                    i, j = live[a], live[b]
+                    similarity = sum(weight * vectors[j].get(word, 0.0) for word, weight in vectors[i].items())
+                    if similarity > 0 and (best is None or similarity > best[0]):
+                        best = (similarity, i, j)
+            if best is None:
+                return
+            _, i, j = best
+            self.merge(j if self.sizes[i] >= self.sizes[j] else i, i if self.sizes[i] >= self.sizes[j] else j)
+
+    def _tfidf(self, live: list[int]) -> dict[int, dict[str, float]]:
+        frequency: Counter[str] = Counter()
+        for index in live:
+            frequency.update(self.vocabulary[index].keys())
+        vectors: dict[int, dict[str, float]] = {}
+        for index in live:
+            total = sum(self.vocabulary[index].values()) or 1
+            weights = {
+                word: (count / total) * math.log(1 + len(live) / frequency[word])
+                for word, count in self.vocabulary[index].items()
+                if frequency[word] < 0.8 * len(live)
+            }
+            norm = math.sqrt(sum(weight * weight for weight in weights.values())) or 1.0
+            vectors[index] = {word: weight / norm for word, weight in weights.items()}
+        return vectors
+
+    def pool(self) -> None:
+        """Over the limit still, the smallest non-hub candidates become one box."""
+        live = [i for i in self.live() if i not in self.hubs]
+        excess = len(self.live()) - LIMIT
+        if excess <= 0 or len(live) < 2:
+            return
+        pooled = live[: excess + 1]
+        target = pooled[-1]
+        for source in pooled[:-1]:
+            self.merge(source, target)
+        self.pooled = target
+
+    pooled: int | None = None
+
+    def groups(self) -> list[CandidateGroup]:
+        groups = []
+        for index, keys in enumerate(self.members):
+            if not keys:
+                continue
+            if index == self.pooled:
+                groups.append(CandidateGroup(OTHER_NAME, tuple(keys), self.terms[index]))
+                continue
+            loose = next((self.by_key[key] for key in keys if self.by_key[key].kind == LOOSE), None)
+            if loose is not None:
+                # What joined the loose files is loose; the box keeps the name a reader knows.
+                groups.append(CandidateGroup(candidate_name(loose), tuple(keys), self.terms[index]))
+                continue
+            # The biggest member names a fold: the box a reader already recognises.
+            biggest = max(self.context.sizes.get(key, 0) for key in keys)
+            name = _plainest([self.by_key[key] for key in keys if self.context.sizes.get(key, 0) == biggest])
+            groups.append(CandidateGroup(name, tuple(keys), self.terms[index]))
+        return groups
 
 
 DETERMINISTIC_GROUPERS: dict[str, type[Grouper]] = {
@@ -231,7 +412,6 @@ def draft_tree(
     max_depth: int,
     *,
     machinery: Iterable[str] = (),
-    share: float = SHARE,
     links: Links | None = None,
 ) -> TreeSpec:
     """Draft the root and every scope below it down to ``max_depth``.
@@ -246,9 +426,7 @@ def draft_tree(
     role_words = role_words_for(machinery)
 
     def build(scope_id: ScopeId, scope_units: list[Unit], parts: tuple[ComponentRule, ...], depth: int) -> None:
-        scope, partition = draft_scope(
-            scope_id, scope_units, role_words, grouper, parts=parts, share=share, links=links
-        )
+        scope, partition = draft_scope(scope_id, scope_units, role_words, grouper, parts=parts, links=links)
         spec.set_scope(scope)
         if depth >= max_depth:
             return
@@ -266,30 +444,26 @@ def draft_scope(
     grouper: Grouper,
     *,
     parts: tuple[ComponentRule, ...] = (),
-    share: float = SHARE,
     links: Links | None = None,
 ) -> tuple[ScopeSpec, Partition]:
-    """Draft one scope's rules from its units: the first rung that splits it wins."""
+    """Draft one scope's rules from its units: the first rung that splits it wins.
+
+    The ladder is the same at every depth: the parts a fold merged, the directory frontier,
+    the layers of a layered directory, the files, their role words, and an island. The root
+    is never refused: a root nothing splits is drawn as the one box the frontier gave it.
+    """
     scope_units = list(units)
     links = links or {}
     rungs: list[tuple[str, Callable[[], tuple[list[ComponentRule], str]]]] = []
 
     def frontier(rung: str, transpose: bool, layers: bool = False) -> tuple[list[ComponentRule], str]:
-        return _frontier_rules(scope_id, scope_units, role_words, grouper, share, rung, links, transpose, layers)
-
-    def vocabulary() -> tuple[list[ComponentRule], str]:
-        return _vocabulary_rules(scope_id, scope_units, role_words, grouper, links)
+        return _frontier_rules(scope_id, scope_units, role_words, grouper, rung, links, transpose, layers)
 
     if len(parts) >= 2:
         rungs.append((UNMERGE, lambda: _unmerge_rules(scope_id, scope_units, parts, role_words, grouper, links)))
-    if is_root(scope_id):
-        rungs.append((FRONTIER, lambda: frontier(FRONTIER, True)))
-        rungs.append((VOCABULARY, vocabulary))
-    elif len(scope_units) > LEAF_UNITS:
-        transpose = len(scope_units) > LEAF_CAP
-        rungs.append((SEGMENT, lambda: frontier(SEGMENT, transpose)))
-        if transpose:
-            rungs.append((VOCABULARY, vocabulary))
+    if is_root(scope_id) or len(scope_units) > LEAF_UNITS:
+        transpose = is_root(scope_id) or len(scope_units) > LEAF_CAP
+        rungs.append((FRONTIER if is_root(scope_id) else SEGMENT, lambda: frontier(SEGMENT, transpose)))
         rungs.append((LAYERS, lambda: frontier(LAYERS, False, layers=True)))
         rungs.append((FILES, lambda: _file_rules(scope_id, scope_units, role_words, grouper, links)))
         rungs.append((ROLE, lambda: _role_rules(scope_id, scope_units, role_words, grouper, links)))
@@ -304,7 +478,6 @@ def draft_scope(
         scope.axis = axis
         return scope, partition
     if is_root(scope_id) and scope_units:
-        # Never refuse: a root nothing splits is drawn as the one box the frontier gave it.
         rules, axis = produced[FRONTIER]
         settled = _settle(scope_id, scope_units, rules, role_words, FRONTIER, guard=False, min_rules=1)
         if settled is not None:
@@ -363,38 +536,17 @@ def _frontier_rules(
     units: list[Unit],
     role_words: frozenset[str],
     grouper: Grouper,
-    share: float,
     rung: str,
     links: Links,
     transpose: bool,
     layers: bool = False,
 ) -> tuple[list[ComponentRule], str]:
-    frontier = walk(Trie(units), role_words, share=share, transpose=transpose, layers=layers)
+    frontier = walk(Trie(units), role_words, transpose=transpose, layers=layers)
     candidates = sorted(frontier.candidates, key=lambda candidate: candidate.key)
     if not candidates:
         return [], frontier.axis
     context = _context(scope_id, units, candidates, role_words, rung, links)
     return _rules_from_groups(grouper.group(candidates, context), candidates), frontier.axis
-
-
-def _vocabulary_rules(
-    scope_id: ScopeId,
-    units: list[Unit],
-    role_words: frozenset[str],
-    grouper: Grouper,
-    links: Links,
-) -> tuple[list[ComponentRule], str]:
-    """One candidate per word the units' own names elect, head noun weighing most."""
-    counts: Counter[str] = Counter()
-    for unit in units:
-        counts.update(_unit_stems(unit))
-    ubiquitous = frozenset(word for word, count in counts.items() if count >= 2 and count >= len(units) / 2)
-    keys = sorted({key for unit in units if (key := _vocabulary_key(unit, role_words, ubiquitous))})
-    candidates = [Candidate(f"{WORD}:{key}", WORD, key, terms=(key,)) for key in keys]
-    if len(candidates) < 2:
-        return [], VOCABULARY
-    context = _context(scope_id, units, candidates, role_words, VOCABULARY, links)
-    return _rules_from_groups(grouper.group(candidates, context), candidates), VOCABULARY
 
 
 def _file_rules(
@@ -557,7 +709,7 @@ def _context(
     rung: str,
     links: Links,
 ) -> GroupingContext:
-    """Size, a few identifiers and links per candidate, from a replay of the candidates as rules."""
+    """Size, a few identifiers, vocabulary, calls and projects per candidate, from a replay of the candidates as rules."""
     provisional = ScopeSpec(
         scope_id,
         [replace(_candidate_rule(candidate), component_id=candidate.key) for candidate in candidates],
@@ -565,50 +717,57 @@ def _context(
     )
     partition = replay(units, provisional, role_words)
     between: Counter[tuple[str, str]] = Counter()
+    calls: Counter[tuple[str, str]] = Counter()
     for (left, right), weight in links.items():
         left_owner, right_owner = partition.assignment.get(left), partition.assignment.get(right)
         if left_owner and right_owner and left_owner != right_owner:
             between[(min(left_owner, right_owner), max(left_owner, right_owner))] += weight
+            calls[(left_owner, right_owner)] += weight
     samples: dict[str, tuple[str, ...]] = {}
+    vocabulary: dict[str, Counter[str]] = {}
+    projects: set[str] = set()
     for candidate in candidates:
         seen: dict[str, None] = {}
+        words: Counter[str] = Counter()
         for unit in partition.members.get(candidate.key, []):
+            if unit.project and unit.position in candidate.prefixes:
+                projects.add(candidate.key)
+            unit_words: set[str] = set()
             for name in unit.names:
-                seen.setdefault(segments(name, ClusteringConfig.QUALIFIED_NAME_DELIMITER)[-1], None)
-                if len(seen) >= SAMPLE_IDENTIFIERS:
-                    break
-            if len(seen) >= SAMPLE_IDENTIFIERS:
-                break
-        samples[candidate.key] = tuple(seen)
+                parts = segments(name, ClusteringConfig.QUALIFIED_NAME_DELIMITER)
+                seen.setdefault(parts[-1], None)
+                for part in parts:
+                    unit_words.update(stems(part))
+            words.update(unit_words)
+        samples[candidate.key] = tuple(list(seen)[:SAMPLE_IDENTIFIERS])
+        vocabulary[candidate.key] = words
     sizes = {candidate.key: partition.size(candidate.key) for candidate in candidates}
-    floor = MIN_UNITS if rung == FRONTIER else _floor(len(units))
-    return GroupingContext(scope_id, role_words, len(units), rung, sizes, samples, dict(between), floor)
-
-
-def _unit_stems(unit: Unit) -> set[str]:
-    return {
-        stem(word)
-        for name in unit.names
-        for part in segments(name, ClusteringConfig.QUALIFIED_NAME_DELIMITER)
-        for word in tokenize(part)
-    }
-
-
-def _vocabulary_key(unit: Unit, role_words: frozenset[str], ubiquitous: frozenset[str]) -> str:
-    votes: Counter[str] = Counter()
-    for name in unit.names:
-        for part in segments(name, ClusteringConfig.QUALIFIED_NAME_DELIMITER):
-            words = tokenize(part)
-            for position, word in enumerate(words):
-                key = stem(word)
-                if key not in role_words and key not in ubiquitous:
-                    votes[key] += 2.0 ** (position - (len(words) - 1))
-    return max(sorted(votes), key=lambda key: (votes[key], key)) if votes else ""
+    return GroupingContext(
+        scope_id,
+        role_words,
+        len(units),
+        rung,
+        sizes,
+        samples,
+        dict(between),
+        dict(calls),
+        vocabulary,
+        frozenset(projects),
+        _floor(len(units)),
+    )
 
 
 def _plainest(members: list[Candidate]) -> str:
-    """``Ordering`` over ``OrderProcessor``: the member with the fewest words names the group."""
-    return candidate_name(min(members, key=lambda candidate: (len(tokenize(candidate.label)), candidate.label)))
+    """``Ordering.API`` over ``OrderProcessor``: the member whose label says the least beyond the group's word.
+
+    Fewest words that are not role words, then fewest words, then the alphabet.
+    """
+
+    def plainness(candidate: Candidate) -> tuple[int, int, str]:
+        words = tokenize(candidate.label)
+        return (sum(1 for word in words if stem(word) not in ROLE_WORDS), len(words), candidate.label)
+
+    return candidate_name(min(members, key=plainness))
 
 
 def _rules_from_groups(groups: list[CandidateGroup], candidates: Sequence[Candidate]) -> list[ComponentRule]:

--- a/static_analyzer/clustering/names/draft.py
+++ b/static_analyzer/clustering/names/draft.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import math
+from pathlib import Path
 from collections import Counter
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass, field, replace
@@ -110,6 +111,9 @@ class CandidateGroup:
     name: str
     keys: tuple[str, ...]
     terms: tuple[str, ...] = ()
+    standing: bool = False
+    """Whether the group is shared infrastructure or a project, which stands on its own even
+    under the floor a rung would otherwise pool it at."""
 
 
 class Grouper(Protocol):
@@ -186,7 +190,6 @@ class _Fold:
         self.members = [list(group.keys) for group in groups]
         self.terms = [group.terms for group in groups]
         self.sizes = [sum(context.sizes.get(key, 0) for key in group.keys) for group in groups]
-        count = len(groups)
         self.links = [
             [self._between(left, right, context.links, ordered=False) for right in self.members]
             for left in self.members
@@ -194,34 +197,26 @@ class _Fold:
         self.calls = [
             [self._between(left, right, context.calls, ordered=True) for right in self.members] for left in self.members
         ]
-        for index in range(count):
+        for index in range(len(groups)):
             self.links[index][index] = self.calls[index][index] = 0
         self.vocabulary = [
             sum((context.vocabulary.get(key, Counter()) for key in group.keys), Counter()) for group in groups
         ]
         self.floor = context.floor
+        self.cap = CAP_SHARE * context.unit_count
         live = self.live()
         threshold = max(MIN_HUB_PARTNERS, HUB_SHARE * (len(live) - 1))
         self.hubs = {i for i in live if sum(1 for j in live if self.calls[j][i] >= MIN_LINKS) >= threshold}
         self.projects = {i for i, keys in enumerate(self.members) if any(key in context.projects for key in keys)}
+        self.fallback = {
+            i for i, keys in enumerate(self.members) if all(self.by_key[k].kind in (LOOSE, RESIDUAL) for k in keys)
+        }
         self.consumers = {i for i in live if self._is_consumer(i)}
         self.kept: set[int] = set()
         self.loose = next(
             (i for i, keys in enumerate(self.members) if any(self.by_key[k].kind == LOOSE for k in keys)), None
         )
-
-    @staticmethod
-    def _between(left: list[str], right: list[str], weights: Mapping[tuple[str, str], int], *, ordered: bool) -> int:
-        if ordered:
-            return sum(weights.get((a, b), 0) for a in left for b in right)
-        return sum(weights.get((min(a, b), max(a, b)), 0) for a in left for b in right)
-
-    def _is_consumer(self, index: int) -> bool:
-        """Loose files, tests, samples, benches and docs call the scope without being part of it."""
-        if any(self.by_key[key].kind == LOOSE for key in self.members[index]):
-            return True
-        labels = (self.by_key[key].label for key in self.members[index])
-        return any(set(stems(label)) & CONSUMER_WORDS for label in labels)
+        self.pooled: int | None = None
 
     def live(self) -> list[int]:
         return sorted((i for i in range(len(self.members)) if self.sizes[i]), key=lambda i: (self.sizes[i], i))
@@ -241,24 +236,26 @@ class _Fold:
             self.calls[source][other] = self.calls[other][source] = 0
         self.links[target][target] = self.calls[target][target] = 0
         self.members[source] = []
-        if source in self.hubs:
-            self.hubs.add(target)
-        if source in self.projects:
-            self.projects.add(target)
+        for flagged in (self.hubs, self.projects, self.kept):
+            if source in flagged:
+                flagged.add(target)
 
     def place(self) -> None:
-        """Every candidate under the floor, by its role in the calls."""
+        """Every candidate under the floor, by its role in the calls.
+
+        Loose files, residues, tests, samples, benches, docs and hubs own no helper; a helper
+        whose owner cannot take it under the cap stays.
+        """
         for index in self.live():
-            if self.sizes[index] >= self.floor:
+            if self.sizes[index] >= self.floor or index in self.fallback:
                 continue
-            # A hub calling a small sibling makes it a subscriber, not a helper: the bus owns no service.
             callers = {
                 j: self.calls[j][index]
                 for j in self.live()
-                if j != index and j not in self.consumers and j not in self.hubs and self.calls[j][index]
+                if j != index and j not in self.consumers and j not in self.hubs and self.calls[j][index] >= MIN_LINKS
             }
-            incoming = sum(callers.values())
             outgoing = sum(self.calls[index][j] for j in self.live() if j != index)
+            fitting = [j for j in callers if self.sizes[j] + self.sizes[index] <= self.cap]
             if index in self.hubs:
                 if self.sizes[index] < MIN_HUB_UNITS and self.loose is not None and self.loose != index:
                     self.merge(index, self.loose)
@@ -266,14 +263,9 @@ class _Fold:
                     self.kept.add(index)
             elif index in self.projects or len(callers) >= 3:
                 self.kept.add(index)
-            elif incoming >= MIN_LINKS and len(callers) == 1:
-                self.merge(index, next(iter(callers)))
-            elif incoming >= MIN_LINKS and len(callers) == 2:
-                # The larger caller, unless taking the helper would grow it past the cap.
-                cap = CAP_SHARE * self.context.unit_count
-                fitting = [j for j in callers if self.sizes[j] + self.sizes[index] <= cap] or list(callers)
+            elif len(callers) in (1, 2) and fitting:
                 self.merge(index, max(fitting, key=lambda j: (self.sizes[j], -j)))
-            elif incoming or outgoing >= MIN_LINKS:
+            elif callers or outgoing >= MIN_LINKS:
                 self.kept.add(index)
             elif self.loose is not None and self.loose != index:
                 self.merge(index, self.loose)
@@ -285,24 +277,27 @@ class _Fold:
 
         Below the floor a candidate the placement left standing joins whoever it links to;
         over the budget a candidate joins only a sibling carrying at least half of its links,
-        so a real component is never folded on the two links a helper brought along.
+        so a real component is never folded on the two links a helper brought along. A
+        consumer (tests, samples, docs) neither takes nor folds, and a fallback-only candidate
+        folds nowhere.
         """
-        cap = CAP_SHARE * self.context.unit_count
         while True:
             live = self.live()
             over_budget = len(live) > BUDGET
             sources = live if over_budget else [i for i in live if self.sizes[i] < self.floor and i not in self.kept]
             chosen = None
             for source in sources:
-                if source in self.hubs:
+                if source in self.hubs or source in self.fallback or source in self.consumers:
                     continue
                 degree = sum(self.links[source][other] for other in live)
                 best: tuple[int, int, int] | None = None
                 for target in live:
                     count = self.links[source][target]
-                    if target == source or target in self.hubs or count < MIN_LINKS:
+                    if target == source or count < MIN_LINKS:
                         continue
-                    if self.sizes[source] + self.sizes[target] > cap:
+                    if target in self.hubs or target in self.consumers or target in self.fallback:
+                        continue
+                    if self.sizes[source] + self.sizes[target] > self.cap:
                         continue
                     if over_budget and self.sizes[source] >= self.floor and count * 2 < degree:
                         continue
@@ -316,14 +311,16 @@ class _Fold:
             self.merge(*chosen)
 
     def by_vocabulary(self) -> None:
-        """Over the limit, the two non-hub candidates whose names share the most vocabulary merge."""
+        """Over the limit, the two candidates whose names share the most vocabulary merge, under the cap."""
         while len(self.live()) > LIMIT:
-            live = [i for i in self.live() if i not in self.hubs]
+            live = [i for i in self.live() if i not in self.hubs and i not in self.consumers and i not in self.fallback]
             vectors = self._tfidf(live)
             best: tuple[float, int, int] | None = None
             for a in range(len(live)):
                 for b in range(a + 1, len(live)):
                     i, j = live[a], live[b]
+                    if self.sizes[i] + self.sizes[j] > self.cap:
+                        continue
                     similarity = sum(weight * vectors[j].get(word, 0.0) for word, weight in vectors[i].items())
                     if similarity > 0 and (best is None or similarity > best[0]):
                         best = (similarity, i, j)
@@ -331,6 +328,53 @@ class _Fold:
                 return
             _, i, j = best
             self.merge(j if self.sizes[i] >= self.sizes[j] else i, i if self.sizes[i] >= self.sizes[j] else j)
+
+    def pool(self) -> None:
+        """Over the limit still, the smallest non-hub candidates become one box."""
+        live = [i for i in self.live() if i not in self.hubs and i not in self.fallback]
+        excess = len(self.live()) - LIMIT
+        if excess <= 0 or len(live) < 2:
+            return
+        pooled = live[: excess + 1]
+        target = pooled[-1]
+        for source in pooled[:-1]:
+            self.merge(source, target)
+        self.pooled = target
+
+    def groups(self) -> list[CandidateGroup]:
+        groups = []
+        for index, keys in enumerate(self.members):
+            if not keys:
+                continue
+            # Only shared infrastructure and a project stand under a rung's floor: at the files
+            # rung every leaf script calls something, and a box per script is not a picture.
+            standing = index in self.hubs or index in self.projects
+            if index == self.pooled:
+                groups.append(CandidateGroup(OTHER_NAME, tuple(keys), self.terms[index]))
+                continue
+            loose = next((self.by_key[key] for key in keys if self.by_key[key].kind == LOOSE), None)
+            if loose is not None:
+                # What joined the loose files is loose; the box keeps the name a reader knows.
+                groups.append(CandidateGroup(candidate_name(loose), tuple(keys), self.terms[index]))
+                continue
+            # The biggest member names a fold: the box a reader already recognises.
+            biggest = max(self.context.sizes.get(key, 0) for key in keys)
+            name = _plainest([self.by_key[key] for key in keys if self.context.sizes.get(key, 0) == biggest])
+            groups.append(CandidateGroup(name, tuple(keys), self.terms[index], standing))
+        return groups
+
+    @staticmethod
+    def _between(left: list[str], right: list[str], weights: Mapping[tuple[str, str], int], *, ordered: bool) -> int:
+        if ordered:
+            return sum(weights.get((a, b), 0) for a in left for b in right)
+        return sum(weights.get((min(a, b), max(a, b)), 0) for a in left for b in right)
+
+    def _is_consumer(self, index: int) -> bool:
+        """Loose files, residues, tests, samples, benches and docs call the scope without being part of it."""
+        if index in self.fallback:
+            return True
+        labels = (self.by_key[key].label for key in self.members[index])
+        return any(set(stems(label)) & CONSUMER_WORDS for label in labels)
 
     def _tfidf(self, live: list[int]) -> dict[int, dict[str, float]]:
         frequency: Counter[str] = Counter()
@@ -347,39 +391,6 @@ class _Fold:
             norm = math.sqrt(sum(weight * weight for weight in weights.values())) or 1.0
             vectors[index] = {word: weight / norm for word, weight in weights.items()}
         return vectors
-
-    def pool(self) -> None:
-        """Over the limit still, the smallest non-hub candidates become one box."""
-        live = [i for i in self.live() if i not in self.hubs]
-        excess = len(self.live()) - LIMIT
-        if excess <= 0 or len(live) < 2:
-            return
-        pooled = live[: excess + 1]
-        target = pooled[-1]
-        for source in pooled[:-1]:
-            self.merge(source, target)
-        self.pooled = target
-
-    pooled: int | None = None
-
-    def groups(self) -> list[CandidateGroup]:
-        groups = []
-        for index, keys in enumerate(self.members):
-            if not keys:
-                continue
-            if index == self.pooled:
-                groups.append(CandidateGroup(OTHER_NAME, tuple(keys), self.terms[index]))
-                continue
-            loose = next((self.by_key[key] for key in keys if self.by_key[key].kind == LOOSE), None)
-            if loose is not None:
-                # What joined the loose files is loose; the box keeps the name a reader knows.
-                groups.append(CandidateGroup(candidate_name(loose), tuple(keys), self.terms[index]))
-                continue
-            # The biggest member names a fold: the box a reader already recognises.
-            biggest = max(self.context.sizes.get(key, 0) for key in keys)
-            name = _plainest([self.by_key[key] for key in keys if self.context.sizes.get(key, 0) == biggest])
-            groups.append(CandidateGroup(name, tuple(keys), self.terms[index]))
-        return groups
 
 
 DETERMINISTIC_GROUPERS: dict[str, type[Grouper]] = {
@@ -463,7 +474,8 @@ def draft_scope(
         rungs.append((UNMERGE, lambda: _unmerge_rules(scope_id, scope_units, parts, role_words, grouper, links)))
     if is_root(scope_id) or len(scope_units) > LEAF_UNITS:
         transpose = is_root(scope_id) or len(scope_units) > LEAF_CAP
-        rungs.append((FRONTIER if is_root(scope_id) else SEGMENT, lambda: frontier(SEGMENT, transpose)))
+        rung = FRONTIER if is_root(scope_id) else SEGMENT
+        rungs.append((rung, lambda: frontier(rung, transpose)))
         rungs.append((LAYERS, lambda: frontier(LAYERS, False, layers=True)))
         rungs.append((FILES, lambda: _file_rules(scope_id, scope_units, role_words, grouper, links)))
         rungs.append((ROLE, lambda: _role_rules(scope_id, scope_units, role_words, grouper, links)))
@@ -560,7 +572,7 @@ def _file_rules(
     by_key: dict[Prefix, list[Unit]] = {}
     for unit in units:
         by_key.setdefault(unit.key, []).append(unit)
-    candidates = [Candidate(f"{FILE}:{'.'.join(key)}", FILE, _label(key), prefixes=(key,)) for key in sorted(by_key)]
+    candidates = [Candidate(f"{FILE}:{'/'.join(key)}", FILE, _label(key), prefixes=(key,)) for key in sorted(by_key)]
     return _grouped_rules(scope_id, units, candidates, role_words, grouper, FILES, links), FILES
 
 
@@ -611,7 +623,7 @@ def _island_rules(
     by_key: dict[Prefix, list[Unit]] = {}
     for unit in units:
         by_key.setdefault(unit.key, []).append(unit)
-    candidates = [Candidate(f"{FILE}:{'.'.join(key)}", FILE, _label(key), prefixes=(key,)) for key in sorted(by_key)]
+    candidates = [Candidate(f"{FILE}:{'/'.join(key)}", FILE, _label(key), prefixes=(key,)) for key in sorted(by_key)]
     if len(candidates) < 2:
         return [], ISLAND
     context = _context(scope_id, units, candidates, role_words, ISLAND, links)
@@ -620,8 +632,8 @@ def _island_rules(
     if len(strong) != 1:
         return [], ISLAND
     family_keys = set(strong[0].keys)
-    family = [unit for unit in units if f"{FILE}:{'.'.join(unit.key)}" in family_keys]
-    rest = [unit for unit in units if f"{FILE}:{'.'.join(unit.key)}" not in family_keys]
+    family = [unit for unit in units if f"{FILE}:{'/'.join(unit.key)}" in family_keys]
+    rest = [unit for unit in units if f"{FILE}:{'/'.join(unit.key)}" not in family_keys]
     if len(family) < ISLAND_SHARE * len(units) or len(rest) < context.floor:
         return [], ISLAND
     family_ids = {unit.unit_id for unit in family}
@@ -675,7 +687,12 @@ def _grouped_rules(
         return []
     context = _context(scope_id, units, candidates, role_words, rung, links)
     groups = grouper.group(candidates, context)
-    strong = [group for group in groups if sum(context.sizes.get(key, 0) for key in group.keys) >= context.floor]
+    # A hub or a project is a box under the floor too.
+    strong = [
+        group
+        for group in groups
+        if group.standing or sum(context.sizes.get(key, 0) for key in group.keys) >= context.floor
+    ]
     if len(strong) < 2:
         return []
     kept = {key for group in strong for key in group.keys}
@@ -686,7 +703,8 @@ def _grouped_rules(
 
 
 def _label(key: Prefix) -> str:
-    return key[-1] if key else ""
+    """The last segment, without a file's extension."""
+    return Path(key[-1]).stem if key else ""
 
 
 def _common_prefix(units: list[Unit]) -> Prefix:
@@ -730,7 +748,7 @@ def _context(
         seen: dict[str, None] = {}
         words: Counter[str] = Counter()
         for unit in partition.members.get(candidate.key, []):
-            if unit.project and unit.position in candidate.prefixes:
+            if unit.project is not None and unit.project in candidate.prefixes:
                 projects.add(candidate.key)
             unit_words: set[str] = set()
             for name in unit.names:

--- a/static_analyzer/clustering/names/draft.py
+++ b/static_analyzer/clustering/names/draft.py
@@ -107,6 +107,9 @@ class KinshipGrouper:
     name = "kinship"
 
     def group(self, candidates: Sequence[Candidate], context: GroupingContext) -> list[CandidateGroup]:
+        if context.rung == UNMERGE:
+            # The parts of a fold are past kinship: merging them again would undo the un-merge.
+            return [CandidateGroup(candidate_name(candidate), (candidate.key,)) for candidate in candidates]
         ubiquitous = ubiquitous_words(candidate.label for candidate in candidates if candidate.label)
         by_word: dict[str, list[Candidate]] = {}
         solo: list[Candidate] = []
@@ -278,7 +281,7 @@ def draft_scope(
         return _vocabulary_rules(scope_id, scope_units, role_words, grouper, links)
 
     if len(parts) >= 2:
-        rungs.append((UNMERGE, lambda: (list(parts), "structural")))
+        rungs.append((UNMERGE, lambda: _unmerge_rules(scope_id, scope_units, parts, role_words, grouper, links)))
     if is_root(scope_id):
         rungs.append((FRONTIER, lambda: frontier(FRONTIER, True)))
         rungs.append((VOCABULARY, vocabulary))
@@ -324,6 +327,35 @@ def _leaf_reason(
     tried = ", ".join(rung for rung, _ in rungs if rung != UNMERGE)
     kind = "cohesive" if unit_count <= LEAF_CAP else "exhausted"
     return f"{kind}: {unit_count} units; {unmerge}; no rung ({tried}) yields two children"
+
+
+def _unmerge_rules(
+    scope_id: ScopeId,
+    units: list[Unit],
+    parts: tuple[ComponentRule, ...],
+    role_words: frozenset[str],
+    grouper: Grouper,
+    links: Links,
+) -> tuple[list[ComponentRule], str]:
+    """The candidates a grouping merged, offered to the grouper again in the scope they now share.
+
+    Why through the grouper: the fold that merged them answered for the parent's budget; a
+    scope of seventy parts is over its own, and folds toward it along its own links. A residual
+    part is offered by its bare label, since ``candidate_name`` appends the suffix again.
+    """
+    candidates = [
+        Candidate(
+            f"part:{index}:{part.name}",
+            part.origin,
+            part.name.removesuffix(" (residual)") if part.origin == RESIDUAL else part.name,
+            part.prefixes,
+            part.fallback_prefixes,
+            part.terms,
+        )
+        for index, part in enumerate(parts)
+    ]
+    context = _context(scope_id, units, candidates, role_words, UNMERGE, links)
+    return _rules_from_groups(grouper.group(candidates, context), candidates), "structural"
 
 
 def _frontier_rules(

--- a/static_analyzer/clustering/names/draft.py
+++ b/static_analyzer/clustering/names/draft.py
@@ -22,7 +22,6 @@ from static_analyzer.clustering.names.spec import (
     ROLE,
     SEGMENT,
     UNMERGE,
-    UNPLACED,
     ComponentRule,
     Prefix,
     ScopeSpec,
@@ -64,7 +63,6 @@ MIN_HUB_UNITS = 3
 """Units a hub needs to be drawn on its own; a smaller one is a loose file everybody calls."""
 CAP_SHARE = 0.6
 """No fold may grow a component past this share of its scope."""
-UNPLACED_NAME = "Unassigned"
 LOOSE_NAME = "Loose files"
 OTHER_NAME = "Other files"
 ISLAND_SHARE = 1 / 3
@@ -863,9 +861,16 @@ def _settle(
         scope.rules.append(replace(rule, component_id=scope.next_id()))
     partition = replay(units, scope, role_words)
     if partition.unplaced:
-        scope.rules.append(ComponentRule(scope.next_id(), UNPLACED_NAME, origin=UNPLACED, kind=UNPLACED))
+        # What no rule claims is loose: a fallback on the scope's own prefix takes it, so nothing is hidden.
+        scope.rules.append(replace(loose_rule(units), component_id=scope.next_id()))
         partition = replay(units, scope, role_words)
     return scope, partition
+
+
+def loose_rule(units: list[Unit]) -> ComponentRule:
+    """The scope's last resort: a fallback-only rule on the prefix every unit shares."""
+    prefix = _common_prefix(units)
+    return _candidate_rule(Candidate(f"{LOOSE}:{'/'.join(prefix)}", LOOSE, "", fallback_prefixes=(prefix,)))
 
 
 def _floor(unit_count: int) -> int:

--- a/static_analyzer/clustering/names/frontier.py
+++ b/static_analyzer/clustering/names/frontier.py
@@ -229,4 +229,5 @@ def _feature_stem(name: str, role_words: frozenset[str], ubiquitous: frozenset[s
 
 
 def _dotted(path: Prefix) -> str:
-    return ".".join(path)
+    """A key for a path: joined on ``/``, which no directory name carries, so ``x/a.b`` and ``x/a/b`` differ."""
+    return "/".join(path)

--- a/static_analyzer/clustering/names/frontier.py
+++ b/static_analyzer/clustering/names/frontier.py
@@ -1,12 +1,11 @@
 """The frontier: where the walk down the trie stops, and what it emits there.
 
-Per node: step through a single child, a layout word, or a child holding nearly everything;
-a node whose children are mostly role-named is layered, and is transposed when feature names
-recur under at least two of its layers, else it is one box; a feature-named child is opened
-only while it holds a share of the scope; a role-named child is a box, never a way in; every
-other child is a box, and a box of one unit is a loose unit of its parent. The walk emits
-rules, never assignments: ``replay`` decides which unit lands where, on this run and every
-later one.
+Per node: step through a single child or a child holding nearly everything; a node whose
+children are mostly role-named is layered, and is transposed when feature names recur under
+at least two of its layers, else it is one box; every other child is a box, and a box of one
+unit is a loose unit of its parent. A directory is its scope's structure, and its inside is
+the next depth. The walk emits rules, never assignments: ``replay`` decides which unit lands
+where, on this run and every later one.
 """
 
 from __future__ import annotations
@@ -16,21 +15,17 @@ from dataclasses import dataclass, field
 from static_analyzer.clustering.names.inventory import Trie, TrieNode
 from static_analyzer.clustering.names.spec import Prefix
 from static_analyzer.clustering.names.tokens import (
-    LAYOUT_WORDS,
     distinctive_word,
     is_role_named,
     stems,
     ubiquitous_words,
 )
 
-SHARE = 0.5
-"""A feature-named child is opened only while it holds at least this share of the scope's
-units: half the scope is the scope's structure, less is one of its parts. Measured identical
-to 0.25 on seven rulers and better on the eighth; 0.25 opens both of a repository's two big
-packages and scatters their contents across the root."""
-
 NEARLY_ALL = 0.8
-"""A child holding this share of its parent is stepped through whatever it is called."""
+"""A child holding this share of its parent is stepped through whatever it is called: ``src``,
+``src/main/java``, the one package of a library. Anything less is a box; opening a child that
+held half a scope was measured to scatter Polly's strategies, AutoMapper's test folders and
+btcpayserver's controllers across their roots."""
 
 ROLE_SHARE = 0.6
 """A node this much of whose units sit under role-named children is a layered node."""
@@ -67,9 +62,7 @@ class Frontier:
     notes: list[str] = field(default_factory=list)
 
 
-def walk(
-    trie: Trie, role_words: frozenset[str], *, share: float = SHARE, transpose: bool = True, layers: bool = False
-) -> Frontier:
+def walk(trie: Trie, role_words: frozenset[str], *, transpose: bool = True, layers: bool = False) -> Frontier:
     """The candidates of a trie.
 
     A layered node whose features recur is transposed onto them only with ``transpose``, else
@@ -81,15 +74,13 @@ def walk(
     top = trie.root
     while len(top.children) == 1 and not top.units:
         top = next(iter(top.children.values()))
-    _visit(top, top.count, role_words, share, frontier, transpose, layers, top=True)
+    _visit(top, role_words, frontier, transpose, layers, top=True)
     return frontier
 
 
 def _visit(
     node: TrieNode,
-    total: int,
     role_words: frozenset[str],
-    share: float,
     out: Frontier,
     transpose: bool,
     layers: bool,
@@ -98,10 +89,10 @@ def _visit(
 ) -> None:
     children = sorted(node.children.items())
     if len(children) == 1 and not node.units:
-        _visit(children[0][1], total, role_words, share, out, transpose, layers, top=top)
+        _visit(children[0][1], role_words, out, transpose, layers, top=top)
         return
     ubiquitous = ubiquitous_words(name for name, _ in children)
-    stepped = {name for name, child in children if _stepped_through(name, child, node)}
+    stepped = {name for name, child in children if child.count >= NEARLY_ALL * node.count}
     role_children = [child for name, child in children if is_role_named(name, role_words, ubiquitous)]
     role_units = sum(child.count for child in role_children)
     if not stepped and len(role_children) >= MIN_LAYERS and node.count and role_units / node.count >= ROLE_SHARE:
@@ -117,36 +108,14 @@ def _visit(
             continue
         scopes += 1
         if name in stepped:
-            _visit(child, total, role_words, share, out, transpose, layers)
+            _visit(child, role_words, out, transpose, layers)
             continue
-        if is_role_named(name, role_words, ubiquitous):
-            out.candidates.append(_box(child))
-            continue
-        child_names = sorted(child.children)
-        child_ubiquitous = ubiquitous_words(child_names)
-        child_layers = [
-            grandchild
-            for grandchild_name, grandchild in child.children.items()
-            if is_role_named(grandchild_name, role_words, child_ubiquitous)
-        ]
-        child_role_share = sum(layer.count for layer in child_layers) / child.count if child.count else 1.0
-        dominant = total > 0 and child.count / total >= share
-        if dominant and child_names and child_role_share < ROLE_SHARE:
-            out.notes.append(f"opened {_dotted(child.path)} ({child.count} units)")
-            _visit(child, total, role_words, share, out, transpose, layers)
-        elif dominant and len(child_layers) >= MIN_LAYERS and child_role_share >= ROLE_SHARE:
-            _layered(child, child_ubiquitous, role_words, out, transpose, layers)
-        else:
-            out.candidates.append(_box(child))
+        out.candidates.append(_box(child))
     if not scopes:
         # Only units and one-unit children: a flat scope is one box, not a pile of loose files.
         out.candidates.append(_box(node))
     elif loose:
         out.candidates.append(_loose(node))
-
-
-def _stepped_through(name: str, child: TrieNode, parent: TrieNode) -> bool:
-    return name.casefold() in LAYOUT_WORDS or child.count >= NEARLY_ALL * parent.count
 
 
 def _layered(

--- a/static_analyzer/clustering/names/inventory.py
+++ b/static_analyzer/clustering/names/inventory.py
@@ -39,8 +39,10 @@ class Unit:
     names: tuple[str, ...]
     position: tuple[str, ...]
     key: tuple[str, ...]
-    project: bool = False
-    """Whether the file's own directory is a project root: a unit a reader separated on purpose."""
+    """``position`` plus the file's name, so a file and a directory of the same name stay apart."""
+    project: tuple[str, ...] | None = None
+    """The nearest directory above the file holding a project manifest, when there is one: a unit
+    a reader separated on purpose."""
 
 
 def units_from_graph(graph: CallGraph, language: str, repo_dir: Path | None = None) -> list[Unit]:
@@ -54,25 +56,20 @@ def units_from_graph(graph: CallGraph, language: str, repo_dir: Path | None = No
         if node.file_path:
             by_file.setdefault(node.file_path, []).append(qualified_name)
     units: list[Unit] = []
-    projects: dict[tuple[str, ...], bool] = {}
+    projects: dict[tuple[str, ...], tuple[str, ...] | None] = {}
     for file_path, names in sorted(by_file.items()):
         if Path(file_path).is_absolute() and repo_dir is None:
             raise ValueError(f"{file_path} is absolute and no repository root was given to position it")
         relative = Path(normalize_repo_path(file_path, repo_dir))
+        if relative.is_absolute() or ".." in relative.parts:
+            raise ValueError(f"{file_path} lies outside the repository root {repo_dir}")
         position = relative.parent.parts
         if position == (".",):
             position = ()
         if position not in projects:
-            projects[position] = repo_dir is not None and _is_project_root(repo_dir / Path(*position))
+            projects[position] = _project_root(repo_dir, position) if repo_dir is not None else None
         units.append(
-            Unit(
-                file_path,
-                language,
-                tuple(sorted(names)),
-                position,
-                position + (relative.stem,),
-                projects[position],
-            )
+            Unit(file_path, language, tuple(sorted(names)), position, position + (relative.name,), projects[position])
         )
     return units
 
@@ -82,6 +79,14 @@ def units_from_graphs(graphs: Mapping[str, CallGraph], repo_dir: Path | None = N
     for language in sorted(graphs):
         units.extend(units_from_graph(graphs[language], language, repo_dir))
     return units
+
+
+def _project_root(repo_dir: Path, position: tuple[str, ...]) -> tuple[str, ...] | None:
+    """The nearest directory at or above ``position`` that holds a manifest; the repository root does not count."""
+    for depth in range(len(position), 0, -1):
+        if _is_project_root(repo_dir / Path(*position[:depth])):
+            return position[:depth]
+    return None
 
 
 def _is_project_root(directory: Path) -> bool:

--- a/static_analyzer/clustering/names/inventory.py
+++ b/static_analyzer/clustering/names/inventory.py
@@ -1,19 +1,33 @@
-"""Units and the trie of their qualified-name prefixes.
+"""Units and the trie of their positions.
 
-A unit is one file: the set of qualified names the engine declared in it. Its *position* is
-the longest prefix its names share, read from the names alone (the engine emits no module
-node, and a file path is never parsed here). The trie over every unit's position is the
-directory tree in every language today, because every adapter derives the prefix from the
-path; a declared namespace would land in the same structure the day an adapter carried one.
+A unit is one file: the qualified names the engine declared in it. Its *position* is the
+file's directory under the repository root, so the trie over every unit's position is the
+repository's directory tree, the same for every language and every engine, whatever an
+adapter chose to call a symbol. Its *key* is the position plus the file's stem: what a rule
+owns to claim this file and not a sibling in the same directory.
 """
 
 from __future__ import annotations
 
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
+from pathlib import Path
 
+from repo_utils.path_utils import normalize_repo_path
 from static_analyzer.cfg import CallGraph
-from static_analyzer.clustering.names.tokens import segments
+
+PROJECT_MANIFESTS = (
+    "package.json",
+    "pyproject.toml",
+    "setup.py",
+    "go.mod",
+    "Cargo.toml",
+    "pom.xml",
+    "build.gradle",
+    "build.gradle.kts",
+    "composer.json",
+)
+"""Files that make a directory a project of its own; a ``.csproj`` or ``.fsproj`` does too."""
 
 
 @dataclass(frozen=True)
@@ -25,53 +39,58 @@ class Unit:
     names: tuple[str, ...]
     position: tuple[str, ...]
     key: tuple[str, ...]
-    """``position`` plus the one symbol the file declares, when it declares one: what a rule owns
-    to claim this file and not a sibling declared in the same module."""
+    project: bool = False
+    """Whether the file's own directory is a project root: a unit a reader separated on purpose."""
 
 
-def unit_key(names: Iterable[str], delimiter: str) -> tuple[str, ...]:
-    """The longest prefix the names share."""
-    shared: list[str] = []
-    for parts in zip(*(tuple(segments(name, delimiter)) for name in names)):
-        if len(set(parts)) != 1:
-            break
-        shared.append(parts[0])
-    return tuple(shared)
+def units_from_graph(graph: CallGraph, language: str, repo_dir: Path | None = None) -> list[Unit]:
+    """One unit per file, positioned by its directory under ``repo_dir``.
 
-
-def unit_position(names: Iterable[str], delimiter: str) -> tuple[str, ...]:
-    """The unit key less a trailing symbol.
-
-    A file declaring one class shares that class's name across every member, so the bare
-    prefix would name the class rather than the module it sits in.
+    ``repo_dir`` is required when the graph carries absolute paths; a relative path is taken
+    as already repository-relative.
     """
-    listed = list(names)
-    key = unit_key(listed, delimiter)
-    return key[:-1] if any(tuple(segments(name, delimiter)) == key for name in listed) else key
-
-
-def units_from_graph(graph: CallGraph, language: str) -> list[Unit]:
     by_file: dict[str, list[str]] = {}
     for qualified_name, node in graph.nodes.items():
         if node.file_path:
             by_file.setdefault(node.file_path, []).append(qualified_name)
-    return [
-        Unit(
-            file_path,
-            language,
-            tuple(sorted(names)),
-            unit_position(names, graph.delimiter),
-            unit_key(names, graph.delimiter),
+    units: list[Unit] = []
+    projects: dict[tuple[str, ...], bool] = {}
+    for file_path, names in sorted(by_file.items()):
+        if Path(file_path).is_absolute() and repo_dir is None:
+            raise ValueError(f"{file_path} is absolute and no repository root was given to position it")
+        relative = Path(normalize_repo_path(file_path, repo_dir))
+        position = relative.parent.parts
+        if position == (".",):
+            position = ()
+        if position not in projects:
+            projects[position] = repo_dir is not None and _is_project_root(repo_dir / Path(*position))
+        units.append(
+            Unit(
+                file_path,
+                language,
+                tuple(sorted(names)),
+                position,
+                position + (relative.stem,),
+                projects[position],
+            )
         )
-        for file_path, names in sorted(by_file.items())
-    ]
+    return units
 
 
-def units_from_graphs(graphs: Mapping[str, CallGraph]) -> list[Unit]:
+def units_from_graphs(graphs: Mapping[str, CallGraph], repo_dir: Path | None = None) -> list[Unit]:
     units: list[Unit] = []
     for language in sorted(graphs):
-        units.extend(units_from_graph(graphs[language], language))
+        units.extend(units_from_graph(graphs[language], language, repo_dir))
     return units
+
+
+def _is_project_root(directory: Path) -> bool:
+    if any((directory / manifest).is_file() for manifest in PROJECT_MANIFESTS):
+        return True
+    try:
+        return any(entry.suffix in (".csproj", ".fsproj") for entry in directory.iterdir())
+    except OSError:
+        return False
 
 
 @dataclass
@@ -84,12 +103,11 @@ class TrieNode:
 
 
 class Trie:
-    """The prefix tree of unit positions.
+    """The prefix tree of unit positions: the directory tree of every file the engine saw.
 
-    A node holding one unit and nothing else is usually that unit's own name (a Python
-    module, a file declaring several C# types); the walk treats such a node as a loose unit
-    of its parent rather than as a scope, but keeps it in the tree, because a one-file
-    feature directory under a layer is evidence the transposition needs.
+    A node holding one unit and nothing else is a one-file directory; the walk treats such a
+    node as a loose unit of its parent rather than as a scope, but keeps it in the tree,
+    because a one-file feature directory under a layer is evidence the transposition needs.
     """
 
     def __init__(self, units: Iterable[Unit]):

--- a/static_analyzer/clustering/names/replay.py
+++ b/static_analyzer/clustering/names/replay.py
@@ -14,13 +14,15 @@ from collections.abc import Iterable
 from dataclasses import dataclass, field
 
 from static_analyzer.clustering.names.inventory import Unit
-from static_analyzer.clustering.names.spec import KEYED_RUNGS, UNPLACED, Prefix, ScopeSpec
+from static_analyzer.clustering.names.spec import KEYED_RUNGS, Prefix, ScopeSpec
 from static_analyzer.clustering.names.tokens import segments, stem, tokenize
 from static_analyzer.config import ClusteringConfig
 
 PREFIX = "prefix"
 TERM = "term"
 FALLBACK = "fallback"
+UNPLACED = "unplaced"
+"""How a unit that no rule claims is reported; the drafting gives every scope a loose-files rule so none is."""
 
 
 @dataclass
@@ -59,7 +61,6 @@ def replay(units: Iterable[Unit], scope: ScopeSpec, role_words: frozenset[str]) 
     # directories added after it, so only a named prefix settles a unit.
     named = [(prefix, component_id) for prefix, component_id in primary if prefix]
     known = {prefix for prefix, _ in named}
-    bucket = scope.unplaced_rule
     keyed = scope.rung in KEYED_RUNGS
     for unit in units:
         where = unit.key if keyed else unit.position
@@ -69,9 +70,7 @@ def replay(units: Iterable[Unit], scope: ScopeSpec, role_words: frozenset[str]) 
         if component_id is None:
             partition.unplaced.append(unit)
             partition.placed_by[unit.unit_id] = UNPLACED
-            if bucket is None:
-                continue
-            component_id = bucket.component_id
+            continue
         partition.assignment[unit.unit_id] = component_id
         partition.members[component_id].append(unit)
         partition.placed_by[unit.unit_id] = how

--- a/static_analyzer/clustering/names/spec.py
+++ b/static_analyzer/clustering/names/spec.py
@@ -139,7 +139,7 @@ class ScopeSpec:
         )
 
 
-SPEC_VERSION = 3
+SPEC_VERSION = 4
 """3: the files and role rungs below the old floor of forty units, whose rules claim a unit by its
 key and may own a role word. 2: ``last_id`` per scope."""
 

--- a/static_analyzer/clustering/names/spec.py
+++ b/static_analyzer/clustering/names/spec.py
@@ -10,10 +10,6 @@ from clustering_ids import ROOT_SCOPE_ID, CodeBoardingClusterIds, ScopeId
 
 Prefix = tuple[str, ...]
 
-COMPONENT = "component"
-UNPLACED = "unplaced"
-"""Kinds of rule. The unplaced bucket owns what no rule claims, so it is drawn rather than
-hidden and can never collide with a component the planner proposes."""
 
 UNMERGE = "unmerge"
 FRONTIER = "frontier"
@@ -47,7 +43,6 @@ class ComponentRule:
     fallback_prefixes: tuple[Prefix, ...] = ()
     parts: tuple[ComponentRule, ...] = ()
     origin: str = "frontier"
-    kind: str = COMPONENT
 
     @property
     def is_fallback_only(self) -> bool:
@@ -55,7 +50,7 @@ class ComponentRule:
         return not self.prefixes and not self.terms
 
     def to_dict(self) -> dict[str, Any]:
-        out: dict[str, Any] = {"id": self.component_id, "name": self.name, "origin": self.origin, "kind": self.kind}
+        out: dict[str, Any] = {"id": self.component_id, "name": self.name, "origin": self.origin}
         if self.prefixes:
             out["prefixes"] = [list(prefix) for prefix in self.prefixes]
         if self.terms:
@@ -76,7 +71,6 @@ class ComponentRule:
             fallback_prefixes=tuple(tuple(prefix) for prefix in raw.get("fallback_prefixes", ())),
             parts=tuple(cls.from_dict(part) for part in raw.get("parts", ())),
             origin=str(raw.get("origin", "frontier")),
-            kind=str(raw.get("kind", COMPONENT)),
         )
 
 
@@ -101,11 +95,7 @@ class ScopeSpec:
 
     @property
     def components(self) -> list[ComponentRule]:
-        return [rule for rule in self.rules if rule.kind == COMPONENT]
-
-    @property
-    def unplaced_rule(self) -> ComponentRule | None:
-        return next((rule for rule in self.rules if rule.kind == UNPLACED), None)
+        return list(self.rules)
 
     def rule(self, component_id: str) -> ComponentRule | None:
         return next((rule for rule in self.rules if rule.component_id == component_id), None)

--- a/static_analyzer/clustering/names/tokens.py
+++ b/static_analyzer/clustering/names/tokens.py
@@ -73,12 +73,6 @@ def segments(qualified_name: str, delimiter: str) -> list[str]:
     return [part for part in out if part]
 
 
-LAYOUT_WORDS = frozenset(
-    {"src", "main", "java", "kotlin", "scala", "lib", "libs", "packages", "pkg", "apps", "modules"}
-    | {"source", "sources", "python", "go", "js", "ts"}
-)
-"""Segments naming a build layout rather than a scope. The walk steps through them."""
-
 ROLE_WORDS = frozenset(
     stem(word)
     for word in """

--- a/static_analyzer/clustering/service.py
+++ b/static_analyzer/clustering/service.py
@@ -74,7 +74,11 @@ def file_leaf_clusters(graph: CallGraph) -> ClusterResult:
 
 
 def unit_links(graphs: Mapping[str, CallGraph]) -> Links:
-    """Edges between files: call edges plus the reference kinds that cross a file."""
+    """Edges between files, directed from the calling file to the called one.
+
+    Call edges plus the reference kinds that cross a file. The direction is what tells a
+    helper (called by one sibling) from an application (calls others, called by none).
+    """
     links: dict[tuple[str, str], int] = {}
     for graph in graphs.values():
         pairs = [(edge.get_source(), edge.get_destination()) for edge in graph.edges]
@@ -84,7 +88,7 @@ def unit_links(graphs: Mapping[str, CallGraph]) -> Links:
             if left is None or right is None or not left.file_path or not right.file_path:
                 continue
             if left.file_path != right.file_path:
-                key = (min(left.file_path, right.file_path), max(left.file_path, right.file_path))
+                key = (left.file_path, right.file_path)
                 links[key] = links.get(key, 0) + 1
     return links
 
@@ -99,8 +103,10 @@ class ClusteringService:
     last build produced or extended; the caller persists it.
     """
 
-    def __init__(self, grouper: Grouper | None = None) -> None:
+    def __init__(self, grouper: Grouper | None = None, repo_dir: Path | None = None) -> None:
         self.grouper: Grouper = grouper if grouper is not None else AffinityGrouper()
+        self._repo_dir = repo_dir
+        """Where the files live: a unit's position is its directory under this root."""
         self.spec = TreeSpec(grouper=self.grouper.name)
         self._links: Links = {}
         self._baseline: _Baseline | None = None
@@ -108,7 +114,7 @@ class ClusteringService:
     def build_full_hierarchy(self, static_analysis: StaticAnalysisResults, max_depth: int) -> ClusterScopeResult:
         """Draft the specification from every language's names and materialize the tree."""
         graphs = static_analysis.available_cfgs()
-        units = units_from_graphs(graphs)
+        units = units_from_graphs(graphs, self._repo_dir)
         self._links = unit_links(graphs)
         self.spec = draft_tree(units, self.grouper, max_depth + 1, links=self._links)
         hierarchy = self._materialize(graphs, units, ROOT_SCOPE_ID, 1, max_depth)
@@ -134,9 +140,10 @@ class ClusteringService:
         if graphs and not base.available_cfgs():
             raise IncrementalCacheMissingError(artifact_dir, "the baseline static analysis carries no call graph")
         self._adopt(spec)
-        units = units_from_graphs(graphs)
+        self._repo_dir = repo_dir
+        units = units_from_graphs(graphs, repo_dir)
         self._links = unit_links(graphs)
-        baseline = _Baseline(persisted_scopes, repo_dir, units_from_graphs(base.available_cfgs()))
+        baseline = _Baseline(persisted_scopes, repo_dir, units_from_graphs(base.available_cfgs(), repo_dir))
         self._baseline = baseline
         hierarchy = self._materialize(graphs, units, ROOT_SCOPE_ID, 1, max_depth, baseline=baseline)
         hierarchy.index_hierarchy()
@@ -158,7 +165,7 @@ class ClusteringService:
             raise ValueError("max_depth must be at least 1")
         self._adopt(spec)
         role_words = role_words_for(spec.machinery)
-        units = self._scope_units(units_from_graphs(graphs), root_scope_id, role_words)
+        units = self._scope_units(units_from_graphs(graphs, self._repo_dir), root_scope_id, role_words)
         if not is_root(root_scope_id):
             # The scope's own graphs, induced by the files its ancestors' replay placed in it, so a
             # partial run sees the units a full run would have handed it, data-only files included.
@@ -226,7 +233,7 @@ class ClusteringService:
         result.connections = self._build_connections(graphs, result.groups)
         for group in result.groups:
             child_graphs = self._induced_graphs(partition.members.get(group.group_id, []), graphs)
-            child_units = units_from_graphs(child_graphs)
+            child_units = units_from_graphs(child_graphs, self._repo_dir)
             child = self._scope_rules(group.group_id, child_units)
             group.expandable = not child.is_leaf and bool(child_units)
             if not group.expandable or depth >= max_depth:

--- a/static_analyzer/clustering/service.py
+++ b/static_analyzer/clustering/service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import replace
 from collections.abc import Iterable, Mapping
 from pathlib import Path
 from typing import Any
@@ -34,10 +35,9 @@ from static_analyzer.clustering.names import (
     role_words_for,
     units_from_graphs,
 )
-from static_analyzer.clustering.names.draft import DETERMINISTIC_GROUPERS, UNPLACED_NAME, Links
+from static_analyzer.clustering.names.draft import DETERMINISTIC_GROUPERS, Links, loose_rule
 from static_analyzer.clustering.names.replay import FALLBACK, PREFIX, TERM, divergence
 from static_analyzer.clustering.names.spec import Prefix, is_root
-from static_analyzer.clustering.names.spec import UNPLACED
 from static_analyzer.config import CALLABLE_TYPES, CLASS_TYPES
 
 AFFINE_REFERENCE_KINDS = frozenset({EdgeKind.INHERITS, EdgeKind.TYPEREF})
@@ -315,8 +315,8 @@ class ClusteringService:
             logger.info("[Names] %s: new scope %s (%d units)", scope.scope_id, ".".join(key), len(members))
         if added:
             partition = replay(units, scope, role_words)
-        if partition.unplaced and scope.unplaced_rule is None:
-            scope.rules.append(ComponentRule(scope.next_id(taken), UNPLACED_NAME, origin=UNPLACED, kind=UNPLACED))
+        if partition.unplaced:
+            scope.rules.append(replace(loose_rule(units), component_id=scope.next_id(taken)))
             partition = replay(units, scope, role_words)
         return partition
 
@@ -326,7 +326,7 @@ class ClusteringService:
         A fallback-only rule stays: it is the scope's last resort and legitimately empty.
         """
         for rule in list(scope.rules):
-            if rule.is_fallback_only or rule.kind == UNPLACED or partition.size(rule.component_id):
+            if rule.is_fallback_only or partition.size(rule.component_id):
                 continue
             scope.rules.remove(rule)
             for scope_id in [

--- a/static_analyzer/engine/adapters/csharp_adapter.py
+++ b/static_analyzer/engine/adapters/csharp_adapter.py
@@ -233,7 +233,7 @@ class CSharpAdapter(LanguageAdapter):
         project_root: Path,
         detail: str = "",
     ) -> str:
-        """Build ``<directory>.<file stem>.<declaring types>.<symbol>``.
+        """Build ``<directories>.<file stem>.<declaring types>.<symbol>``, from the repository root.
 
         C# has no file scope, so a file may declare several top-level types. The stem then
         names none of them and stays a plain segment. Folding it in, as a file declaring one
@@ -245,7 +245,7 @@ class CSharpAdapter(LanguageAdapter):
             return detail
 
         rel = file_path.relative_to(project_root)
-        module = ".".join(p for p in rel.with_suffix("").parts if p != "src")
+        module = ".".join(rel.with_suffix("").parts)
         # Skip File and Namespace: the namespace is encoded in the path for C#.
         code_parents = [name for name, kind in parent_chain if kind not in (NodeType.FILE, NodeType.NAMESPACE)]
 

--- a/static_analyzer/engine/adapters/java_adapter.py
+++ b/static_analyzer/engine/adapters/java_adapter.py
@@ -22,7 +22,6 @@ from utils import CODEBOARDING_DIR_NAME, get_config
 logger = logging.getLogger(__name__)
 
 # The languages a JVM source root can be named for, in ``src/<source set>/<language>``.
-JVM_SOURCE_LANGUAGES = frozenset({"java", "kotlin", "groovy", "scala"})
 
 
 class JavaAdapter(LanguageAdapter):
@@ -142,7 +141,7 @@ class JavaAdapter(LanguageAdapter):
         project_root: Path,
         detail: str = "",
     ) -> str:
-        """Build ``<module>.<source set>.<package>.<declaring types>.<symbol>``.
+        """Build ``<directories>.<declaring types>.<symbol>``, from the repository root.
 
         Why no file stem: Java requires it to equal the top-level type, so folding it in
         made that type a sibling of its own members and CONTAINS could not link them.
@@ -152,19 +151,8 @@ class JavaAdapter(LanguageAdapter):
         return ".".join(part for part in (self.get_package_for_file(file_path, project_root), *segments) if part)
 
     def get_package_for_file(self, file_path: Path, project_root: Path) -> str:
-        """The directory holding the file, without the Maven or Gradle source root.
-
-        Why: ``src/main/java`` names no package, and prefixed every symbol in a Maven tree
-        with three segments the compiler does not recognise. The source set itself is kept
-        unless it is ``main``, because ``src/test/java`` and ``src/main/java`` can hold the
-        same package and the same type name.
-        """
-        parts = file_path.relative_to(project_root).parent.parts
-        for i in range(len(parts) - 2):
-            if parts[i] == "src" and parts[i + 2] in JVM_SOURCE_LANGUAGES:
-                source_set = () if parts[i + 1] == "main" else (parts[i + 1],)
-                return ".".join(parts[:i] + source_set + parts[i + 3 :])
-        return ".".join(parts)
+        """The directory holding the file, from the repository root, spelled as it is on disk."""
+        return ".".join(file_path.relative_to(project_root).parent.parts)
 
     @staticmethod
     def _clean_symbol_name(name: str) -> str:

--- a/static_analyzer/engine/call_graph_builder.py
+++ b/static_analyzer/engine/call_graph_builder.py
@@ -29,11 +29,14 @@ class CallGraphBuilder:
         lsp_client: LSPClient,
         adapter: LanguageAdapter,
         project_root: Path,
+        repository_path: Path,
         memory_budget_bytes: int = 0,
     ) -> None:
         self._lsp = lsp_client
         self._adapter = adapter
         self._root = project_root.resolve()
+        self._repository = repository_path.resolve()
+        """Names are spelled from here, whichever nested solution or project the server was started on."""
         # 0 means "one server at a time", so the recycler uses the whole allowance.
         self._memory_budget_bytes = memory_budget_bytes
 
@@ -210,8 +213,8 @@ class CallGraphBuilder:
                     opened_early.append(file_path)
                     self._lsp.did_open(file_path)
                     symbols = self._lsp.document_symbol(file_path)
-            self._adapter.record_document_symbols(file_path, symbols, self._root)
-            self._symbol_table.register_symbols(file_path, symbols, parent_chain=[], project_root=self._root)
+            self._adapter.record_document_symbols(file_path, symbols, self._repository)
+            self._symbol_table.register_symbols(file_path, symbols, parent_chain=[], project_root=self._repository)
             pbar.set_postfix(symbols=len(self._symbol_table.symbols))
             pbar.update(1)
         pbar.finish()
@@ -372,7 +375,7 @@ class CallGraphBuilder:
 
     def _build_package_deps(self, edge_set: EdgeMap, source_files: list[Path]) -> dict[str, dict]:
         """Phase 4: Infer package dependencies from cross-package edges."""
-        all_packages = self._adapter.get_all_packages(source_files, self._root)
+        all_packages = self._adapter.get_all_packages(source_files, self._repository)
 
         package_deps: dict[str, dict] = {}
         for pkg in sorted(all_packages):
@@ -384,8 +387,8 @@ class CallGraphBuilder:
             dst_sym = st.symbols.get(dst)
             if not src_sym or not dst_sym:
                 continue
-            src_pkg = self._adapter.get_package_for_file(src_sym.file_path, self._root)
-            dst_pkg = self._adapter.get_package_for_file(dst_sym.file_path, self._root)
+            src_pkg = self._adapter.get_package_for_file(src_sym.file_path, self._repository)
+            dst_pkg = self._adapter.get_package_for_file(dst_sym.file_path, self._repository)
             if src_pkg != dst_pkg:
                 if src_pkg in package_deps and dst_pkg not in package_deps[src_pkg]["imports"]:
                     package_deps[src_pkg]["imports"].append(dst_pkg)

--- a/static_analyzer/engine/language_adapter.py
+++ b/static_analyzer/engine/language_adapter.py
@@ -105,9 +105,11 @@ class LanguageAdapter(ABC):
     ) -> str:
         """Build the original-casing qualified name for a symbol.
 
-        Default: ``module.parent1.parent2.symbol_name`` where module is the
-        dot-joined relative path without suffix.  Override for languages that
-        need different logic (Go receiver notation, Java name cleaning, etc.).
+        ``project_root`` is the repository root: every adapter spells the path from there,
+        segment for segment as it is on disk, so two files in one directory carry the same
+        prefix whatever language they are. Default: ``module.parent1.parent2.symbol_name``
+        where module is the dot-joined relative path without suffix. Override only for what
+        a language means (Go receivers, Rust's implicit module files), never for layout.
         """
         rel = file_path.relative_to(project_root)
         module = ".".join(rel.with_suffix("").parts)

--- a/static_analyzer/incremental_orchestrator.py
+++ b/static_analyzer/incremental_orchestrator.py
@@ -53,6 +53,7 @@ def update_cfg_for_changed_files(
     changed_files: set[Path],
     adapter: LanguageAdapter,
     project_path: Path,
+    repository_path: Path,
     engine_client: LSPClient,
     ignore_manager: RepoIgnoreManager,
 ) -> dict[str, Any]:
@@ -94,7 +95,7 @@ def update_cfg_for_changed_files(
     ]
 
     if changed_source_files:
-        builder = CallGraphBuilder(engine_client, adapter, project_path)
+        builder = CallGraphBuilder(engine_client, adapter, project_path, repository_path)
         engine_result = builder.build(changed_source_files)
         new_analysis = convert_to_codeboarding_format(builder.symbol_table, engine_result, adapter)
     else:

--- a/tests/diagram_analysis/test_diagram_analysis.py
+++ b/tests/diagram_analysis/test_diagram_analysis.py
@@ -1287,9 +1287,9 @@ class TestDiagramGenerator(unittest.TestCase):
         gen.tree_spec = TreeSpec(
             scopes={
                 ROOT_SCOPE_ID: ScopeSpec(
-                    ROOT_SCOPE_ID, [ComponentRule("2", "Persisted", prefixes=(("persisted",),))], rung="files"
+                    ROOT_SCOPE_ID, [ComponentRule("2", "Persisted", prefixes=(("persisted.py",),))], rung="files"
                 ),
-                "2": ScopeSpec("2", [ComponentRule("2.1", "Persisted", prefixes=(("persisted",),))], rung="files"),
+                "2": ScopeSpec("2", [ComponentRule("2.1", "Persisted", prefixes=(("persisted.py",),))], rung="files"),
             }
         )
         component = Component(

--- a/tests/diagram_analysis/test_diagram_analysis.py
+++ b/tests/diagram_analysis/test_diagram_analysis.py
@@ -1282,13 +1282,14 @@ class TestDiagramGenerator(unittest.TestCase):
         graph.add_node(Node("pkg.other.run", NodeType.FUNCTION, str(self.repo_location / "other.py"), 1, 4))
         gen.static_analysis = StaticAnalysisResults()
         gen.static_analysis.add_cfg(Language.PYTHON, graph)
-        # The service replays from the root down, so the spec carries the root that places pkg.persisted in 2.
+        # The service replays from the root down, so the spec carries the root that places persisted.py in 2.
+        # Both files sit at the repository root, so a rule owns one by its file key, as the files rung does.
         gen.tree_spec = TreeSpec(
             scopes={
                 ROOT_SCOPE_ID: ScopeSpec(
-                    ROOT_SCOPE_ID, [ComponentRule("2", "Persisted", prefixes=(("pkg", "persisted"),))]
+                    ROOT_SCOPE_ID, [ComponentRule("2", "Persisted", prefixes=(("persisted",),))], rung="files"
                 ),
-                "2": ScopeSpec("2", [ComponentRule("2.1", "Persisted", prefixes=(("pkg", "persisted"),))]),
+                "2": ScopeSpec("2", [ComponentRule("2.1", "Persisted", prefixes=(("persisted",),))], rung="files"),
             }
         )
         component = Component(

--- a/tests/static_analyzer/names/conftest.py
+++ b/tests/static_analyzer/names/conftest.py
@@ -1,14 +1,19 @@
 """Builders shared by the names tests: units straight from qualified names, no engine."""
 
 from static_analyzer.cfg import CallGraph
-from static_analyzer.clustering.names import ComponentRule, ScopeSpec, TreeSpec, Trie, Unit, unit_key, unit_position
+from pathlib import Path
+
+from static_analyzer.clustering.names import ComponentRule, ScopeSpec, TreeSpec, Trie, Unit
 from static_analyzer.clustering.names.inventory import TrieNode
 from static_analyzer.config import NodeType
 from static_analyzer.node import Node
 
 
-def unit(file_path: str, *names: str, language: str = "python") -> Unit:
-    return Unit(file_path, language, tuple(sorted(names)), unit_position(names, "."), unit_key(names, "."))
+def unit(file_path: str, *names: str, language: str = "python", project: bool = False) -> Unit:
+    """A unit positioned by its path, the way the inventory positions a file under the repository root."""
+    relative = Path(file_path)
+    position = () if relative.parent.parts == (".",) else relative.parent.parts
+    return Unit(file_path, language, tuple(sorted(names)), position, position + (relative.stem,), project)
 
 
 def units_from_layout(layout: dict[str, list[str]], language: str = "python") -> list[Unit]:

--- a/tests/static_analyzer/names/conftest.py
+++ b/tests/static_analyzer/names/conftest.py
@@ -9,11 +9,11 @@ from static_analyzer.config import NodeType
 from static_analyzer.node import Node
 
 
-def unit(file_path: str, *names: str, language: str = "python", project: bool = False) -> Unit:
+def unit(file_path: str, *names: str, language: str = "python", project: tuple[str, ...] | None = None) -> Unit:
     """A unit positioned by its path, the way the inventory positions a file under the repository root."""
     relative = Path(file_path)
     position = () if relative.parent.parts == (".",) else relative.parent.parts
-    return Unit(file_path, language, tuple(sorted(names)), position, position + (relative.stem,), project)
+    return Unit(file_path, language, tuple(sorted(names)), position, position + (relative.name,), project)
 
 
 def units_from_layout(layout: dict[str, list[str]], language: str = "python") -> list[Unit]:

--- a/tests/static_analyzer/names/test_draft.py
+++ b/tests/static_analyzer/names/test_draft.py
@@ -1,5 +1,9 @@
 """Drafting: the frontier grouped into components, the ladder below them, and the guard."""
 
+import re
+from collections import Counter
+from dataclasses import replace
+
 import pytest
 
 from clustering_ids import ROOT_SCOPE_ID
@@ -15,6 +19,8 @@ from static_analyzer.clustering.names import (
 )
 from static_analyzer.clustering.names.draft import (
     BUDGET,
+    LIMIT,
+    OTHER_NAME,
     CAP_SHARE,
     FILES,
     FRONTIER,
@@ -30,10 +36,9 @@ from static_analyzer.clustering.names.draft import (
     ROLE,
     SEGMENT,
     UNMERGE,
-    VOCABULARY,
     GroupingContext,
 )
-from static_analyzer.clustering.names.frontier import BOX
+from static_analyzer.clustering.names.frontier import BOX, LOOSE
 from static_analyzer.clustering.names.spec import UNPLACED
 from tests.static_analyzer.names.conftest import rule_of, scope_of, units_from_layout
 
@@ -74,11 +79,11 @@ class TestRootDraft:
             ROOT_SCOPE_ID, units_from_layout(eshop(), "csharp"), ROLE_WORDS, KinshipGrouper()
         )
         assert scope.rung == FRONTIER and scope.axis == "structural"
-        assert names_of(scope) == ["Ordering", "Catalog", "Webhooks", "Basket", "PaymentProcessor"]
+        assert names_of(scope) == ["Ordering.API", "Catalog.API", "WebhookClient", "Basket.API", "PaymentProcessor"]
         ordering = rule_of(scope, "1")
-        assert ordering.prefixes == (("OrderProcessor",), ("Ordering",))
+        assert ordering.prefixes == (("src", "OrderProcessor"), ("src", "Ordering.API"), ("src", "Ordering.Domain"))
         assert ordering.terms == ("order",)
-        assert [part.name for part in ordering.parts] == ["OrderProcessor", "Ordering"]
+        assert [part.name for part in ordering.parts] == ["OrderProcessor", "Ordering.API", "Ordering.Domain"]
         assert partition.size("1") == 19
         assert rule_of(scope, "5").parts == ()
 
@@ -90,7 +95,7 @@ class TestRootDraft:
         """A two-file directory is a box; small boxes are the grouper's to merge, not hidden."""
         layout = eshop() | project("Tiny.API", 2)
         scope, _ = draft_scope(ROOT_SCOPE_ID, units_from_layout(layout, "csharp"), ROLE_WORDS, KinshipGrouper())
-        assert "Tiny" in names_of(scope)
+        assert "Tiny.API" in names_of(scope)
 
     def test_a_transposed_root_places_loose_units_by_their_words(self):
         layout: dict[str, list[str]] = {}
@@ -112,9 +117,9 @@ class TestRootDraft:
         assert scope.axis == "transposed"
         by_name = {rule.name: rule.component_id for rule in scope.rules}
         assert partition.assignment["Beacon.Application/IncidentResolvedMetricsHandler.cs"] == by_name["Metrics"]
-        assert partition.assignment["Beacon.Application/Bootstrap.cs"] == by_name["Application (residual)"]
+        assert partition.assignment["Beacon.Application/Bootstrap.cs"] == by_name["Beacon.Application (residual)"]
 
-    def test_one_box_at_the_root_falls_through_to_the_words(self):
+    def test_one_box_at_the_root_falls_through_to_its_files(self):
         layout = {
             f"converters/{fmt}_{index}.py": [
                 f"converters.{fmt}_{index}.{fmt.capitalize()}Converter",
@@ -124,8 +129,8 @@ class TestRootDraft:
             for index in range(2)
         }
         scope, partition = draft_scope(ROOT_SCOPE_ID, units_from_layout(layout), ROLE_WORDS, KinshipGrouper())
-        assert scope.rung == VOCABULARY
-        assert names_of(scope) == ["Docx", "Pdf", "Pptx"]
+        assert scope.rung == FILES
+        assert names_of(scope) == ["docx_0", "pdf_0", "pptx_0"]
         assert all(partition.size(rule.component_id) == 2 for rule in scope.rules)
 
     def test_what_no_rule_claims_gets_a_bucket(self):
@@ -136,10 +141,9 @@ class TestRootDraft:
         }
         layout["converters/base.py"] = ["converters.base.Converter"]
         scope, partition = draft_scope(ROOT_SCOPE_ID, units_from_layout(layout), ROLE_WORDS, KinshipGrouper())
-        bucket = scope.unplaced_rule
-        assert bucket is not None and bucket.kind == UNPLACED
-        assert partition.assignment["converters/base.py"] == bucket.component_id
-        assert [unit.unit_id for unit in partition.unplaced] == ["converters/base.py"]
+        loose = next(rule for rule in scope.rules if rule.is_fallback_only)
+        assert partition.assignment["converters/base.py"] == loose.component_id
+        assert partition.placed_by["converters/base.py"] == "fallback"
 
     def test_a_layered_root_without_a_grid_draws_its_layers_before_reading_words(self):
         """serilog's shape: every top-level directory is role-named and no feature recurs."""
@@ -159,7 +163,7 @@ class TestRootDraft:
         layout = project("Ordering.API", 40) | project("Catalog.API", 40)
         layout["src/Program.cs"] = ["Program", "Program.Main()"]
         scope, partition = draft_scope(ROOT_SCOPE_ID, units_from_layout(layout, "csharp"), ROLE_WORDS, KinshipGrouper())
-        assert names_of(scope) == ["Catalog", "Ordering", "Loose files"]
+        assert names_of(scope) == ["Catalog.API", "Ordering.API", "Loose files in src"]
         assert partition.assignment["src/Program.cs"] == "3"
 
     def test_a_root_of_one_box_plus_loose_files_reads_its_words(self):
@@ -170,7 +174,7 @@ class TestRootDraft:
         }
         layout["setup.py"] = ["setup.main"]
         scope, _ = draft_scope(ROOT_SCOPE_ID, units_from_layout(layout), ROLE_WORDS, KinshipGrouper())
-        assert scope.rung == VOCABULARY
+        assert scope.rung == FILES and names_of(scope) == ["docx_reader", "pdf_reader", "Loose files"]
 
     def test_a_machinery_word_from_the_planner_is_a_role_word(self):
         layout = {
@@ -205,13 +209,13 @@ class TestLadder:
         spec = draft_tree(units_from_layout(eshop(), "csharp"), KinshipGrouper(), 2)
         child = scope_of(spec, "1")
         assert child.rung == UNMERGE
-        assert names_of(child) == ["Ordering", "OrderProcessor"]
-        assert [rule.component_id for rule in child.rules] == ["1.1", "1.2"]
-        assert rule_of(scope_of(spec, "1"), "1.1").prefixes == (("Ordering",),)
+        assert names_of(child) == ["Ordering.API", "Ordering.Domain", "OrderProcessor"]
+        assert [rule.component_id for rule in child.rules] == ["1.1", "1.2", "1.3"]
+        assert rule_of(scope_of(spec, "1"), "1.1").prefixes == (("src", "Ordering.API"),)
 
     def test_un_merge_keeps_the_parts_kinship_would_merge_again(self):
         child = scope_of(draft_tree(units_from_layout(eshop(), "csharp"), AffinityGrouper(), 2), "1")
-        assert child.rung == UNMERGE and names_of(child) == ["Ordering", "OrderProcessor"]
+        assert child.rung == UNMERGE and names_of(child) == ["Ordering.API", "Ordering.Domain", "OrderProcessor"]
 
     def test_un_merge_folds_the_parts_toward_the_budget(self):
         """Twelve parts one word merged at the root fold along their own links inside the box."""
@@ -247,7 +251,7 @@ class TestLadder:
         spec = draft_tree(units_from_layout(layout, "csharp"), KinshipGrouper(), 2)
         assert [part.name for part in rule_of(scope_of(spec, ROOT_SCOPE_ID), "1").parts] == [
             "OrderProcessor",
-            "Ordering",
+            "Ordering.API",
         ]
         assert scope_of(spec, "1").is_leaf
 
@@ -283,7 +287,7 @@ class TestLadder:
 
         def client_app(count: int):
             layout = project(
-                "ClientApp", count, "Models.Orders", "Services.Order", "Models.Basket", "Services.Basket", "Views"
+                "ClientApp", count, "Models/Orders", "Services/Order", "Models/Basket", "Services/Basket", "Views"
             )
             layout |= project("Beta", 40) | project("Gamma", 40)
             return scope_of(draft_tree(units_from_layout(layout, "csharp"), AffinityGrouper(), 2), "1")
@@ -294,8 +298,14 @@ class TestLadder:
         assert transposed.rung == SEGMENT and transposed.axis == "transposed"
         assert {"Orders", "Basket"} <= set(names_of(transposed))
 
+    @staticmethod
+    def _module(class_name: str) -> str:
+        return re.sub(r"(?<!^)(?=[A-Z])", "_", class_name).lower()
+
     def _flat_feature(self, *class_names: str) -> dict[str, list[str]]:
-        layout = {f"pkg/feat/{name.lower()}.py": [f"pkg.feat.{name.lower()}.{name}"] for name in class_names}
+        layout = {
+            f"pkg/feat/{self._module(name)}.py": [f"pkg.feat.{self._module(name)}.{name}"] for name in class_names
+        }
         return layout | {f"pkg/other/{index}.py": [f"pkg.other.m{index}.f"] for index in range(3)}
 
     def test_a_flat_component_groups_its_files_by_their_words(self):
@@ -315,10 +325,10 @@ class TestLadder:
         units = units_from_layout(layout)
         feature = scope_of(draft_tree(units, KinshipGrouper(), 2), "1")
         assert feature.rung == FILES
-        assert names_of(feature) == [LOOSE_NAME, "RetryBuilder", "TimeoutBuilder"]
+        assert names_of(feature) == [LOOSE_NAME, "retry_options", "timeout_options"]
         retry = rule_of(feature, "1.2")
         assert retry.terms == ("retry",) and len(retry.prefixes) == 3
-        assert ("pkg", "feat", "retrypolicy", "RetryPolicy") in retry.prefixes
+        assert ("pkg", "feat", "retry_policy") in retry.prefixes
         loose = rule_of(feature, "1.1")
         assert loose.is_fallback_only and loose.fallback_prefixes == (("pkg", "feat"),)
         placed = replay(units, feature, ROLE_WORDS)
@@ -361,7 +371,7 @@ class TestLadder:
             name for name in members if name in ("HtmlConverter", "DocxConverter", "EpubConverter", "PptxConverter")
         }
         links = {
-            (f"pkg/feat/{a.lower()}.py", f"pkg/feat/{b.lower()}.py"): 2
+            (f"pkg/feat/{self._module(a)}.py", f"pkg/feat/{self._module(b)}.py"): 2
             for a in sorted(html)
             for b in sorted(html)
             if a < b
@@ -382,7 +392,7 @@ class TestLadder:
         )
         feature = scope_of(draft_tree(units, AffinityGrouper(), 3, links=links), "1")
         assert feature.rung == ISLAND
-        assert names_of(feature) == ["Other converters", "DocxConverter"]
+        assert names_of(feature) == ["Other converters", "docx_converter"]
         rest, family = feature.rules
         assert len(rest.prefixes) == 5 and rest.fallback_prefixes == (("pkg", "feat"),)
         assert len(family.prefixes) == 4
@@ -402,8 +412,8 @@ class TestLadder:
             "ZipConverter",
             "CsvConverter",
         )
-        for name in ("pdfconverter", "audioconverter", "imageconverter"):
-            links[("pkg/feat/htmlconverter.py", f"pkg/feat/{name}.py")] = 1
+        for name in ("pdf_converter", "audio_converter", "image_converter"):
+            links[("pkg/feat/html_converter.py", f"pkg/feat/{name}.py")] = 1
         feature = scope_of(draft_tree(units, AffinityGrouper(), 2, links=links), "1")
         assert feature.is_leaf and "island" in feature.leaf_reason
 
@@ -454,23 +464,18 @@ class TestLadder:
         layout |= {f"pkg/other/{index}.py": [f"pkg.other.m{index}.f"] for index in range(3)}
         return layout
 
-    def test_a_large_flat_component_reads_its_words(self):
-        spec = draft_tree(units_from_layout(self._flat(23)), KinshipGrouper(), 2)
-        big = scope_of(spec, "1")
-        assert big.rung == VOCABULARY
-        assert names_of(big) == ["Docx", "Pdf", "Pptx"]
-
-    def test_the_leaf_cap_is_a_boundary(self):
-        """135 units is a leaf; 136 reads its words."""
+    def test_a_large_flat_component_groups_its_files_by_their_words(self):
+        """Above the leaf cap as below it: the file names, not a separate vocabulary, draw the boxes."""
 
         def big_scope(extra: int):
             layout = self._flat(22) | {f"pkg/big/x{i}.py": [f"pkg.big.x{i}.f"] for i in range(extra)}
             return scope_of(draft_tree(units_from_layout(layout), KinshipGrouper(), 2), "1")
 
         assert 3 * 2 * 22 + 3 == LEAF_CAP
-        at_cap = big_scope(3)
-        assert at_cap.rung == FILES and names_of(at_cap) == ["DocxCodec", "PdfCodec", "PptxCodec", LOOSE_NAME]
-        assert big_scope(4).rung == VOCABULARY
+        for extra in (3, 4):
+            scope = big_scope(extra)
+            assert scope.rung == FILES
+            assert names_of(scope) == ["docx_reader_0", "pdf_reader_0", "pptx_reader_0", LOOSE_NAME]
 
     def test_a_large_component_nothing_splits_is_an_exhausted_leaf(self):
         layout = {f"pkg/big/m{i}.py": [f"pkg.big.m{i}.Thing"] for i in range(LEAF_CAP + 5)}
@@ -535,6 +540,7 @@ def context(
         FRONTIER,
         sizes={f"box:{name}": size for name, size in sizes.items()},
         links={tuple(sorted((f"box:{a}", f"box:{b}"))): count for (a, b), count in links.items()},  # type: ignore[misc]
+        calls={(f"box:{a}", f"box:{b}"): count for (a, b), count in links.items()},
         floor=floor,
     )
 
@@ -556,16 +562,38 @@ class TestAffinityGrouper:
 
     def test_within_budget_only_a_candidate_below_the_floor_folds(self):
         sizes = {"alpha": 5, "beta": 5, "tiny": 2}
-        links = {("tiny", "alpha"): 2, ("alpha", "beta"): 9}
+        links = {("alpha", "tiny"): 2, ("alpha", "beta"): 9}
         assert len(AffinityGrouper().group(boxes(*sizes), context(sizes, links))) == 3
         folded = AffinityGrouper().group(boxes(*sizes), context(sizes, links, floor=3))
         assert members_of(folded) == {"alpha": ("alpha", "tiny"), "beta": ("beta",)}
+
+    def test_a_small_candidate_that_only_calls_others_is_an_application_and_stays(self):
+        """PaymentProcessor calls the bus; nothing calls it. It is a service, not the bus's helper."""
+        sizes = {"bus": 5, "orders": 5, "payment": 2}
+        links = {("payment", "bus"): 6, ("orders", "bus"): 6}
+        assert len(AffinityGrouper().group(boxes(*sizes), context(sizes, links, floor=3))) == 3
 
     def test_a_hub_is_nobody_s_closest_sibling(self):
         sizes = {"utils": 9, "billing": 5, "tiny": 2} | dict.fromkeys(self.BIG, 5)
         links = {("tiny", "utils"): 3, ("tiny", "billing"): 3} | {("utils", name): 10 for name in self.BIG}
         folded = AffinityGrouper().group(boxes(*sizes), context(sizes, links, floor=3))
         assert members_of(folded)["billing"] == ("billing", "tiny")
+
+    def test_a_hub_neither_absorbs_a_sibling_nor_folds_into_one(self):
+        """An event bus every service calls is drawn as its own box, and so is the smallest service."""
+        sizes = {"bus": 4, "orders": 30, "catalog": 20, "basket": 6, "payment": 3, "webhooks": 12}
+        links = {(name, "bus"): 6 for name in ("orders", "catalog", "basket", "payment", "webhooks")}
+        assert len(AffinityGrouper().group(boxes(*sizes), context(sizes, links, floor=5))) == len(sizes)
+        two_callers = {("orders", "bus"): 6, ("payment", "bus"): 6}
+        folded = AffinityGrouper().group(boxes(*sizes), context(sizes, two_callers, floor=5))
+        assert members_of(folded)["orders"] == ("orders", "bus"), "shared by two, the bus joins the larger caller"
+
+    def test_a_fold_takes_the_sibling_it_links_to_most(self):
+        """Fifteen links to a busy sibling outweigh three to a quiet one."""
+        sizes = {"web": 20, "hybrid": 6, "components": 3, "orders": 20}
+        links = {("web", "components"): 15, ("hybrid", "components"): 3, ("web", "orders"): 40}
+        folded = AffinityGrouper().group(boxes(*sizes), context(sizes, links, floor=5))
+        assert members_of(folded)["web"] == ("web", "components")
 
     def test_one_link_is_noise(self):
         sizes = {"alpha": 5, "tiny": 2}
@@ -574,17 +602,99 @@ class TestAffinityGrouper:
 
     def test_the_cap_sends_a_fold_to_the_next_sibling(self):
         sizes = {"big": 6, "mid": 3, "tiny": 2}
-        links = {("tiny", "big"): 3, ("tiny", "mid"): 2}
+        links = {("big", "tiny"): 3, ("mid", "tiny"): 2}
         assert 6 + 2 > CAP_SHARE * 11 >= 3 + 2
         folded = AffinityGrouper().group(boxes(*sizes), context(sizes, links, floor=3))
         assert members_of(folded) == {"big": ("big",), "mid": ("mid", "tiny")}
 
     def test_kinship_comes_first_and_a_fold_keeps_every_word(self):
         sizes = {"Ordering": 8, "OrderProcessor": 2, "Basket": 5, "tiny": 2}
-        links = {("tiny", "Basket"): 2}
+        links = {("Basket", "tiny"): 2}
         folded = AffinityGrouper().group(boxes(*sizes), context(sizes, links, floor=3))
         assert members_of(folded) == {"Ordering": ("Ordering", "OrderProcessor"), "Basket": ("Basket", "tiny")}
         assert next(group.terms for group in folded if group.name == "Ordering") == ("order",)
+
+
+class TestPlacementByRole:
+    """Small candidates are placed by what the calls say about them, before any fold."""
+
+    def test_a_helper_called_by_one_sibling_goes_inside_it(self):
+        sizes = {"cli": 20, "engine": 20, "core": 3}
+        folded = AffinityGrouper().group(boxes(*sizes), context(sizes, {("cli", "core"): 4}, floor=5))
+        assert members_of(folded)["cli"] == ("cli", "core")
+
+    def test_a_hub_called_by_many_stays_whatever_its_size(self):
+        sizes = {"bus": 3, "a": 20, "b": 20, "c": 20, "d": 20}
+        links = {(name, "bus"): 3 for name in "abcd"}
+        assert len(AffinityGrouper().group(boxes(*sizes), context(sizes, links, floor=5))) == 5
+
+    def test_a_hub_under_three_units_joins_the_loose_files(self):
+        sizes = {"log": 2, "a": 20, "b": 20, "c": 20, "d": 20}
+        links = {(name, "log"): 3 for name in "abcd"}
+        candidates = boxes(*sizes) + [Candidate("loose:", LOOSE, "", fallback_prefixes=((),))]
+        ctx = context(sizes | {"loose:": 0}, links, floor=5)
+        ctx.sizes["loose:"] = 2
+        groups = {group.name: group.keys for group in AffinityGrouper().group(candidates, ctx)}
+        assert groups["Loose files"] == ("loose:", "box:log")
+
+    def test_a_project_root_is_never_a_helper(self):
+        sizes = {"core": 40, "extensions": 3}
+        ctx = context(sizes, {("core", "extensions"): 6}, floor=5)
+        assert len(AffinityGrouper().group(boxes(*sizes), replace(ctx, projects=frozenset({"box:extensions"})))) == 2
+
+    def test_shared_by_three_stays_and_by_two_joins_the_larger(self):
+        sizes = {"a": 30, "b": 20, "c": 20, "shared": 3}
+        by_three = {(name, "shared"): 2 for name in "abc"}
+        assert len(AffinityGrouper().group(boxes(*sizes), context(sizes, by_three, floor=5))) == 4
+        by_two = {("a", "shared"): 2, ("b", "shared"): 2}
+        folded = AffinityGrouper().group(boxes(*sizes), context(sizes, by_two, floor=5))
+        assert members_of(folded)["a"] == ("a", "shared")
+
+    def test_a_hub_calling_a_small_sibling_does_not_own_it(self):
+        """The event bus dispatches to every service's handlers; a service is its subscriber, not its helper."""
+        sizes = {"bus": 11, "a": 30, "b": 30, "c": 30, "d": 30, "basket": 4}
+        links = {(name, "bus"): 5 for name in "abcd"} | {("bus", "basket"): 6, ("basket", "bus"): 3}
+        assert len(AffinityGrouper().group(boxes(*sizes), context(sizes, links, floor=5))) == len(sizes)
+
+    def test_loose_files_tests_and_samples_own_no_helper(self):
+        sizes = {"lib": 30, "samples": 20, "printer": 3}
+        links = {("samples", "printer"): 9}
+        assert len(AffinityGrouper().group(boxes(*sizes), context(sizes, links, floor=5))) == 3
+
+    def test_a_candidate_with_no_links_joins_the_loose_files(self):
+        sizes = {"a": 30, "b": 20, "stray": 2}
+        candidates = boxes(*sizes) + [Candidate("loose:", LOOSE, "", fallback_prefixes=((),))]
+        ctx = context(sizes, {("a", "b"): 5}, floor=5)
+        ctx.sizes["loose:"] = 1
+        groups = {group.name: group.keys for group in AffinityGrouper().group(candidates, ctx)}
+        assert groups["Loose files"] == ("loose:", "box:stray")
+
+
+class TestBudgetAndLimit:
+    def test_over_the_budget_a_real_component_folds_only_into_a_dominant_partner(self):
+        """Webhooks must not join Catalog on the two links a shared helper brought along."""
+        sizes = dict.fromkeys((f"s{i}" for i in range(9)), 20) | {"webhooks": 20, "bus": 10}
+        links = {(name, "bus"): 30 for name in sizes if name != "bus"} | {("webhooks", "s0"): 2}
+        groups = AffinityGrouper().group(boxes(*sizes), context(sizes, links, floor=5))
+        assert len(groups) == len(sizes), "the bus is a hub and two links out of thirty-two are not a home"
+
+    def test_over_the_limit_the_names_vocabulary_merges_the_closest_pair(self):
+        sizes = dict.fromkeys((f"pkg{i}" for i in range(15)), 20) | {"tenants": 20, "tenancy": 20}
+        ctx = context(sizes, {}, floor=5)
+        vocabulary = {key: Counter({key.removeprefix("box:"): 1}) for key in ctx.sizes}
+        vocabulary["box:tenants"] = Counter({"tenant": 3, "manager": 1})
+        vocabulary["box:tenancy"] = Counter({"tenant": 3, "resolver": 1})
+        groups = AffinityGrouper().group(boxes(*sizes), replace(ctx, vocabulary=vocabulary))
+        assert len(groups) == LIMIT
+        merged = next(group for group in groups if "box:tenants" in group.keys)
+        assert set(merged.keys) == {"box:tenants", "box:tenancy"}
+
+    def test_over_the_limit_with_nothing_to_merge_the_smallest_are_pooled(self):
+        sizes = {f"pkg{i:02d}": 30 - i for i in range(18)}
+        groups = AffinityGrouper().group(boxes(*sizes), context(sizes, {}, floor=5))
+        assert len(groups) == LIMIT
+        pooled = next(group for group in groups if group.name == OTHER_NAME)
+        assert set(pooled.keys) == {f"box:pkg{i}" for i in (14, 15, 16, 17)}
 
 
 class TestGroupingContractErrors:

--- a/tests/static_analyzer/names/test_draft.py
+++ b/tests/static_analyzer/names/test_draft.py
@@ -209,6 +209,27 @@ class TestLadder:
         assert [rule.component_id for rule in child.rules] == ["1.1", "1.2"]
         assert rule_of(scope_of(spec, "1"), "1.1").prefixes == (("Ordering",),)
 
+    def test_un_merge_keeps_the_parts_kinship_would_merge_again(self):
+        child = scope_of(draft_tree(units_from_layout(eshop(), "csharp"), AffinityGrouper(), 2), "1")
+        assert child.rung == UNMERGE and names_of(child) == ["Ordering", "OrderProcessor"]
+
+    def test_un_merge_folds_the_parts_toward_the_budget(self):
+        """Twelve parts one word merged at the root fold along their own links inside the box."""
+        suffixes = "ABCDEFGHIJKL"
+        others = "Basket Catalog Identity Payment Shipping Webhooks Search Pricing Billing Tax Loyalty Reviews Wishlist"
+        assert len(others.split()) > len(suffixes), "a word half the siblings carry is ubiquitous, not kinship"
+        layout: dict[str, list[str]] = {}
+        for name in others.split():
+            layout |= project(name, 20)
+        for suffix in suffixes:
+            layout |= project(f"Order{suffix}", 6)
+        links = {("src/OrderA//OrderAType0.cs", f"src/Order{suffix}//Order{suffix}Type0.cs"): 3 for suffix in "JKL"}
+        spec = draft_tree(units_from_layout(layout, "csharp"), AffinityGrouper(), 2, links=links)
+        assert len(rule_of(scope_of(spec, ROOT_SCOPE_ID), "1").parts) == len(suffixes)
+        order = scope_of(spec, "1")
+        assert order.rung == UNMERGE and len(order.components) == BUDGET
+        assert sorted(len(rule.prefixes) for rule in order.rules) == [1] * (BUDGET - 1) + [4]
+
     def test_a_small_component_is_a_leaf_that_says_why(self):
         spec = draft_tree(units_from_layout(eshop(), "csharp"), KinshipGrouper(), 2)
         basket = scope_of(spec, "4")

--- a/tests/static_analyzer/names/test_draft.py
+++ b/tests/static_analyzer/names/test_draft.py
@@ -39,7 +39,6 @@ from static_analyzer.clustering.names.draft import (
     GroupingContext,
 )
 from static_analyzer.clustering.names.frontier import BOX, LOOSE
-from static_analyzer.clustering.names.spec import UNPLACED
 from tests.static_analyzer.names.conftest import rule_of, scope_of, units_from_layout
 
 

--- a/tests/static_analyzer/names/test_draft.py
+++ b/tests/static_analyzer/names/test_draft.py
@@ -328,7 +328,7 @@ class TestLadder:
         assert names_of(feature) == [LOOSE_NAME, "retry_options", "timeout_options"]
         retry = rule_of(feature, "1.2")
         assert retry.terms == ("retry",) and len(retry.prefixes) == 3
-        assert ("pkg", "feat", "retry_policy") in retry.prefixes
+        assert ("pkg", "feat", "retry_policy.py") in retry.prefixes
         loose = rule_of(feature, "1.1")
         assert loose.is_fallback_only and loose.fallback_prefixes == (("pkg", "feat"),)
         placed = replay(units, feature, ROLE_WORDS)
@@ -539,10 +539,19 @@ def context(
         unit_count or sum(sizes.values()),
         FRONTIER,
         sizes={f"box:{name}": size for name, size in sizes.items()},
-        links={tuple(sorted((f"box:{a}", f"box:{b}"))): count for (a, b), count in links.items()},  # type: ignore[misc]
+        links=_undirected(links),
         calls={(f"box:{a}", f"box:{b}"): count for (a, b), count in links.items()},
         floor=floor,
     )
+
+
+def _undirected(links: dict[tuple[str, str], int]) -> dict[tuple[str, str], int]:
+    """Both directions of a pair summed, the way the production context counts them."""
+    summed: dict[tuple[str, str], int] = {}
+    for (a, b), count in links.items():
+        key = (min(f"box:{a}", f"box:{b}"), max(f"box:{a}", f"box:{b}"))
+        summed[key] = summed.get(key, 0) + count
+    return summed
 
 
 def members_of(groups: list[CandidateGroup]) -> dict[str, tuple[str, ...]]:
@@ -669,6 +678,26 @@ class TestPlacementByRole:
         groups = {group.name: group.keys for group in AffinityGrouper().group(candidates, ctx)}
         assert groups["Loose files"] == ("loose:", "box:stray")
 
+    def test_two_one_link_callers_are_noise_not_a_shared_helper(self):
+        sizes = {"a": 30, "b": 20, "helper": 3}
+        links = {("a", "helper"): 1, ("b", "helper"): 1}
+        assert len(AffinityGrouper().group(boxes(*sizes), context(sizes, links, floor=5))) == 3
+
+    def test_a_helper_stays_when_its_owner_cannot_take_it_under_the_cap(self):
+        sizes = {"big": 58, "helper": 4, "other": 38}
+        links = {("big", "helper"): 6}
+        assert len(AffinityGrouper().group(boxes(*sizes), context(sizes, links, floor=5))) == 3
+
+    def test_a_small_hub_or_application_stands_at_the_files_rung(self):
+        """A one-file event bus every feature calls is a box, not a loose file."""
+        layout = {f"pkg/feat/{name}.py": [f"pkg.feat.{name}.{name.capitalize()}"] for name in ("bus",)}
+        for feature in ("alpha", "beta", "gamma", "delta"):
+            layout |= {f"pkg/feat/{feature}_{part}.py": [f"pkg.feat.{feature}_{part}.X"] for part in ("a", "b", "c")}
+        layout |= {f"pkg/other/{index}.py": [f"pkg.other.m{index}.f"] for index in range(3)}
+        links = {(f"pkg/feat/{feature}_a.py", "pkg/feat/bus.py"): 3 for feature in ("alpha", "beta", "gamma", "delta")}
+        feature = scope_of(draft_tree(units_from_layout(layout), AffinityGrouper(), 2, links=links), "1")
+        assert feature.rung == FILES and "bus" in names_of(feature)
+
 
 class TestBudgetAndLimit:
     def test_over_the_budget_a_real_component_folds_only_into_a_dominant_partner(self):
@@ -688,6 +717,21 @@ class TestBudgetAndLimit:
         assert len(groups) == LIMIT
         merged = next(group for group in groups if "box:tenants" in group.keys)
         assert set(merged.keys) == {"box:tenants", "box:tenancy"}
+
+    def test_a_consumer_takes_nothing_over_the_budget(self):
+        sizes = dict.fromkeys((f"s{i}" for i in range(9)), 20) | {"samples": 20, "printer": 6}
+        links = {("samples", "printer"): 12}
+        groups = AffinityGrouper().group(boxes(*sizes), context(sizes, links, floor=5))
+        assert len(groups) == len(sizes)
+
+    def test_the_vocabulary_merge_respects_the_cap(self):
+        sizes = dict.fromkeys((f"pkg{i}" for i in range(14)), 2) | {"tenants": 35, "tenancy": 35}
+        ctx = context(sizes, {}, floor=1)
+        vocabulary = {key: Counter({key.removeprefix("box:"): 1}) for key in ctx.sizes}
+        vocabulary["box:tenants"] = Counter({"tenant": 3})
+        vocabulary["box:tenancy"] = Counter({"tenant": 3})
+        groups = AffinityGrouper().group(boxes(*sizes), replace(ctx, vocabulary=vocabulary))
+        assert not any({"box:tenants", "box:tenancy"} <= set(group.keys) for group in groups)
 
     def test_over_the_limit_with_nothing_to_merge_the_smallest_are_pooled(self):
         sizes = {f"pkg{i:02d}": 30 - i for i in range(18)}

--- a/tests/static_analyzer/names/test_draft.py
+++ b/tests/static_analyzer/names/test_draft.py
@@ -694,8 +694,8 @@ class TestPlacementByRole:
             layout |= {f"pkg/feat/{feature}_{part}.py": [f"pkg.feat.{feature}_{part}.X"] for part in ("a", "b", "c")}
         layout |= {f"pkg/other/{index}.py": [f"pkg.other.m{index}.f"] for index in range(3)}
         links = {(f"pkg/feat/{feature}_a.py", "pkg/feat/bus.py"): 3 for feature in ("alpha", "beta", "gamma", "delta")}
-        feature = scope_of(draft_tree(units_from_layout(layout), AffinityGrouper(), 2, links=links), "1")
-        assert feature.rung == FILES and "bus" in names_of(feature)
+        scope = scope_of(draft_tree(units_from_layout(layout), AffinityGrouper(), 2, links=links), "1")
+        assert scope.rung == FILES and "bus" in names_of(scope)
 
 
 class TestBudgetAndLimit:

--- a/tests/static_analyzer/names/test_end_to_end.py
+++ b/tests/static_analyzer/names/test_end_to_end.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 """The public path the pipeline will use: CallGraph -> units -> draft -> replay."""
 
 from clustering_ids import ROOT_SCOPE_ID
@@ -40,22 +42,24 @@ def test_a_two_language_repo_drafts_replays_and_survives_json():
             "/repo/frontend/catalog/ItemList.tsx": [("frontend.catalog.ItemList.ItemList", NodeType.FUNCTION)],
         },
     )
-    units = units_from_graphs({"python": python, "typescript": typescript})
+    units = units_from_graphs({"python": python, "typescript": typescript}, Path("/repo"))
     assert [unit.language for unit in units] == ["python"] * 5 + ["typescript"] * 5
 
     spec = draft_tree(units, KinshipGrouper(), 2)
     root = scope_of(spec, ROOT_SCOPE_ID)
-    assert sorted(rule.name for rule in root.components if not rule.is_fallback_only) == ["catalog", "orders"]
-    orders = next(rule for rule in root.components if rule.name == "orders")
-    assert orders.prefixes == (("backend", "orders"), ("frontend", "orders"))
+    assert sorted(rule.name for rule in root.components) == ["backend", "frontend"]
+    backend = next(rule for rule in root.components if rule.name == "backend")
+    assert backend.prefixes == (("backend",),)
 
     partition = replay(units, root, role_words_for(spec.machinery))
     by_unit = {unit_id: rule_of(root, component_id).name for unit_id, component_id in partition.assignment.items()}
-    assert by_unit["/repo/frontend/orders/OrderRow.tsx"] == "orders"
-    assert by_unit["/repo/backend/catalog/views.py"] == "catalog"
-    assert by_unit["/repo/backend/main.py"] == "Loose files in backend"
+    assert by_unit["/repo/frontend/orders/OrderRow.tsx"] == "frontend"
+    assert by_unit["/repo/backend/main.py"] == "backend"
+
+    inside = scope_of(spec, backend.component_id)
+    assert inside.is_leaf and inside.leaf_reason.startswith("small: 5 units")
 
     reloaded = spec.__class__.from_dict(spec.to_dict())
     again = replay(units, scope_of(reloaded, ROOT_SCOPE_ID), role_words_for(reloaded.machinery))
     assert again.assignment == partition.assignment
-    assert scope_of(reloaded, orders.component_id).rung == "unmerge"
+    assert scope_of(reloaded, backend.component_id).rung == "leaf"

--- a/tests/static_analyzer/names/test_frontier.py
+++ b/tests/static_analyzer/names/test_frontier.py
@@ -29,7 +29,7 @@ class TestFeatureShapedRoot:
         )
         frontier = walk(Trie(units_from_layout(layout, "csharp")), ROLE_WORDS)
         assert frontier.axis == "structural"
-        assert sorted(keys(frontier)) == ["box:src.Basket.API", "box:src.Catalog.API", "box:src.Identity.API"]
+        assert sorted(keys(frontier)) == ["box:src/Basket.API", "box:src/Catalog.API", "box:src/Identity.API"]
 
     def test_a_dotted_directory_is_one_segment(self):
         """``Ordering.API`` and ``Ordering.Domain`` are two projects; kinship, not the walk, relates them."""
@@ -39,7 +39,7 @@ class TestFeatureShapedRoot:
             | project("Catalog.API", 4)
         )
         frontier = walk(Trie(units_from_layout(layout, "csharp")), ROLE_WORDS)
-        assert sorted(keys(frontier)) == ["box:src.Catalog.API", "box:src.Ordering.API", "box:src.Ordering.Domain"]
+        assert sorted(keys(frontier)) == ["box:src/Catalog.API", "box:src/Ordering.API", "box:src/Ordering.Domain"]
 
     def test_a_dominant_directory_is_a_box_and_its_inside_is_the_next_depth(self):
         layout = {
@@ -52,13 +52,13 @@ class TestFeatureShapedRoot:
         }
         frontier = walk(Trie(units_from_layout(layout)), ROLE_WORDS)
         assert not frontier.notes
-        assert sorted(keys(frontier)) == ["box:django.contrib", "box:django.forms", "box:django.views"]
+        assert sorted(keys(frontier)) == ["box:django/contrib", "box:django/forms", "box:django/views"]
 
     def test_a_layout_word_is_a_box_unless_it_holds_nearly_everything(self):
         """``src`` beside a ``tools`` of the same size is structure; ``src`` holding everything is not."""
         layout = project("Catalog.API", 3) | project("Basket.API", 3)
         frontier = walk(Trie(units_from_layout(layout, "csharp")), ROLE_WORDS)
-        assert sorted(keys(frontier)) == ["box:src.Basket.API", "box:src.Catalog.API"]
+        assert sorted(keys(frontier)) == ["box:src/Basket.API", "box:src/Catalog.API"]
         layout |= {f"tools/t{i}.py": [f"tools.t{i}.f"] for i in range(4)}
         frontier = walk(Trie(units_from_layout(layout, "csharp")), ROLE_WORDS)
         assert sorted(keys(frontier)) == ["box:src", "box:tools"]
@@ -72,7 +72,7 @@ class TestFeatureShapedRoot:
         layout["tools/x.py"] = ["tools.x.f"]
         frontier = walk(Trie(units_from_layout(layout)), ROLE_WORDS)
         assert "box:app" not in keys(frontier)
-        assert {"box:app.billing", "box:app.catalog", "box:app.search"} <= set(keys(frontier))
+        assert {"box:app/billing", "box:app/catalog", "box:app/search"} <= set(keys(frontier))
 
     def test_a_role_named_child_holding_a_share_is_a_box_not_a_way_in(self):
         """eShop's ClientApp is a box even though its children are layers with recurring features."""
@@ -81,7 +81,7 @@ class TestFeatureShapedRoot:
         )
         layout |= project("Ordering.API", 20, "Apis") | project("Basket.API", 20, "Apis")
         frontier = walk(Trie(units_from_layout(layout, "csharp")), ROLE_WORDS)
-        assert sorted(keys(frontier)) == ["box:src.Basket.API", "box:src.ClientApp", "box:src.Ordering.API"]
+        assert sorted(keys(frontier)) == ["box:src/Basket.API", "box:src/ClientApp", "box:src/Ordering.API"]
 
     def test_one_unit_directories_and_root_files_are_loose(self):
         layout = {
@@ -96,8 +96,8 @@ class TestFeatureShapedRoot:
         del layout["setup.py"]
         inside = walk(Trie(units_from_layout(layout)), ROLE_WORDS)
         assert [candidate.key for candidate in inside.candidates if candidate.kind == LOOSE] == ["loose:pkg"]
-        assert "box:pkg.b" in keys(inside)
-        assert "box:pkg.a" not in keys(inside)
+        assert "box:pkg/b" in keys(inside)
+        assert "box:pkg/a" not in keys(inside)
 
 
 class TestThresholds:
@@ -113,9 +113,9 @@ class TestThresholds:
 
         others = 8
         for dominant in (2, others, 3 * others):
-            assert "box:top.big" in keys(walk(Trie(units_from_layout(layout(dominant))), ROLE_WORDS))
+            assert "box:top/big" in keys(walk(Trie(units_from_layout(layout(dominant))), ROLE_WORDS))
         stepped = walk(Trie(units_from_layout(layout(4 * others + 2))), ROLE_WORDS)
-        assert "box:top.big" not in keys(stepped) and "box:top.big.alpha" in keys(stepped)
+        assert "box:top/big" not in keys(stepped) and "box:top/big/alpha" in keys(stepped)
 
     def test_a_node_is_layered_at_the_role_share_and_not_below_it(self):
         def layout(role_units: int, feature_units: int) -> dict[str, list[str]]:
@@ -148,7 +148,7 @@ class TestThresholds:
         layout |= {f"tests/t{i}.py": [f"tests.t{i}.f"] for i in range(2)}
         layout |= {f"docs/d{i}.py": [f"docs.d{i}.f"] for i in range(2)}
         frontier = walk(Trie(units_from_layout(layout)), ROLE_WORDS)
-        assert {"box:app.billing", "box:app.catalog", "box:app.search", "box:tests", "box:docs"} <= set(keys(frontier))
+        assert {"box:app/billing", "box:app/catalog", "box:app/search", "box:tests", "box:docs"} <= set(keys(frontier))
 
 
 class TestLayeredRoot:

--- a/tests/static_analyzer/names/test_frontier.py
+++ b/tests/static_analyzer/names/test_frontier.py
@@ -1,7 +1,7 @@
 """The walk over synthetic layouts shaped like the rulers it was measured on."""
 
 from static_analyzer.clustering.names import ROLE_WORDS, Trie, walk
-from static_analyzer.clustering.names.frontier import BOX, FEATURE, LOOSE, NEARLY_ALL, RESIDUAL, ROLE_SHARE, SHARE
+from static_analyzer.clustering.names.frontier import BOX, FEATURE, LOOSE, NEARLY_ALL, RESIDUAL, ROLE_SHARE
 from tests.static_analyzer.names.conftest import units_from_layout
 
 
@@ -29,19 +29,19 @@ class TestFeatureShapedRoot:
         )
         frontier = walk(Trie(units_from_layout(layout, "csharp")), ROLE_WORDS)
         assert frontier.axis == "structural"
-        assert sorted(keys(frontier)) == ["box:Basket", "box:Catalog", "box:Identity"]
+        assert sorted(keys(frontier)) == ["box:src.Basket.API", "box:src.Catalog.API", "box:src.Identity.API"]
 
-    def test_a_dotted_directory_is_one_scope_with_role_children(self):
-        """``Ordering.API`` and ``Ordering.Domain`` nest under ``Ordering``, which is never split."""
+    def test_a_dotted_directory_is_one_segment(self):
+        """``Ordering.API`` and ``Ordering.Domain`` are two projects; kinship, not the walk, relates them."""
         layout = (
             project("Ordering.API", 8, "Apis", "Application")
             | project("Ordering.Domain", 4)
             | project("Catalog.API", 4)
         )
         frontier = walk(Trie(units_from_layout(layout, "csharp")), ROLE_WORDS)
-        assert sorted(keys(frontier)) == ["box:Catalog", "box:Ordering"]
+        assert sorted(keys(frontier)) == ["box:src.Catalog.API", "box:src.Ordering.API", "box:src.Ordering.Domain"]
 
-    def test_a_dominant_feature_directory_is_opened(self):
+    def test_a_dominant_directory_is_a_box_and_its_inside_is_the_next_depth(self):
         layout = {
             f"django/contrib/{app}/{mod}.py": [f"django.contrib.{app}.{mod}.f"]
             for app in ("admin", "auth", "gis")
@@ -51,20 +51,17 @@ class TestFeatureShapedRoot:
             f"django/{pkg}/{mod}.py": [f"django.{pkg}.{mod}.f"] for pkg in ("forms", "views") for mod in ("a", "b", "c")
         }
         frontier = walk(Trie(units_from_layout(layout)), ROLE_WORDS)
-        assert "opened django.contrib (9 units)" in frontier.notes
-        assert sorted(keys(frontier)) == [
-            "box:django.contrib.admin",
-            "box:django.contrib.auth",
-            "box:django.contrib.gis",
-            "box:django.forms",
-            "box:django.views",
-        ]
+        assert not frontier.notes
+        assert sorted(keys(frontier)) == ["box:django.contrib", "box:django.forms", "box:django.views"]
 
-    def test_a_layout_word_is_stepped_through(self):
+    def test_a_layout_word_is_a_box_unless_it_holds_nearly_everything(self):
+        """``src`` beside a ``tools`` of the same size is structure; ``src`` holding everything is not."""
         layout = project("Catalog.API", 3) | project("Basket.API", 3)
-        layout = {f"src/{path}": [f"src.{name}" for name in names] for path, names in layout.items()}
         frontier = walk(Trie(units_from_layout(layout, "csharp")), ROLE_WORDS)
-        assert sorted(keys(frontier)) == ["box:src.Basket", "box:src.Catalog"]
+        assert sorted(keys(frontier)) == ["box:src.Basket.API", "box:src.Catalog.API"]
+        layout |= {f"tools/t{i}.py": [f"tools.t{i}.f"] for i in range(4)}
+        frontier = walk(Trie(units_from_layout(layout, "csharp")), ROLE_WORDS)
+        assert sorted(keys(frontier)) == ["box:src", "box:tools"]
 
     def test_a_child_holding_nearly_everything_is_stepped_through_whatever_its_name(self):
         layout = {
@@ -84,7 +81,7 @@ class TestFeatureShapedRoot:
         )
         layout |= project("Ordering.API", 20, "Apis") | project("Basket.API", 20, "Apis")
         frontier = walk(Trie(units_from_layout(layout, "csharp")), ROLE_WORDS)
-        assert sorted(keys(frontier)) == ["box:Basket", "box:ClientApp", "box:Ordering"]
+        assert sorted(keys(frontier)) == ["box:src.Basket.API", "box:src.ClientApp", "box:src.Ordering.API"]
 
     def test_one_unit_directories_and_root_files_are_loose(self):
         layout = {
@@ -94,14 +91,17 @@ class TestFeatureShapedRoot:
             "setup.py": ["setup.main"],
         }
         frontier = walk(Trie(units_from_layout(layout)), ROLE_WORDS)
-        loose = {candidate.key for candidate in frontier.candidates if candidate.kind == LOOSE}
-        assert loose == {"loose:", "loose:pkg"}
-        assert "box:pkg.b" in keys(frontier)
-        assert "box:pkg.a" not in keys(frontier)
+        assert [candidate.key for candidate in frontier.candidates if candidate.kind == LOOSE] == ["loose:"]
+        assert "box:pkg" in keys(frontier)
+        del layout["setup.py"]
+        inside = walk(Trie(units_from_layout(layout)), ROLE_WORDS)
+        assert [candidate.key for candidate in inside.candidates if candidate.kind == LOOSE] == ["loose:pkg"]
+        assert "box:pkg.b" in keys(inside)
+        assert "box:pkg.a" not in keys(inside)
 
 
 class TestThresholds:
-    def test_a_feature_child_is_opened_at_the_share_and_boxed_just_below_it(self):
+    def test_a_child_is_a_box_at_any_share_below_nearly_all(self):
         def layout(dominant: int) -> dict[str, list[str]]:
             out = {
                 f"top/big/{sub}/{i}.py": [f"top.big.{sub}.m{i}.f"]
@@ -111,11 +111,11 @@ class TestThresholds:
             out |= {f"top/other{j}/{i}.py": [f"top.other{j}.m{i}.f"] for j in range(4) for i in range(2)}
             return out
 
-        total = 8
-        opened = walk(Trie(units_from_layout(layout(round(SHARE * (total + 8) / (1 - SHARE)) + 1))), ROLE_WORDS)
-        assert any(note.startswith("opened top.big") for note in opened.notes)
-        boxed = walk(Trie(units_from_layout(layout(2))), ROLE_WORDS)
-        assert "box:top.big" in keys(boxed)
+        others = 8
+        for dominant in (2, others, 3 * others):
+            assert "box:top.big" in keys(walk(Trie(units_from_layout(layout(dominant))), ROLE_WORDS))
+        stepped = walk(Trie(units_from_layout(layout(4 * others + 2))), ROLE_WORDS)
+        assert "box:top.big" not in keys(stepped) and "box:top.big.alpha" in keys(stepped)
 
     def test_a_node_is_layered_at_the_role_share_and_not_below_it(self):
         def layout(role_units: int, feature_units: int) -> dict[str, list[str]]:
@@ -175,7 +175,7 @@ class TestLayeredRoot:
         features = {candidate.label: candidate for candidate in frontier.candidates if candidate.kind == FEATURE}
         assert set(features) == {"Incidents", "Escalation", "Teams"}
         assert features["Incidents"].terms == ("incident",)
-        assert ("Beacon", "Domain", "Incidents") in features["Incidents"].prefixes
+        assert ("Beacon.Domain", "Incidents") in features["Incidents"].prefixes
         residuals = [candidate.key for candidate in frontier.candidates if candidate.kind == RESIDUAL]
         assert residuals == [
             f"residual:Beacon.{layer}" for layer in ("Application", "Contracts", "Domain", "Infrastructure")
@@ -192,7 +192,7 @@ class TestLayeredRoot:
         frontier = walk(Trie(units_from_layout(layout, "csharp")), ROLE_WORDS)
         features = {candidate.label: candidate for candidate in frontier.candidates if candidate.kind == FEATURE}
         assert set(features) == {"Orders", "Customers"}
-        assert ("Shop", "Application", "Handlers", "Orders") in features["Orders"].prefixes
+        assert ("Shop.Application", "Handlers", "Orders") in features["Orders"].prefixes
 
     def test_a_product_name_on_every_feature_directory_is_not_the_feature(self):
         layout: dict[str, list[str]] = {}
@@ -254,13 +254,10 @@ class TestLayeredRoot:
                     for i in range(2):
                         layout[f"{project}/{layer}/{feature}/{i}.cs"] = [f"{project}.{layer}.{feature}.T{i}"]
         frontier = walk(Trie(units_from_layout(layout, "csharp")), ROLE_WORDS)
-        features = sorted(candidate.key for candidate in frontier.candidates if candidate.kind == FEATURE)
-        assert features == [
-            "feature:Billing:customer",
-            "feature:Billing:payment",
-            "feature:Orders:customer",
-            "feature:Orders:payment",
-        ]
+        assert keys(frontier) == ["box:Billing", "box:Orders"], "two projects are two boxes, transposed inside"
+        billing = walk(Trie([u for u in units_from_layout(layout, "csharp") if u.position[0] == "Billing"]), ROLE_WORDS)
+        features = sorted(candidate.key for candidate in billing.candidates if candidate.kind == FEATURE)
+        assert features == ["feature:Billing:customer", "feature:Billing:payment"]
 
     def test_the_walk_does_not_depend_on_unit_order(self):
         units = units_from_layout(self._beacon(), "csharp")
@@ -280,12 +277,12 @@ class TestLayeredRoot:
 
     def test_a_grid_is_one_box_when_the_walk_may_not_transpose(self):
         frontier = walk(Trie(units_from_layout(self._beacon(), "csharp")), ROLE_WORDS, transpose=False)
-        assert keys(frontier) == ["box:Beacon"]
+        assert keys(frontier) == ["box:"]
         assert any(note.endswith("kept as one box") for note in frontier.notes)
 
     def test_a_grid_is_drawn_layer_by_layer_when_asked(self):
         frontier = walk(Trie(units_from_layout(self._beacon(), "csharp")), ROLE_WORDS, transpose=False, layers=True)
-        assert keys(frontier) == [f"box:Beacon.{layer}" for layer in sorted(self.LAYERS[:3])] + ["loose:Beacon"]
+        assert keys(frontier) == [f"box:Beacon.{layer}" for layer in sorted(self.LAYERS[:3])] + ["loose:"]
         assert any("a grid drawn layer by layer" in note for note in frontier.notes)
 
     def test_the_shallowest_feature_directory_keys_its_subtree(self):
@@ -295,8 +292,8 @@ class TestLayeredRoot:
         layout["Beacon.Infrastructure/Metrics/MetricStore.cs"] = ["Beacon.Infrastructure.Metrics.MetricStore"]
         frontier = walk(Trie(units_from_layout(layout, "csharp")), ROLE_WORDS)
         features = {candidate.label: candidate for candidate in frontier.candidates if candidate.kind == FEATURE}
-        assert ("Beacon", "Domain", "Incidents", "Metrics") not in features["Metrics"].prefixes
-        assert ("Beacon", "Application", "Metrics") in features["Metrics"].prefixes
+        assert ("Beacon.Domain", "Incidents", "Metrics") not in features["Metrics"].prefixes
+        assert ("Beacon.Application", "Metrics") in features["Metrics"].prefixes
 
 
 class TestTheWalkEmitsRulesNotAssignments:

--- a/tests/static_analyzer/names/test_inventory.py
+++ b/tests/static_analyzer/names/test_inventory.py
@@ -1,92 +1,71 @@
-from static_analyzer.clustering.names import Trie, unit_key, unit_position, units_from_graph, units_from_graphs
+from pathlib import Path
+
+import pytest
+
+from static_analyzer.clustering.names import Trie, units_from_graph, units_from_graphs
 from tests.static_analyzer.names.conftest import graph_from_layout, node_of, unit
 
 
-class TestUnitPosition:
-    def test_python_module_with_several_symbols(self):
-        names = [
-            "agents.scope_analysis_agent.ScopeAnalysisAgent",
-            "agents.scope_analysis_agent.ScopeAnalysisAgent.analyze",
-            "agents.scope_analysis_agent.helper",
-        ]
-        assert unit_position(names, ".") == ("agents", "scope_analysis_agent")
-
-    def test_the_key_keeps_the_one_class_a_file_declares(self):
-        assert unit_key(["pkg.mod.Thing", "pkg.mod.Thing.run"], ".") == ("pkg", "mod", "Thing")
-        assert unit_key(["pkg.mod.a", "pkg.mod.b"], ".") == ("pkg", "mod")
-
-    def test_a_file_declaring_one_class_sits_in_its_module_not_its_class(self):
-        names = [
-            "diagram_analysis.scope_assembly.ScopeAssembler",
-            "diagram_analysis.scope_assembly.ScopeAssembler.build",
-        ]
-        assert unit_position(names, ".") == ("diagram_analysis", "scope_assembly")
-
-    def test_a_file_with_one_symbol(self):
-        assert unit_position(["pkg.mod.only"], ".") == ("pkg", "mod")
-
-    def test_csharp_single_type_file_sits_in_its_directory(self):
-        """Why: the adapter folds a single-type file's stem into the type, so the directory is the position."""
-        names = ["Basket.API.Model.CustomerBasket", "Basket.API.Model.CustomerBasket.CustomerBasket()"]
-        assert unit_position(names, ".") == ("Basket", "API", "Model")
-
-    def test_csharp_file_with_sibling_types_keeps_its_stem(self):
-        names = ["Basket.API.Extensions.Extensions.Ext", "Basket.API.Extensions.Extensions.IntegrationEventContext"]
-        assert unit_position(names, ".") == ("Basket", "API", "Extensions", "Extensions")
-
-    def test_java_type_sits_in_its_package(self):
-        assert unit_position(["core.org.mockito.Fixture", "core.org.mockito.Fixture.run()"], ".") == (
-            "core",
-            "org",
-            "mockito",
-        )
-
-    def test_generic_and_parameter_delimiters_do_not_split(self):
-        names = ["A.B.Repo<T>.Add(Map<K, V.W> item)", "A.B.Repo<T>"]
-        assert unit_position(names, ".") == ("A", "B")
-
-    def test_names_sharing_nothing_sit_at_the_root(self):
-        assert unit_position(["a.x", "b.y"], ".") == ()
-
-
 class TestUnitsFromGraph:
-    def test_one_unit_per_file_keyed_by_the_engine_path(self):
+    def test_one_unit_per_file_positioned_by_its_directory(self):
         graph = graph_from_layout(
             {
-                "/repo/pkg/a.py": ["pkg.a.f", "pkg.a.g"],
-                "/repo/pkg/b.py": ["pkg.b.C", "pkg.b.C.m"],
+                "pkg/a.py": ["pkg.a.f", "pkg.a.g"],
+                "pkg/sub/b.py": ["whatever.the.adapter.said"],
             }
         )
         units = units_from_graph(graph, "python")
-        assert [unit.unit_id for unit in units] == ["/repo/pkg/a.py", "/repo/pkg/b.py"]
+        assert [u.unit_id for u in units] == ["pkg/a.py", "pkg/sub/b.py"]
         assert units[0].names == ("pkg.a.f", "pkg.a.g")
-        assert units[1].position == ("pkg", "b")
+        assert units[0].position == ("pkg",) and units[0].key == ("pkg", "a")
+        assert units[1].position == ("pkg", "sub") and units[1].key == ("pkg", "sub", "b")
 
-    def test_the_path_is_an_identity_and_never_read(self):
-        """Blanking every path segment changes no position: the names carry the structure."""
-        layout = {"/x/y/z.py": ["pkg.mod.C", "pkg.mod.C.m"]}
-        opaque = {"0": layout["/x/y/z.py"]}
-        assert units_from_graph(graph_from_layout(layout), "python")[0].position == (
-            units_from_graph(graph_from_layout(opaque), "python")[0].position
+    def test_the_names_are_never_read_for_structure(self):
+        """Two files spelled differently by two adapters sit together when they share a directory."""
+        graph = graph_from_layout({"src/WebApp/x.cs": ["WebApp.x"], "src/WebApp/y.js": ["src.WebApp.y.f"]})
+        assert {u.position for u in units_from_graph(graph, "csharp")} == {("src", "WebApp")}
+
+    def test_a_dotted_directory_is_one_segment(self):
+        graph = graph_from_layout({"BTCPayServer.Client/C.cs": ["BTCPayServer.Client.C"]}, "csharp")
+        assert units_from_graph(graph, "csharp")[0].position == ("BTCPayServer.Client",)
+
+    def test_an_absolute_path_is_positioned_under_the_repository_root(self, tmp_path: Path):
+        graph = graph_from_layout({str(tmp_path / "pkg" / "a.py"): ["pkg.a.f"]})
+        assert units_from_graph(graph, "python", tmp_path)[0].position == ("pkg",)
+        with pytest.raises(ValueError, match="absolute"):
+            units_from_graph(graph, "python")
+
+    def test_a_root_file_has_an_empty_position(self):
+        graph = graph_from_layout({"setup.py": ["setup.main"]})
+        assert units_from_graph(graph, "python")[0].position == ()
+
+    def test_a_directory_with_a_manifest_is_a_project(self, tmp_path: Path):
+        (tmp_path / "lib").mkdir()
+        (tmp_path / "lib" / "Lib.csproj").write_text("<Project/>")
+        (tmp_path / "app").mkdir()
+        graph = graph_from_layout(
+            {str(tmp_path / "lib" / "a.cs"): ["a"], str(tmp_path / "app" / "b.cs"): ["b"]}, "csharp"
         )
+        units = {u.position: u.project for u in units_from_graph(graph, "csharp", tmp_path)}
+        assert units == {("lib",): True, ("app",): False}
 
     def test_languages_are_read_in_sorted_order(self):
         graphs = {
-            "typescript": graph_from_layout({"/r/ts.ts": ["src.ts.f"]}, "typescript"),
-            "python": graph_from_layout({"/r/py.py": ["src.py.f"]}),
+            "typescript": graph_from_layout({"r/ts.ts": ["src.ts.f"]}, "typescript"),
+            "python": graph_from_layout({"r/py.py": ["src.py.f"]}),
         }
-        assert [unit.language for unit in units_from_graphs(graphs)] == ["python", "typescript"]
+        assert [u.language for u in units_from_graphs(graphs)] == ["python", "typescript"]
 
 
 class TestTrie:
     def test_counts_units_per_subtree(self):
-        trie = Trie([unit("a", "p.x.A"), unit("b", "p.x.B"), unit("c", "p.y.C")])
+        trie = Trie([unit("p/x/a.py", "A"), unit("p/x/b.py", "B"), unit("p/y/c.py", "C")])
         assert trie.root.count == 3
         assert node_of(trie, ("p", "x")).count == 2
         assert node_of(trie, ("p", "y")).count == 1
         assert trie.node(("p", "z")) is None
 
     def test_a_unit_at_the_root_is_a_root_unit(self):
-        trie = Trie([unit("a", "A"), unit("b", "p.B")])
-        assert [u.unit_id for u in trie.root.units] == ["a"]
+        trie = Trie([unit("a.py", "A"), unit("p/b.py", "B")])
+        assert [u.unit_id for u in trie.root.units] == ["a.py"]
         assert node_of(trie, ("p",)).count == 1

--- a/tests/static_analyzer/names/test_inventory.py
+++ b/tests/static_analyzer/names/test_inventory.py
@@ -17,8 +17,14 @@ class TestUnitsFromGraph:
         units = units_from_graph(graph, "python")
         assert [u.unit_id for u in units] == ["pkg/a.py", "pkg/sub/b.py"]
         assert units[0].names == ("pkg.a.f", "pkg.a.g")
-        assert units[0].position == ("pkg",) and units[0].key == ("pkg", "a")
-        assert units[1].position == ("pkg", "sub") and units[1].key == ("pkg", "sub", "b")
+        assert units[0].position == ("pkg",) and units[0].key == ("pkg", "a.py")
+        assert units[1].position == ("pkg", "sub") and units[1].key == ("pkg", "sub", "b.py")
+
+    def test_a_file_and_a_directory_of_one_name_have_distinct_keys(self):
+        graph = graph_from_layout({"pkg/foo.py": ["pkg.foo.f"], "pkg/foo/stray.py": ["pkg.foo.stray.g"]})
+        keys = [u.key for u in units_from_graph(graph, "python")]
+        assert keys == [("pkg", "foo.py"), ("pkg", "foo", "stray.py")]
+        assert keys[1][: len(keys[0])] != keys[0]
 
     def test_the_names_are_never_read_for_structure(self):
         """Two files spelled differently by two adapters sit together when they share a directory."""
@@ -39,15 +45,26 @@ class TestUnitsFromGraph:
         graph = graph_from_layout({"setup.py": ["setup.main"]})
         assert units_from_graph(graph, "python")[0].position == ()
 
-    def test_a_directory_with_a_manifest_is_a_project(self, tmp_path: Path):
-        (tmp_path / "lib").mkdir()
+    def test_the_nearest_manifest_above_a_file_names_its_project(self, tmp_path: Path):
+        (tmp_path / "lib" / "src").mkdir(parents=True)
         (tmp_path / "lib" / "Lib.csproj").write_text("<Project/>")
         (tmp_path / "app").mkdir()
+        (tmp_path / "package.json").write_text("{}")
         graph = graph_from_layout(
-            {str(tmp_path / "lib" / "a.cs"): ["a"], str(tmp_path / "app" / "b.cs"): ["b"]}, "csharp"
+            {str(tmp_path / "lib" / "src" / "a.cs"): ["a"], str(tmp_path / "app" / "b.cs"): ["b"]}, "csharp"
         )
         units = {u.position: u.project for u in units_from_graph(graph, "csharp", tmp_path)}
-        assert units == {("lib",): True, ("app",): False}
+        assert units == {
+            ("lib", "src"): ("lib",),
+            ("app",): None,
+        }, "the repository root's own manifest is not a project"
+
+    def test_a_path_outside_the_repository_root_is_refused(self, tmp_path: Path):
+        graph = graph_from_layout({str(tmp_path.parent / "elsewhere" / "a.py"): ["a"]})
+        with pytest.raises(ValueError, match="outside"):
+            units_from_graph(graph, "python", tmp_path)
+        with pytest.raises(ValueError, match="outside"):
+            units_from_graph(graph_from_layout({"../a.py": ["a"]}), "python")
 
     def test_languages_are_read_in_sorted_order(self):
         graphs = {

--- a/tests/static_analyzer/names/test_replay.py
+++ b/tests/static_analyzer/names/test_replay.py
@@ -1,8 +1,7 @@
 """Replay is a pure function of a unit's names and the rules: nothing else may move a unit."""
 
 from static_analyzer.clustering.names import ROLE_WORDS, ComponentRule, ScopeSpec, replay
-from static_analyzer.clustering.names.replay import FALLBACK, PREFIX, TERM
-from static_analyzer.clustering.names.spec import UNPLACED
+from static_analyzer.clustering.names.replay import FALLBACK, PREFIX, TERM, UNPLACED
 from tests.static_analyzer.names.conftest import unit
 
 
@@ -81,13 +80,6 @@ class TestFallbackAndUnplaced:
         result = replay([unit("f", "Shared.OrderTotals"), unit("g", "Shared.Misc")], scope(ORDER, LOOSE), ROLE_WORDS)
         assert result.assignment == {"f": "2", "g": "3"}
         assert result.placed_by["g"] == FALLBACK
-
-    def test_unplaced_units_land_in_the_bucket_and_are_still_reported(self):
-        bucket = ComponentRule("4", "Unassigned", kind=UNPLACED)
-        result = replay([unit("f", "Shipping.Api.Ship")], scope(CATALOG, ORDER, bucket), ROLE_WORDS)
-        assert result.assignment == {"f": "4"}
-        assert [u.unit_id for u in result.unplaced] == ["f"]
-        assert result.placed_by["f"] == UNPLACED
 
     def test_without_a_bucket_an_unplaced_unit_is_only_reported(self):
         result = replay([unit("f", "Shipping.Api.Ship")], scope(CATALOG, ORDER), ROLE_WORDS)

--- a/tests/static_analyzer/names/test_replay.py
+++ b/tests/static_analyzer/names/test_replay.py
@@ -18,12 +18,13 @@ LOOSE = ComponentRule("3", "Loose files", fallback_prefixes=((),))
 class TestPrefixes:
     def test_the_longest_matching_prefix_wins(self):
         deep = ComponentRule("9", "Catalog items", prefixes=(("Catalog", "API", "Model"),))
+        f, g = "Catalog/API/Model/CatalogItem.cs", "Catalog/API/Apis/CatalogApi.cs"
         result = replay(
-            [unit("f", "Catalog.API.Model.CatalogItem"), unit("g", "Catalog.API.Apis.CatalogApi")],
+            [unit(f, "Catalog.API.Model.CatalogItem"), unit(g, "Catalog.API.Apis.CatalogApi")],
             scope(CATALOG, deep),
             ROLE_WORDS,
         )
-        assert result.assignment == {"f": "9", "g": "1"}
+        assert result.assignment == {f: "9", g: "1"}
         assert set(result.placed_by.values()) == {PREFIX}
 
     def test_a_prefix_never_matches_a_partial_segment(self):
@@ -94,11 +95,12 @@ class TestFallbackAndUnplaced:
         assert [u.unit_id for u in result.unplaced] == ["f"]
 
     def test_unplaced_units_are_grouped_where_they_leave_the_known_tree(self):
-        units = [unit("f", "Shipping.Api.Ship"), unit("g", "Shipping.Domain.Parcel"), unit("h", "Loose")]
+        f, g, h = "Shipping/Api/Ship.cs", "Shipping/Domain/Parcel.cs", "Loose.cs"
+        units = [unit(f, "Shipping.Api.Ship"), unit(g, "Shipping.Domain.Parcel"), unit(h, "Loose")]
         result = replay(units, scope(CATALOG, ORDER), ROLE_WORDS)
         assert {key: [u.unit_id for u in members] for key, members in result.new_scopes.items()} == {
-            ("Shipping",): ["f", "g"],
-            (): ["h"],
+            ("Shipping",): [f, g],
+            (): [h],
         }
 
     def test_members_follow_rule_order_and_include_empty_rules(self):
@@ -110,29 +112,34 @@ class TestFallbackAndUnplaced:
 class TestNewScopes:
     def test_units_a_loose_rule_catches_still_surface_where_they_diverge(self):
         """A root with loose files must not hide a new top-level directory behind 'Loose files'."""
-        shipping = [unit(f"s{i}", f"Shipping.API.Ship{i}") for i in range(3)]
-        result = replay([unit("p", "Program"), *shipping], scope(CATALOG, ORDER, LOOSE), ROLE_WORDS)
+        shipping = [unit(f"Shipping/API/Ship{i}.cs", f"Shipping.API.Ship{i}") for i in range(3)]
+        result = replay([unit("Program.cs", "Program"), *shipping], scope(CATALOG, ORDER, LOOSE), ROLE_WORDS)
         assert all(result.assignment[u.unit_id] == "3" for u in shipping)
-        assert [u.unit_id for u in result.new_scopes[("Shipping",)]] == ["s0", "s1", "s2"]
-        assert [u.unit_id for u in result.new_scopes[()]] == ["p"]
+        assert [u.unit_id for u in result.new_scopes[("Shipping",)]] == [u.unit_id for u in shipping]
+        assert [u.unit_id for u in result.new_scopes[()]] == ["Program.cs"]
 
     def test_a_unit_a_word_claims_outside_every_prefix_is_still_a_new_scope_candidate(self):
         """A new directory is a new directory, whatever its names happen to say."""
-        result = replay([unit("s0", "Shipping.OrderShipment.Run()")], scope(ORDER), ROLE_WORDS)
-        assert result.assignment["s0"] == "2"
-        assert [u.unit_id for u in result.new_scopes[("Shipping",)]] == ["s0"]
+        s0 = "Shipping/OrderShipment.cs"
+        result = replay([unit(s0, "Shipping.OrderShipment.Run()")], scope(ORDER), ROLE_WORDS)
+        assert result.assignment[s0] == "2"
+        assert [u.unit_id for u in result.new_scopes[("Shipping",)]] == [s0]
 
     def test_a_root_drawn_as_one_box_does_not_hide_the_directories_added_after_it(self):
         everything = ComponentRule("1", "All files", prefixes=((),))
+        s0, s1 = "Shipping/Ship.cs", "Shipping/Dock.cs"
         result = replay(
-            [unit("s0", "Shipping.Ship.Run()"), unit("s1", "Shipping.Dock.Run()")], scope(everything), ROLE_WORDS
+            [unit(s0, "Shipping.Ship.Run()"), unit(s1, "Shipping.Dock.Run()")], scope(everything), ROLE_WORDS
         )
-        assert result.assignment == {"s0": "1", "s1": "1"}
-        assert [u.unit_id for u in result.new_scopes[("Shipping",)]] == ["s0", "s1"]
+        assert result.assignment == {s0: "1", s1: "1"}
+        assert [u.unit_id for u in result.new_scopes[("Shipping",)]] == [s0, s1]
 
     def test_a_unit_a_prefix_claims_is_not_a_new_scope(self):
         result = replay(
-            [unit("f", "Catalog.API.Item"), unit("g", "OrderProcessor.Totals")],
+            [
+                unit("Catalog/API/Item.cs", "Catalog.API.Item"),
+                unit("OrderProcessor/Totals.cs", "OrderProcessor.Totals"),
+            ],
             scope(CATALOG, ORDER, LOOSE),
             ROLE_WORDS,
         )
@@ -144,8 +151,9 @@ class TestNewScopes:
         feature = ComponentRule(
             "5", "Incidents", prefixes=(("Beacon", "Application", "Incidents"),), terms=("incident",)
         )
-        result = replay([unit("f", "Beacon.Application.Billing.Invoice")], scope(residual, feature), ROLE_WORDS)
-        assert result.assignment == {"f": "4"}
+        f = "Beacon/Application/Billing/Invoice.cs"
+        result = replay([unit(f, "Beacon.Application.Billing.Invoice")], scope(residual, feature), ROLE_WORDS)
+        assert result.assignment == {f: "4"}
         assert list(result.new_scopes) == [("Beacon", "Application", "Billing")]
 
 

--- a/tests/static_analyzer/names/test_spec.py
+++ b/tests/static_analyzer/names/test_spec.py
@@ -1,6 +1,6 @@
 from clustering_ids import ROOT_SCOPE_ID
 from static_analyzer.clustering.names import ComponentRule, KinshipGrouper, ScopeSpec, TreeSpec, draft_tree
-from static_analyzer.clustering.names.spec import SPEC_VERSION, UNPLACED
+from static_analyzer.clustering.names.spec import SPEC_VERSION
 from tests.static_analyzer.names.conftest import units_from_layout
 
 
@@ -94,10 +94,9 @@ class TestScopeSpec:
         spec = TreeSpec(scopes={s: ScopeSpec(s) for s in ("1.1", "10", "2", "root", "1")})
         assert list(spec.to_dict()["scopes"]) == ["root", "1", "2", "10", "1.1"]
 
-    def test_components_exclude_the_bucket(self):
-        scope = ScopeSpec("root", [ComponentRule("1", "a"), ComponentRule("2", "Unassigned", kind=UNPLACED)])
-        assert [rule.component_id for rule in scope.components] == ["1"]
-        assert scope.unplaced_rule is not None and scope.unplaced_rule.component_id == "2"
+    def test_every_rule_is_a_component(self):
+        scope = ScopeSpec("root", [ComponentRule("1", "a"), ComponentRule("2", "Loose files", fallback_prefixes=((),))])
+        assert [rule.component_id for rule in scope.components] == ["1", "2"]
         assert scope.rule("9") is None
 
     def test_a_rule_without_prefix_or_word_is_fallback_only(self):

--- a/tests/static_analyzer/test_analysis_cache_inmem.py
+++ b/tests/static_analyzer/test_analysis_cache_inmem.py
@@ -218,6 +218,7 @@ class TestWarmStartDeletion(unittest.TestCase):
                 {deleted_file},
                 adapter,
                 project_path,
+                project_path,
                 engine_client,
                 ignore_manager,
             )

--- a/tests/static_analyzer/test_call_graph_builder.py
+++ b/tests/static_analyzer/test_call_graph_builder.py
@@ -71,7 +71,7 @@ class TestCallGraphBuilderInit:
     def test_creates_symbol_table_and_inspector(self):
         lsp = _make_lsp()
         adapter = _make_adapter()
-        builder = CallGraphBuilder(lsp, adapter, Path("/project"))
+        builder = CallGraphBuilder(lsp, adapter, Path("/project"), Path("/project"))
 
         assert builder.symbol_table is not None
         assert builder._source_inspector is not None
@@ -79,7 +79,7 @@ class TestCallGraphBuilderInit:
     def test_resolves_project_root(self):
         lsp = _make_lsp()
         adapter = _make_adapter()
-        builder = CallGraphBuilder(lsp, adapter, Path("/project"))
+        builder = CallGraphBuilder(lsp, adapter, Path("/project"), Path("/project"))
         assert builder._root == Path("/project").resolve()
 
 
@@ -87,7 +87,7 @@ class TestDiscoverSymbols:
     def test_opens_files_and_queries_symbols(self):
         lsp = _make_lsp()
         adapter = _make_adapter()
-        builder = CallGraphBuilder(lsp, adapter, Path("/project"))
+        builder = CallGraphBuilder(lsp, adapter, Path("/project"), Path("/project"))
 
         files = [Path("/project/a.py"), Path("/project/b.py")]
         lsp.document_symbol.return_value = []
@@ -101,7 +101,7 @@ class TestDiscoverSymbols:
         """The probe result from the sync wait should be reused for the first file."""
         lsp = _make_lsp()
         adapter = _make_adapter()
-        builder = CallGraphBuilder(lsp, adapter, Path("/project"))
+        builder = CallGraphBuilder(lsp, adapter, Path("/project"), Path("/project"))
 
         probe_symbols = [
             {
@@ -123,7 +123,7 @@ class TestDiscoverSymbols:
     def test_empty_source_files(self):
         lsp = _make_lsp()
         adapter = _make_adapter()
-        builder = CallGraphBuilder(lsp, adapter, Path("/project"))
+        builder = CallGraphBuilder(lsp, adapter, Path("/project"), Path("/project"))
 
         builder._discover_symbols([])
         lsp.did_open.assert_not_called()
@@ -132,7 +132,7 @@ class TestDiscoverSymbols:
     def test_batches_did_open_calls(self, mock_sleep):
         lsp = _make_lsp()
         adapter = _make_adapter()
-        builder = CallGraphBuilder(lsp, adapter, Path("/project"))
+        builder = CallGraphBuilder(lsp, adapter, Path("/project"), Path("/project"))
 
         # Create more files than a single batch
         files = [Path(f"/project/file_{i}.py") for i in range(DID_OPEN_BATCH_SIZE + 5)]
@@ -147,7 +147,7 @@ class TestDiscoverSymbols:
     def test_probe_timeout_scales_linearly_with_file_count(self):
         lsp = _make_lsp()
         adapter = _make_adapter()
-        builder = CallGraphBuilder(lsp, adapter, Path("/project"))
+        builder = CallGraphBuilder(lsp, adapter, Path("/project"), Path("/project"))
 
         files = [Path(f"/project/file_{i}.py") for i in range(100)]
         lsp.document_symbol.return_value = []
@@ -161,7 +161,7 @@ class TestDiscoverSymbols:
     def test_probe_timeout_capped_at_maximum(self):
         lsp = _make_lsp()
         adapter = _make_adapter()
-        builder = CallGraphBuilder(lsp, adapter, Path("/project"))
+        builder = CallGraphBuilder(lsp, adapter, Path("/project"), Path("/project"))
 
         files = [Path(f"/project/file_{i}.py") for i in range(20000)]
         lsp.document_symbol.return_value = []
@@ -175,7 +175,7 @@ class TestDiscoverSymbols:
         lsp = _make_lsp()
         adapter = _make_adapter()
         adapter.interleave_did_open_with_symbols = True
-        builder = CallGraphBuilder(lsp, adapter, Path("/project"))
+        builder = CallGraphBuilder(lsp, adapter, Path("/project"), Path("/project"))
         files = [Path("/project/a.go"), Path("/project/b.go")]
 
         builder._discover_symbols(files)
@@ -202,7 +202,7 @@ class TestDiscoverSymbols:
         lsp.document_symbol.side_effect = lambda path, timeout=None: [served] if path == files[0] else []
         read = {"name": "Shared", "kind": NodeType.CLASS, "range": _range(0, 3), "selectionRange": _range(0, 0)}
         adapter.read_document_symbols.return_value = [read]
-        builder = CallGraphBuilder(lsp, adapter, Path("/project"))
+        builder = CallGraphBuilder(lsp, adapter, Path("/project"), Path("/project"))
 
         builder._discover_symbols(files)
 
@@ -226,7 +226,7 @@ class TestDiscoverSymbols:
         lsp.document_symbol.side_effect = lambda path, timeout=None: (
             [served] if path == files[0] else ([loose] if path in opened else [])
         )
-        builder = CallGraphBuilder(lsp, adapter, Path("/project"))
+        builder = CallGraphBuilder(lsp, adapter, Path("/project"), Path("/project"))
 
         builder._discover_symbols(files)
 
@@ -249,7 +249,7 @@ class TestBuild:
     def test_returns_language_analysis_result(self):
         lsp = _make_lsp()
         adapter = _make_adapter()
-        builder = CallGraphBuilder(lsp, adapter, Path("/project"))
+        builder = CallGraphBuilder(lsp, adapter, Path("/project"), Path("/project"))
 
         lsp.document_symbol.return_value = [
             {
@@ -272,7 +272,7 @@ class TestBuild:
     def test_build_with_no_files(self):
         lsp = _make_lsp()
         adapter = _make_adapter()
-        builder = CallGraphBuilder(lsp, adapter, Path("/project"))
+        builder = CallGraphBuilder(lsp, adapter, Path("/project"), Path("/project"))
 
         result = builder.build([])
 
@@ -382,7 +382,7 @@ class Main {
         source.write_text(self.SOURCE)
         adapter = _make_adapter()
         adapter.expands_constructors = expands_constructors
-        builder = CallGraphBuilder(_make_lsp(), adapter, tmp_path)
+        builder = CallGraphBuilder(_make_lsp(), adapter, tmp_path, tmp_path)
 
         caller = SymbolInfo("main", "app.main", NodeType.FUNCTION, source, 3, 4, 7, 0)
         cls = SymbolInfo("Dog", "app.Dog", NodeType.CLASS, source, 25, 0, 50, 0)
@@ -479,7 +479,7 @@ class TestBuildPackageDeps:
     def test_cross_package_dependencies(self):
         lsp = _make_lsp()
         adapter = _make_adapter()
-        builder = CallGraphBuilder(lsp, adapter, Path("/project"))
+        builder = CallGraphBuilder(lsp, adapter, Path("/project"), Path("/project"))
 
         sym_a = SymbolInfo("foo", "pkg_a.foo", NodeType.FUNCTION, Path("/project/pkg_a/mod.py"), 0, 0, 10, 0)
         sym_b = SymbolInfo("bar", "pkg_b.bar", NodeType.FUNCTION, Path("/project/pkg_b/mod.py"), 0, 0, 10, 0)
@@ -500,7 +500,7 @@ class TestBuildPackageDeps:
     def test_same_package_edges_excluded(self):
         lsp = _make_lsp()
         adapter = _make_adapter()
-        builder = CallGraphBuilder(lsp, adapter, Path("/project"))
+        builder = CallGraphBuilder(lsp, adapter, Path("/project"), Path("/project"))
 
         sym_a = SymbolInfo("foo", "pkg.foo", NodeType.FUNCTION, Path("/project/pkg/a.py"), 0, 0, 10, 0)
         sym_b = SymbolInfo("bar", "pkg.bar", NodeType.FUNCTION, Path("/project/pkg/b.py"), 0, 0, 10, 0)
@@ -520,7 +520,7 @@ class TestBuildPackageDeps:
     def test_missing_symbols_in_edge_set(self):
         lsp = _make_lsp()
         adapter = _make_adapter()
-        builder = CallGraphBuilder(lsp, adapter, Path("/project"))
+        builder = CallGraphBuilder(lsp, adapter, Path("/project"), Path("/project"))
 
         adapter.get_all_packages.return_value = {"pkg"}
 

--- a/tests/static_analyzer/test_clustering_service.py
+++ b/tests/static_analyzer/test_clustering_service.py
@@ -280,11 +280,12 @@ class TestIncrementalHierarchy(unittest.TestCase):
         rule = rule_of(scope_of(service.spec, ROOT_SCOPE_ID), "6")
         self.assertEqual((rule.origin, rule.prefixes, rule.terms), (NEW_SCOPE, (("src", "Shipping.API"),), ()))
 
-    def test_a_single_new_file_nothing_claims_lands_in_the_bucket(self):
+    def test_a_single_new_file_nothing_claims_lands_in_the_loose_files(self):
         service, hierarchy = self._incremental(self.layout | {"src/Shipping/Ship.cs": ["Shipping.Ship"]})
         root = scope_of(service.spec, ROOT_SCOPE_ID)
-        assert root.unplaced_rule is not None
-        bucket = next(group for group in hierarchy.groups if group.group_id == root.unplaced_rule.component_id)
+        loose = next(rule for rule in root.rules if rule.is_fallback_only)
+        self.assertEqual(loose.name, "Loose files in src")
+        bucket = next(group for group in hierarchy.groups if group.group_id == loose.component_id)
         self.assertEqual(bucket.qualified_names, {"Shipping.Ship"})
         self.assertEqual([rule.origin for rule in root.rules if rule.origin == NEW_SCOPE], [])
 

--- a/tests/static_analyzer/test_clustering_service.py
+++ b/tests/static_analyzer/test_clustering_service.py
@@ -108,7 +108,7 @@ def persisted_from(hierarchy: ClusterScopeResult) -> dict[str, AnalysisInsights]
 class TestFullHierarchy(unittest.TestCase):
     def setUp(self):
         self.graph = graph("csharp", eshop() | {"src/Ordering.API/Apis/consts.cs": ["Ordering.API.Apis.limits_var"]})
-        self.service = ClusteringService()
+        self.service = ClusteringService(repo_dir=Path("/repo"))
         self.hierarchy = self.service.build_full_hierarchy(analysis_for(self.graph), max_depth=2)
 
     def test_groups_are_the_specification_rules(self):
@@ -116,7 +116,7 @@ class TestFullHierarchy(unittest.TestCase):
         self.assertEqual(
             [group.group_id for group in self.hierarchy.groups], [rule.component_id for rule in root.rules]
         )
-        self.assertEqual(rule_of(root, "1").name, "Ordering")
+        self.assertEqual(rule_of(root, "1").name, "Ordering.API")
 
     def test_leaves_are_files_and_members_are_callables_and_classes(self):
         leaves = self.hierarchy.leaf_clusters_by_language["csharp"]
@@ -143,7 +143,7 @@ class TestFullHierarchy(unittest.TestCase):
         ordering, basket = self.hierarchy.groups[0], self.hierarchy.groups[3]
         self.assertTrue(ordering.expandable)
         assert ordering.children is not None
-        self.assertEqual([group.group_id for group in ordering.children.groups], ["1.1", "1.2"])
+        self.assertEqual([group.group_id for group in ordering.children.groups], ["1.1", "1.2", "1.3"])
         self.assertFalse(basket.expandable)
         self.assertIsNone(basket.children)
         self.assertIn("1.1", self.service.spec.scopes, "the spec is drafted one level deeper than the tree")
@@ -156,11 +156,13 @@ class TestFullHierarchy(unittest.TestCase):
         for name in ("Alpha", "Beta", "Gamma", "Delta", "Epsilon", "Zeta", "Eta", "Theta", "Iota"):
             layout |= project(name, 3)
         edges = [(f"Tiny.API.TinyType{i}.Run()", "Ordering.API.Apis.OrderingType0.Run()") for i in range(2)]
-        service = ClusteringService()
+        service = ClusteringService(repo_dir=Path("/repo"))
         service.build_full_hierarchy(analysis_for(graph("csharp", layout, edges)), max_depth=1)
         ordering = rule_of(scope_of(service.spec, ROOT_SCOPE_ID), "1")
-        self.assertIn(("Tiny",), ordering.prefixes)
-        self.assertEqual([part.name for part in ordering.parts], ["OrderProcessor", "Ordering", "Tiny"])
+        self.assertIn(("src", "Tiny.API"), ordering.prefixes)
+        self.assertEqual(
+            [part.name for part in ordering.parts], ["OrderProcessor", "Ordering.API", "Ordering.Domain", "Tiny.API"]
+        )
 
     def test_unit_links_count_calls_and_reference_edges_between_files(self):
         csharp = graph("csharp", {"a.cs": ["A", "A.Run()"], "b.cs": ["B", "B.Run()"]}, [("A.Run()", "B.Run()")])
@@ -171,7 +173,9 @@ class TestFullHierarchy(unittest.TestCase):
 
     def test_a_rule_whose_units_own_no_callable_or_class_is_not_drawn(self):
         layout = eshop() | {f"src/Assets/Asset{i}.cs": [f"Assets.asset{i}_var"] for i in range(6)}
-        hierarchy = ClusteringService().build_full_hierarchy(analysis_for(graph("csharp", layout)), max_depth=2)
+        hierarchy = ClusteringService(repo_dir=Path("/repo")).build_full_hierarchy(
+            analysis_for(graph("csharp", layout)), max_depth=2
+        )
 
         def visit(scope: ClusterScopeResult) -> None:
             for group in scope.groups:
@@ -184,12 +188,16 @@ class TestFullHierarchy(unittest.TestCase):
 
     def test_connections_come_from_the_graph(self):
         edges = [("Catalog.API.Model.CatalogType0.Run()", "Ordering.API.Apis.OrderingType0.Run()")]
-        hierarchy = ClusteringService().build_full_hierarchy(analysis_for(graph("csharp", eshop(), edges)), max_depth=1)
+        hierarchy = ClusteringService(repo_dir=Path("/repo")).build_full_hierarchy(
+            analysis_for(graph("csharp", eshop(), edges)), max_depth=1
+        )
         self.assertEqual([(c.source_group_id, c.target_group_id) for c in hierarchy.connections], [("2", "1")])
         self.assertEqual(hierarchy.connections[0].edges[0].call_sites, [{"file": "x.cs", "line": 1}])
 
     def test_materialized_groups_explain_every_file_placement(self):
-        hierarchy = ClusteringService().build_full_hierarchy(analysis_for(graph("csharp", eshop())), max_depth=1)
+        hierarchy = ClusteringService(repo_dir=Path("/repo")).build_full_hierarchy(
+            analysis_for(graph("csharp", eshop())), max_depth=1
+        )
         clustered_files = {
             file_path
             for clusters in hierarchy.leaf_clusters_by_language.values()
@@ -210,7 +218,7 @@ class TestFullHierarchy(unittest.TestCase):
 class TestIncrementalHierarchy(unittest.TestCase):
     def setUp(self):
         self.layout = eshop()
-        first = ClusteringService()
+        first = ClusteringService(repo_dir=Path("/repo"))
         baseline = first.build_full_hierarchy(analysis_for(graph("csharp", self.layout)), max_depth=2)
         self.spec = TreeSpec.from_dict(first.spec.to_dict())
         self.persisted = persisted_from(baseline)
@@ -218,7 +226,7 @@ class TestIncrementalHierarchy(unittest.TestCase):
     def _incremental(self, layout: dict[str, list[str]]) -> tuple[ClusteringService, ClusterScopeResult]:
         analysis = analysis_for(graph("csharp", layout))
         analysis.incremental_base_results = analysis_for(graph("csharp", self.layout))
-        service = ClusteringService()
+        service = ClusteringService(repo_dir=Path("/repo"))
         hierarchy = service.build_incremental_hierarchy(
             analysis, 2, self.spec, self.persisted, REPO, REPO / ".codeboarding"
         )
@@ -235,11 +243,11 @@ class TestIncrementalHierarchy(unittest.TestCase):
                     ]
         layout["src/Beacon.Application/Constants/Limits.cs"] = ["Beacon.Application.Constants.Limits.max_var"]
         layout["src/Beacon.Application/Constants/Defaults.cs"] = ["Beacon.Application.Constants.Defaults.min_var"]
-        first = ClusteringService()
+        first = ClusteringService(repo_dir=Path("/repo"))
         baseline = first.build_full_hierarchy(analysis_for(graph("csharp", layout)), max_depth=1)
         analysis = analysis_for(graph("csharp", layout))
         analysis.incremental_base_results = analysis_for(graph("csharp", layout))
-        service = ClusteringService()
+        service = ClusteringService(repo_dir=Path("/repo"))
         hierarchy = service.build_incremental_hierarchy(
             analysis, 1, TreeSpec.from_dict(first.spec.to_dict()), persisted_from(baseline), REPO, REPO
         )
@@ -270,7 +278,7 @@ class TestIncrementalHierarchy(unittest.TestCase):
         self.assertEqual(shipping.group_id, "6")
         self.assertEqual(len(shipping.qualified_names), 6)
         rule = rule_of(scope_of(service.spec, ROOT_SCOPE_ID), "6")
-        self.assertEqual((rule.origin, rule.prefixes, rule.terms), (NEW_SCOPE, (("Shipping",),), ()))
+        self.assertEqual((rule.origin, rule.prefixes, rule.terms), (NEW_SCOPE, (("src", "Shipping.API"),), ()))
 
     def test_a_single_new_file_nothing_claims_lands_in_the_bucket(self):
         service, hierarchy = self._incremental(self.layout | {"src/Shipping/Ship.cs": ["Shipping.Ship"]})
@@ -293,7 +301,7 @@ class TestIncrementalHierarchy(unittest.TestCase):
         spec = TreeSpec.from_dict(self.spec.to_dict() | {"grouper": "kinship"})
         analysis = analysis_for(graph("csharp", self.layout))
         analysis.incremental_base_results = analysis_for(graph("csharp", self.layout))
-        service = ClusteringService()
+        service = ClusteringService(repo_dir=Path("/repo"))
         service.build_incremental_hierarchy(analysis, 2, spec, self.persisted, REPO, REPO)
         self.assertEqual(service.grouper.name, "kinship")
 
@@ -301,7 +309,9 @@ class TestIncrementalHierarchy(unittest.TestCase):
         analysis = analysis_for(graph("csharp", self.layout))
         analysis.incremental_base_results = StaticAnalysisResults()
         with self.assertRaisesRegex(IncrementalCacheMissingError, "call graph"):
-            ClusteringService().build_incremental_hierarchy(analysis, 2, self.spec, self.persisted, REPO, REPO)
+            ClusteringService(repo_dir=Path("/repo")).build_incremental_hierarchy(
+                analysis, 2, self.spec, self.persisted, REPO, REPO
+            )
 
     def test_a_new_directory_in_a_scope_drawn_from_words_is_still_a_new_component(self):
         """No rule owns a prefix here, so the new files must be keyed by where they leave the old units."""
@@ -317,10 +327,10 @@ class TestIncrementalHierarchy(unittest.TestCase):
         }
         analysis = analysis_for(graph("csharp", new))
         analysis.incremental_base_results = analysis_for(graph("csharp", old))
-        service = ClusteringService()
+        service = ClusteringService(repo_dir=Path("/repo"))
         hierarchy = service.build_incremental_hierarchy(analysis, 1, spec, {}, REPO, REPO)
         sampling = rule_of(scope_of(service.spec, ROOT_SCOPE_ID), "3")
-        self.assertEqual((sampling.origin, sampling.prefixes), (NEW_SCOPE, (("Serilog", "Sampling"),)))
+        self.assertEqual((sampling.origin, sampling.prefixes), (NEW_SCOPE, (("src", "Serilog", "Sampling"),)))
         self.assertEqual(len(next(group for group in hierarchy.groups if group.group_id == "3").qualified_names), 6)
 
     def test_a_new_directory_whose_names_vote_elsewhere_is_still_a_new_component(self):
@@ -333,17 +343,19 @@ class TestIncrementalHierarchy(unittest.TestCase):
         shipping = next(group for group in hierarchy.groups if group.previous_component_id == "")
         self.assertEqual(len(shipping.qualified_names), 6)
         rule = rule_of(scope_of(service.spec, ROOT_SCOPE_ID), shipping.group_id)
-        self.assertEqual((rule.origin, rule.prefixes), (NEW_SCOPE, (("Shipping",),)))
+        self.assertEqual((rule.origin, rule.prefixes), (NEW_SCOPE, (("src", "Shipping"),)))
 
     def test_a_baseline_without_a_specification_cannot_be_built_on(self):
         analysis = analysis_for(graph("csharp", self.layout))
         analysis.incremental_base_results = StaticAnalysisResults()
         with self.assertRaisesRegex(IncrementalCacheMissingError, "tree specification"):
-            ClusteringService().build_incremental_hierarchy(analysis, 2, TreeSpec(), self.persisted, REPO, REPO)
+            ClusteringService(repo_dir=Path("/repo")).build_incremental_hierarchy(
+                analysis, 2, TreeSpec(), self.persisted, REPO, REPO
+            )
 
     def test_a_cold_static_analysis_cannot_be_built_on(self):
         with self.assertRaises(IncrementalCacheMissingError):
-            ClusteringService().build_incremental_hierarchy(
+            ClusteringService(repo_dir=Path("/repo")).build_incremental_hierarchy(
                 analysis_for(graph("csharp", self.layout)), 2, self.spec, self.persisted, REPO, REPO
             )
 
@@ -351,24 +363,28 @@ class TestIncrementalHierarchy(unittest.TestCase):
 class TestScopeHierarchy(unittest.TestCase):
     def setUp(self):
         self.graph = graph("csharp", eshop())
-        first = ClusteringService()
+        first = ClusteringService(repo_dir=Path("/repo"))
         self.hierarchy = first.build_full_hierarchy(analysis_for(self.graph), max_depth=1)
         self.spec = first.spec
 
     def _scope(self, component_id: str) -> ClusterScopeResult:
-        return ClusteringService().build_scope_hierarchy({"csharp": self.graph}, 1, component_id, self.spec)
+        return ClusteringService(repo_dir=Path("/repo")).build_scope_hierarchy(
+            {"csharp": self.graph}, 1, component_id, self.spec
+        )
 
     def test_a_grouped_component_replays_its_parts(self):
         scope = self._scope("1")
-        self.assertEqual([group.group_id for group in scope.groups], ["1.1", "1.2"])
+        self.assertEqual([group.group_id for group in scope.groups], ["1.1", "1.2", "1.3"])
 
     def test_a_partial_run_holds_the_units_a_full_run_placed_data_only_files_included(self):
         graph_with_consts = graph(
             "csharp", eshop() | {"src/Ordering.API/Apis/consts.cs": ["Ordering.API.Apis.limits_var"]}
         )
-        first = ClusteringService()
+        first = ClusteringService(repo_dir=Path("/repo"))
         full = first.build_full_hierarchy(analysis_for(graph_with_consts), max_depth=2)
-        partial = ClusteringService().build_scope_hierarchy({"csharp": graph_with_consts}, 1, "1", first.spec)
+        partial = ClusteringService(repo_dir=Path("/repo")).build_scope_hierarchy(
+            {"csharp": graph_with_consts}, 1, "1", first.spec
+        )
         assert full.groups[0].children is not None
         self.assertEqual(
             [(g.group_id, sorted(g.cluster_ids)) for g in partial.groups],
@@ -378,7 +394,7 @@ class TestScopeHierarchy(unittest.TestCase):
     def test_a_scope_the_planner_never_drew_is_not_drawn_by_another_grouper(self):
         spec = TreeSpec.from_dict(self.spec.to_dict() | {"grouper": "planner"})
         with self.assertRaisesRegex(PlannerUnavailableError, "never drafted"):
-            ClusteringService().build_scope_hierarchy({"csharp": self.graph}, 2, "1", spec)
+            ClusteringService(repo_dir=Path("/repo")).build_scope_hierarchy({"csharp": self.graph}, 2, "1", spec)
 
     def test_a_small_component_comes_back_without_groups(self):
         self.assertEqual(self._scope("4").groups, [])

--- a/tests/static_analyzer/test_csharp_adapter.py
+++ b/tests/static_analyzer/test_csharp_adapter.py
@@ -163,7 +163,7 @@ class TestBuildQualifiedName:
             project_root=self.root,
         )
         # File and Namespace skipped, DownloadService matches filename -> deduped
-        assert result == "Contoso.Processing.Download.DownloadService.ProcessAsync"
+        assert result == "src.Contoso.Processing.Download.DownloadService.ProcessAsync"
 
     def test_namespace_symbol_uses_detail(self):
         """Namespace symbols use their detail field as the qualified name."""
@@ -186,10 +186,10 @@ class TestBuildQualifiedName:
             parent_chain=[("Program.cs", NodeType.FILE)],
             project_root=self.root,
         )
-        assert result == "Contoso.Api.Program"
+        assert result == "src.Contoso.Api.Program"
 
-    def test_src_prefix_stripped(self):
-        """The 'src' directory is stripped from qualified names."""
+    def test_src_is_a_directory_like_any_other(self):
+        """Every adapter spells the path from the repository root; nothing is dropped."""
         result = self.adapter.build_qualified_name(
             file_path=Path("/repo/src/Contoso.Core/Models/Media.cs"),
             symbol_name="Media",
@@ -197,7 +197,7 @@ class TestBuildQualifiedName:
             parent_chain=[],
             project_root=self.root,
         )
-        assert result == "Contoso.Core.Models.Media"
+        assert result == "src.Contoso.Core.Models.Media"
 
 
 class TestFilesDeclaringSeveralTypes:

--- a/tests/static_analyzer/test_java_adapter.py
+++ b/tests/static_analyzer/test_java_adapter.py
@@ -13,10 +13,11 @@ def _name(rel: str, symbol: str, kind: int = NodeType.CLASS, parents: list[tuple
 
 
 class TestBuildQualifiedName:
-    def test_maven_source_root_names_no_package(self):
+    def test_a_maven_source_root_is_spelled_as_it_is_on_disk(self):
+        """Every adapter spells the path from the repository root; the walk over the tree steps through ``src``."""
         assert (
             _name("mockito-core/src/main/java/org/mockito/Answers.java", "Answers")
-            == "mockito-core.org.mockito.Answers"
+            == "mockito-core.src.main.java.org.mockito.Answers"
         )
 
     def test_a_type_is_not_doubled_by_its_own_file(self):
@@ -38,16 +39,18 @@ class TestBuildQualifiedName:
     def test_a_test_source_set_stays_in_the_name(self):
         """`src/main/java` and `src/test/java` can hold the same package and type name."""
         assert (
-            _name("core/src/test/java/org/mockito/Fixture.java", "Fixture") == "core.test.org.mockito.Fixture"
-        ) and _name("core/src/main/java/org/mockito/Fixture.java", "Fixture") == "core.org.mockito.Fixture"
+            _name("core/src/test/java/org/mockito/Fixture.java", "Fixture") == "core.src.test.java.org.mockito.Fixture"
+        ) and _name(
+            "core/src/main/java/org/mockito/Fixture.java", "Fixture"
+        ) == "core.src.main.java.org.mockito.Fixture"
 
     def test_an_arbitrary_gradle_source_set_is_recognised(self):
         """Gradle names its own: `integrationTest`, Android's `androidTest`."""
         name = _name("app/src/integrationTest/java/com/acme/SmokeTest.java", "SmokeTest")
-        assert name == "app.integrationTest.com.acme.SmokeTest"
+        assert name == "app.src.integrationTest.java.com.acme.SmokeTest"
 
-    def test_a_kotlin_source_root_is_stripped(self):
-        assert _name("app/src/main/kotlin/com/acme/Main.kt", "Main") == "app.com.acme.Main"
+    def test_a_kotlin_source_root_is_kept_too(self):
+        assert _name("app/src/main/kotlin/com/acme/Main.kt", "Main") == "app.src.main.kotlin.com.acme.Main"
 
     def test_a_flat_layout_keeps_every_directory(self):
         assert _name("com/acme/Widget.java", "Widget") == "com.acme.Widget"
@@ -68,7 +71,7 @@ class TestGetPackageForFile:
         adapter = JavaAdapter()
         source = ROOT / "mockito-core/src/main/java/org/mockito/Answers.java"
         package = adapter.get_package_for_file(source, ROOT)
-        assert package == "mockito-core.org.mockito"
+        assert package == "mockito-core.src.main.java.org.mockito"
         assert adapter.build_qualified_name(source, "Answers", NodeType.CLASS, [], ROOT).startswith(package + ".")
 
     def test_every_package_is_collected(self):
@@ -77,4 +80,4 @@ class TestGetPackageForFile:
             ROOT / "a/src/main/java/com/acme/One.java",
             ROOT / "b/src/main/java/com/acme/Two.java",
         ]
-        assert adapter.get_all_packages(sources, ROOT) == {"a.com.acme", "b.com.acme"}
+        assert adapter.get_all_packages(sources, ROOT) == {"a.src.main.java.com.acme", "b.src.main.java.com.acme"}

--- a/tests/static_analyzer/test_warmstart_changed_files.py
+++ b/tests/static_analyzer/test_warmstart_changed_files.py
@@ -16,6 +16,7 @@ from static_analyzer.analysis_result import StaticAnalysisResults
 
 def _analyzer_with_one_engine(project_path: Path, changed_files: set[Path] | None) -> StaticAnalyzer:
     analyzer = object.__new__(StaticAnalyzer)
+    analyzer.repository_path = project_path
     adapter = MagicMock()
     adapter.language = "Python"
     adapter.language_enum = MagicMock()


### PR DESCRIPTION
Stacked on #583. Five commits: the un-merge fix, the rebuild of the clustering rules around one idea: **a directory is the structure, and a small directory is placed by its role in the calls.** Replaces the earlier hub-rule commit of this PR, which produced 50 root boxes on abp. Then the review round, one naming rule for every adapter, and the end of the Unassigned bucket.

## The rules, the same at every depth

**Structure**
1. A file's position in the tree is its directory under the repository root. Names are no longer parsed for structure, so the engine root, a dotted project directory (`BTCPayServer.Client`) and each adapter's spelling stop deciding the boxes.
2. A directory holding nearly all of a scope (80%) is stepped through; every other directory is a box and its inside is the next depth. The 50% opening rule and the layout-word list are gone.

**Placement by role** (small candidates, under 5% of the scope; edge direction is what tells them apart)
3. A hub (called by 40% of its siblings), an application (calls, never called), a project root (a manifest in its directory) or a candidate shared by three siblings stays.
4. A helper, called by one sibling only, goes inside that sibling. Loose files, tests, samples, benches, docs and hubs own nothing: the bus dispatching to a service's handlers does not make the service its helper.
5. Shared by exactly two: into the larger caller. Linked to nothing: into the loose files. A hub under three files: into the loose files.

**Budget**
6. Over 9: the smallest joins the sibling carrying at least half of its links, never a hub. Over 15: the two candidates whose identifier vocabulary is closest merge. Still over 15: the smallest are pooled into one box named "Other files".
7. A folded component opens at the next depth through the same rules (the first commit).

The vocabulary rung (one candidate per word, the source of today's 51- and 60-child scopes) is deleted. Tree specifications drafted before this replay under a different position scheme, so `SPEC_VERSION` is bumped and a full run is required once.

## Measured, no model, fifteen repositories at depth 3

Root boxes · widest scope at depth 1 / 2 / 3 · scopes over 15.

| repo | today | this PR |
|---|---|---|
| eShop | 9 · 9/9/8 · 0 · **5 of 9** published boxes | 10 · 10/8/9 · 0 · **9 of 9** (F1 1.000) |
| abp | 9 · 9/**31**/9 · 4, four 1,500-file bags | 6 · 6/15/12 · 0: framework, modules, templates, npm, tools, abp_io |
| btcpayserver | **27** · 27/16/9 · 2 | 8 · 8/11/15 · 0: its eight projects |
| nopCommerce | 8 · 8/9/**51** · 1 | 4 · 4/15/15 · 0 |
| Polly | 9 · 9/8/9, strategies scattered at root | 8 · 8/11/6: its projects |
| AutoMapper | 9 · 9/7/6, test folders at root | 4 · 4/7/8 |
| serilog | 9 (forced from 13) | 9 · 9/4/4, helpers inside Core, Configuration, Formatting |
| mermaid | 9 | 6 · 6/11/10 |
| CodeBoarding | 9 | 9 · 9/4/7 |
| django, LMCache, mem0, junit4, fzf, markitdown, nanoclaw, modulify | 3 to 9 | 3 to 11, no scope over 15 |

Not one scope above 15 on any repository at any depth. abp's csproj V-measure at depth 1 reads 0.279 against today's 0.447 and that is by construction: six boxes over two hundred projects cannot be homogeneous, and the six are the repository's own top level.

## Before and after, in the product's viewer

Same graph, today's fold on the left, this PR's on the right (CodeBoarding-evals `eval/abp-type-references`, section "The fold").

![eShop](https://github.com/CodeBoarding/CodeBoarding-evals/blob/83e724fefb29811b6839b09f5bf3e2d7084c0424/runs/type-reference-eval/shots/eShop-pr583-fold-vs-pr586-fold.png?raw=true)
![abp](https://github.com/CodeBoarding/CodeBoarding-evals/blob/83e724fefb29811b6839b09f5bf3e2d7084c0424/runs/type-reference-eval/shots/abp-pr583-fold-vs-pr586-fold.png?raw=true)
![Polly](https://github.com/CodeBoarding/CodeBoarding-evals/blob/83e724fefb29811b6839b09f5bf3e2d7084c0424/runs/type-reference-eval/shots/Polly-pr583-fold-vs-pr586-fold.png?raw=true)

## After review

The bot comments were each addressed in the third commit: containment of paths under the repository root, the nearest manifest above a file as its project, file keys distinct from directory prefixes, collision-free candidate keys, one-link callers as noise, the cap on helper and vocabulary merges, consumers neither taking nor folding, fallback-only parts never folding, hubs and projects standing under a rung's floor, and the design document brought in line. Replies sit on each thread.

## Verification

- 2,155 unit tests pass (the only failure on this machine is the pre-existing macOS `/private/tmp` case in `tests/test_cli_parser.py`). 29 new tests cover positions from paths, the single frontier rule, each placement rule, the dominant-partner budget, the vocabulary merge, the pool and what the review found.
- The sweep above is the zero-LLM harness in the evals branch's README; every number there is reproducible from the pickled graphs.

## Names spelled from the repository root

One rule for every adapter: a qualified name starts with the file's path from the repository root, segment for segment as it is on disk. The C# adapter no longer drops `src`, the Java adapter no longer drops `src/main/java`, and a nested solution's or project's engine no longer spells its files relative to itself, so the same directory carries the same prefix whatever language or engine produced the symbol, and two solutions with the same inner layout cannot collide. The builder takes the repository root beside the engine root it starts the server on; the incremental path passes it through; cache tag v10. Clustering positions files by path already, so the trees on all seventeen repositories are byte-identical before and after this commit; what changes is what a reader sees in a name (`src.Basket.API.Grpc.BasketService`, `mockito-core.src.main.java.org.mockito.Answers`). The exact edge-case fixtures in CodeBoarding-tests are regenerated on the paired branch.

## No Unassigned bucket

A settled scope whose replay leaves a unit unplaced now gets a fallback-only "Loose files" rule on its own prefix, drafted on the spot, both in a full run and when an incremental run admits new units. The `Unassigned` rule kind and its bucket are gone, so a reader meets one name for the files a scope holds directly.

## What stays open

- Inside a wide flat scope (abp's `framework`, a hundred packages) the rules give fifteen package families, not the eight themes a reader would draw. That is a semantic gap; the dependency-fingerprint proxy and, failing that, the planner on such scopes only, are the next steps.
- Ocelot cannot be analysed on the stack: a nested `samples/Eureka` solution with a missing project reference raises the fatal "0 symbols" error and aborts the whole run. Separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Clustering now organizes files by repository directories and recognizes project boundaries from common manifest files.
  * Grouping better reflects caller–callee relationships, roles, shared infrastructure, vocabulary, and file-count limits.
  * Large or loosely related sets are consolidated into clearer “Other files” groupings.
  * Hierarchy generation now provides more consistent root, component, file, and fallback groupings.
  * Generated path keys use slash-separated directory paths.

* **Documentation**
  * Updated the name-tree design documentation to describe the revised file-based clustering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

