### PR TITLE
refactor: share analysis context across engine and incremental runs

### DIFF
--- a/static_analyzer/__init__.py
+++ b/static_analyzer/__init__.py
@@ -8,13 +8,14 @@ from pathlib import Path
 
 from repo_utils.git_ops import get_changed_files_since
 from repo_utils.ignore import RepoIgnoreManager
-from static_analyzer.analysis_cache import StaticAnalysisCache
+from static_analyzer.analysis_cache import StaticAnalysisCache, invalidate_files, _rederive_inherits_edges
 from static_analyzer.analysis_result import StaticAnalysisResults
 from static_analyzer.cfg import CallGraph
-from static_analyzer.config import AdapterName, Language
+from static_analyzer.config import GRAPH_NODE_TYPES, AdapterName, Language
 from static_analyzer.csharp_config_scanner import SOLUTION_GLOBS, CSharpConfigScanner, CSharpProjectConfig
 from static_analyzer.dotnet_solution import solution_projects
 from static_analyzer.engine.adapters import get_adapter
+from static_analyzer.engine.analysis_context import AnalysisContext
 from static_analyzer.engine.call_graph_builder import CallGraphBuilder
 from static_analyzer.engine.language_adapter import LanguageAdapter
 from static_analyzer.engine.lsp_client import LSPClient
@@ -22,7 +23,11 @@ from static_analyzer.engine.lsp_recycler import default_memory_budget, per_engin
 from static_analyzer.engine.result_converter import convert_to_codeboarding_format
 from static_analyzer.engine.source_inspector import SourceInspector
 from static_analyzer.engine.utils import uri_to_path
-from static_analyzer.incremental_orchestrator import update_cfg_for_changed_files
+from static_analyzer.incremental_orchestrator import (
+    MissingSymbolSnapshotError,
+    affected_source_files,
+    update_cfg_for_changed_files,
+)
 from static_analyzer.java_config_scanner import JavaConfigScanner
 from static_analyzer.lsp_client.diagnostics import FileDiagnosticsMap
 from static_analyzer.programming_language import ProgrammingLanguage
@@ -729,6 +734,7 @@ class StaticAnalyzer:
         explicitly requested ``skip_cache=True``.
         """
         results = StaticAnalysisResults()
+        self._analysis_context = AnalysisContext()
         absorb_lock = threading.Lock()
         spawned: list[str] = []
         spawn_failures: list[str] = []
@@ -737,9 +743,12 @@ class StaticAnalyzer:
         # (nested solution roots) do collide, so completion order would let two
         # identical runs keep different nodes and produce different component IDs.
         completed: dict[int, tuple[Language, dict]] = {}
+        collected: set[int] = set()
 
-        def run_one(engine_config: EngineConfig, engine_client: LSPClient | None, order: int = 0) -> None:
+        def run_one(engine_config: EngineConfig, engine_client: LSPClient | None, order: int, collect: bool) -> None:
             """Analyze one engine. Owns the client's lifetime when given none."""
+            if not collect and order not in collected:
+                return
             adapter, project_path = engine_config.adapter, engine_config.project_path
             language = adapter.results_language
             t_lang_start = time.monotonic()
@@ -756,6 +765,11 @@ class StaticAnalyzer:
                         spawned.append(adapter.language)
                     engine_client = owned_client
                 logger.info(f"Starting engine analysis for {adapter.language} in {project_path}")
+                if collect:
+                    self._collect_symbols(engine_config, engine_client)
+                    with absorb_lock:
+                        collected.add(order)
+                    return
                 analysis = self._run_full_analysis(engine_config, engine_client)
                 duration_ms = round((time.monotonic() - t_lang_start) * 1000)
                 logger.info(f"Engine analysis for {adapter.language} completed in {duration_ms / 1000:.1f}s")
@@ -793,33 +807,35 @@ class StaticAnalyzer:
                         logger.exception(f"Error shutting down {adapter.language} client for {project_path}")
 
         cap = max_concurrent_engines()
-        if not cap:
-            for order, (engine_config, engine_client) in enumerate(self._engine_clients):
-                run_one(engine_config, engine_client, order)
-        else:
-            pending = [cfg for cfg in self._engine_configs if cfg.source_files]
-            logger.info("Running %d engine(s) with at most %d resident at a time", len(pending), cap)
-            # Not ``with``: its ``__exit__`` waits without cancelling, so one
-            # engine's fatal error would still drain every queued engine — a full
-            # pass over a monorepo — before propagating. Cancel the queue, then
-            # wait so each in-flight ``run_one`` still shuts its own client down.
-            pool = ThreadPoolExecutor(max_workers=cap)
-            try:
-                futures = [pool.submit(run_one, cfg, None, order) for order, cfg in enumerate(pending)]
-                for future in as_completed(futures):
-                    future.result()
-            finally:
-                pool.shutdown(wait=True, cancel_futures=True)
-            if pending and not spawned:
-                details = f"; failures: {'; '.join(spawn_failures)}" if spawn_failures else ""
-                raise RuntimeError(
-                    "Failed to start any engine LSP client "
-                    f"(attempted: {', '.join(cfg.adapter.language for cfg in pending)}){details}"
-                )
+        for collect in (True, False):
+            if not collect:
+                self._analysis_context.freeze()
+            if not cap:
+                for order, (engine_config, engine_client) in enumerate(self._engine_clients):
+                    run_one(engine_config, engine_client, order, collect)
+            else:
+                pending = [cfg for cfg in self._engine_configs if cfg.source_files]
+                logger.info("Running %d engine(s) with at most %d resident at a time", len(pending), cap)
+                pool = ThreadPoolExecutor(max_workers=cap)
+                try:
+                    futures = [pool.submit(run_one, cfg, None, order, collect) for order, cfg in enumerate(pending)]
+                    for future in as_completed(futures):
+                        future.result()
+                finally:
+                    pool.shutdown(wait=True, cancel_futures=True)
+                if pending and not spawned:
+                    details = f"; failures: {'; '.join(spawn_failures)}" if spawn_failures else ""
+                    raise RuntimeError(
+                        "Failed to start any engine LSP client "
+                        f"(attempted: {', '.join(cfg.adapter.language for cfg in pending)}){details}"
+                    )
 
+        if (self._engine_clients or self._engine_configs) and not completed:
+            raise StaticAnalysisFatalError("No engine completed edge analysis; refusing to cache an empty graph.")
         for order in sorted(completed):
             language, analysis = completed[order]
             self._absorb_into_results(results, language, analysis)
+        self._snapshot_context(results)
 
         summaries = []
         for language in results.get_languages():
@@ -843,69 +859,93 @@ class StaticAnalyzer:
         cached_results: StaticAnalysisResults,
         cached_sha: str,
     ) -> StaticAnalysisResults:
-        """Bring *cached_results* up to date in-memory, scoped to the changed files.
-
-        Per language: determine the changed-file list, hand it to
-        ``update_cfg_for_changed_files`` along with the language's portion of the
-        cached state, and put the merged result back into a fresh
-        ``StaticAnalysisResults``.
-
-        Changed-file source: ``self.changed_files`` when set at construction
-        (git-free — e.g. the wrapper's fingerprint diff), else ``git diff`` via
-        ``get_changed_files_since``. If git fails (*cached_sha* unreachable, a
-        non-git frozen copy, or a content-hash SHA that isn't a git object), fall
-        back to a full re-LSP for that language so the run still produces valid
-        output.
-        """
+        """Hydrate once, replace all changed declarations, then requery affected callers."""
+        clients = self._live_clients("warm-start")
+        self._analysis_context = AnalysisContext()
         results = StaticAnalysisResults()
-        # One dict per language, threaded through every engine config of that language and
-        # absorbed once. Why: each config re-LSPs only the changed files under its own root,
-        # so a config that took its own copy of the cache would hand back the nodes another
-        # config had just invalidated, and the merge would resurrect deleted files.
+        baseline: dict[Language, dict] = {}
         carried: dict[Language, dict] = {}
-        for engine_config, engine_client in self._live_clients("warm-start"):
-            adapter, project_path = engine_config.adapter, engine_config.project_path
+        changes: dict[Language, set[Path]] = {}
+        engine_changes: list[set[Path]] = []
+        for config, _ in clients:
+            adapter = config.adapter
             language = adapter.results_language
-            t_lang_start = time.monotonic()
-            changed_files = self._changed_files_for_language(project_path, cached_sha, adapter.language)
-
-            if changed_files is None:
-                analysis = self._run_full_analysis(engine_config, engine_client)
-                self._absorb_into_results(results, language, analysis)
-            else:
-                changed_files = {
-                    path
-                    for path in changed_files
-                    if not any(path.is_relative_to(root) for root in engine_config.excluded_roots)
-                }
-                logger.info(f"warmstart {adapter.language}: re-LSPing {len(changed_files)} changed file(s)")
-                cached_lang_dict = carried.get(language) or self._extract_language_dict(cached_results, language)
-                analysis = update_cfg_for_changed_files(
-                    cached_lang_dict, changed_files, adapter, project_path, engine_client, self.ignore_manager
+            if language not in baseline:
+                data = self._extract_language_dict(cached_results, language)
+                if data.get("symbols") is None:
+                    raise MissingSymbolSnapshotError(
+                        f"{language.value} has no symbol snapshot. Run a full analysis first."
+                    )
+                baseline[language] = data
+                self._analysis_context.hydrate(
+                    adapter, data["symbols"], data["unresolved_files"], data.get("closed_documents", set())
                 )
-                carried[language] = analysis
+            detected = self._changed_files_for_language(config.project_path, cached_sha, adapter.language)
+            if detected is None:
+                raise StaticAnalysisFatalError("Cannot determine incremental changes. Run a full analysis explicitly.")
+            scoped = {
+                path
+                for path in detected
+                if path.suffix in adapter.file_extensions
+                and not any(path.is_relative_to(root) for root in config.excluded_roots)
+                and not self.ignore_manager.should_ignore(path)
+            }
+            engine_changes.append(scoped)
+            changes.setdefault(language, set()).update(scoped)
 
-            self._collect_diagnostics_for(adapter, engine_client, analysis)
+        for language, data in baseline.items():
+            self._analysis_context.tables[language].remove_files(changes[language])
+            self._analysis_context.unresolved_files.difference_update(str(p) for p in changes[language])
+            carried[language] = invalidate_files(data, changes[language]).analysis.to_dict()
+        for config, client in clients:
+            language = config.adapter.results_language
+            client.refresh_files(changes[language], {Path(p) for p in baseline[language]["source_files"]})
+        for (config, client), changed in zip(clients, engine_changes):
+            files = sorted(path for path in changed if path.is_file())
+            if files:
+                self._collect_symbols(EngineConfig(config.adapter, config.project_path, files), client)
+            else:
+                self._analysis_context.prepared[(config.adapter.results_language, config.project_path.resolve())] = []
+        self._analysis_context.freeze()
+
+        for config, client in clients:
+            adapter, language = config.adapter, config.adapter.results_language
+            t_start = time.monotonic()
+            queries = affected_source_files(baseline[language], changes[language], adapter, self._analysis_context)
+            queries = {
+                p
+                for p in queries
+                if p.is_relative_to(config.project_path)
+                and not any(p.is_relative_to(root) for root in config.excluded_roots)
+            }
+            carried[language] = update_cfg_for_changed_files(
+                carried[language],
+                set(),
+                adapter,
+                config.project_path,
+                client,
+                self.ignore_manager,
+                context=self._analysis_context,
+                query_files=queries,
+            )
+            analysis = carried[language]
+            self._collect_diagnostics_for(adapter, client, analysis)
             track_lsp_result(
                 language=adapter.language_enum.value,
                 loc=self._loc_for_adapter(adapter),
                 status="success",
-                duration_ms=round((time.monotonic() - t_lang_start) * 1000),
+                duration_ms=round((time.monotonic() - t_start) * 1000),
                 analysis=analysis,
                 diagnostics=self.collected_diagnostics.get(adapter.results_language, {}),
             )
         for language, analysis in carried.items():
             self._absorb_into_results(results, language, analysis)
+        self._snapshot_context(results)
         results.incremental_base_results = cached_results
         return results
 
     def _changed_files_for_language(self, project_path: Path, cached_sha: str, language: str) -> set[Path] | None:
-        """The warm-start changed-file set scoped to one language's project root.
-
-        ``self.changed_files`` when set (git-free), else ``git diff`` via
-        ``get_changed_files_since``. ``None`` means "detect failed / no set" and
-        the caller does a full re-LSP for the language.
-        """
+        """Scope supplied or git changes; None makes incremental analysis fail explicitly."""
         if self.changed_files is not None:
             # Scope the repo-wide set to this language's project root so a
             # multi-language repo doesn't re-LSP every changed file per engine.
@@ -915,7 +955,7 @@ class StaticAnalyzer:
         except Exception as e:
             logger.warning(
                 f"get_changed_files_since failed for {language} (cached_sha={cached_sha}): {e}; "
-                "falling back to full re-LSP for this language"
+                "incremental analysis cannot proceed"
             )
             return None
 
@@ -935,6 +975,7 @@ class StaticAnalyzer:
             package_relations = {}
         cached_refs = list(cached_results.iter_reference_nodes(language))
         cached_source_files = [Path(p) for p in cached_results.get_source_files(language)]
+        bucket = cached_results.results.get(language)
         return {
             "call_graph": cached_cfg,
             "class_hierarchies": class_hierarchies,
@@ -942,6 +983,9 @@ class StaticAnalyzer:
             "references": cached_refs,
             "source_files": cached_source_files,
             "diagnostics": cached_results.diagnostics.get(language, {}),
+            "symbols": bucket.symbols if bucket is not None else None,
+            "unresolved_files": set(bucket.unresolved_files) if bucket is not None else set(),
+            "closed_documents": set(bucket.closed_documents) if bucket is not None else set(),
         }
 
     def _absorb_into_results(self, results: StaticAnalysisResults, language: Language, analysis: dict) -> None:
@@ -995,6 +1039,73 @@ class StaticAnalyzer:
                 total += pl.size
         return total
 
+    def _collect_symbols(self, config: EngineConfig, client: LSPClient) -> None:
+        files = config.source_files or config.adapter.discover_source_files(config.project_path, self.ignore_manager)
+        builder = CallGraphBuilder(client, config.adapter, config.project_path, context=self._analysis_context)
+        builder.collect_symbols(files)
+        if (
+            config.adapter.fail_on_empty_symbols is True
+            and files
+            and not any(str(path) in builder.symbol_table.file_symbols for path in files)
+        ):
+            raise StaticAnalysisFatalError(f"{config.adapter.language} produced no symbols in {config.project_path}")
+
+    def _snapshot_context(self, results: StaticAnalysisResults) -> None:
+        for language, bucket in results.results.items():
+            table = self._analysis_context.tables.get(language)
+            if table is not None:
+                bucket.symbols = table.snapshot()
+                bucket.unresolved_files = self._analysis_context.unresolved_files.intersection(table.file_symbols)
+                bucket.closed_documents = {
+                    str(p) for p in self._analysis_context.closed_documents if str(p) in table.file_symbols
+                }
+            graph = bucket.cfg.graph
+            if graph is None:
+                continue
+            participants = {name for edge in graph.edges for name in (edge.get_source(), edge.get_destination())}
+            graph = graph.filter(
+                lambda node: node.type in GRAPH_NODE_TYPES or node.fully_qualified_name in participants
+            )
+            bucket.cfg.graph = graph
+            hierarchy = {
+                name: {**info, "subclasses": []}
+                for name, info in (bucket.hierarchy.entries or {}).items()
+                if name in graph.nodes
+            }
+            bucket.hierarchy.entries = hierarchy
+            for child, info in hierarchy.items():
+                for parent in info.get("superclasses", []):
+                    if parent in hierarchy:
+                        hierarchy[parent]["subclasses"].append(child)
+            _rederive_inherits_edges(graph, hierarchy)
+            file_packages: dict[str, str] = {}
+            configs = [c for c in self._engine_configs if c.adapter.results_language == language]
+            for path in bucket.source_files.paths or []:
+                owners = [
+                    c
+                    for c in configs
+                    if Path(path).is_relative_to(c.project_path)
+                    and not any(Path(path).is_relative_to(r) for r in c.excluded_roots)
+                ]
+                if owners:
+                    owner = max(owners, key=lambda c: (len(c.project_path.parts), str(c.project_path)))
+                    file_packages[path] = owner.adapter.get_package_for_file(Path(path), owner.project_path)
+            dependencies: dict[str, dict] = {}
+            for path, package in sorted(file_packages.items()):
+                dependencies.setdefault(package, {"files": [], "imports": [], "imported_by": []})["files"].append(path)
+            for edge in graph.edges:
+                src = file_packages.get(edge.src_node.file_path)
+                dst = file_packages.get(edge.dst_node.file_path)
+                if src is not None and dst is not None and src != dst:
+                    if dst not in dependencies[src]["imports"]:
+                        dependencies[src]["imports"].append(dst)
+                    if src not in dependencies[dst]["imported_by"]:
+                        dependencies[dst]["imported_by"].append(src)
+            for info in dependencies.values():
+                info["imports"].sort()
+                info["imported_by"].sort()
+            bucket.dependencies.entries = dependencies
+
     def _run_full_analysis(self, engine_config: EngineConfig, engine_client: LSPClient) -> dict:
         """Run a full analysis using the engine pipeline.
 
@@ -1028,6 +1139,7 @@ class StaticAnalyzer:
             adapter,
             project_path,
             memory_budget_bytes=per_engine_memory_budget(max(max_concurrent_engines(), 1)),
+            context=getattr(self, "_analysis_context", None),
         )
         engine_result = builder.build(source_files)
         logger.info(f"CallGraphBuilder.build() for {adapter.language}: {time.monotonic() - t_build_start:.1f}s")

--- a/static_analyzer/analysis_cache.py
+++ b/static_analyzer/analysis_cache.py
@@ -70,7 +70,7 @@ _LEGACY_CACHE_SUBDIR = "cache"
 # v8: a C# file compiled into several projects has symbols and callers, and a
 # nested solution's files are named by its own engine only.
 # Older pickles are treated as cache misses and re-run.
-_TAG_VERSION = "v8"
+_TAG_VERSION = "v10"  # Lossless symbol snapshots and shared cross-engine resolution.
 
 
 class StaticAnalysisCache:
@@ -406,6 +406,11 @@ def invalidate_files(analysis_result: dict[str, Any], changed_files: set[Path]) 
         references=references,
         source_files=source_files,
         diagnostics=diagnostics,
+        symbols=(
+            None if cached.symbols is None else [s for s in cached.symbols if str(s.file_path) not in changed_file_strs]
+        ),
+        unresolved_files=cached.unresolved_files - changed_file_strs,
+        closed_documents=cached.closed_documents - changed_file_strs,
     )
 
     _validate_no_dangling_references(updated_result)
@@ -453,6 +458,9 @@ def merge_results(
         source_files=[path for path in cached_result.source_files if str(path) not in new_file_paths]
         + new.source_files,
         diagnostics=merged_diagnostics or None,
+        symbols=new.symbols if new.symbols is not None else cached_result.symbols,
+        unresolved_files=(cached_result.unresolved_files - new_file_paths) | new.unresolved_files,
+        closed_documents=(cached_result.closed_documents - new_file_paths) | new.closed_documents,
     )
     return merged
 

--- a/static_analyzer/analysis_result.py
+++ b/static_analyzer/analysis_result.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from static_analyzer.cfg import CallGraph, CallSiteLocation
 from static_analyzer.config import FAMILY_OWNER, SOURCE_EXTENSION_TO_LANGUAGE, Language
+from static_analyzer.engine.models import SymbolInfo
 from static_analyzer.language_results import LanguageResults
 from static_analyzer.lsp_client.diagnostics import FileDiagnosticsMap
 from static_analyzer.node import Node
@@ -47,6 +48,9 @@ class AnalysisData:
     references: list[Node]
     source_files: list[Path]
     diagnostics: FileDiagnosticsMap | None = None
+    symbols: list[SymbolInfo] | None = None
+    unresolved_files: set[str] = field(default_factory=set)
+    closed_documents: set[str] = field(default_factory=set)
 
     @classmethod
     def from_dict(cls, analysis: dict[str, Any]) -> "AnalysisData":
@@ -57,6 +61,9 @@ class AnalysisData:
             references=analysis["references"],
             source_files=analysis["source_files"],
             diagnostics=analysis.get("diagnostics"),
+            symbols=analysis.get("symbols"),
+            unresolved_files=set(analysis.get("unresolved_files", set())),
+            closed_documents=set(analysis.get("closed_documents", set())),
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -66,6 +73,9 @@ class AnalysisData:
             "package_relations": self.package_relations,
             "references": self.references,
             "source_files": self.source_files,
+            "symbols": self.symbols,
+            "unresolved_files": self.unresolved_files,
+            "closed_documents": self.closed_documents,
         }
         if self.diagnostics is not None:
             analysis["diagnostics"] = self.diagnostics

--- a/static_analyzer/engine/analysis_context.py
+++ b/static_analyzer/engine/analysis_context.py
@@ -1,0 +1,53 @@
+"""Analysis-scoped symbol ownership, shared by full and incremental engine sessions."""
+
+from pathlib import Path
+from threading import RLock, local
+
+from static_analyzer.config import Language
+from static_analyzer.engine.language_adapter import LanguageAdapter
+from static_analyzer.engine.models import SymbolInfo
+from static_analyzer.engine.source_inspector import SourceInspector
+from static_analyzer.engine.symbol_table import SymbolTable
+
+
+class AnalysisContext:
+    """Own lossless language partitions; engine sessions own only their LSP clients."""
+
+    def __init__(self) -> None:
+        self.lock = RLock()
+        self._inspectors = local()
+        self.tables: dict[Language, SymbolTable] = {}
+        self.prepared: dict[tuple[Language, Path], list[Path]] = {}
+        self.closed_documents: set[Path] = set()
+        self.unresolved_files: set[str] = set()
+
+    @property
+    def source_inspector(self) -> SourceInspector:
+        """Tree-sitter parsers stay on their worker; semantic symbols are shared."""
+        if not hasattr(self._inspectors, "value"):
+            self._inspectors.value = SourceInspector()
+        return self._inspectors.value
+
+    def symbols_for(self, adapter: LanguageAdapter) -> SymbolTable:
+        with self.lock:
+            language = adapter.results_language
+            if language not in self.tables:
+                self.tables[language] = SymbolTable(adapter)
+            return self.tables[language]
+
+    def hydrate(
+        self,
+        adapter: LanguageAdapter,
+        symbols: list[SymbolInfo],
+        unresolved_files: set[str],
+        closed_documents: set[str],
+    ) -> None:
+        """Restore declarations and the source-query state omitted from output graphs."""
+        self.symbols_for(adapter).add_symbols(symbols)
+        self.unresolved_files.update(unresolved_files)
+        self.closed_documents.update(Path(path) for path in closed_documents)
+
+    def freeze(self) -> None:
+        """Build derived indices after every engine has registered its declarations."""
+        for table in self.tables.values():
+            table.build_indices()

--- a/static_analyzer/engine/call_graph_builder.py
+++ b/static_analyzer/engine/call_graph_builder.py
@@ -6,6 +6,7 @@ import logging
 import time
 from pathlib import Path
 
+from static_analyzer.engine.analysis_context import AnalysisContext
 from static_analyzer.engine.edge_build_context import EdgeBuildContext
 from static_analyzer.engine.edge_builder import EdgeMap, build_edges_via_definitions, build_edges_via_references
 from static_analyzer.engine.progress import ProgressLogger
@@ -15,7 +16,6 @@ from static_analyzer.engine.lsp_client import LSPClient
 from static_analyzer.engine.lsp_constants import DID_OPEN_BATCH_SIZE, EdgeStrategy
 from static_analyzer.engine.lsp_recycler import LSPRecycler
 from static_analyzer.engine.models import CallFlowGraph, LanguageAnalysisResult
-from static_analyzer.engine.source_inspector import SourceInspector
 from static_analyzer.engine.symbol_table import SymbolTable
 
 logger = logging.getLogger(__name__)
@@ -30,6 +30,7 @@ class CallGraphBuilder:
         adapter: LanguageAdapter,
         project_root: Path,
         memory_budget_bytes: int = 0,
+        context: AnalysisContext | None = None,
     ) -> None:
         self._lsp = lsp_client
         self._adapter = adapter
@@ -37,15 +38,26 @@ class CallGraphBuilder:
         # 0 means "one server at a time", so the recycler uses the whole allowance.
         self._memory_budget_bytes = memory_budget_bytes
 
-        self._symbol_table = SymbolTable(adapter)
-        self._source_inspector = SourceInspector()
+        self._context = context if context is not None else AnalysisContext()
+        self._symbol_table = self._context.symbols_for(adapter)
+        self._source_inspector = self._context.source_inspector
 
     @property
     def symbol_table(self) -> SymbolTable:
         """Public access to the symbol table for result conversion."""
         return self._symbol_table
 
-    def build(self, source_files: list[Path], skip_hierarchy: bool = False) -> LanguageAnalysisResult:
+    def collect_symbols(self, source_files: list[Path]) -> None:
+        """Register this session's declarations before any engine resolves edges."""
+        self._discover_symbols(source_files)
+        self._context.prepared[(self._adapter.results_language, self._root)] = list(source_files)
+
+    def build(
+        self,
+        source_files: list[Path],
+        skip_hierarchy: bool = False,
+        definition_files: tuple[Path, ...] = (),
+    ) -> LanguageAnalysisResult:
         """Run the full analysis pipeline and return results.
 
         Args:
@@ -56,18 +68,32 @@ class CallGraphBuilder:
         """
         t_pipeline = time.monotonic()
 
-        self._discover_symbols(source_files)
+        key = (self._adapter.results_language, self._root)
+        if key not in self._context.prepared:
+            self.collect_symbols(source_files)
+            self._context.freeze()
+        else:
+            # A bounded worker may have restarted its server after symbol collection.
+            self._bulk_did_open([f for f in source_files if f not in self._context.closed_documents])
+            self._send_sync_probe(source_files, self._probe_timeout(len(source_files)))
         t_symbols_done = time.monotonic()
         logger.info("Phase 1 total (discover symbols): %.1fs", t_symbols_done - t_pipeline)
 
-        self._symbol_table.build_indices()
         t_indices_done = time.monotonic()
         logger.info("Build indices: %.1fs", t_indices_done - t_symbols_done)
 
         ctx = EdgeBuildContext(
-            self._lsp, self._symbol_table, self._source_inspector, recycler=self._build_recycler(source_files)
+            self._lsp,
+            self._symbol_table,
+            self._source_inspector,
+            recycler=self._build_recycler(source_files),
+            unresolved_files=self._context.unresolved_files,
         )
         edge_set = self._build_edges(ctx, source_files)
+        if definition_files and self._adapter.edge_strategy != EdgeStrategy.DEFINITIONS:
+            for edge, sites in build_edges_via_definitions(self._adapter, ctx, list(definition_files)).items():
+                current = edge_set.setdefault(edge, [])
+                current.extend(site for site in sites if site not in current)
         edge_set = self._postprocess_edges(edge_set)
         t_edges_done = time.monotonic()
         logger.info("Phase 2 total (build edges): %.1fs, %d edges", t_edges_done - t_indices_done, len(edge_set))
@@ -78,7 +104,7 @@ class CallGraphBuilder:
             logger.info("Phase %d (hierarchy): skipped", next_phase)
         else:
             hierarchy_builder = HierarchyBuilder(self._lsp, self._symbol_table, self._source_inspector, self._adapter)
-            hierarchy = hierarchy_builder.build()
+            hierarchy = hierarchy_builder.build(source_files)
             logger.info("Phase %d (hierarchy): %.1fs", next_phase, time.monotonic() - t_edges_done)
             next_phase += 1
 
@@ -210,7 +236,10 @@ class CallGraphBuilder:
                     self._lsp.did_open(file_path)
                     symbols = self._lsp.document_symbol(file_path)
             self._adapter.record_document_symbols(file_path, symbols, self._root)
-            self._symbol_table.register_symbols(file_path, symbols, parent_chain=[], project_root=self._root)
+            with self._context.lock:
+                self._symbol_table.register_symbols(
+                    file_path, symbols, parent_chain=[], project_root=self._root, naming=self._adapter
+                )
             pbar.set_postfix(symbols=len(self._symbol_table.symbols))
             pbar.update(1)
         pbar.finish()
@@ -218,6 +247,7 @@ class CallGraphBuilder:
             already = set(read_from_source) | set(opened_early)
             self._bulk_did_open([file_path for file_path in source_files if file_path not in already])
         if read_from_source:
+            self._context.closed_documents.update(read_from_source)
             logger.info(
                 "Phase 1: %d file(s) compiled into more than one project were read from source",
                 len(read_from_source),

--- a/static_analyzer/engine/edge_build_context.py
+++ b/static_analyzer/engine/edge_build_context.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from static_analyzer.engine.lsp_client import LSPClient
 from static_analyzer.engine.lsp_recycler import LSPRecycler
@@ -20,3 +20,4 @@ class EdgeBuildContext:
     # Set only for servers that may be restarted mid-phase; None means the
     # strategy runs against a single server process for the whole phase.
     recycler: LSPRecycler | None = None
+    unresolved_files: set[str] = field(default_factory=set)

--- a/static_analyzer/engine/edge_builder.py
+++ b/static_analyzer/engine/edge_builder.py
@@ -14,10 +14,6 @@ from pathlib import Path
 from static_analyzer.engine.edge_build_context import EdgeBuildContext
 from static_analyzer.engine.progress import ProgressLogger
 from static_analyzer.config import NodeType
-from static_analyzer.engine.lsp_constants import (
-    CALLABLE_KINDS,
-    CLASS_LIKE_KINDS,
-)
 from static_analyzer.engine.models import CallSite, SymbolInfo
 from static_analyzer.engine.protocols import EdgeBuildAdapter
 from static_analyzer.engine.symbol_table import SymbolTable
@@ -89,6 +85,8 @@ def build_edges_via_references(
     st = ctx.symbol_table
 
     pos_to_syms, unique_positions = _prepare_trackable_symbols(adapter, st)
+    owned_files = {str(path) for path in source_files}
+    unique_positions = [pos for pos in unique_positions if pos[0] in owned_files]
 
     total_unique = len(unique_positions)
 
@@ -317,19 +315,13 @@ def build_edges_via_definitions(
     queries are ~20ms each, so we scan source for call sites and resolve
     them via definition, then query implementations for polymorphic dispatch.
     """
-    st = ctx.symbol_table
+    resolution = _resolve_definitions(adapter, ctx, source_files)
 
-    pos_to_sym, line_to_syms = _build_definition_lookups(st)
-
-    resolution = _resolve_definitions(adapter, ctx, source_files, pos_to_sym, line_to_syms)
-
-    total_impl_resolved = _resolve_implementations(
-        ctx, resolution.edge_set, resolution.impl_queries_pending, pos_to_sym, line_to_syms
-    )
+    total_impl_resolved = _resolve_implementations(ctx, resolution.edge_set, resolution.impl_queries_pending)
 
     total_iterated = 0
     if adapter.resolves_iterated_types:
-        total_iterated = _resolve_iterated_types(ctx, resolution.edge_set, source_files, pos_to_sym, line_to_syms)
+        total_iterated = _resolve_iterated_types(ctx, resolution.edge_set, source_files)
 
     logger.info(
         "Phase 2 summary: %d call sites, %d def resolved, %d impl resolved, %d iterated, %d raw edges",
@@ -346,8 +338,6 @@ def _resolve_iterated_types(
     ctx: EdgeBuildContext,
     edge_set: EdgeMap,
     source_files: list[Path],
-    pos_to_sym: dict[tuple[str, int, int], SymbolInfo],
-    line_to_syms: dict[tuple[str, int], list[SymbolInfo]],
 ) -> int:
     """Edge from a loop to the type it enumerates.
 
@@ -381,8 +371,11 @@ def _resolve_iterated_types(
                 if not caller:
                     continue
                 for result in results[index] if index < len(results) else []:
-                    target = _resolve_definition_to_symbol(result, pos_to_sym, line_to_syms)
-                    if target is None or not _is_valid_edge(caller, target):
+                    target = st.resolve_definition(result)
+                    if target is None:
+                        ctx.unresolved_files.add(str(file_path))
+                        continue
+                    if not _is_valid_edge(caller, target):
                         continue
                     resolved += 1
                     attributed = st.attribution_symbol(caller)
@@ -397,33 +390,10 @@ def _resolve_iterated_types(
     return resolved
 
 
-def _build_definition_lookups(
-    st: SymbolTable,
-) -> tuple[dict[tuple[str, int, int], SymbolInfo], dict[tuple[str, int], list[SymbolInfo]]]:
-    """Build position-based lookups for resolving definition results.
-
-    Returns (pos_to_sym, line_to_syms). Prefers the symbol with the longest
-    qualified name at each position (e.g. Container.Item.describe() over
-    Container.describe()).
-    """
-    pos_to_sym: dict[tuple[str, int, int], SymbolInfo] = {}
-    line_to_syms: dict[tuple[str, int], list[SymbolInfo]] = {}
-    for sym in st.symbols.values():
-        pos = sym.definition_location
-        existing = pos_to_sym.get(pos)
-        if existing is None or len(sym.qualified_name) > len(existing.qualified_name):
-            pos_to_sym[pos] = sym
-        key = (str(sym.file_path), sym.start_line)
-        line_to_syms.setdefault(key, []).append(sym)
-    return pos_to_sym, line_to_syms
-
-
 def _resolve_definitions(
     adapter: EdgeBuildAdapter,
     ctx: EdgeBuildContext,
     source_files: list[Path],
-    pos_to_sym: dict[tuple[str, int, int], SymbolInfo],
-    line_to_syms: dict[tuple[str, int], list[SymbolInfo]],
 ) -> DefinitionResolution:
     """Phase 2a: Resolve call sites via textDocument/definition."""
     edge_set: EdgeMap = {}
@@ -434,7 +404,11 @@ def _resolve_definitions(
     batch_size = 50
     impl_queries_pending: list[ImplementationQuery] = []
 
-    dispatch = _build_dispatch_index(adapter, ctx, source_files) if adapter.expands_virtual_dispatch else None
+    dispatch = (
+        _build_dispatch_index(adapter, ctx, [Path(f) for f in st.primary_file_symbols])
+        if adapter.expands_virtual_dispatch
+        else None
+    )
 
     pbar = ProgressLogger("Phase 2 (definitions)", total_files, unit="file")
     for file_path in source_files:
@@ -472,6 +446,7 @@ def _resolve_definitions(
             for i, call_site in enumerate(batch):
                 defs = results[i] if i < len(results) else []
                 if not defs:
+                    ctx.unresolved_files.add(str(file_path))
                     continue
 
                 caller = st.find_containing_symbol(file_path, call_site.lsp_line, call_site.lsp_column)
@@ -482,8 +457,10 @@ def _resolve_definitions(
                     continue
 
                 for def_result in defs:
-                    target = _resolve_definition_to_symbol(def_result, pos_to_sym, line_to_syms)
+                    target = st.resolve_definition(def_result)
                     if not target:
+                        if definition_location(def_result) is not None:
+                            ctx.unresolved_files.add(str(file_path))
                         continue
                     total_resolved += 1
 
@@ -556,8 +533,6 @@ def _resolve_implementations(
     ctx: EdgeBuildContext,
     edge_set: EdgeMap,
     impl_queries_pending: list[ImplementationQuery],
-    pos_to_sym: dict[tuple[str, int, int], SymbolInfo],
-    line_to_syms: dict[tuple[str, int], list[SymbolInfo]],
 ) -> int:
     """Phase 2b: Resolve implementations for polymorphic call targets.
 
@@ -598,7 +573,7 @@ def _resolve_implementations(
             callers = target_pos_to_callers[tgt_key]
 
             for impl_result in impls:
-                impl_sym = _resolve_definition_to_symbol(impl_result, pos_to_sym, line_to_syms)
+                impl_sym = st.resolve_definition(impl_result)
                 if not impl_sym:
                     continue
                 total_impl_resolved += 1
@@ -747,48 +722,3 @@ def _is_valid_edge(caller: SymbolInfo, target: SymbolInfo) -> bool:
     if (str(target.file_path), target.start_line) == (str(caller.file_path), caller.start_line):
         return False
     return True
-
-
-def _resolve_definition_to_symbol(
-    def_result: dict,
-    pos_to_sym: dict[tuple[str, int, int], SymbolInfo],
-    line_to_syms: dict[tuple[str, int], list[SymbolInfo]],
-) -> SymbolInfo | None:
-    """Resolve a definition LSP result to a SymbolInfo in our table."""
-    location = definition_location(def_result)
-    if location is None:
-        return None
-    file_path, line, char = location
-    file_key = str(file_path)
-
-    # Exact match on (file, line, char)
-    sym = pos_to_sym.get((file_key, line, char))
-    if sym:
-        return sym
-
-    # Fuzzy: match on (file, line) — prefer callable > class > other, longest name wins
-    candidates = line_to_syms.get((file_key, line), [])
-    if candidates:
-        best = _best_candidate(candidates)
-        if best:
-            return best
-
-    # Try adjacent lines (definition range start vs selectionRange start)
-    for delta in (1, -1, 2, -2):
-        candidates = line_to_syms.get((file_key, line + delta), [])
-        if candidates:
-            best = _best_candidate(candidates)
-            if best:
-                return best
-    return None
-
-
-def _best_candidate(candidates: list[SymbolInfo]) -> SymbolInfo | None:
-    """Pick the best symbol from candidates: callable > class > other, longest name wins."""
-    callables = [c for c in candidates if c.kind in CALLABLE_KINDS]
-    if callables:
-        return max(callables, key=lambda c: len(c.qualified_name))
-    classes = [c for c in candidates if c.kind in CLASS_LIKE_KINDS]
-    if classes:
-        return max(classes, key=lambda c: len(c.qualified_name))
-    return max(candidates, key=lambda c: len(c.qualified_name)) if candidates else None

--- a/static_analyzer/engine/hierarchy_builder.py
+++ b/static_analyzer/engine/hierarchy_builder.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import re
 import time
+from pathlib import Path
 
 from static_analyzer.engine.language_adapter import LanguageAdapter
 from static_analyzer.engine.lsp_client import LSPClient, MethodNotFoundError
@@ -31,7 +32,7 @@ class HierarchyBuilder:
         self._source_inspector = source_inspector
         self._adapter = adapter
 
-    def build(self) -> dict[str, dict]:
+    def build(self, source_files: list[Path] | None = None) -> dict[str, dict]:
         """Build class hierarchy using primary symbols only."""
         t_start = time.monotonic()
         hierarchy: dict[str, dict] = {}
@@ -57,6 +58,8 @@ class HierarchyBuilder:
         logger.info("Hierarchy: %d class symbols to process", len(class_symbols))
         type_hierarchy_supported = False
         for sym in class_symbols:
+            if source_files is not None and sym.file_path not in source_files:
+                continue
             try:
                 items = self._lsp.type_hierarchy_prepare(sym.file_path, sym.start_line, sym.start_char)
                 if not items:
@@ -99,7 +102,11 @@ class HierarchyBuilder:
 
         if not type_hierarchy_supported:
             logger.info("Type hierarchy not supported, inferring from source code")
-            self._infer_hierarchy_from_source(class_symbols, class_names, hierarchy)
+            self._infer_hierarchy_from_source(
+                [s for s in class_symbols if source_files is None or s.file_path in source_files],
+                class_names,
+                hierarchy,
+            )
 
         links = sum(len(h["superclasses"]) for h in hierarchy.values())
         logger.info(
@@ -108,7 +115,11 @@ class HierarchyBuilder:
             links,
             time.monotonic() - t_start,
         )
-        return hierarchy
+        return {
+            sym.qualified_name: hierarchy[sym.qualified_name]
+            for sym in class_symbols
+            if source_files is None or sym.file_path in source_files
+        }
 
     def _resolve_type_hierarchy_item(self, item: dict) -> str | None:
         """Resolve a type hierarchy item to a qualified name in our symbol table."""

--- a/static_analyzer/engine/lsp_client.py
+++ b/static_analyzer/engine/lsp_client.py
@@ -323,6 +323,21 @@ class LSPClient:
         self._opened_uris.discard(uri)
         self._doc_versions.pop(uri, None)
 
+    def refresh_files(self, changed_files: set[Path], known_files: set[Path]) -> None:
+        """Refresh open overlays and notify the workspace of dependency edits."""
+        changes = []
+        for path in sorted(changed_files):
+            uri = path.resolve().as_uri()
+            exists = path.is_file()
+            if uri in self._opened_uris:
+                if exists:
+                    self.did_change(path, path.read_text(errors="replace"))
+                else:
+                    self.did_close(path)
+            changes.append({"uri": uri, "type": (2 if path in known_files else 1) if exists else 3})
+        if changes:
+            self._send_notification("workspace/didChangeWatchedFiles", {"changes": changes})
+
     # ---- LSP queries ----
 
     def document_symbol(self, file_path: Path, timeout: int | None = None) -> list[dict]:

--- a/static_analyzer/engine/models.py
+++ b/static_analyzer/engine/models.py
@@ -29,6 +29,7 @@ class SymbolInfo:
     # Empty for a top-level symbol and for every alias.
     # Why: slicing a qualified name finds the real owner only by luck of the naming scheme.
     owner_qualified_name: str = ""
+    is_primary: bool = True
 
     @property
     def definition_location(self) -> tuple[str, int, int]:

--- a/static_analyzer/engine/symbol_table.py
+++ b/static_analyzer/engine/symbol_table.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import logging
+from copy import deepcopy
 from pathlib import Path
 
 from static_analyzer.engine.protocols import SymbolNaming
 from static_analyzer.config import ANONYMOUS_SYMBOL_MARKERS, NodeType
-from static_analyzer.engine.lsp_constants import CALLABLE_KINDS
+from static_analyzer.engine.lsp_constants import CALLABLE_KINDS, CLASS_LIKE_KINDS
 from static_analyzer.engine.models import SymbolInfo
+from static_analyzer.engine.utils import definition_location
 
 logger = logging.getLogger(__name__)
 
@@ -37,6 +39,9 @@ class SymbolTable:
         self._file_name_index: dict[tuple[str, str], list[SymbolInfo]] = {}
         # class qualified_name -> list of constructor qualified_names
         self._class_to_ctors: dict[str, list[str]] = {}
+        self._definition_positions: dict[tuple[str, int, int], SymbolInfo] = {}
+        self._definition_lines: dict[tuple[str, int], list[SymbolInfo]] = {}
+        self._indices_dirty = False
 
     @property
     def symbols(self) -> dict[str, SymbolInfo]:
@@ -65,8 +70,10 @@ class SymbolTable:
         parent_chain: list[tuple[str, int]],
         project_root: Path,
         owner_qualified_name: str = "",
+        naming: SymbolNaming | None = None,
     ) -> None:
         """Recursively register symbols with dual registration."""
+        naming = naming or self._naming
         for sym in symbols:
             name = sym.get("name", "")
             kind = sym.get("kind", 0)
@@ -96,11 +103,7 @@ class SymbolTable:
             end_line = end.get("line", 0)
             end_char = end.get("character", 0)
 
-            file_key = str(file_path)
-
-            qualified_name = self._naming.build_qualified_name(
-                file_path, name, kind, parent_chain, project_root, detail
-            )
+            qualified_name = naming.build_qualified_name(file_path, name, kind, parent_chain, project_root, detail)
 
             info = SymbolInfo(
                 name=name,
@@ -116,17 +119,13 @@ class SymbolTable:
             info.parent_chain = list(parent_chain)
             info.owner_qualified_name = owner_qualified_name
 
-            self._symbols[qualified_name] = info
-            ref_key = self._naming.build_reference_key(qualified_name)
-            self._ref_key_to_symbol[ref_key] = info
-            self._file_symbols.setdefault(file_key, []).append(info)
-            self._primary_file_symbols.setdefault(file_key, []).append(info)
+            registrations = [info]
 
             # Dual registration: register unqualified form(s) for symbols with parents
             # Aliases go into _file_symbols but NOT _primary_file_symbols
             if parent_chain:
-                unqualified_name = self._naming.build_qualified_name(file_path, name, kind, [], project_root, detail)
-                if unqualified_name != qualified_name and unqualified_name not in self._symbols:
+                unqualified_name = naming.build_qualified_name(file_path, name, kind, [], project_root, detail)
+                if unqualified_name != qualified_name:
                     unq_info = SymbolInfo(
                         name=name,
                         qualified_name=unqualified_name,
@@ -137,20 +136,18 @@ class SymbolTable:
                         end_line=end_line,
                         end_char=end_char,
                         promoted_from_variable=promoted,
+                        is_primary=False,
                     )
                     unq_info.parent_chain = []
-                    self._symbols[unqualified_name] = unq_info
-                    unq_ref_key = self._naming.build_reference_key(unqualified_name)
-                    self._ref_key_to_symbol[unq_ref_key] = unq_info
-                    self._file_symbols[file_key].append(unq_info)
+                    registrations.append(unq_info)
 
                 if len(parent_chain) >= 2:
                     for skip in range(1, len(parent_chain)):
                         partial_chain = parent_chain[skip:]
-                        partial_name = self._naming.build_qualified_name(
+                        partial_name = naming.build_qualified_name(
                             file_path, name, kind, partial_chain, project_root, detail
                         )
-                        if partial_name != qualified_name and partial_name not in self._symbols:
+                        if partial_name != qualified_name:
                             p_info = SymbolInfo(
                                 name=name,
                                 qualified_name=partial_name,
@@ -161,26 +158,97 @@ class SymbolTable:
                                 end_line=end_line,
                                 end_char=end_char,
                                 promoted_from_variable=promoted,
+                                is_primary=False,
                             )
                             p_info.parent_chain = list(partial_chain)
-                            self._symbols[partial_name] = p_info
-                            p_ref_key = self._naming.build_reference_key(partial_name)
-                            self._ref_key_to_symbol[p_ref_key] = p_info
-                            self._file_symbols[file_key].append(p_info)
+                            registrations.append(p_info)
 
+            self.add_symbols(registrations)
             children = sym.get("children", [])
             if children:
                 child_chain = parent_chain + [(name, kind)]
-                self.register_symbols(file_path, children, child_chain, project_root, qualified_name)
+                self.register_symbols(file_path, children, child_chain, project_root, qualified_name, naming)
+
+    def add_symbols(self, symbols: list[SymbolInfo]) -> None:
+        """Merge declarations and aliases, choosing collisions by declaration location."""
+        for sym in symbols:
+            existing = self._symbols.get(sym.qualified_name)
+            if existing is not None:
+                if self._registration_key(existing) <= self._registration_key(sym):
+                    continue
+                file_key = str(existing.file_path)
+                self._file_symbols[file_key].remove(existing)
+                if not self._file_symbols[file_key]:
+                    del self._file_symbols[file_key]
+                if existing.is_primary:
+                    self._primary_file_symbols[file_key].remove(existing)
+                    if not self._primary_file_symbols[file_key]:
+                        del self._primary_file_symbols[file_key]
+            self._symbols[sym.qualified_name] = sym
+            file_key = str(sym.file_path)
+            self._file_symbols.setdefault(file_key, []).append(sym)
+            if sym.is_primary:
+                self._primary_file_symbols.setdefault(file_key, []).append(sym)
+            ref_key = self._naming.build_reference_key(sym.qualified_name)
+            ref_symbol = self._ref_key_to_symbol.get(ref_key)
+            if ref_symbol is None or self._registration_key(sym) < self._registration_key(ref_symbol):
+                self._ref_key_to_symbol[ref_key] = sym
+            self._indices_dirty = True
+
+    def remove_files(self, files: set[Path]) -> None:
+        """Remove declarations from changed or deleted files and refresh all lookups."""
+        retained = [sym for sym in self._symbols.values() if sym.file_path not in files]
+        self._symbols.clear()
+        self._file_symbols.clear()
+        self._primary_file_symbols.clear()
+        self._ref_key_to_symbol.clear()
+        self.add_symbols(retained)
+        self.build_indices()
+
+    def snapshot(self) -> list[SymbolInfo]:
+        """Return detached, deterministic declarations and aliases without naming adapters."""
+        return deepcopy(sorted(self._symbols.values(), key=self._registration_key))
+
+    def resolve_definition(self, definition: dict) -> SymbolInfo | None:
+        """Resolve an LSP definition by exact position, then callable-first nearby lines."""
+        if self._indices_dirty:
+            self.build_indices()
+        location = definition_location(definition)
+        if location is None:
+            return None
+        file_path, line, character = location
+        file_key = str(file_path)
+        exact = self._definition_positions.get((file_key, line, character))
+        if exact is not None:
+            return exact
+        for delta in (0, 1, -1, 2, -2):
+            candidates = self._definition_lines.get((file_key, line + delta), [])
+            if candidates:
+                return max(
+                    candidates,
+                    key=lambda sym: (
+                        2 if sym.kind in CALLABLE_KINDS else 1 if sym.kind in CLASS_LIKE_KINDS else 0,
+                        len(sym.qualified_name),
+                    ),
+                )
+        return None
 
     def build_indices(self) -> None:
-        """Build optimized lookup indices after symbol registration.
+        """Rebuild name, constructor, and definition indices from registered symbols."""
+        self._file_name_index.clear()
+        self._class_to_ctors.clear()
+        self._definition_positions.clear()
+        self._definition_lines.clear()
+        for sym in sorted(self._symbols.values(), key=self._registration_key):
+            position = sym.definition_location
+            existing = self._definition_positions.get(position)
+            if existing is None or len(sym.qualified_name) > len(existing.qualified_name):
+                self._definition_positions[position] = sym
+            self._definition_lines.setdefault((str(sym.file_path), sym.start_line), []).append(sym)
 
-        Called once after all symbols are registered. Provides O(1)
-        name-based equivalent lookups and class-to-constructor mappings.
-        """
         # Build (file, name) -> symbols index for equivalent name lookup
         for file_key, syms in self._file_symbols.items():
+            syms.sort(key=self._registration_key)
             for sym in syms:
                 idx_key = (file_key, sym.name)
                 self._file_name_index.setdefault(idx_key, []).append(sym)
@@ -188,9 +256,14 @@ class SymbolTable:
         # Class -> constructors, keyed on the declaring symbol.
         # Why not a slice at the first "(": that names the class only where the scheme
         # doubles it, and it cannot tell a primary symbol from an alias.
+        for syms in self._primary_file_symbols.values():
+            syms.sort(key=self._registration_key)
         for sym in (s for syms in self._primary_file_symbols.values() for s in syms):
             if sym.kind == NodeType.CONSTRUCTOR and sym.owner_qualified_name:
                 self._class_to_ctors.setdefault(sym.owner_qualified_name, []).append(sym.qualified_name)
+        for constructors in self._class_to_ctors.values():
+            constructors.sort()
+        self._indices_dirty = False
 
     def find_containing_symbol(self, file_path: Path, line: int, character: int) -> SymbolInfo | None:
         """Find the innermost symbol whose range contains the given position.
@@ -363,6 +436,22 @@ class SymbolTable:
                 return True
 
         return False
+
+    @staticmethod
+    def _registration_key(sym: SymbolInfo) -> tuple:
+        """Order declarations independently of engine completion order."""
+        return (
+            *sym.definition_location,
+            not sym.is_primary,
+            sym.end_line,
+            sym.end_char,
+            sym.qualified_name,
+            sym.name,
+            sym.kind,
+            sym.parent_chain,
+            sym.owner_qualified_name,
+            sym.promoted_from_variable,
+        )
 
     def _is_unnameable(self, sym: SymbolInfo) -> bool:
         """Whether this symbol's own name is not one a reader would use as a caller."""

--- a/static_analyzer/incremental_orchestrator.py
+++ b/static_analyzer/incremental_orchestrator.py
@@ -1,632 +1,169 @@
-"""Pkl warm-start updater: bring cached per-language analysis up to date.
+"""Refresh affected edges against the same lossless symbols used by full analysis."""
 
-Warm-start flow:
-1. Keep unchanged files from the pkl and invalidate changed/deleted files.
-2. Re-LSP existing changed files and merge their fresh nodes/references back in.
-3. Restore cached cross-boundary edges only when live references still prove them.
-4. Add new outbound edges by resolving changed-file call sites with definitions.
-5. Keep unchanged-only edges cached and let ``StaticAnalyzer`` persist the new pkl.
-"""
-
-import logging
 from pathlib import Path
-from typing import Any
 
 from repo_utils.ignore import RepoIgnoreManager
-from static_analyzer.analysis_result import AnalysisData, InvalidatedEdge
-from static_analyzer.analysis_cache import (
-    invalidate_files,
-    merge_results,
-)
-from static_analyzer.config import NodeType
+from static_analyzer.analysis_cache import invalidate_files, merge_results
+from static_analyzer.cfg import CallGraph, EdgeKind
+from static_analyzer.engine.analysis_context import AnalysisContext
 from static_analyzer.engine.call_graph_builder import CallGraphBuilder
 from static_analyzer.engine.language_adapter import LanguageAdapter
 from static_analyzer.engine.lsp_client import LSPClient
 from static_analyzer.engine.lsp_constants import EdgeStrategy
+from static_analyzer.engine.models import LanguageAnalysisResult
 from static_analyzer.engine.result_converter import convert_to_codeboarding_format
-from static_analyzer.engine.source_inspector import SourceInspector
-from static_analyzer.engine.utils import definition_location, uri_to_path
-from static_analyzer.cfg import CallGraph, EdgeKind
-from static_analyzer.internal_references import is_self_or_container_edge, parent_qualified_name
-from static_analyzer.node import Node
 
-logger = logging.getLogger(__name__)
 
-_DEFINITION_BATCH_SIZE = 50
+class MissingSymbolSnapshotError(RuntimeError):
+    """The cached graph cannot substitute for a lossless declaration snapshot."""
+
+
+def affected_source_files(
+    cached_analysis: dict,
+    changed_files: set[Path],
+    adapter: LanguageAdapter,
+    context: AnalysisContext,
+) -> set[Path]:
+    """Select callers affected by edits, unresolved calls, and dispatch dependencies."""
+    if not changed_files:
+        return set()
+    affected = {path for path in changed_files if path.is_file()}
+    affected.update(Path(path) for path in cached_analysis.get("unresolved_files", set()))
+    target_files = set(changed_files)
+    graph = cached_analysis["call_graph"]
+    if adapter.expands_virtual_dispatch:
+        table = context.symbols_for(adapter)
+        # This is a conservative file dependency closure, not symbol resolution.
+        ancestors = set(changed_files)
+        pending = list(changed_files)
+        while pending:
+            file_path = pending.pop()
+            bases = (
+                {base for _, names in context.source_inspector.find_type_bases(file_path) for base in names}
+                if file_path.is_file()
+                else set()
+            )
+            dependencies = {
+                sym.file_path
+                for sym in table.symbols.values()
+                if adapter.is_class_like(sym.kind) and (sym.name in bases or sym.qualified_name in bases)
+            }
+            dependencies.update(
+                Path(graph.nodes[ref.dst].file_path)
+                for ref in graph.reference_edges
+                if ref.kind is EdgeKind.INHERITS
+                and ref.src in graph.nodes
+                and ref.dst in graph.nodes
+                and Path(graph.nodes[ref.src].file_path) == file_path
+            )
+            pending.extend(dependencies - ancestors)
+            ancestors.update(dependencies)
+        target_files.update(ancestors)
+    for edge in graph.edges:
+        if Path(edge.dst_node.file_path) in target_files:
+            affected.add(Path(edge.src_node.file_path))
+            affected.update(Path(str(site["file"])) for site in edge.call_sites)
+    return {path for path in affected if path.is_file() and path.suffix in adapter.file_extensions}
 
 
 def update_cfg_for_changed_files(
-    cached_analysis: dict[str, Any],
+    cached_analysis: dict,
     changed_files: set[Path],
     adapter: LanguageAdapter,
     project_path: Path,
     engine_client: LSPClient,
     ignore_manager: RepoIgnoreManager,
-) -> dict[str, Any]:
-    """Apply *changed_files* to *cached_analysis* via re-LSP-and-merge.
-
-    Steps:
-
-    1. ``invalidate_files`` drops every node/edge/reference/class/package
-       entry sourced from a changed file, leaving the cached state of every
-       *unchanged* file intact.
-    2. The LSP re-analyses just the changed files (existing ones; deleted
-       files contribute nothing).
-    3. ``merge_results`` unions the kept-from-cache state with the fresh
-       per-file result.
-    4. Surviving entries are filtered against the live filesystem so a
-       deleted file's references / classes / package members are removed
-       from the merged dict.
-
-    Returns a fresh dict with the same shape as ``cached_analysis``. The
-    caller stuffs it into ``StaticAnalysisResults`` and saves the pkl
-    tagged with the *current* source SHA.
-    """
-    if not changed_files:
+    context: AnalysisContext | None = None,
+    query_files: set[Path] | None = None,
+) -> dict:
+    """Requery affected files without rediscovering an injected, frozen context."""
+    if context is None and cached_analysis.get("symbols") is None:
+        raise MissingSymbolSnapshotError(
+            "Incremental analysis requires a cached symbol snapshot. Run a full analysis first to refresh the cache."
+        )
+    if not changed_files and not query_files:
         return cached_analysis
 
-    existing_files = {f for f in changed_files if f.exists()}
-    deleted_files = {f for f in changed_files if not f.exists()}
-    logger.info(
-        "update_cfg_for_changed_files: %d changed (%d existing, %d deleted)",
-        len(changed_files),
-        len(existing_files),
-        len(deleted_files),
-    )
+    root = project_path.resolve()
 
-    updated_cache = invalidate_files(cached_analysis, changed_files)
+    def eligible(path: Path) -> bool:
+        return (
+            path.is_file()
+            and path.resolve().is_relative_to(root)
+            and path.suffix in adapter.file_extensions
+            and not ignore_manager.should_ignore(path)
+        )
 
-    changed_source_files = [
-        f for f in existing_files if f.suffix in adapter.file_extensions and not ignore_manager.should_ignore(f)
-    ]
-
-    if changed_source_files:
-        builder = CallGraphBuilder(engine_client, adapter, project_path)
-        engine_result = builder.build(changed_source_files)
-        new_analysis = convert_to_codeboarding_format(builder.symbol_table, engine_result, adapter)
-    else:
-        new_analysis = {
-            "call_graph": CallGraph(language=adapter.language),
-            "class_hierarchies": {},
-            "package_relations": {},
-            "references": [],
-            "source_files": [],
-            "diagnostics": {},
-        }
-
-    fresh_diagnostics = engine_client.get_collected_diagnostics()
-    if fresh_diagnostics:
-        new_analysis["diagnostics"] = fresh_diagnostics
-
-    merged_analysis = merge_results(updated_cache.analysis, new_analysis)
-    _rebuild_changed_file_edges(
-        merged_analysis,
-        updated_cache.invalidated_edges,
-        updated_cache.invalidated_files,
-        changed_source_files,
-        adapter,
-        engine_client,
-    )
-    return _filter_to_live_files(merged_analysis).to_dict()
-
-
-def _rebuild_changed_file_edges(
-    merged_analysis: AnalysisData,
-    invalidated_edges: list[InvalidatedEdge],
-    changed_file_strs: set[str],
-    changed_source_files: list[Path],
-    adapter: LanguageAdapter,
-    engine_client: LSPClient,
-) -> None:
-    source_inspector = SourceInspector()
-    _restore_cross_boundary_edges(
-        merged_analysis.call_graph, invalidated_edges, changed_file_strs, adapter, engine_client, source_inspector
-    )
-    _add_outbound_edges_from_changed_files(
-        merged_analysis.call_graph,
-        changed_source_files,
-        engine_client,
-        source_inspector,
-        adapter,
-    )
-
-
-def _restore_cross_boundary_edges(
-    call_graph: CallGraph,
-    invalidated_edges: list[InvalidatedEdge],
-    changed_file_strs: set[str],
-    adapter: LanguageAdapter,
-    engine_client: LSPClient,
-    source_inspector: SourceInspector,
-) -> None:
-    if not invalidated_edges:
-        return
-
-    if adapter.edge_strategy == EdgeStrategy.DEFINITIONS:
-        _restore_inbound_edges_via_definitions(
-            call_graph,
-            invalidated_edges,
-            changed_file_strs,
+    standalone = context is None
+    if context is None:
+        context = AnalysisContext()
+        context.hydrate(
             adapter,
-            engine_client,
-            include_callable_parent=True,
+            cached_analysis["symbols"],
+            cached_analysis.get("unresolved_files", set()),
+            cached_analysis.get("closed_documents", set()),
         )
-        return
-
-    checked = {"inbound": 0, "outbound": 0}
-    restored = {"inbound": 0, "outbound": 0}
-    references_cache: dict[str, list[dict]] = {}
-
-    for src_name, dst_name, old_src_node, old_dst_node, _cached_sites in invalidated_edges:
-        src_changed = old_src_node.file_path in changed_file_strs
-        dst_changed = old_dst_node.file_path in changed_file_strs
-        if src_changed == dst_changed:
-            continue
-        if not call_graph.has_node(src_name) or not call_graph.has_node(dst_name):
-            continue
-
-        src_node = call_graph.nodes[src_name]
-        dst_node = call_graph.nodes[dst_name]
-        direction = "outbound" if src_changed else "inbound"
-
-        checked[direction] += 1
-        refs = references_cache.get(dst_name)
-        if refs is None:
-            try:
-                dst_path = Path(dst_node.file_path)
-                engine_client.did_open(dst_path)
-                refs = engine_client.references(Path(dst_node.file_path), dst_node.line_start - 1, dst_node.col_start)
-            except Exception as exc:
-                # An empty result here means the cached edge is not re-confirmed and
-                # is therefore deleted, which is a silent loss rather than a retry.
-                logger.debug("Failed to validate references for %s", dst_name, exc_info=True)
-                refs = []
-            references_cache[dst_name] = refs
-
-        call_sites = _edge_reference_call_sites(src_node, dst_node, refs, adapter, source_inspector)
-        if call_sites:
-            try:
-                call_graph.add_edge(src_name, dst_name, call_sites=call_sites)
-                restored[direction] += 1
-            except ValueError:
-                logger.debug("Failed to restore edge %s -> %s", src_name, dst_name, exc_info=True)
-
-    logger.info(
-        "Validated cached cross-boundary edges, restored inbound %d/%d and outbound %d/%d",
-        restored["inbound"],
-        checked["inbound"],
-        restored["outbound"],
-        checked["outbound"],
-    )
-
-
-def _restore_inbound_edges_via_definitions(
-    call_graph: CallGraph,
-    invalidated_edges: list[InvalidatedEdge],
-    changed_file_strs: set[str],
-    adapter: LanguageAdapter,
-    engine_client: LSPClient,
-    include_callable_parent: bool,
-) -> None:
-    """Re-resolve invalidated edges whose source file is unchanged, from their cached call sites.
-
-    Why not references: an adapter on the definitions strategy is there because
-    its server answers references far too slowly to sit on this path, and the
-    hot symbols an edit invalidates are its worst cases. The cached call sites
-    let us ask the same question with a definition query instead: does this
-    position still resolve to that destination? Restoring without asking is not
-    enough, an unchanged caller can still lose the edge when the destination's
-    own declaration moves out from under it.
-
-    The outbound direction is absent here on purpose:
-    ``_add_outbound_edges_from_changed_files`` re-resolves those from live source.
-    """
-    pending: dict[tuple[str, str], list[dict[str, str | int]]] = {}
-    for src_name, dst_name, old_src_node, _old_dst_node, cached_sites in invalidated_edges:
-        if old_src_node.file_path in changed_file_strs:
-            continue
-        if not call_graph.has_node(src_name) or not call_graph.has_node(dst_name):
-            continue
-        if cached_sites:
-            pending[(src_name, dst_name)] = cached_sites
-    if not pending:
-        return
-
-    for file_path in {str(site["file"]) for sites in pending.values() for site in sites}:
-        try:
-            engine_client.did_open(Path(file_path))
-        except Exception:
-            logger.debug("Failed to open %s while restoring cached edges", file_path, exc_info=True)
-
-    queries: list[tuple[Path, int, int]] = []
-    lookup: list[tuple[tuple[str, str], dict[str, str | int]]] = []
-    for edge, sites in pending.items():
-        for site in sites:
-            queries.append((Path(str(site["file"])), int(site["line"]) - 1, int(site["column"]) - 1))
-            lookup.append((edge, site))
-
-    confirmed: dict[tuple[str, str], list[dict[str, str | int]]] = {}
-    for start in range(0, len(queries), _DEFINITION_BATCH_SIZE):
-        batch = lookup[start : start + _DEFINITION_BATCH_SIZE]
-        try:
-            definition_results, _ = engine_client.send_definition_batch(queries[start : start + _DEFINITION_BATCH_SIZE])
-        except Exception:
-            logger.debug("Definition batch failed while restoring cached edges", exc_info=True)
-            continue
-        for (edge, site), definitions in zip(batch, definition_results):
-            # A polymorphic call resolves to the interface or base declaration, never
-            # to the implementation the cached edge names, so exact equality alone
-            # drops every caller-to-implementation edge whose implementation file
-            # changed -- silently, while the update reports success.
-            resolved = [
-                dst_node
-                for definition in definitions
-                for dst_node in _definition_nodes(call_graph, definition, include_callable_parent)
-            ]
-            reachable = {node.fully_qualified_name for node in resolved}
-            if adapter.expands_virtual_dispatch:
-                for node in resolved:
-                    reachable.update(o.fully_qualified_name for o in _override_nodes(call_graph, node))
-            if edge[1] in reachable:
-                confirmed.setdefault(edge, []).append(site)
-
-    restored = 0
-    for (src_name, dst_name), sites in confirmed.items():
-        try:
-            call_graph.add_edge(src_name, dst_name, call_sites=sites)
-            restored += 1
-        except ValueError:
-            logger.debug("Failed to restore edge %s -> %s", src_name, dst_name, exc_info=True)
-
-    logger.info("Restored %d of %d cached inbound edge(s) via definitions", restored, len(pending))
-
-
-def _edge_reference_call_sites(
-    src_node: Node,
-    dst_node: Node,
-    refs: list[dict],
-    adapter: LanguageAdapter,
-    source_inspector: SourceInspector,
-) -> list[dict[str, str | int]]:
-    call_sites: list[dict[str, str | int]] = []
-    for ref in refs:
-        ref_file = uri_to_path(ref.get("uri", ""))
-        if ref_file is None or str(ref_file) != src_node.file_path:
-            continue
-
-        ref_range = ref.get("range", {})
-        ref_start = ref_range.get("start", {})
-        ref_end = ref_range.get("end", {})
-        ref_line = ref_start.get("line", -1)
-        ref_char = ref_start.get("character", -1)
-        ref_end_char = ref_end.get("character", -1)
-        if not _position_inside_node(src_node, ref_line, ref_char):
-            continue
-        if not _reference_matches_edge_kind(
-            dst_node, ref_file, ref_line, ref_char, ref_end_char, adapter, source_inspector
-        ):
-            continue
-        call_sites.append({"file": str(ref_file), "line": ref_line + 1, "column": ref_char + 1})
-    return call_sites
-
-
-def _members_named(call_graph: CallGraph, owner: Node, name: str) -> list[Node]:
-    """Nodes for ``owner``'s members called *name*, by qualified-name prefix.
-
-    The full rebuild reads these off the symbol table; incrementally only the
-    merged graph is available, so the owning type's members are found by name.
-    """
-    prefix = f"{owner.fully_qualified_name}.{name}"
-    return [node for qname, node in call_graph.nodes.items() if qname == prefix or qname.startswith(f"{prefix}(")]
-
-
-def _override_nodes(call_graph: CallGraph, target: Node) -> list[Node]:
-    """Same-named members on types that inherit the target's owner.
-
-    A call through a base-typed reference resolves to the base declaration, so
-    without this the incremental graph stops where the full rebuild continues.
-    The full rebuild builds a subclass index from source; here the INHERITS
-    edges already in the merged graph carry the same relation.
-    """
-    if not target.is_callable():
-        return []
-    owner_qname = parent_qualified_name(target.fully_qualified_name)
-    owner = call_graph.nodes.get(owner_qname)
-    if owner is None:
-        return []
-    member = target.fully_qualified_name[len(owner_qname) + 1 :].split("(")[0]
-    overrides: list[Node] = []
-    for ref in call_graph.reference_edges:
-        if ref.kind is EdgeKind.INHERITS and ref.dst == owner_qname:
-            derived = call_graph.nodes.get(ref.src)
-            if derived is not None:
-                overrides.extend(_members_named(call_graph, derived, member))
-    return overrides
-
-
-def _add_outbound_edges_from_changed_files(
-    call_graph: CallGraph,
-    changed_source_files: list[Path],
-    engine_client: LSPClient,
-    source_inspector: SourceInspector,
-    adapter: LanguageAdapter,
-) -> None:
-    if not changed_source_files:
-        return
-
-    include_callable_parent = adapter.edge_strategy == EdgeStrategy.DEFINITIONS
-    added = 0
-    changed_file_strs = {str(file_path) for file_path in changed_source_files}
-
-    for file_path in changed_source_files:
-        call_sites = source_inspector.find_call_sites(file_path)
-        method_group_positions: set[tuple[int, int]] = set()
-        if adapter.resolves_method_groups:
-            known = {(site.lsp_line, site.lsp_column) for site in call_sites}
-            for site in source_inspector.find_method_group_sites(file_path):
-                if (site.lsp_line, site.lsp_column) in known:
-                    continue
-                method_group_positions.add((site.lsp_line, site.lsp_column))
-                call_sites.append(site)
-        collection_positions: set[tuple[int, int]] = set()
-        if adapter.resolves_collection_initializers:
-            collection_positions = {
-                (site.lsp_line, site.lsp_column)
-                for site in source_inspector.find_collection_initializer_sites(file_path)
-            }
-        added += _add_iterated_type_edges(
-            call_graph,
-            file_path,
-            engine_client,
-            source_inspector,
-            adapter,
-            changed_file_strs,
+    table = context.symbols_for(adapter)
+    builder = CallGraphBuilder(engine_client, adapter, project_path, context=context)
+    changed_sources = sorted(path for path in changed_files if eligible(path))
+    if standalone:
+        engine_client.refresh_files(changed_files, {Path(p) for p in cached_analysis["source_files"]})
+        table.remove_files(changed_files)
+        builder.collect_symbols(changed_sources)
+        context.freeze()
+    # An injected context may have no changed declarations in this particular engine.
+    context.prepared.setdefault((adapter.results_language, root), changed_sources)
+    queries = {
+        path
+        for path in (
+            affected_source_files(cached_analysis, changed_files, adapter, context)
+            if query_files is None
+            else query_files
         )
-        if not call_sites:
-            continue
-        queries = [(file_path, site.lsp_line, site.lsp_column) for site in call_sites]
-        try:
-            definition_results, _ = engine_client.send_definition_batch(queries)
-        except Exception:
-            logger.debug("Failed to resolve outbound definitions for %s", file_path, exc_info=True)
-            continue
-
-        for site, definitions in zip(call_sites, definition_results):
-            line = site.lsp_line
-            char = site.lsp_column
-            src_node = _containing_source_node(call_graph, file_path, line, char)
-            if src_node is None:
-                continue
-            is_method_group = (line, char) in method_group_positions
-            for definition in definitions:
-                for resolved in _definition_nodes(call_graph, definition, include_callable_parent):
-                    # Same rule as the full rebuild: an argument position is a
-                    # method group only when it resolves to something callable.
-                    if is_method_group and not (resolved.is_callable() or resolved.is_class()):
-                        continue
-                    targets = [resolved]
-                    if adapter.expands_virtual_dispatch:
-                        targets += _override_nodes(call_graph, resolved)
-                    if (line, char) in collection_positions:
-                        targets += _members_named(call_graph, resolved, "Add")
-                    for dst_node in targets:
-                        # The fresh partial analysis already owns changed-to-changed edges.
-                        if dst_node.file_path in changed_file_strs:
-                            continue
-                        if is_self_or_container_edge(src_node.fully_qualified_name, dst_node.fully_qualified_name):
-                            continue
-                        try:
-                            before = len(call_graph.edges)
-                            call_graph.add_edge(
-                                src_node.fully_qualified_name,
-                                dst_node.fully_qualified_name,
-                                call_sites=[{"file": site.file, "line": site.line, "column": site.column}],
-                            )
-                            if len(call_graph.edges) > before:
-                                added += 1
-                        except ValueError:
-                            logger.debug(
-                                "Failed to add outbound edge %s -> %s",
-                                src_node.fully_qualified_name,
-                                dst_node.fully_qualified_name,
-                                exc_info=True,
-                            )
-
-    if added:
-        logger.info("Added %d new outbound edge(s) from changed files", added)
-
-
-def _add_iterated_type_edges(
-    call_graph: CallGraph,
-    file_path: Path,
-    engine_client: LSPClient,
-    source_inspector: SourceInspector,
-    adapter: LanguageAdapter,
-    changed_file_strs: set[str],
-) -> int:
-    """``foreach (var x in bag)`` calls ``bag.GetEnumerator()`` with no call written.
-
-    A definition query at that position returns the variable, so the full
-    rebuild asks for the type instead. Without the same pass here, every
-    enumerator edge in a changed file disappears until a full rebuild.
-    """
-    if not adapter.resolves_iterated_types:
-        return 0
-    sites = source_inspector.find_iterated_expression_sites(file_path)
-    if not sites:
-        return 0
-    try:
-        results, _ = engine_client.send_type_definition_batch(
-            [(file_path, site.lsp_line, site.lsp_column) for site in sites]
-        )
-    except Exception:
-        logger.warning("Failed to resolve iterated types for %s", file_path, exc_info=True)
-        return 0
-
-    added = 0
-    for site, definitions in zip(sites, results):
-        src_node = _containing_source_node(call_graph, file_path, site.lsp_line, site.lsp_column)
-        if src_node is None:
-            continue
-        for definition in definitions:
-            for type_node in _definition_nodes(call_graph, definition, include_callable_parent=False):
-                for dst_node in [type_node] + _members_named(call_graph, type_node, "GetEnumerator"):
-                    if dst_node.file_path in changed_file_strs:
-                        continue
-                    if is_self_or_container_edge(src_node.fully_qualified_name, dst_node.fully_qualified_name):
-                        continue
-                    try:
-                        before = len(call_graph.edges)
-                        call_graph.add_edge(
-                            src_node.fully_qualified_name,
-                            dst_node.fully_qualified_name,
-                            call_sites=[{"file": site.file, "line": site.line, "column": site.column}],
-                        )
-                        if len(call_graph.edges) > before:
-                            added += 1
-                    except ValueError:
-                        logger.debug("Failed to add iterated-type edge", exc_info=True)
-    return added
-
-
-def _containing_source_node(call_graph: CallGraph, file_path: Path, line: int, char: int) -> Node | None:
-    """The node an edge from this position belongs to, callable or otherwise.
-
-    A field initializer -- ``private readonly Store _store = new Store();`` -- calls
-    a constructor from outside any method, so a callable-only lookup finds nothing
-    and the edge is dropped. The full rebuild attributes it to the enclosing class,
-    and an incremental run has to agree or it loses the edge on every edit to that
-    file, including edits that change nothing.
-    """
-    callable_node = _most_specific_node_at_position(call_graph, file_path, line, char, callable_only=True)
-    if callable_node is not None:
-        return callable_node
-    return _most_specific_node_at_position(call_graph, file_path, line, char)
-
-
-def _most_specific_node_at_position(
-    call_graph: CallGraph,
-    file_path: Path,
-    line: int,
-    char: int,
-    callable_only: bool = False,
-) -> Node | None:
-    matches = [
-        node
-        for node in call_graph.nodes.values()
-        if node.file_path == str(file_path)
-        and (not callable_only or node.is_callable())
-        and _position_inside_node(node, line, char)
-    ]
-    if not matches:
-        return None
-    return max(
-        matches,
-        key=lambda node: (
-            node.line_start,
-            node.col_start,
-            -node.line_end,
-            len(node.fully_qualified_name),
-        ),
-    )
-
-
-def _definition_nodes(
-    call_graph: CallGraph,
-    definition: dict[str, Any],
-    include_callable_parent: bool = False,
-) -> list[Node]:
-    location = definition_location(definition)
-    if location is None:
-        return []
-    file_path, line, character = location
-    target = _most_specific_node_at_position(call_graph, file_path, line, character)
-    if target is None:
-        same_line = [
-            node
-            for node in call_graph.nodes.values()
-            if node.file_path == str(file_path) and node.line_start == line + 1
-        ]
-        if same_line:
-            target = max(
-                same_line,
-                key=lambda node: (
-                    node.is_class(),
-                    node.is_callable(),
-                    len(node.fully_qualified_name),
-                ),
-            )
-    if target is None:
-        return []
-
-    targets = [target]
-    if (include_callable_parent and target.is_callable()) or target.type == NodeType.CONSTRUCTOR:
-        parent = call_graph.nodes.get(parent_qualified_name(target.fully_qualified_name))
-        if parent is not None and parent.is_class():
-            targets.append(parent)
-    return targets
-
-
-def _position_inside_node(node: Node, zero_based_line: int, character: int) -> bool:
-    line = zero_based_line + 1
-    if line < node.line_start or line > node.line_end:
-        return False
-    if line == node.line_start and character < node.col_start:
-        return False
-    return True
-
-
-def _reference_matches_edge_kind(
-    dst_node: Node,
-    ref_file: Path,
-    ref_line: int,
-    ref_char: int,
-    ref_end_char: int,
-    adapter: LanguageAdapter,
-    source_inspector: SourceInspector,
-) -> bool:
-    if adapter.is_class_like(dst_node.type) and not source_inspector.is_invocation(ref_file, ref_line, ref_end_char):
-        return False
-    if dst_node.type == NodeType.CONSTANT and not source_inspector.is_invocation(ref_file, ref_line, ref_end_char):
-        return False
-    if dst_node.type == NodeType.VARIABLE and not source_inspector.is_callable_usage(
-        ref_file, ref_line, ref_char, ref_end_char
-    ):
-        return False
-    return True
-
-
-def _filter_to_live_files(merged_analysis: AnalysisData) -> AnalysisData:
-    """Drop entries whose file no longer exists on disk.
-
-    A file in ``source_files`` may have been re-LSPed earlier in the run and
-    then removed by a subsequent edit; this final filter keeps the merged
-    dict consistent with the live filesystem.
-    """
-    # Normalize: ``merge_results`` may contain a mix of Path (from the cached
-    # side) and str (from the LSP-rebuilt new side); coerce before ``.exists()``.
-    all_existing = {Path(f) for f in merged_analysis.source_files if Path(f).exists()}
-    existing_file_strs = {str(f) for f in all_existing}
-
-    merged_analysis.source_files = list(all_existing)
-    merged_analysis.references = [ref for ref in merged_analysis.references if ref.file_path in existing_file_strs]
-
-    merged_analysis.call_graph = merged_analysis.call_graph.filter(lambda node: node.file_path in existing_file_strs)
-
-    # Hierarchy entries are keyed by class qname and carry no file_path, so filter by whether the
-    # class still exists as a live call-graph node (already filtered above) — the old
-    # ``info.get("file_path")`` check was always None and dropped every hierarchy, which then
-    # starved the warm-start INHERITS re-derivation of its source on the next run.
-    live_class_names = set(merged_analysis.call_graph.nodes.keys())
-    merged_analysis.class_hierarchies = {
-        name: info for name, info in merged_analysis.class_hierarchies.items() if name in live_class_names
+        if eligible(path)
     }
+    kept = invalidate_files(cached_analysis, changed_files).analysis
+    graph = CallGraph(language=adapter.language)
+    for node in kept.call_graph.nodes.values():
+        graph.add_node(node)
+    for edge in kept.call_graph.edges:
+        if Path(edge.src_node.file_path) in queries:
+            continue
+        sites = [site for site in edge.call_sites if Path(str(site["file"])) not in queries]
+        if edge.call_sites and not sites:
+            continue
+        graph.add_edge(edge.get_source(), edge.get_destination(), call_sites=sites)
+    for ref in kept.call_graph.reference_edges:
+        graph.add_reference_edge(ref)
+    kept.call_graph = graph
+    kept.class_hierarchies = {name: info for name, info in kept.class_hierarchies.items() if name in graph.nodes}
 
-    filtered_packages: dict[str, Any] = {}
-    for pkg_name, pkg_info in merged_analysis.package_relations.items():
-        existing_pkg_files = [f for f in pkg_info.get("files", []) if f in existing_file_strs]
-        if existing_pkg_files:
-            filtered_packages[pkg_name] = {**pkg_info, "files": existing_pkg_files}
-    merged_analysis.package_relations = filtered_packages
-
-    return merged_analysis
+    context.unresolved_files.difference_update(str(path) for path in queries)
+    if standalone:
+        context.unresolved_files.difference_update(str(path) for path in changed_files)
+    reference_files = set(queries)
+    if adapter.edge_strategy != EdgeStrategy.DEFINITIONS:
+        # Revalidate non-invocation references from changed callers as well.
+        reference_files.update(
+            Path(edge.dst_node.file_path)
+            for edge in cached_analysis["call_graph"].edges
+            if (
+                Path(edge.src_node.file_path) in queries
+                or any(Path(str(site["file"])) in queries for site in edge.call_sites)
+            )
+            and eligible(Path(edge.dst_node.file_path))
+        )
+    engine_result = (
+        builder.build(sorted(reference_files), definition_files=tuple(sorted(queries)))
+        if reference_files
+        else LanguageAnalysisResult()
+    )
+    fresh = convert_to_codeboarding_format(table, engine_result, adapter, ignore_manager)
+    fresh["source_files"] = sorted(
+        {Path(path) for path in table.file_symbols} | {Path(path) for path in kept.source_files} | set(changed_sources)
+    )
+    fresh["symbols"] = table.snapshot()
+    fresh["unresolved_files"] = context.unresolved_files & {str(path) for path in fresh["source_files"]}
+    fresh["closed_documents"] = {str(p) for p in context.closed_documents if str(p) in table.file_symbols}
+    fresh["diagnostics"] = {**(kept.diagnostics or {}), **engine_client.get_collected_diagnostics()}
+    return merge_results(kept, fresh).to_dict()

--- a/static_analyzer/language_results.py
+++ b/static_analyzer/language_results.py
@@ -10,8 +10,10 @@ empty containers) so callers can distinguish "never populated" (raises
 from collections.abc import Callable
 from dataclasses import dataclass, field
 import logging
+from pathlib import Path
 
 from static_analyzer.cfg import CallGraph
+from static_analyzer.engine.models import SymbolInfo
 from static_analyzer.node import Node
 
 logger = logging.getLogger(__name__)
@@ -160,6 +162,10 @@ class LanguageResults:
     references: References = field(default_factory=References)
     dependencies: PackageDependencies = field(default_factory=PackageDependencies)
     source_files: SourceFiles = field(default_factory=SourceFiles)
+    # None identifies a graph-only baseline that cannot hydrate an analysis context.
+    symbols: list[SymbolInfo] | None = None
+    unresolved_files: set[str] = field(default_factory=set)
+    closed_documents: set[str] = field(default_factory=set)
 
     def visit_paths(self, fn: Callable[[str], str]) -> None:
         self.cfg.visit_paths(fn)
@@ -167,3 +173,7 @@ class LanguageResults:
         self.references.visit_paths(fn)
         self.dependencies.visit_paths(fn)
         self.source_files.visit_paths(fn)
+        for symbol in self.symbols or []:
+            symbol.file_path = Path(fn(str(symbol.file_path)))
+        self.unresolved_files = {fn(path) for path in self.unresolved_files}
+        self.closed_documents = {fn(path) for path in self.closed_documents}

--- a/tests/static_analyzer/test_analysis_cache_inmem.py
+++ b/tests/static_analyzer/test_analysis_cache_inmem.py
@@ -10,19 +10,18 @@ import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from static_analyzer import EngineConfig, StaticAnalyzer
-from static_analyzer.analysis_cache import StaticAnalysisCache, invalidate_files, merge_results
-from static_analyzer.analysis_result import AnalysisData, StaticAnalysisResults
-from static_analyzer.config import Language, NodeType
+from static_analyzer.analysis_cache import invalidate_files, merge_results
+from static_analyzer.analysis_result import AnalysisData
+from static_analyzer.config import NodeType
 from static_analyzer.cfg import CallGraph
 from static_analyzer.node import Node
 from static_analyzer.incremental_orchestrator import (
-    _definition_nodes,
-    _restore_cross_boundary_edges,
+    MissingSymbolSnapshotError,
     update_cfg_for_changed_files,
 )
-from static_analyzer.engine.source_inspector import SourceInspector
-from utils import CODEBOARDING_DIR_NAME
+from static_analyzer.engine.adapters.python_adapter import PythonAdapter
+from static_analyzer.engine.analysis_context import AnalysisContext
+from static_analyzer.engine.models import SymbolInfo
 
 
 def _node(qname: str, file_path: str, line_start: int = 1) -> Node:
@@ -202,10 +201,9 @@ class TestWarmStartDeletion(unittest.TestCase):
                 references=[_node("a.foo", str(deleted_file)), _node("b.bar", str(live_file))],
                 source_files=[str(deleted_file), str(live_file)],
             )
+            cached["symbols"] = [SymbolInfo("bar", "b.bar", NodeType.FUNCTION, live_file, 0, 0, 1, 8)]
 
-            adapter = MagicMock()
-            adapter.file_extensions = [".py"]
-            adapter.language = "python"
+            adapter = PythonAdapter()
             engine_client = MagicMock()
             engine_client.get_collected_diagnostics.return_value = {}
             ignore_manager = MagicMock()
@@ -228,128 +226,23 @@ class TestWarmStartDeletion(unittest.TestCase):
 class TestWarmStartOutboundEdges(unittest.TestCase):
     def test_definition_resolution_accepts_declaration_range_before_symbol_name(self) -> None:
         file_path = Path("/repo/unchanged.php")
-        call_graph = CallGraph(language="php")
-        call_graph.add_node(
-            Node(
-                fully_qualified_name="unchanged.unchanged_target",
-                node_type=NodeType.FUNCTION,
-                file_path=str(file_path),
-                line_start=3,
-                line_end=3,
-                col_start=9,
-            )
-        )
+        table = AnalysisContext().symbols_for(PythonAdapter())
+        table.add_symbols([SymbolInfo("unchanged_target", "unchanged.unchanged_target", 12, file_path, 2, 9, 2, 66)])
         definition = {
             "uri": file_path.as_uri(),
             "range": {"start": {"line": 2, "character": 0}, "end": {"line": 2, "character": 66}},
         }
 
-        matches = _definition_nodes(call_graph, definition)
+        match = table.resolve_definition(definition)
+        self.assertIsNotNone(match)
+        assert match is not None
+        self.assertEqual(match.qualified_name, "unchanged.unchanged_target")
 
-        self.assertEqual([node.fully_qualified_name for node in matches], ["unchanged.unchanged_target"])
-
-    def test_definition_resolution_includes_the_most_specific_node_and_its_class(self) -> None:
-        file_path = Path("/repo/pkg/converter.py")
-        call_graph = CallGraph(language="python")
-        call_graph.add_node(
-            Node(
-                fully_qualified_name="pkg.converter.DocumentConverter",
-                node_type=NodeType.CLASS,
-                file_path=str(file_path),
-                line_start=1,
-                line_end=40,
+    def test_requires_lossless_snapshot(self) -> None:
+        with self.assertRaisesRegex(MissingSymbolSnapshotError, "full analysis"):
+            update_cfg_for_changed_files(
+                {}, {Path("deleted.py")}, PythonAdapter(), Path.cwd(), MagicMock(), MagicMock()
             )
-        )
-        call_graph.add_node(
-            Node(
-                fully_qualified_name="pkg.converter.DocumentConverter.convert",
-                node_type=NodeType.METHOD,
-                file_path=str(file_path),
-                line_start=10,
-                line_end=20,
-                col_start=4,
-            )
-        )
-        definition = {
-            "uri": file_path.as_uri(),
-            "range": {"start": {"line": 9, "character": 8}, "end": {"line": 9, "character": 15}},
-        }
-
-        matches = _definition_nodes(call_graph, definition, include_callable_parent=True)
-
-        self.assertEqual(
-            [node.fully_qualified_name for node in matches],
-            [
-                "pkg.converter.DocumentConverter.convert",
-                "pkg.converter.DocumentConverter",
-            ],
-        )
-
-    def test_definition_resolution_same_line_fallback_prefers_class_over_nested_method(self) -> None:
-        file_path = Path("/repo/pkg/target.php")
-        call_graph = CallGraph(language="php")
-        call_graph.add_node(
-            Node(
-                fully_qualified_name="pkg.target.Target",
-                node_type=NodeType.CLASS,
-                file_path=str(file_path),
-                line_start=1,
-                line_end=1,
-                col_start=6,
-            )
-        )
-        call_graph.add_node(
-            Node(
-                fully_qualified_name="pkg.target.Target.method",
-                node_type=NodeType.METHOD,
-                file_path=str(file_path),
-                line_start=1,
-                line_end=1,
-                col_start=29,
-            )
-        )
-        definition = {
-            "uri": file_path.as_uri(),
-            "range": {"start": {"line": 0, "character": 0}, "end": {"line": 0, "character": 6}},
-        }
-
-        matches = _definition_nodes(call_graph, definition)
-
-        self.assertEqual([node.fully_qualified_name for node in matches], ["pkg.target.Target"])
-
-    def test_definition_resolution_includes_constructor_parent_without_definition_strategy(self) -> None:
-        file_path = Path("/repo/pkg/target.php")
-        call_graph = CallGraph(language="php")
-        call_graph.add_node(
-            Node(
-                fully_qualified_name="pkg.target.Target",
-                node_type=NodeType.CLASS,
-                file_path=str(file_path),
-                line_start=1,
-                line_end=5,
-            )
-        )
-        call_graph.add_node(
-            Node(
-                fully_qualified_name="pkg.target.Target.__construct",
-                node_type=NodeType.CONSTRUCTOR,
-                file_path=str(file_path),
-                line_start=2,
-                line_end=2,
-                col_start=5,
-            )
-        )
-        definition = {
-            "uri": file_path.as_uri(),
-            "range": {"start": {"line": 1, "character": 5}, "end": {"line": 1, "character": 16}},
-        }
-
-        matches = _definition_nodes(call_graph, definition)
-
-        self.assertEqual(
-            [node.fully_qualified_name for node in matches],
-            ["pkg.target.Target.__construct", "pkg.target.Target"],
-        )
 
     def test_cached_outbound_edge_is_restored_from_live_non_call_reference(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -375,32 +268,45 @@ class TestWarmStartOutboundEdges(unittest.TestCase):
             call_graph = CallGraph(language="python")
             call_graph.add_node(source)
             call_graph.add_node(target)
-            engine_client = MagicMock()
-            engine_client.references.return_value = [
-                {
-                    "uri": changed_file.as_uri(),
-                    "range": {
-                        "start": {"line": 1, "character": 11},
-                        "end": {"line": 1, "character": 30},
-                    },
-                }
-            ]
-            adapter = MagicMock()
-            adapter.language_id = "python"
-            adapter.is_class_like.return_value = False
-
-            _restore_cross_boundary_edges(
-                call_graph,
-                [(source.fully_qualified_name, target.fully_qualified_name, source, target, [])],
-                {str(changed_file)},
-                adapter,
-                engine_client,
-                SourceInspector(),
+            call_graph.add_edge(source.fully_qualified_name, target.fully_qualified_name)
+            adapter = PythonAdapter()
+            context = AnalysisContext()
+            context.symbols_for(adapter).add_symbols(
+                [
+                    SymbolInfo("convert", source.fully_qualified_name, 12, changed_file, 0, 0, 1, 40),
+                    SymbolInfo("text_content", target.fully_qualified_name, 6, target_file, 1, 4, 1, 40),
+                ]
             )
-
-            self.assertEqual(len(call_graph.edges), 1)
+            context.freeze()
+            engine_client = MagicMock()
+            reference = {
+                "uri": changed_file.as_uri(),
+                "range": {
+                    "start": {"line": 1, "character": 11},
+                    "end": {"line": 1, "character": 30},
+                },
+            }
+            engine_client.send_references_batch.side_effect = lambda queries, **kwargs: (
+                [[reference] if path == target_file else [] for path, _, _ in queries],
+                set(),
+            )
+            engine_client.get_collected_diagnostics.return_value = {}
+            ignore = MagicMock()
+            ignore.should_ignore.return_value = False
+            with patch("static_analyzer.incremental_orchestrator.CallGraphBuilder.collect_symbols") as collect:
+                updated = update_cfg_for_changed_files(
+                    _result(call_graph, source_files=[str(changed_file), str(target_file)]),
+                    {changed_file},
+                    adapter,
+                    Path(temp_dir),
+                    engine_client,
+                    ignore,
+                    context,
+                )
+            collect.assert_not_called()
+            self.assertEqual(len(updated["call_graph"].edges), 1)
             self.assertEqual(
-                call_graph.edges[0].call_sites,
+                updated["call_graph"].edges[0].call_sites,
                 [{"file": str(changed_file), "line": 2, "column": 12}],
             )
 

--- a/tests/static_analyzer/test_edge_builder.py
+++ b/tests/static_analyzer/test_edge_builder.py
@@ -7,12 +7,10 @@ from unittest.mock import MagicMock, patch
 
 from static_analyzer.engine.edge_builder import (
     EdgeMap,
-    _best_candidate,
     _is_valid_edge,
     _process_references_for_position,
     _build_dispatch_index,
     _override_targets,
-    _resolve_definition_to_symbol,
     build_edges_via_definitions,
     build_edges_via_references,
 )
@@ -82,8 +80,8 @@ def test_reference_call_in_expression_body_produces_edge(tmp_path: Path):
     caller = _sym("Caller", "Caller.Caller", NodeType.METHOD, str(source), 0, 0, 0, 42)
     target_class = _sym("Target", "Target", NodeType.CLASS, str(target_file), 0, 0, 0, 45)
     target = _sym("Target", "Target.Target", NodeType.METHOD, str(target_file), 0, 21, 0, 27)
-    ctx.symbol_table.symbols[target_class.qualified_name] = target_class
-    ctx.symbol_table.file_symbols[str(source)] = [caller]
+    ctx.symbol_table.add_symbols([caller, target_class, target])
+    ctx.symbol_table.build_indices()
     edge_set: EdgeMap = {}
     reference = {
         "uri": source.as_uri(),
@@ -108,7 +106,8 @@ def test_reference_in_constructor_initializer_is_not_a_call_edge(tmp_path: Path)
     caller_start = source_text.index("Cat(string")
     caller = _sym("Cat", "Cat.Cat", NodeType.CONSTRUCTOR, str(source), 0, caller_start, 0, len(source_text))
     target = _sym("Animal", "Animal.Animal", NodeType.CONSTRUCTOR, str(target_file), 0, 10, 0, 30)
-    ctx.symbol_table.file_symbols[str(source)] = [caller]
+    ctx.symbol_table.add_symbols([caller, target])
+    ctx.symbol_table.build_indices()
     edge_set: EdgeMap = {}
     ref_start = source_text.index("base")
     reference = {
@@ -133,7 +132,8 @@ def test_reference_at_caller_declaration_position_is_not_an_edge(tmp_path: Path)
     ctx, adapter = _make_ctx()
     caller = _sym("target", "Caller.target", NodeType.METHOD, str(source), 0, 19, 0, 25)
     target = _sym("target", "Target.target", NodeType.FUNCTION, str(target_file), 0, 16, 0, 22)
-    ctx.symbol_table.file_symbols[str(source)] = [caller]
+    ctx.symbol_table.add_symbols([caller, target])
+    ctx.symbol_table.build_indices()
     reference = {
         "uri": source.as_uri(),
         "range": {"start": {"line": 0, "character": 19}, "end": {"line": 0, "character": 25}},
@@ -157,7 +157,8 @@ def test_a_typescript_concise_arrow_body_is_an_edge(tmp_path: Path):
     ctx, adapter = _make_ctx()
     caller = _sym("caller", "Caller.caller", NodeType.FUNCTION, str(source), 0, 6, 0, 30)
     target = _sym("target", "Target.target", NodeType.FUNCTION, str(target_file), 0, 16, 0, 22)
-    ctx.symbol_table.file_symbols[str(source)] = [caller]
+    ctx.symbol_table.add_symbols([caller, target])
+    ctx.symbol_table.build_indices()
     reference = {
         "uri": source.as_uri(),
         "range": {"start": {"line": 0, "character": 21}, "end": {"line": 0, "character": 27}},
@@ -180,7 +181,8 @@ def test_a_csharp_declaration_line_reference_is_still_ignored_by_default(tmp_pat
     ctx, adapter = _make_ctx()
     caller = _sym("Call", "C.Call", NodeType.METHOD, str(source), 0, 17, 0, 36)
     target = _sym("Target", "T.Target", NodeType.METHOD, str(target_file), 0, 30, 0, 36)
-    ctx.symbol_table.file_symbols[str(source)] = [caller]
+    ctx.symbol_table.add_symbols([caller, target])
+    ctx.symbol_table.build_indices()
     reference = {
         "uri": source.as_uri(),
         "range": {"start": {"line": 0, "character": 27}, "end": {"line": 0, "character": 33}},
@@ -201,7 +203,8 @@ def test_a_call_interpolated_into_a_concise_arrow_body_is_an_edge(tmp_path: Path
     ctx, adapter = _make_ctx()
     caller = _sym("caller", "Caller.caller", NodeType.FUNCTION, str(source), 0, 6, 0, 42)
     target = _sym("target", "Target.target", NodeType.FUNCTION, str(target_file), 0, 16, 0, 22)
-    ctx.symbol_table.file_symbols[str(source)] = [caller]
+    ctx.symbol_table.add_symbols([caller, target])
+    ctx.symbol_table.build_indices()
     reference = {
         "uri": source.as_uri(),
         "range": {"start": {"line": 0, "character": 31}, "end": {"line": 0, "character": 37}},
@@ -223,7 +226,8 @@ def test_reference_in_same_line_block_body_is_an_edge(tmp_path: Path):
     ctx, adapter = _make_ctx()
     caller = _sym("caller", "Caller.caller", NodeType.FUNCTION, str(source), 0, 16, 0, 44)
     target = _sym("target", "Target.target", NodeType.FUNCTION, str(target_file), 0, 16, 0, 22)
-    ctx.symbol_table.file_symbols[str(source)] = [caller]
+    ctx.symbol_table.add_symbols([caller, target])
+    ctx.symbol_table.build_indices()
     reference = {
         "uri": source.as_uri(),
         "range": {"start": {"line": 0, "character": 34}, "end": {"line": 0, "character": 40}},
@@ -244,7 +248,8 @@ def test_non_call_reference_in_same_line_block_body_is_not_an_edge(tmp_path: Pat
     ctx, adapter = _make_ctx()
     caller = _sym("caller", "Caller.caller", NodeType.FUNCTION, str(source), 0, 16, 0, 53)
     target = _sym("target", "Target.target", NodeType.FUNCTION, str(target_file), 0, 16, 0, 22)
-    ctx.symbol_table.file_symbols[str(source)] = [caller]
+    ctx.symbol_table.add_symbols([caller, target])
+    ctx.symbol_table.build_indices()
     reference_start = source.read_text().index("target")
     reference = {
         "uri": source.as_uri(),
@@ -269,7 +274,8 @@ def test_callback_reference_in_multiline_body_is_an_edge(tmp_path: Path):
     ctx, adapter = _make_ctx()
     caller = _sym("caller", "Caller.caller", NodeType.FUNCTION, str(source), 0, 16, 2, 1)
     target = _sym("target", "Target.target", NodeType.FUNCTION, str(target_file), 0, 16, 0, 22)
-    ctx.symbol_table.file_symbols[str(source)] = [caller]
+    ctx.symbol_table.add_symbols([caller, target])
+    ctx.symbol_table.build_indices()
     reference_start = source.read_text().splitlines()[1].index("target")
     reference = {
         "uri": source.as_uri(),
@@ -295,7 +301,8 @@ def test_non_call_reference_in_expression_body_is_not_an_edge(tmp_path: Path):
     ctx = EdgeBuildContext(_make_lsp(), SymbolTable(adapter), SourceInspector())
     caller = _sym("Caller", "Caller.Caller", NodeType.METHOD, str(source), 0, 0, 0, 47)
     target = _sym("Target", "Target.Target", NodeType.METHOD, str(target_file), 0, 21, 0, 27)
-    ctx.symbol_table.file_symbols[str(source)] = [caller]
+    ctx.symbol_table.add_symbols([caller, target])
+    ctx.symbol_table.build_indices()
     reference_start = source.read_text().index("Target;")
     reference = {
         "uri": source.as_uri(),
@@ -348,106 +355,124 @@ class TestIsValidEdge:
 
 
 # ---------------------------------------------------------------------------
-# _resolve_definition_to_symbol
+# SymbolTable.resolve_definition
 # ---------------------------------------------------------------------------
 
 
 class TestResolveDefinitionToSymbol:
     def test_exact_match_with_location_format(self):
         sym = _sym("foo", "a.foo", NodeType.FUNCTION, "/p/a.py", 10, 4)
-        pos_to_sym = {(str(Path("/p/a.py")), 10, 4): sym}
-        result = _resolve_definition_to_symbol(
+        st = SymbolTable(_TestAdapter())
+        st.add_symbols([sym])
+        result = st.resolve_definition(
             {"uri": Path("/p/a.py").as_uri(), "range": {"start": {"line": 10, "character": 4}}},
-            pos_to_sym,
-            {},
         )
         assert result is sym
 
     def test_exact_match_with_location_link_format(self):
         sym = _sym("foo", "a.foo", NodeType.FUNCTION, "/p/a.py", 10, 4)
-        pos_to_sym = {(str(Path("/p/a.py")), 10, 4): sym}
-        result = _resolve_definition_to_symbol(
+        st = SymbolTable(_TestAdapter())
+        st.add_symbols([sym])
+        result = st.resolve_definition(
             {
                 "targetUri": Path("/p/a.py").as_uri(),
                 "targetSelectionRange": {"start": {"line": 10, "character": 4}},
             },
-            pos_to_sym,
-            {},
         )
         assert result is sym
 
     def test_fuzzy_match_on_same_line(self):
         sym = _sym("foo", "a.foo", NodeType.FUNCTION, "/p/a.py", 10, 4)
-        line_to_syms = {(str(Path("/p/a.py")), 10): [sym]}
-        result = _resolve_definition_to_symbol(
+        st = SymbolTable(_TestAdapter())
+        st.add_symbols([sym])
+        result = st.resolve_definition(
             {"uri": Path("/p/a.py").as_uri(), "range": {"start": {"line": 10, "character": 0}}},
-            {},
-            line_to_syms,
         )
         assert result is sym
 
     def test_fuzzy_match_on_adjacent_line(self):
         sym = _sym("foo", "a.foo", NodeType.FUNCTION, "/p/a.py", 11, 4)
-        line_to_syms = {(str(Path("/p/a.py")), 11): [sym]}
-        result = _resolve_definition_to_symbol(
+        st = SymbolTable(_TestAdapter())
+        st.add_symbols([sym])
+        result = st.resolve_definition(
             {"uri": Path("/p/a.py").as_uri(), "range": {"start": {"line": 10, "character": 0}}},
-            {},
-            line_to_syms,
         )
         assert result is sym
 
     def test_returns_none_for_invalid_uri(self):
-        result = _resolve_definition_to_symbol(
+        st = SymbolTable(_TestAdapter())
+        result = st.resolve_definition(
             {"uri": "invalid-uri", "range": {"start": {"line": 0, "character": 0}}},
-            {},
-            {},
         )
         assert result is None
 
     def test_returns_none_for_missing_position(self):
-        result = _resolve_definition_to_symbol(
+        st = SymbolTable(_TestAdapter())
+        result = st.resolve_definition(
             {"uri": Path("/p/a.py").as_uri(), "range": {}},
-            {},
-            {},
         )
         assert result is None
 
     def test_returns_none_when_no_match(self):
-        result = _resolve_definition_to_symbol(
+        st = SymbolTable(_TestAdapter())
+        result = st.resolve_definition(
             {"uri": Path("/p/a.py").as_uri(), "range": {"start": {"line": 100, "character": 0}}},
-            {},
-            {},
         )
         assert result is None
 
 
 # ---------------------------------------------------------------------------
-# _best_candidate
+# SymbolTable.resolve_definition candidate preference
 # ---------------------------------------------------------------------------
 
 
 class TestBestCandidate:
     def test_prefers_callable_over_class(self):
         cls = _sym("Foo", "a.Foo", NodeType.CLASS, "/p/a.py", 0)
-        method = _sym("foo", "a.Foo.foo", NodeType.METHOD, "/p/a.py", 5)
-        assert _best_candidate([cls, method]) is method
+        method = _sym("foo", "a.Foo.foo", NodeType.METHOD, "/p/a.py", 0)
+        st = SymbolTable(_TestAdapter())
+        st.add_symbols([cls, method])
+        assert (
+            st.resolve_definition({"uri": Path("/p/a.py").as_uri(), "range": {"start": {"line": 0, "character": 1}}})
+            is method
+        )
 
     def test_prefers_class_over_variable(self):
         var = _sym("x", "a.x", NodeType.VARIABLE, "/p/a.py", 0)
         cls = _sym("Foo", "a.Foo", NodeType.CLASS, "/p/a.py", 0)
-        assert _best_candidate([var, cls]) is cls
+        st = SymbolTable(_TestAdapter())
+        st.add_symbols([var, cls])
+        assert (
+            st.resolve_definition({"uri": Path("/p/a.py").as_uri(), "range": {"start": {"line": 0, "character": 1}}})
+            is cls
+        )
 
     def test_prefers_longest_qualified_name(self):
         short = _sym("foo", "a.foo", NodeType.FUNCTION, "/p/a.py", 0)
         long = _sym("foo", "a.b.c.foo", NodeType.FUNCTION, "/p/a.py", 0)
-        assert _best_candidate([short, long]) is long
+        st = SymbolTable(_TestAdapter())
+        st.add_symbols([short, long])
+        assert (
+            st.resolve_definition({"uri": Path("/p/a.py").as_uri(), "range": {"start": {"line": 0, "character": 1}}})
+            is long
+        )
 
     def test_empty_list(self):
-        assert _best_candidate([]) is None
+        st = SymbolTable(_TestAdapter())
+        st.add_symbols([])
+        assert (
+            st.resolve_definition({"uri": Path("/p/a.py").as_uri(), "range": {"start": {"line": 0, "character": 1}}})
+            is None
+        )
 
     def test_single_variable(self):
         var = _sym("x", "a.x", NodeType.VARIABLE, "/p/a.py", 0)
-        assert _best_candidate([var]) is var
+        st = SymbolTable(_TestAdapter())
+        st.add_symbols([var])
+        assert (
+            st.resolve_definition({"uri": Path("/p/a.py").as_uri(), "range": {"start": {"line": 0, "character": 1}}})
+            is var
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -467,10 +492,7 @@ class TestBuildEdgesViaDefinitions:
 
         caller = _sym("main", "app.main", NodeType.FUNCTION, str(src), 0, 4, 1)
         callee = _sym("helper", "app.helper", NodeType.FUNCTION, str(src), 3, 4, 4)
-        st._symbols["app.main"] = caller
-        st._symbols["app.helper"] = callee
-        st._file_symbols[str(src)] = [caller, callee]
-        st._primary_file_symbols[str(src)] = [caller, callee]
+        st.add_symbols([caller, callee])
         st.build_indices()
 
         # Call sites: main( at (0,4), helper( at (1,4), helper( def at (3,4)
@@ -515,9 +537,7 @@ class TestBuildEdgesViaDefinitions:
         src.write_text("def main():\n    helper()\n")
 
         caller = _sym("main", "app.main", NodeType.FUNCTION, str(src), 0, 4, 1)
-        st._symbols["app.main"] = caller
-        st._file_symbols[str(src)] = [caller]
-        st._primary_file_symbols[str(src)] = [caller]
+        st.add_symbols([caller])
         st.build_indices()
 
         lsp.send_definition_batch.side_effect = Exception("LSP crash")
@@ -545,11 +565,7 @@ class TestBuildEdgesViaDefinitions:
             5,
             parent_chain=[("Dog", NodeType.CLASS)],
         )
-        st._symbols["app.main"] = caller
-        st._symbols["app.Dog"] = cls
-        st._symbols["app.Dog.__init__"] = ctor
-        st._file_symbols[str(src)] = [caller, cls, ctor]
-        st._primary_file_symbols[str(src)] = [caller, cls, ctor]
+        st.add_symbols([caller, cls, ctor])
         st.build_indices()
 
         # Dog( at (1,4) resolves to __init__ at (4,8); other sites resolve to nothing
@@ -582,11 +598,7 @@ class TestBuildEdgesViaDefinitions:
         caller = _sym("main", "app.main", NodeType.FUNCTION, str(src), 0, 4, 1)
         target = _sym("speak", "app.speak", NodeType.METHOD, str(src), 3, 4, 4)
         impl = _sym("dog_speak", "app.dog_speak", NodeType.METHOD, str(src), 6, 4, 7)
-        st._symbols["app.main"] = caller
-        st._symbols["app.speak"] = target
-        st._symbols["app.dog_speak"] = impl
-        st._file_symbols[str(src)] = [caller, target, impl]
-        st._primary_file_symbols[str(src)] = [caller, target, impl]
+        st.add_symbols([caller, target, impl])
         st.build_indices()
 
         # speak( at (1,4) resolves to speak def at (3,4); others to nothing
@@ -622,10 +634,7 @@ class TestBuildEdgesViaDefinitions:
 
         caller = _sym("main", "app.main", NodeType.FUNCTION, str(src), 0, 4, 1)
         target = _sym("speak", "app.speak", NodeType.METHOD, str(src), 3, 4, 4)
-        st._symbols["app.main"] = caller
-        st._symbols["app.speak"] = target
-        st._file_symbols[str(src)] = [caller, target]
-        st._primary_file_symbols[str(src)] = [caller, target]
+        st.add_symbols([caller, target])
         st.build_indices()
 
         # speak( at (1,4) resolves to speak def at (3,4)
@@ -661,10 +670,7 @@ class TestBuildEdgesViaReferencesExtra:
 
         caller = _sym("main", "app.main", NodeType.FUNCTION, "/project/app.py", 0, 0, 20)
         cls = _sym("Dog", "app.Dog", NodeType.CLASS, "/project/app.py", 25, 0, 50)
-        st._symbols["app.main"] = caller
-        st._symbols["app.Dog"] = cls
-        st._file_symbols[str(Path("/project/app.py"))] = [caller, cls]
-        st._primary_file_symbols[str(Path("/project/app.py"))] = [caller, cls]
+        st.add_symbols([caller, cls])
         st.build_indices()
 
         # Reference to Dog that is NOT an invocation (e.g., type annotation)
@@ -688,10 +694,7 @@ class TestBuildEdgesViaReferencesExtra:
 
         outer = _sym("outer", "app.outer", NodeType.FUNCTION, "/project/app.py", 0, 0, 20)
         inner = _sym("inner", "app.outer.inner", NodeType.FUNCTION, "/project/app.py", 5, 4, 10)
-        st._symbols["app.outer"] = outer
-        st._symbols["app.outer.inner"] = inner
-        st._file_symbols[str(Path("/project/app.py"))] = [outer, inner]
-        st._primary_file_symbols[str(Path("/project/app.py"))] = [outer, inner]
+        st.add_symbols([outer, inner])
         st.build_indices()
 
         # Reference to inner from within outer
@@ -737,16 +740,7 @@ class TestBuildEdgesViaReferencesExtra:
         bad_func1 = _sym("bad_fn1", "bad.bad_fn1", NodeType.FUNCTION, "/project/bad.py", 0, 0, 10)
         bad_func2 = _sym("bad_fn2", "bad.bad_fn2", NodeType.FUNCTION, "/project/bad.py", 15, 0, 25)
 
-        st._symbols["good.good_fn"] = good_func
-        st._symbols["bad.bad_fn1"] = bad_func1
-        st._symbols["bad.bad_fn2"] = bad_func2
-        for key in [str(Path("/project/good.py")), str(Path("/project/bad.py"))]:
-            st._file_symbols[key] = []
-            st._primary_file_symbols[key] = []
-        st._file_symbols[str(Path("/project/good.py"))] = [good_func]
-        st._primary_file_symbols[str(Path("/project/good.py"))] = [good_func]
-        st._file_symbols[str(Path("/project/bad.py"))] = [bad_func1, bad_func2]
-        st._primary_file_symbols[str(Path("/project/bad.py"))] = [bad_func1, bad_func2]
+        st.add_symbols([good_func, bad_func1, bad_func2])
         st.build_indices()
 
         def mock_refs_with_errors(queries, per_query_timeout=0):
@@ -824,9 +818,7 @@ class TestMethodGroupArguments:
 
         caller = _sym("Main", "P.Main", NodeType.METHOD, str(src), 1, 7, 1)
         handler = _sym("Handle", "P.Handle", NodeType.METHOD, str(src), 2, 7, 2)
-        st._symbols.update({"P.Main": caller, "P.Handle": handler})
-        st._file_symbols[str(src)] = [caller, handler]
-        st._primary_file_symbols[str(src)] = [caller, handler]
+        st.add_symbols([caller, handler])
         st.build_indices()
 
         lsp.send_definition_batch.side_effect = self._definitions_at(src, {(1, 25): (2, 7)})
@@ -841,9 +833,7 @@ class TestMethodGroupArguments:
 
         caller = _sym("Main", "P.Main", NodeType.METHOD, str(src), 1, 7, 1)
         field = _sym("total", "P.total", NodeType.FIELD, str(src), 2, 6, 2)
-        st._symbols.update({"P.Main": caller, "P.total": field})
-        st._file_symbols[str(src)] = [caller, field]
-        st._primary_file_symbols[str(src)] = [caller, field]
+        st.add_symbols([caller, field])
         st.build_indices()
 
         lsp.send_definition_batch.side_effect = self._definitions_at(src, {(1, 34): (2, 6)})
@@ -859,9 +849,7 @@ class TestMethodGroupArguments:
 
         caller = _sym("Invoke", "M.Invoke", NodeType.METHOD, str(src), 1, 7, 1)
         field = _sym("_next", "M._next", NodeType.FIELD, str(src), 2, 18, 2)
-        st._symbols.update({"M.Invoke": caller, "M._next": field})
-        st._file_symbols[str(src)] = [caller, field]
-        st._primary_file_symbols[str(src)] = [caller, field]
+        st.add_symbols([caller, field])
         st.build_indices()
 
         lsp.send_definition_batch.side_effect = self._definitions_at(src, {(1, 17): (2, 18)})
@@ -880,7 +868,9 @@ class TestOverrideTargets:
             paths.append(path)
         for qname, file_name in classes.items():
             simple = qname.rsplit(".", 1)[-1]
-            ctx.symbol_table._symbols[qname] = _sym(simple, qname, NodeType.CLASS, str(tmp_path / file_name), 0)
+            kind = NodeType.INTERFACE if files[file_name].startswith("interface ") else NodeType.CLASS
+            ctx.symbol_table.add_symbols([_sym(simple, qname, kind, str(tmp_path / file_name), 0)])
+        ctx.symbol_table.build_indices()
         return _build_dispatch_index(adapter, ctx, paths), ctx.symbol_table
 
     def test_expands_to_an_override(self, tmp_path: Path):
@@ -892,10 +882,15 @@ class TestOverrideTargets:
             },
             {"Animal": "Animal.cs", "Dog": "Dog.cs"},
         )
-        st._symbols["Animal.Speak"] = _sym("Speak", "Animal.Speak", NodeType.METHOD, str(tmp_path / "Animal.cs"), 0)
-        st._symbols["Dog.Speak"] = _sym("Speak", "Dog.Speak", NodeType.METHOD, str(tmp_path / "Dog.cs"), 0)
+        st.add_symbols(
+            [
+                _sym("Speak", "Animal.Speak", NodeType.METHOD, str(tmp_path / "Animal.cs"), 0),
+                _sym("Speak", "Dog.Speak", NodeType.METHOD, str(tmp_path / "Dog.cs"), 0),
+            ]
+        )
+        st.build_indices()
 
-        targets = _override_targets(st._symbols["Animal.Speak"], st, dispatch)
+        targets = _override_targets(st.symbols["Animal.Speak"], st, dispatch)
         assert [t.qualified_name for t in targets] == ["Dog.Speak"]
 
     def test_skips_a_hidden_member(self, tmp_path: Path):
@@ -907,10 +902,15 @@ class TestOverrideTargets:
             },
             {"Base": "Base.cs", "Derived": "Derived.cs"},
         )
-        st._symbols["Base.Plain"] = _sym("Plain", "Base.Plain", NodeType.METHOD, str(tmp_path / "Base.cs"), 0)
-        st._symbols["Derived.Plain"] = _sym("Plain", "Derived.Plain", NodeType.METHOD, str(tmp_path / "Derived.cs"), 0)
+        st.add_symbols(
+            [
+                _sym("Plain", "Base.Plain", NodeType.METHOD, str(tmp_path / "Base.cs"), 0),
+                _sym("Plain", "Derived.Plain", NodeType.METHOD, str(tmp_path / "Derived.cs"), 0),
+            ]
+        )
+        st.build_indices()
 
-        assert _override_targets(st._symbols["Base.Plain"], st, dispatch) == []
+        assert _override_targets(st.symbols["Base.Plain"], st, dispatch) == []
 
     def test_interface_member_reaches_an_implicit_implementation(self, tmp_path: Path):
         dispatch, st = self._index(
@@ -921,11 +921,15 @@ class TestOverrideTargets:
             },
             {"IThing": "IThing.cs", "Impl": "Impl.cs"},
         )
-        st._symbols["IThing"] = _sym("IThing", "IThing", NodeType.INTERFACE, str(tmp_path / "IThing.cs"), 0)
-        st._symbols["IThing.Run"] = _sym("Run", "IThing.Run", NodeType.METHOD, str(tmp_path / "IThing.cs"), 0)
-        st._symbols["Impl.Run"] = _sym("Run", "Impl.Run", NodeType.METHOD, str(tmp_path / "Impl.cs"), 0)
+        st.add_symbols(
+            [
+                _sym("Run", "IThing.Run", NodeType.METHOD, str(tmp_path / "IThing.cs"), 0),
+                _sym("Run", "Impl.Run", NodeType.METHOD, str(tmp_path / "Impl.cs"), 0),
+            ]
+        )
+        st.build_indices()
 
-        targets = _override_targets(st._symbols["IThing.Run"], st, dispatch)
+        targets = _override_targets(st.symbols["IThing.Run"], st, dispatch)
         assert [t.qualified_name for t in targets] == ["Impl.Run"]
 
     def test_base_name_declared_twice_is_not_expanded(self, tmp_path: Path):
@@ -943,10 +947,13 @@ class TestOverrideTargets:
                 "Beta.Other": "Other.cs",
             },
         )
-        st._symbols["Alpha.Base.Run"] = _sym(
-            "Run", "Alpha.Base.Run", NodeType.METHOD, str(tmp_path / "AlphaBase.cs"), 0
+        st.add_symbols(
+            [
+                _sym("Run", "Alpha.Base.Run", NodeType.METHOD, str(tmp_path / "AlphaBase.cs"), 0),
+                _sym("Run", "Beta.Other.Run", NodeType.METHOD, str(tmp_path / "Other.cs"), 0),
+            ]
         )
-        st._symbols["Beta.Other.Run"] = _sym("Run", "Beta.Other.Run", NodeType.METHOD, str(tmp_path / "Other.cs"), 0)
+        st.build_indices()
 
         assert "Base" in dispatch.ambiguous
-        assert _override_targets(st._symbols["Alpha.Base.Run"], st, dispatch) == []
+        assert _override_targets(st.symbols["Alpha.Base.Run"], st, dispatch) == []

--- a/tests/static_analyzer/test_incremental_context.py
+++ b/tests/static_analyzer/test_incremental_context.py
@@ -1,0 +1,107 @@
+"""Incremental boundaries use shared declarations and the normal edge pipeline."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from static_analyzer.cfg import CallGraph, EdgeKind, ReferenceEdge
+from static_analyzer.engine.adapters.csharp_adapter import CSharpAdapter
+from static_analyzer.engine.adapters.python_adapter import PythonAdapter
+from static_analyzer.engine.analysis_context import AnalysisContext
+from static_analyzer.engine.models import LanguageAnalysisResult, SymbolInfo
+from static_analyzer.engine.result_converter import convert_to_codeboarding_format
+from static_analyzer.incremental_orchestrator import affected_source_files, update_cfg_for_changed_files
+from static_analyzer.node import Node
+from static_analyzer.config import NodeType
+
+
+def test_dispatch_dependencies_include_added_and_removed_descendants(tmp_path: Path) -> None:
+    base, child, caller, unresolved = [tmp_path / name for name in ("Base.cs", "Child.cs", "Caller.cs", "Other.cs")]
+    base.write_text("class Base {}")
+    child.write_text("class Child : Base {}")
+    caller.write_text("class Caller {}")
+    unresolved.write_text("class Other {}")
+    adapter = CSharpAdapter()
+    context = AnalysisContext()
+    context.symbols_for(adapter).add_symbols([SymbolInfo("Base", "Base", 5, base, 0, 6, 0, 13)])
+    graph = CallGraph(language="CSharp")
+    for name, path in (("Base", base), ("Child", child), ("Caller", caller)):
+        graph.add_node(Node(name, NodeType.CLASS, str(path), 1, 1))
+    graph.add_edge("Caller", "Base")
+    cached = {"call_graph": graph, "unresolved_files": {str(unresolved)}}
+    assert affected_source_files(cached, {child}, adapter, context) == {child, caller, unresolved}
+    assert affected_source_files(cached, set(), adapter, context) == set()
+    graph.add_reference_edge(ReferenceEdge("Child", "Base", EdgeKind.INHERITS))
+    child.unlink()
+    assert affected_source_files(cached, {child}, adapter, context) == {caller, unresolved}
+
+
+def test_reference_strategy_discovers_new_outbound_field_in_other_engine(tmp_path: Path) -> None:
+    source = tmp_path / "source.py"
+    other = tmp_path / "other" / "target.py"
+    other.parent.mkdir()
+    source.write_text("def run():\n    callback()\n")
+    other.write_text("callback = lambda: None\n")
+    adapter = PythonAdapter()
+    context = AnalysisContext()
+    table = context.symbols_for(adapter)
+    table.add_symbols([SymbolInfo("run", "source.run", 12, source, 0, 4, 1, 14)])
+    cached = convert_to_codeboarding_format(table, LanguageAnalysisResult(source_files=[str(source)]), adapter)
+    table.add_symbols([SymbolInfo("callback", "target.callback", 13, other, 0, 0, 0, 23)])
+    context.freeze()
+    assert "target.callback" not in cached["call_graph"].nodes
+    client = MagicMock()
+    client.get_collected_diagnostics.return_value = {}
+    client.send_references_batch.side_effect = lambda queries, **kwargs: ([[] for _ in queries], set())
+    definition = {"uri": other.as_uri(), "range": {"start": {"line": 0, "character": 0}}}
+    client.send_definition_batch.side_effect = lambda queries: ([[definition] for _ in queries], set())
+    ignore = MagicMock()
+    ignore.should_ignore.return_value = False
+    with patch("static_analyzer.incremental_orchestrator.CallGraphBuilder.collect_symbols") as collect:
+        result = update_cfg_for_changed_files(cached, {source}, adapter, tmp_path, client, ignore, context)
+    collect.assert_not_called()
+    assert [(edge.get_source(), edge.get_destination()) for edge in result["call_graph"].edges] == [
+        ("source.run", "target.callback")
+    ]
+    assert set(result["source_files"]) == {source, other}
+    assert result["symbols"] == table.snapshot()
+
+
+def test_requery_removes_only_outgoing_edges_and_scopes_files(tmp_path: Path) -> None:
+    paths = [tmp_path / name for name in ("caller.py", "target.py", "inbound.py", "ignored.py")]
+    for path in paths:
+        path.write_text("def f(): pass\n")
+    caller, target, inbound, ignored = paths
+    adapter = PythonAdapter()
+    context = AnalysisContext()
+    table = context.symbols_for(adapter)
+    table.add_symbols([SymbolInfo(path.stem, path.stem, 12, path, 0, 4, 0, 13) for path in paths])
+    context.freeze()
+    cached = convert_to_codeboarding_format(table, LanguageAnalysisResult(source_files=list(map(str, paths))), adapter)
+    cached["call_graph"].add_edge("caller", "target")
+    cached["call_graph"].add_edge("inbound", "caller")
+    cached["diagnostics"] = {str(target): ["kept"]}
+    context.unresolved_files.add(str(ignored))
+    client = MagicMock()
+    client.get_collected_diagnostics.return_value = {str(caller): ["fresh"]}
+    ignore = MagicMock()
+    ignore.should_ignore.side_effect = lambda path: path == ignored
+    with patch(
+        "static_analyzer.incremental_orchestrator.CallGraphBuilder.build", return_value=LanguageAnalysisResult()
+    ) as build:
+        result = update_cfg_for_changed_files(
+            cached,
+            set(),
+            adapter,
+            tmp_path,
+            client,
+            ignore,
+            context,
+            {caller, ignored, tmp_path.parent / "external.py"},
+        )
+    assert set(build.call_args.args[0]) == {caller, target}
+    assert set(result["call_graph"].nodes) == {path.stem for path in paths}
+    assert [(edge.get_source(), edge.get_destination()) for edge in result["call_graph"].edges] == [
+        ("inbound", "caller")
+    ]
+    assert result["diagnostics"] == {str(target): ["kept"], str(caller): ["fresh"]}
+    assert result["unresolved_files"] == {str(ignored)}

--- a/tests/static_analyzer/test_lsp_client.py
+++ b/tests/static_analyzer/test_lsp_client.py
@@ -18,6 +18,36 @@ from static_analyzer.engine.lsp_client import (
 )
 
 
+def test_refresh_updates_open_overlays_and_reports_closed_dependencies(tmp_path: Path):
+    edited, added, deleted = [tmp_path / name for name in ("edited.py", "added.py", "deleted.py")]
+    edited.write_text("new content")
+    added.write_text("new dependency")
+    client = LSPClient(["fake-server"], tmp_path)
+    client._opened_uris = {edited.as_uri(), deleted.as_uri()}
+    with patch.object(client, "_send_notification") as notify:
+        client.refresh_files({edited, added, deleted}, {edited, deleted})
+    calls = notify.call_args_list
+    assert [(c.args[0], c.args[1]["textDocument"]["uri"]) for c in calls[:-1]] == [
+        ("textDocument/didClose", deleted.as_uri()),
+        ("textDocument/didChange", edited.as_uri()),
+    ]
+    assert calls[-2].args[1]["contentChanges"] == [{"text": "new content"}]
+    assert calls[-1].args == (
+        "workspace/didChangeWatchedFiles",
+        {
+            "changes": [
+                {"uri": added.as_uri(), "type": 1},
+                {"uri": deleted.as_uri(), "type": 3},
+                {"uri": edited.as_uri(), "type": 2},
+            ]
+        },
+    )
+    assert added.as_uri() not in client._opened_uris
+    with patch.object(client, "_send_notification") as notify:
+        client.refresh_files(set(), set())
+    notify.assert_not_called()
+
+
 class TestLSPClientInit:
     def test_default_attributes(self):
         client = LSPClient(["fake-server"], Path("/project"))

--- a/tests/static_analyzer/test_max_concurrent_engines.py
+++ b/tests/static_analyzer/test_max_concurrent_engines.py
@@ -170,6 +170,7 @@ class TestBoundedFullPass:
         analyzer._loc_for_adapter = MagicMock(return_value=0)
         analyzer._absorb_into_results = MagicMock()
         analyzer._collect_diagnostics_for = MagicMock()
+        analyzer._collect_symbols = MagicMock()
         return analyzer
 
     def test_every_client_failing_to_start_raises(self, tmp_path: Path):
@@ -183,11 +184,9 @@ class TestBoundedFullPass:
 
     def test_one_survivor_is_not_a_total_failure(self, tmp_path: Path):
         analyzer = self._analyzer(tmp_path, engines=3)
-        calls = {"n": 0}
 
-        def spawn(_config):
-            calls["n"] += 1
-            if calls["n"] > 1:
+        def spawn(config):
+            if config.project_path.name != "p0":
                 raise RuntimeError("csharp-ls missing")
             return MagicMock()
 
@@ -196,6 +195,17 @@ class TestBoundedFullPass:
 
         with patch.dict("os.environ", {MAX_CONCURRENT_ENGINES_ENV_VAR: "1"}):
             analyzer._run_full_lsp_pass()
+        analyzer._run_full_analysis.assert_called_once()
+
+    def test_second_pass_start_failure_does_not_cache_empty_analysis(self, tmp_path: Path):
+        analyzer = self._analyzer(tmp_path, engines=1)
+        absorb = MagicMock()
+        analyzer._absorb_into_results = absorb
+        analyzer._spawn_engine_client = MagicMock(side_effect=[MagicMock(), RuntimeError("restart failed")])
+        with patch.dict("os.environ", {MAX_CONCURRENT_ENGINES_ENV_VAR: "1"}):
+            with pytest.raises(StaticAnalysisFatalError, match="No engine completed"):
+                analyzer._run_full_lsp_pass()
+        absorb.assert_not_called()
 
     def test_a_fatal_error_cancels_the_engines_still_queued(self, tmp_path: Path):
         analyzer = self._analyzer(tmp_path, engines=12)

--- a/tests/static_analyzer/test_shared_analysis_context.py
+++ b/tests/static_analyzer/test_shared_analysis_context.py
@@ -1,0 +1,126 @@
+"""Cross-engine resolution uses the same complete declarations on cold and warm runs."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from static_analyzer import EngineConfig, StaticAnalyzer
+from static_analyzer.analysis_cache import StaticAnalysisCache
+from static_analyzer.config import Language, NodeType
+from static_analyzer.engine.adapters.csharp_adapter import CSharpAdapter
+
+
+def declaration(name: str, kind: int, line: int, column: int, end: int, children: list[dict] = []) -> dict:
+    return {
+        "name": name,
+        "kind": kind,
+        "range": {"start": {"line": line, "character": 0}, "end": {"line": end, "character": 100}},
+        "selectionRange": {"start": {"line": line, "character": column}},
+        "children": children,
+    }
+
+
+def analyzer_for(root: Path, reverse: bool = False) -> tuple[StaticAnalyzer, Path, Path]:
+    caller, target = root / "app" / "Caller.cs", root / "lib" / "Target.cs"
+    caller.parent.mkdir(exist_ok=True)
+    target.parent.mkdir(exist_ok=True)
+    caller.write_text("class Caller {\n  void Run() {\n    Target.Next();\n  }\n}\n")
+    target.write_text("class Target {\n  public static Action Next;\n}\n")
+    symbols = {
+        caller: [declaration("Caller", NodeType.CLASS, 0, 6, 4, [declaration("Run()", NodeType.METHOD, 1, 7, 3)])],
+        target: [declaration("Target", NodeType.CLASS, 0, 6, 2, [declaration("Next", NodeType.FIELD, 1, 23, 1)])],
+    }
+    analyzer = StaticAnalyzer.__new__(StaticAnalyzer)
+    analyzer.repository_path = root
+    analyzer.changed_files = set()
+    analyzer.collected_diagnostics = {}
+    analyzer.ignore_manager = MagicMock()
+    analyzer.ignore_manager.should_ignore.return_value = False
+    analyzer._loc_for_adapter = MagicMock(return_value=0)
+    analyzer._collect_diagnostics_for = MagicMock()
+    analyzer._engine_clients = []
+    for path in (target, caller) if reverse else (caller, target):
+        client = MagicMock()
+        client.document_symbol.side_effect = lambda path, **kwargs: symbols[path] if path.exists() else []
+        client.send_definition_batch.side_effect = lambda queries: (
+            [
+                [{"uri": target.as_uri(), "range": {"start": {"line": 1, "character": 23}}}] if target.exists() else []
+                for _ in queries
+            ],
+            set(),
+        )
+        client.send_implementation_batch.side_effect = lambda queries: ([[] for _ in queries], set())
+        client.type_hierarchy_prepare.return_value = []
+        client.get_collected_diagnostics.return_value = {}
+        analyzer._engine_clients.append((EngineConfig(CSharpAdapter(), path.parent, [path]), client))
+    analyzer._engine_configs = [config for config, _ in analyzer._engine_clients]
+    return analyzer, caller, target
+
+
+def edges(result) -> set[tuple[str, str, tuple]]:
+    return {
+        (
+            edge.src_node.file_path,
+            edge.dst_node.file_path,
+            tuple((site["line"], site["column"]) for site in edge.call_sites),
+        )
+        for edge in result.get_cfg(Language.CSHARP).edges
+    }
+
+
+@pytest.mark.parametrize("reverse", [False, True])
+def test_cross_solution_field_and_target_only_addition_match_full(tmp_path: Path, reverse: bool) -> None:
+    analyzer, caller, target = analyzer_for(tmp_path, reverse)
+    with (
+        patch("static_analyzer.engine.call_graph_builder.time.sleep"),
+        patch("static_analyzer.max_concurrent_engines", return_value=0),
+    ):
+        full = analyzer._run_full_lsp_pass()
+        assert edges(full) == {(str(caller), str(target), ((3, 12),))}
+        snapshot = full.results[Language.CSHARP].symbols
+        assert snapshot is not None
+        assert any(s.kind == NodeType.FIELD for s in snapshot)
+        assert full.get_package_dependencies(Language.CSHARP)["Caller"]["imports"] == ["Target"]
+        target.unlink()
+        analyzer.changed_files = {target}
+        deleted = analyzer._update_cached_results(full, "baseline")
+        assert not edges(deleted)
+        assert str(caller) in deleted.results[Language.CSHARP].unresolved_files
+        target.write_text("class Target {\n  public static Action Next;\n}\n")
+        restored = analyzer._update_cached_results(deleted, "baseline")
+        assert edges(restored) == edges(full)
+        assert str(caller) not in restored.results[Language.CSHARP].unresolved_files
+        assert restored.get_package_dependencies(Language.CSHARP) == full.get_package_dependencies(Language.CSHARP)
+        caller.write_text("class Caller {\n  void Run() {\n\n  }\n}\n")
+        analyzer.changed_files = {caller}
+        without_call = analyzer._update_cached_results(restored, "baseline")
+        rebuilt = analyzer._run_full_lsp_pass()
+        assert set(without_call.get_cfg(Language.CSHARP).nodes) == set(rebuilt.get_cfg(Language.CSHARP).nodes)
+        assert not edges(without_call)
+        assert without_call.get_package_dependencies(Language.CSHARP)["Caller"]["imports"] == []
+        assert edges(full) == {(str(caller), str(target), ((3, 12),))}
+
+
+def test_snapshot_survives_cache_relocation_without_runtime_adapters(tmp_path: Path) -> None:
+    analyzer, caller, target = analyzer_for(tmp_path)
+    with (
+        patch("static_analyzer.engine.call_graph_builder.time.sleep"),
+        patch("static_analyzer.max_concurrent_engines", return_value=0),
+    ):
+        result = analyzer._run_full_lsp_pass()
+    result.results[Language.CSHARP].closed_documents = {str(target)}
+    result.results[Language.CSHARP].unresolved_files = {str(caller)}
+    cache = StaticAnalysisCache(tmp_path / "artifact", tmp_path)
+    cache.save(result, "baseline")
+    moved = tmp_path / "moved"
+    loaded = StaticAnalysisCache(tmp_path / "artifact", moved).load_with_sha()
+    assert loaded is not None
+    symbols = loaded[0].results[Language.CSHARP].symbols
+    assert symbols is not None
+    assert {s.file_path for s in symbols} == {moved / "app" / caller.name, moved / "lib" / target.name}
+    assert loaded[0].results[Language.CSHARP].closed_documents == {str(moved / "lib" / target.name)}
+    assert loaded[0].results[Language.CSHARP].unresolved_files == {str(moved / "app" / caller.name)}
+    original_symbols = result.results[Language.CSHARP].symbols
+    assert original_symbols is not None
+    assert all(s.file_path.is_relative_to(tmp_path) and not s.file_path.is_relative_to(moved) for s in original_symbols)

--- a/tests/static_analyzer/test_symbol_table.py
+++ b/tests/static_analyzer/test_symbol_table.py
@@ -426,3 +426,142 @@ class TestIsLocalVariable:
         st._file_symbols["mod.py"] = [alias, parented]
 
         assert st.is_local_variable(alias) is True
+
+
+class TestReusableSymbolTable:
+    def test_repeated_registration_and_indices_are_idempotent(self):
+        st = SymbolTable(_make_adapter())
+        declarations = _class_with_child("__init__", NodeType.CONSTRUCTOR)
+        for _ in range(3):
+            st.register_symbols(Path("/mod.py"), declarations, [], Path("/"))
+            st.build_indices()
+            st.build_indices()
+        assert len(st.symbols) == 3
+        assert len(st.file_symbols["/mod.py"]) == 3
+        assert len(st.primary_file_symbols["/mod.py"]) == 2
+        assert st.get_equivalent_names("MyClass.__init__") == ["mod.__init__"]
+        assert st.class_to_ctors == {"mod.MyClass": ["MyClass.__init__"]}
+        assert len(st._definition_lines[("/mod.py", 0)]) == 3
+
+    def test_snapshot_roundtrip_preserves_nested_alias_metadata(self):
+        st = SymbolTable(_make_adapter())
+        declarations = _class_with_child("__init__", NodeType.CONSTRUCTOR)
+        declarations[0]["range"]["end"]["character"] = 17
+        st.register_symbols(Path("/mod.py"), declarations, [("Outer", NodeType.CLASS)], Path("/"))
+        st.build_indices()
+        snapshot = st.snapshot()
+        restored = SymbolTable(_make_adapter())
+        restored.add_symbols(snapshot)
+        restored.build_indices()
+        assert restored.snapshot() == st.snapshot()
+        assert restored.file_symbols == st.file_symbols
+        assert restored.primary_file_symbols == st.primary_file_symbols
+        assert restored.class_to_ctors == {"Outer.MyClass": ["Outer.MyClass.__init__"]}
+        assert restored._ref_key_to_symbol == st._ref_key_to_symbol
+        assert restored.symbols["Outer.MyClass.__init__"].end_char == 17
+        assert restored.symbols["MyClass.__init__"].is_primary is False
+        assert restored.symbols["mod.__init__"].is_primary is False
+        assert restored.symbols["MyClass.__init__"].parent_chain == [("MyClass", NodeType.CLASS)]
+        snapshot[0].parent_chain.append(("Mutation", NodeType.CLASS))
+        assert snapshot != st.snapshot()
+
+    def test_registration_uses_session_naming_recursively(self):
+        default = _make_adapter()
+        session = _make_adapter()
+        session.build_qualified_name.side_effect = lambda fp, name, kind, chain, root, detail="": ".".join(
+            ["session", *(n for n, _ in chain), name]
+        )
+        st = SymbolTable(default)
+        st.register_symbols(
+            Path("/mod.py"), _class_with_child("method", NodeType.METHOD), [], Path("/"), naming=session
+        )
+        assert set(st.symbols) == {"session.MyClass", "session.MyClass.method", "session.method"}
+        default.build_qualified_name.assert_not_called()
+        st.register_symbols(Path("/other.py"), [{"name": "foo", "kind": NodeType.FUNCTION}], [], Path("/"))
+        assert "other.foo" in st.symbols
+
+    def test_changed_and_deleted_files_clear_all_lookups(self):
+        st = SymbolTable(_make_adapter())
+        st.register_symbols(Path("/mod.py"), _class_with_child("__init__", NodeType.CONSTRUCTOR), [], Path("/"))
+        retained = _sym("keep", "other.keep", NodeType.FUNCTION, "/other.py")
+        st.add_symbols([retained])
+        st.build_indices()
+        st.remove_files({Path("/mod.py")})
+        assert st.resolve_definition(_definition(0, 0)) is None
+        assert st.get_equivalent_names("MyClass.__init__") == []
+        assert st.class_to_ctors == {}
+        assert set(st.file_symbols) == set(st.primary_file_symbols) == {"/other.py"}
+        assert st._ref_key_to_symbol == {"other.keep": retained}
+        replacement = _sym("new", "mod.new", NodeType.FUNCTION, "/mod.py", start_line=10)
+        st.add_symbols([replacement])
+        assert st.resolve_definition(_definition(10, 0)) is replacement
+        assert st.resolve_definition(_definition(0, 0)) is None
+        st.remove_files({Path("/mod.py"), Path("/other.py")})
+        assert st.snapshot() == []
+        assert st._definition_positions == st._definition_lines == st._file_name_index == {}
+
+    def test_collision_winner_is_independent_of_registration_order(self):
+        candidates = [
+            _sym("foo", "shared.foo", NodeType.FUNCTION, "/z.py", start_line=0),
+            _sym("foo", "shared.foo", NodeType.FUNCTION, "/a.py", start_line=5),
+            _sym("foo", "shared.foo", NodeType.FUNCTION, "/a.py", start_line=2, start_char=8),
+            _sym("foo", "shared.foo", NodeType.FUNCTION, "/a.py", start_line=2, start_char=4),
+        ]
+        tables = [SymbolTable(_make_adapter()), SymbolTable(_make_adapter())]
+        for st, order in zip(tables, (candidates, list(reversed(candidates)))):
+            for sym in order:
+                st.add_symbols([sym])
+                st.build_indices()
+            assert st.symbols == {"shared.foo": candidates[-1]}
+            assert st.file_symbols == st.primary_file_symbols == {"/a.py": [candidates[-1]]}
+            assert st._ref_key_to_symbol == {"shared.foo": candidates[-1]}
+            assert set(st._definition_positions) == {("/a.py", 2, 4)}
+        assert tables[0].snapshot() == tables[1].snapshot()
+
+
+class TestResolveDefinition:
+    def test_exact_overload_is_not_replaced_by_longer_fuzzy_match(self):
+        st = SymbolTable(_make_adapter())
+        short = _sym("run", "C.run()", NodeType.METHOD, "/mod.py", start_line=5, start_char=4)
+        long = _sym("run", "C.run(string)", NodeType.METHOD, "/mod.py", start_line=5, start_char=20)
+        st.add_symbols([short, long])
+        assert st.resolve_definition(_definition(5, 4)) is short
+        assert st.resolve_definition(_definition(5, 20)) is long
+        assert st.resolve_definition(_definition(5, 0)) is long
+        for line in (3, 4, 6, 7):
+            assert st.resolve_definition(_definition(line, 0)) is long
+        assert st.resolve_definition(_definition(8, 0)) is None
+
+    def test_exact_longest_name_but_fuzzy_callable_then_class(self):
+        st = SymbolTable(_make_adapter())
+        variable = _sym("v", "very.long.variable", NodeType.VARIABLE, "/mod.py", start_line=5)
+        cls = _sym("C", "mod.Class", NodeType.CLASS, "/mod.py", start_line=5)
+        method = _sym("m", "C.m", NodeType.METHOD, "/mod.py", start_line=5)
+        st.add_symbols([variable, cls])
+        assert st.resolve_definition(_definition(5, 1)) is cls
+        st.add_symbols([method])
+        assert st.resolve_definition(_definition(5, 0)) is variable
+        assert st.resolve_definition(_definition(5, 1)) is method
+
+    def test_adjacent_line_order_and_location_link_selection_range(self):
+        st = SymbolTable(_make_adapter())
+        before = _sym("before", "long.before", NodeType.FUNCTION, "/mod.py", start_line=4)
+        after = _sym("after", "after", NodeType.FUNCTION, "/mod.py", start_line=6)
+        st.add_symbols([before, after])
+        assert st.resolve_definition(_definition(5, 0)) is after
+        assert (
+            st.resolve_definition(
+                {
+                    "targetUri": "file:///mod.py",
+                    "targetRange": {"start": {"line": 6, "character": 0}},
+                    "targetSelectionRange": {"start": {"line": 4, "character": 0}},
+                }
+            )
+            is before
+        )
+        for invalid in ({}, {"uri": "https://example.com/mod.py"}, {"uri": "file:///mod.py"}):
+            assert st.resolve_definition(invalid) is None
+
+
+def _definition(line: int, character: int) -> dict:
+    return {"uri": "file:///mod.py", "range": {"start": {"line": line, "character": character}}}

--- a/tests/static_analyzer/test_warmstart_changed_files.py
+++ b/tests/static_analyzer/test_warmstart_changed_files.py
@@ -1,28 +1,27 @@
-"""Warm-start can be scoped git-free from a caller-supplied changed-file set.
-
-The wrapper analyses a frozen, non-git COPY of the working tree, so the git
-``get_changed_files_since`` path can't run there. When the analyzer is built with
-a changed-file set (its fingerprint diff), ``_update_cached_results`` must use it
-directly and never touch git.
-"""
+"""Warm-start scopes supplied or git changes before shared language refreshes."""
 
 import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from static_analyzer import EngineConfig, StaticAnalyzer
+from static_analyzer import EngineConfig, StaticAnalysisFatalError, StaticAnalyzer
+from static_analyzer.analysis_cache import invalidate_files
 from static_analyzer.analysis_result import StaticAnalysisResults
+from static_analyzer.cfg import CallGraph
+from static_analyzer.config import Language
+from static_analyzer.engine.adapters.python_adapter import PythonAdapter
+from static_analyzer.engine.analysis_context import AnalysisContext
+from static_analyzer.incremental_orchestrator import MissingSymbolSnapshotError
 
 
 def _analyzer_with_one_engine(project_path: Path, changed_files: set[Path] | None) -> StaticAnalyzer:
     analyzer = object.__new__(StaticAnalyzer)
-    adapter = MagicMock()
-    adapter.language = "Python"
-    adapter.language_enum = MagicMock()
+    adapter = PythonAdapter()
     client = MagicMock()
     analyzer._engine_clients = [(EngineConfig(adapter=adapter, project_path=project_path), client)]
     analyzer.collected_diagnostics = {}
     analyzer.ignore_manager = MagicMock()
+    analyzer.ignore_manager.should_ignore.return_value = False
     analyzer._loc_for_adapter = MagicMock(return_value=0)
     analyzer.changed_files = changed_files
     return analyzer
@@ -32,135 +31,159 @@ class TestWarmStartChangedFiles(unittest.TestCase):
     def setUp(self) -> None:
         self.project = Path("/proj").resolve()
         self.cached = StaticAnalysisResults()
+        self.baseline = {
+            "call_graph": CallGraph(),
+            "class_hierarchies": {},
+            "package_relations": {},
+            "references": [],
+            "source_files": [],
+            "symbols": [],
+            "unresolved_files": set(),
+        }
+        self.extract = self.enterContext(
+            patch.object(StaticAnalyzer, "_extract_language_dict", return_value=self.baseline)
+        )
+        self.absorb = self.enterContext(patch.object(StaticAnalyzer, "_absorb_into_results"))
+        self.collect = self.enterContext(patch.object(StaticAnalyzer, "_collect_symbols"))
+        self.enterContext(patch.object(StaticAnalyzer, "_collect_diagnostics_for"))
+        self.enterContext(patch("static_analyzer.track_lsp_result"))
+        self.enterContext(patch.object(Path, "is_file", return_value=True))
+        self.invalidate = self.enterContext(patch("static_analyzer.invalidate_files", wraps=invalidate_files))
+        self.update = self.enterContext(
+            patch("static_analyzer.update_cfg_for_changed_files", side_effect=lambda data, *args, **kwargs: data)
+        )
 
-    @patch("static_analyzer.update_cfg_for_changed_files", return_value={})
     @patch("static_analyzer.get_changed_files_since")
-    def test_supplied_changed_files_bypass_git(self, mock_git, mock_update) -> None:
+    def test_supplied_changed_files_bypass_git(self, mock_git) -> None:
         supplied = {self.project / "a.py", self.project / "b.py"}
         analyzer = _analyzer_with_one_engine(self.project, changed_files=supplied)
-        with (
-            patch.object(analyzer, "_extract_language_dict", return_value={}),
-            patch.object(analyzer, "_absorb_into_results"),
-            patch.object(analyzer, "_collect_diagnostics_for"),
-            patch("static_analyzer.track_lsp_result"),
-        ):
-            analyzer._update_cached_results(self.cached, cached_sha="deadbeef")
+        analyzer._update_cached_results(self.cached, cached_sha="deadbeef")
 
-        # Git is never consulted on the supplied path.
         mock_git.assert_not_called()
-        # The supplied set (scoped to this engine's project root) reaches the merger.
-        passed = (
-            mock_update.call_args.args[1]
-            if mock_update.call_args.args
-            else mock_update.call_args.kwargs["changed_files"]
-        )
-        self.assertEqual(passed, supplied)
+        self.invalidate.assert_called_once_with(self.baseline, supplied)
+        self.assertEqual(self.update.call_args.args[1], set())
+        self.assertEqual(self.update.call_args.kwargs["query_files"], supplied)
+        self.assertIs(self.update.call_args.kwargs["context"], analyzer._analysis_context)
 
-    @patch("static_analyzer.update_cfg_for_changed_files", return_value={})
     @patch("static_analyzer.get_changed_files_since")
-    def test_files_outside_project_root_are_scoped_out(self, mock_git, mock_update) -> None:
+    def test_files_outside_project_root_are_scoped_out(self, mock_git) -> None:
         inside = self.project / "keep.py"
         outside = Path("/other/repo/skip.py").resolve()
         analyzer = _analyzer_with_one_engine(self.project, changed_files={inside, outside})
-        with (
-            patch.object(analyzer, "_extract_language_dict", return_value={}),
-            patch.object(analyzer, "_absorb_into_results"),
-            patch.object(analyzer, "_collect_diagnostics_for"),
-            patch("static_analyzer.track_lsp_result"),
-        ):
-            analyzer._update_cached_results(self.cached, cached_sha="deadbeef")
+        analyzer._update_cached_results(self.cached, cached_sha="deadbeef")
+
         mock_git.assert_not_called()
-        passed = (
-            mock_update.call_args.args[1]
-            if mock_update.call_args.args
-            else mock_update.call_args.kwargs["changed_files"]
-        )
-        self.assertEqual(passed, {inside})
+        self.invalidate.assert_called_once_with(self.baseline, {inside})
+        self.assertEqual(self.update.call_args.kwargs["query_files"], {inside})
 
     @patch("static_analyzer.get_changed_files_since")
     def test_engine_configs_of_one_language_thread_one_dict_and_absorb_once(self, mock_git) -> None:
-        """Why: a config that copies the cache hands back the nodes another config invalidated."""
-        analyzer = _analyzer_with_one_engine(self.project, changed_files={self.project / "a.py"})
+        """Why: later engines must not restore declarations invalidated by earlier engines."""
+        outer_file = self.project / "a.py"
+        inner_root = self.project / "sub"
+        inner_file = inner_root / "b.py"
+        changes = {outer_file, inner_file}
+        analyzer = _analyzer_with_one_engine(self.project, changed_files=changes)
         ((config, client),) = analyzer._engine_clients
-        analyzer._engine_clients.append(
-            (EngineConfig(adapter=config.adapter, project_path=self.project / "sub"), client)
-        )
-        first, second = {"call_graph": "first"}, {"call_graph": "second"}
-        with (
-            patch("static_analyzer.update_cfg_for_changed_files", side_effect=[first, second]) as mock_update,
-            patch.object(analyzer, "_extract_language_dict", return_value={"call_graph": "cached"}) as extract,
-            patch.object(analyzer, "_absorb_into_results") as absorb,
-            patch.object(analyzer, "_collect_diagnostics_for"),
-            patch("static_analyzer.track_lsp_result"),
-        ):
+        config.excluded_roots = [inner_root]
+        analyzer._engine_clients.append((EngineConfig(config.adapter, inner_root), client))
+        first, second = dict(self.baseline), dict(self.baseline)
+
+        def collect(config, client):
+            self.invalidate.assert_called_once_with(self.baseline, changes)
+            self.update.assert_not_called()
+
+        def update(data, *args, **kwargs):
+            self.assertEqual(self.collect.call_count, 2)
+            return first if self.update.call_count == 1 else second
+
+        self.collect.side_effect = collect
+        self.update.side_effect = update
+        with patch.object(AnalysisContext, "hydrate", autospec=True, side_effect=AnalysisContext.hydrate) as hydrate:
             analyzer._update_cached_results(self.cached, cached_sha="deadbeef")
+
         mock_git.assert_not_called()
-        extract.assert_called_once()
-        self.assertIs(mock_update.call_args_list[1].args[0], first)
-        absorb.assert_called_once()
-        self.assertIs(absorb.call_args.args[2], second)
+        self.extract.assert_called_once_with(self.cached, Language.PYTHON)
+        hydrate.assert_called_once_with(analyzer._analysis_context, config.adapter, [], set(), set())
+        self.assertEqual(
+            [call.args[0].source_files for call in self.collect.call_args_list], [[outer_file], [inner_file]]
+        )
+        self.assertIs(self.update.call_args_list[1].args[0], first)
+        for call, expected in zip(self.update.call_args_list, [{outer_file}, {inner_file}]):
+            self.assertEqual(call.args[1], set())
+            self.assertIs(call.kwargs["context"], analyzer._analysis_context)
+            self.assertEqual(call.kwargs["query_files"], expected)
+        self.absorb.assert_called_once()
+        self.assertIs(self.absorb.call_args.args[2], second)
 
     def test_discovery_exclusions_scope_supplied_and_git_changes_before_invalidation(self) -> None:
         inner_root = self.project / "plugins"
         excluded = inner_root / "Inner"
-        inner_changes = {excluded / name for name in ("modified.cs", "added.cs", "deleted.cs")}
-        outer_changes = {self.project / "Outer.cs", self.project / "plugins-extra" / "Other.cs"}
+        inner_changes = {excluded / name for name in ("modified.py", "added.py", "deleted.py")}
+        outer_changes = {self.project / "Outer.py", self.project / "plugins-extra" / "Other.py"}
+        all_changes = inner_changes | outer_changes
+        deleted = excluded / "deleted.py"
         for use_git in (False, True):
             with self.subTest(use_git=use_git):
-                analyzer = _analyzer_with_one_engine(
-                    self.project, changed_files=None if use_git else inner_changes | outer_changes
-                )
+                self.invalidate.reset_mock()
+                self.update.reset_mock()
+                self.collect.reset_mock()
+                analyzer = _analyzer_with_one_engine(self.project, changed_files=None if use_git else all_changes)
                 ((outer, client),) = analyzer._engine_clients
                 outer.excluded_roots = [excluded]
-                outer.source_files = [self.project / "Unchanged.cs"]
-                inner = EngineConfig(outer.adapter, inner_root, source_files=[excluded / "modified.cs"])
+                outer.source_files = [self.project / "Unchanged.py"]
+                inner = EngineConfig(outer.adapter, inner_root, source_files=[excluded / "modified.py"])
                 analyzer._engine_clients.append((inner, client))
                 with (
-                    patch(
-                        "static_analyzer.get_changed_files_since",
-                        side_effect=[inner_changes | outer_changes, inner_changes],
-                    ),
-                    patch("static_analyzer.update_cfg_for_changed_files", return_value={}) as update,
-                    patch.object(analyzer, "_extract_language_dict", return_value={}),
-                    patch.object(analyzer, "_absorb_into_results"),
-                    patch.object(analyzer, "_collect_diagnostics_for"),
-                    patch("static_analyzer.track_lsp_result"),
+                    patch("static_analyzer.get_changed_files_since", side_effect=[all_changes, inner_changes]) as git,
+                    patch.object(Path, "is_file", new=lambda path: path != deleted),
                 ):
                     analyzer._update_cached_results(self.cached, cached_sha="baseline")
-                self.assertEqual(update.call_args_list[0].args[1], outer_changes)
-                # Added/deleted paths are absent from source_files but still belong to the inner engine.
-                self.assertEqual(update.call_args_list[1].args[1], inner_changes)
 
-    @patch("static_analyzer.update_cfg_for_changed_files", return_value={})
+                self.assertEqual(git.call_count, 2 if use_git else 0)
+                self.invalidate.assert_called_once_with(self.baseline, all_changes)
+                self.assertEqual(self.update.call_args_list[0].kwargs["query_files"], outer_changes)
+                self.assertEqual(self.update.call_args_list[1].kwargs["query_files"], inner_changes - {deleted})
+                self.assertEqual(set(self.collect.call_args_list[0].args[0].source_files), outer_changes)
+                self.assertEqual(set(self.collect.call_args_list[1].args[0].source_files), inner_changes - {deleted})
+
     @patch("static_analyzer.get_changed_files_since", return_value={Path("/proj/x.py")})
-    def test_none_falls_back_to_git(self, mock_git, mock_update) -> None:
+    def test_none_falls_back_to_git(self, mock_git) -> None:
         analyzer = _analyzer_with_one_engine(self.project, changed_files=None)
-        with (
-            patch.object(analyzer, "_extract_language_dict", return_value={}),
-            patch.object(analyzer, "_absorb_into_results"),
-            patch.object(analyzer, "_collect_diagnostics_for"),
-            patch("static_analyzer.track_lsp_result"),
-        ):
-            analyzer._update_cached_results(self.cached, cached_sha="HEAD~1")
-        # No supplied set => git IS consulted (legacy CLI-on-a-real-checkout path).
-        mock_git.assert_called_once()
+        analyzer._update_cached_results(self.cached, cached_sha="HEAD~1")
 
-    @patch("static_analyzer.update_cfg_for_changed_files", return_value={})
+        mock_git.assert_called_once_with(self.project, "HEAD~1")
+        self.invalidate.assert_called_once_with(self.baseline, {self.project / "x.py"})
+        self.assertEqual(self.update.call_args.kwargs["query_files"], {self.project / "x.py"})
+
     @patch("static_analyzer.get_changed_files_since", side_effect=RuntimeError("Invalid Git repository"))
-    def test_git_failure_falls_back_to_full_relsp(self, mock_git, mock_update) -> None:
-        # When git fails (non-git dir / bad sha) and nothing was supplied, the
-        # language re-LSPs fully rather than crashing.
+    def test_git_failure_fails_loud_without_full_analysis(self, mock_git) -> None:
         analyzer = _analyzer_with_one_engine(self.project, changed_files=None)
-        with (
-            patch.object(analyzer, "_extract_language_dict", return_value={}),
-            patch.object(analyzer, "_run_full_analysis", return_value={}) as mock_full,
-            patch.object(analyzer, "_absorb_into_results"),
-            patch.object(analyzer, "_collect_diagnostics_for"),
-            patch("static_analyzer.track_lsp_result"),
-        ):
-            analyzer._update_cached_results(self.cached, cached_sha="badsha")
-        mock_full.assert_called_once()
-        mock_update.assert_not_called()
+        with patch.object(analyzer, "_run_full_analysis") as full:
+            with self.assertRaisesRegex(StaticAnalysisFatalError, "Cannot determine incremental changes"):
+                analyzer._update_cached_results(self.cached, cached_sha="badsha")
+
+        mock_git.assert_called_once_with(self.project, "badsha")
+        full.assert_not_called()
+        self.invalidate.assert_not_called()
+        self.collect.assert_not_called()
+        self.update.assert_not_called()
+        self.absorb.assert_not_called()
+
+    @patch("static_analyzer.get_changed_files_since")
+    def test_missing_symbol_snapshot_fails_loud(self, mock_git) -> None:
+        self.baseline.pop("symbols")
+        analyzer = _analyzer_with_one_engine(self.project, changed_files=set())
+        with patch.object(analyzer, "_run_full_analysis") as full:
+            with self.assertRaisesRegex(MissingSymbolSnapshotError, "no symbol snapshot"):
+                analyzer._update_cached_results(self.cached, cached_sha="baseline")
+
+        mock_git.assert_not_called()
+        full.assert_not_called()
+        self.invalidate.assert_not_called()
+        self.collect.assert_not_called()
+        self.update.assert_not_called()
+        self.absorb.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why

Addresses the shared-context design concern raised in #583. This PR is based directly on main, not stacked on #583.

## Design

- One analysis-scoped context owns lossless symbol tables partitioned by language. Engines register declarations into it before any engine resolves edges.
- Definition position and line lookups live in SymbolTable. Full and incremental analysis reuse the engine edge pipeline; the graph-derived incremental resolver is removed.
- Warm starts hydrate symbol snapshots, invalidate changed declarations once per language, collect all replacements, and requery affected callers. Unresolved caller files survive the cache so a target-only addition can repair an unchanged caller.
- Live LSP overlays and watched-file notifications are refreshed before incremental collection, including servers that reference another engine’s changed file.
- Output projection and final package dependencies use the completed graph. Symbol metadata, aliases, and linked-document state survive cache relocation without serializing clients or adapters.

## Tradeoffs

- Bounded cold analysis has two server passes: declaration collection, then edge construction. This preserves the resident-server cap but can add startup/indexing cost. Large-repository performance has not been benchmarked.
- The cache format changes; an older graph-only baseline requires an explicit full analysis before incremental analysis can resume.
- Existing qualified-name schemes remain; this is not a universal compilation-context symbol-ID redesign.

## Verification

- `uv run black .` and the Black commit hook passed.
- `uv run mypy .`: no issues in 308 source files.
- `uv run pytest --cov=. --cov-report=term --cov-fail-under=80`: 2,142 passed, 6 skipped, 87.23% coverage. One unrelated tool-registry test fails because dotnet is absent; the identical failure was reproduced in a clean origin/main worktree.
- A live smoke check using two real Pyright sessions verified cross-engine calls, removal after a target rename, and repair of an unchanged caller after restoring the target.
- Unit regressions cover both engine orders, externally invoked fields, target deletion/addition, stale-node and package-edge removal, cache relocation, snapshot metadata, incremental scoping, and bounded second-pass failure.
- Real C# integration and the private integration suite were not run locally; the orb has no .NET SDK.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Incremental analysis now preserves and reuses symbol information for more accurate updates across files and languages.
  - Changes to inheritance, references, and dependent files are reflected more consistently in analysis results.
  - File refreshes now correctly handle edited, added, and deleted documents.

- **Bug Fixes**
  - Improved definition and reference resolution, including unresolved-file tracking.
  - Incremental analysis now reports a clear error when required analysis data is unavailable or a recovery pass cannot complete.

- **Chores**
  - Analysis cache data now includes additional symbol and document state for reliable reuse.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->