### PR TITLE
feat(clustering): the limit holds in the ladder, and a small candidate folds only where its links lead

### DIFF
--- a/docs/design/clustering-ledger.md
+++ b/docs/design/clustering-ledger.md
@@ -1,0 +1,120 @@
+# Clustering: what has been tried
+
+A ledger of every approach measured or reasoned out for the component partition: what was
+tried, what came out, and why it was kept or discarded. Add a row whenever something is
+measured; never delete a row; when new evidence changes a decision, change the decision column
+and say what the evidence was. Companion to `name-tree.md` (the design as it stands).
+
+Decisions read **kept**, **discarded**, **kept with a limit** (works in some cases, bounded
+where it costs) or **not run** (discarded on an argument stated in the row; measure it before
+disagreeing).
+
+Sources: `[design]` = `name-tree.md`; `[handoff]` = `CLUSTERING-HANDOFF.md` in the workspace;
+`[eval]` = `PR586-analysis.md` (five unseen repositories); `[fix]` = `PR586-limit-fix.md`;
+`[study X]` = the named study in CodeBoarding-tests or CodeBoarding-evals; `[notes]` = session
+notes, with dates.
+
+## 1. What is partitioned, and where structure comes from
+
+| what we tried | what came out | decision, and why | source |
+|---|---|---|---|
+| Leiden communities on the call graph as leaves, a modularity peak to group them, seeded Leiden on incremental runs | eShop's graph has 204 connected components against 10 published boxes and no resolution keeps one box whole and separated; 84–93% of leaf clusters had no inter-cluster edge, so 28–40% of methods were placed by a tie-break; the shipped pipeline scored below the all-in-one floor on two of four rulers | **discarded.** The call graph can validate a partition but cannot generate one; the boxes come from what things are called | [design §1], [notes clustering ceiling 24 Aug], [notes partitioner rebuild 15 Aug] |
+| Leaves are files, positioned by their directory under the repository root | Beacon 0.34 → 0.94, eShop 0.67 → 1.00 against the rulers | **kept.** A file pools its identifiers and crosses no boundary in any ruler; leaf clusters crossed the boundaries names want to keep | [design §2], [notes qualified-name clustering 31 Aug] |
+| Declared C# namespaces as the primary key | on eShop 125 of 213 namespaces differ from the path only by a product root, and where they differ the namespace is coarser (all `Platforms/*` collapse); maintainers put vendored IdentityServer files in the project box | **discarded as primary, allowed as a merge hint.** When namespace and project disagree, the project wins | [notes qname defect 2 Sep], [notes namespace grouping 25 Aug] |
+| Qualified names parsed for structure (adapter spellings, the engine root of a nested solution) | abp's `framework/` invisible, btcpayserver transposed into 75 word boxes, eShop's two JS files a box of their own | **discarded.** Positions come from paths; every adapter now spells names from the repository root, so name and position agree | [design §3.1], [handoff §3.1, §3.5] |
+| Frontier opens a child holding ≥ 25% or ≥ 50% of its scope | Polly 21 root boxes, AutoMapper 12, LMCache 26, btcpayserver 27 | **discarded; only stepping through a child at ≥ 80% survives.** Opening scattered a directory's contents across its parent. Measured before path positions, when Polly's `Polly` namespace held over half; under path positions Polly's largest child is 37%, so the Polly part of the evidence is stale | [notes budget study 10 Sep], [design §3.2] |
+| Layout words (`src`, `lib`, …) stepped through by name | replaced by the 80% rule with no loss on the rulers | **discarded.** A list of names cannot be complete; the share rule needs none | [notes name-tree stack 2 Sep] |
+| Transposing a layered node onto recurring feature names | Beacon 0.70 → 0.889 once features must recur under two layers; below 135 units it over-splits every maintainer-drawn leaf on eShop depth 2 (0.974 whole, 0.59 transposed at 40 units, 0.67 at 70) | **kept above the leaf cap only.** Below it a grid is drawn layer by layer | [design §3.5, §8] |
+| Folding one-unit subtrees into the trie | erased the one-file feature directories the transposition needs; Beacon 0.70 → 0.889 once un-folded | **discarded.** A one-unit subtree is a loose unit of its parent at walk time, kept in the tree | [notes name-tree stack] |
+| Role vocabulary learned from identifier frequencies | `Incident` outranks `Handler` on Beacon; learned-only Beacon 0.24, eShop 0.61 against a fixed list's 0.89, 0.98 | **discarded.** Closed-class layer names never appear as identifier heads; the list is fixed, the planner may add a per-repo tail | [notes qualified-name clustering], [design §3.2] |
+| Ubiquity (a product namesake) by set intersection over siblings | one odd sibling keeps the product name alive as everyone's distinctive word | **discarded.** Frequency over at least three siblings and half of them | [design §3.2] |
+| Dotted C# directory names nested as trie segments (`Ordering.API` → `Ordering/API`) | makes `Ordering` one node with role children, un-merged into Ordering + OrderProcessor at depth 2 | **kept.** Merging dotted directories into one segment was only ever a fix for the old name-derived trie | [notes name-tree stack], [notes budget study] |
+| Module-first from build manifests, Leiden per module | eShop 0.235 → 0.667 and 1/12 → 7/12 boxes, but abp's largest component 22% → 58% and the action repository collapsed to one box | **superseded.** The right unit (files) plus names does what modules did without the collapse | [notes partitioner rebuild] |
+| Tests, docs and samples in a separate scope | never measured as a partition rule | **discarded by product call.** Only static-analysis names are partitioned; consumers are ordinary candidates that neither take nor fold | Svilen, 2 Sep [notes name-tree stack] |
+
+## 2. Grouping the frontier's candidates (the fold)
+
+| what we tried | what came out | decision, and why | source |
+|---|---|---|---|
+| Kinship: merge candidates sharing their distinctive word | eShop depth 1 0.979 → 1.000 (9 boxes), deterministic; letting a component's owned words merge instead pulled PaymentProcessor into Ordering (0.84) | **kept, always first.** Namesake grouping is deterministic; cross-token grouping is not | [design §3.3], [notes qualified-name clustering] |
+| An LLM planner grouping the candidates (three draws, medoid) | no better than kinship on the rulers (eShop 0.986 vs 0.88), 6/7/2 boxes across three draws on markitdown, and its names never ship because the abstraction agent renames every box | **kept as an escape hatch only.** Variance and cost without a measured gain | [study grouper, tests#32], [design §3.3] |
+| Affinity by observed-over-expected links (degree-normalised) | sent WebAppComponents to HybridApp on 3 links over WebApp on 15; folded every service into the event bus once the recovered call sites made the bus everyone's busiest partner | **discarded.** The ratio rewards quiet partners; the hub exclusion does what it was meant to do, by name | [handoff §5], [notes hub-fold study 10 Sep] |
+| Raw link counts, a hub (called by 40% of siblings, three at least) neither absorbs nor folds | eShop 0.600 → 1.000 on the recovered graph; abp root 9 → 50 and Polly 9 → 21 until a limit existed; in MassTransit's core 22 of 38 candidates are hubs, the sixteen non-hubs become the only homes and everything small drains into them (the funnel) | **kept for the budget fold, with the limit and the dominance rows below.** Right in sparse scopes; the dense case needs a dominance test, not a different hub | [notes hub-fold study], [eval], [fix §1] |
+| A hub as a last resort past the budget | abp 62% grab bag | **discarded.** Infrastructure absorbing its users is the picture nobody wants | [handoff §5] |
+| Exactly nine boxes everywhere | eShop 7/9 | **discarded.** Nine is a target along links, never a count to force | [handoff §5] |
+| Modularity (CNM) over the candidates | eShop 4/11, abp 21 boxes | **discarded.** No gain over links with the hub exclusion | [notes budget study] |
+| Capping hubs to the top few by fan-in, or a density-relative hub threshold | not run | **not run.** The all-hubs case is what makes a single-package library right (jackson-databind: 10 of 15 root candidates are hubs, the directories stand, and the eval called it the win); the funnel comes from folding on "most links" without a dominance test, and fewer hubs only widens the set of sinks | [fix §1], this ledger |
+| Vocabulary merge over the limit (closest TF-IDF pair) | merged nothing on the wide scopes it was written for (abp `framework`: the budget fold alone takes 76 → 15); once hubs may join it, a merged vector is closer to everything and it snowballs into a 1,183-file "Configuration" (59% of MassTransit's core) | **discarded.** Identifier vocabulary inside one namespace is noise, and pair merging is a snowball | [fix §1] |
+| Pool of the smallest past the limit, hubs spared | MassTransit's core: 23 children, a 344-file "Other files" made of every non-hub, a 7-file hub standing beside it | **discarded.** A limit that spares most candidates cannot act | [eval §4] |
+| Pool of the smallest past the limit, roles ignored | 39 → 15 on MassTransit's core; jackson-databind unchanged; nothing else moved | **kept.** In a dense scope the hub label carries no information about size | [fix §2] |
+| Dominance for a small candidate: its home must carry half of the links it could follow (links to siblings able to take it) | alone it passes every funnel fold in a dense scope, because the followable slice is a sliver of the candidate's links (Topology → MessageData: 33 of 54 followable, 33 of 1,141 in all) | **kept together with the next row.** Right denominator for a home above the floor (MessagePack joins Abstractions on 53% of what it could follow), wrong alone for a small home | [fix §1] |
+| A small home must also carry a quarter of *all* the candidate's links | separates every funnel fold (at most 0.18 of the source's links) from every family kept (at least 0.33) on MassTransit and abp | **kept.** Two small candidates joined are a new box under one of their names, which needs a real share of the links; 0.25 sits in the measured gap, not on a principle | [fix §2] |
+| Dominance everywhere: a quarter or a third of all links for every fold, one rule | roots under the limit inflate: small satellites whose main partner is the hub stand (MassTransit 12 root boxes, five under 1%; hugo 15; jackson 15); a third refuses RabbitMQ → EventBus at 0.328 | **discarded.** The evidence a detail needs depends on what it joins | this session, sweeps `xD25/xD33/xD50` |
+| A standing box absorbs any small candidate on most links (no share test when the home is big) | the home becomes a sink once it crosses the floor: abp's `Ddd.Application` 135 → 1,622 files in 45 consecutive folds | **discarded.** A big box has many links to everyone; "most links" is not evidence | this session, variant `wPBW` |
+| Peer-size test instead of the share test (source at most half the home) | not run | **not run.** A small home grows with each absorption, so a chain of small candidates passes the size test one at a time and builds the bag anyway; the share test is a property of the source | this session |
+| Freezing the link matrix at the original candidates | not run | **not run.** Removes the snowball but not the funnel: MessageData is genuinely the best non-hub partner of the small directories | this session |
+| "Shared by three" counting hub callers; only non-hubs may own a helper | without it, in a scope where most siblings are hubs, every shared candidate reads as the helper of the few that are not (MessageData, called by 8 siblings, became JobService's helper as "shared by two") | **kept.** What three siblings call is shared, whoever they are | [fix §2] |
+| A candidate under three units follows its links wherever they lead | keeps eShop's two-file `Shared` inside Catalog instead of on the root diagram | **kept.** The leaf ladder already needs one-file candidates to fold on most links; two files are never a box | [fix §2] |
+| One fold rule replacing the role placement (helper, application, shared, project) | same aggregate numbers with fewer rules, but eShop changes below the root (ClientApp's 5-file `Animations` layer folds into `Services`; `Shared` moves to Ordering) and two-child scopes rise 51 → 63 | **discarded.** The application rule (called by none: a service, not a helper) is direction, which one undirected rule loses; the change on eShop has no reason a ruler can show | this session, variants `one`…`four` |
+| At-the-floor candidates fold within budget when a sibling holds half of all their links | a 20-file box with three links joins a 6-file box; dropping the rule entirely leaves twelve equal parts of an un-merge unfolded | **kept only past the budget**, as shipped. Count pressure is what makes the rule safe | this session |
+| A project root is never a helper | added for Polly.Extensions-like packages; projects already fold past the budget, so the rule acts within budget only | **kept, weakly.** No measurement either way | [design §3.3], `test_a_project_root_is_never_a_helper` |
+| Opening a dominant directory at the root (its directories as candidates), at 0.4–0.6 of the scope | LMCache 71% → 14 boxes with three under 1%; btcpayserver 66% → 14 boxes and a worse subtree; at 0.45 MassTransit's root grows a 503-file "Other files" | **discarded.** Twenty to fifty candidates dumped into a root that the fold then pools | [fix §4] |
+| Promoting a dominant directory's own fold among its siblings, at 0.4–0.6 | draws main's root for MassTransit at 0.45 (14 boxes, none under 1%) and lifts abp's depth-1 V 0.28 → 0.50 at 0.5; but the promoted boxes are folded again under a hub threshold and a kinship ubiquity computed over the new count (satellite projects merge by a shared word, two "Other files" at one root), and the threshold sits one point above MassTransit's share | **not shipped.** Would need promoted boxes protected from the parent's fold, pools merged and ubiquity computed before promotion; Svilen does not require a bound on a directory's share | [fix §4], Svilen 11 Sep |
+| Dependency-fingerprint proxy for wide flat scopes (packages that depend on the same hubs) | not run | **open.** Proposed for abp's `framework` (100 packages → families) | [handoff §6.5] |
+
+## 3. Depth: the ladder below a component
+
+| what we tried | what came out | decision, and why | source |
+|---|---|---|---|
+| Un-merge: a fold's parts offered to the grouper again inside their scope | eShop depth 2 0.999; abp's widest depth-2 scope 31 → 10 from this alone | **kept, always the first rung below the root.** A box folded from seventy candidates opens onto nine, not seventy | [design §3.5], [notes hub-fold study] |
+| Next trie segment below the leaf cap | over-splits 7 of 7 leaf parents on eShop depth 2 (0.496) | **kept above 135 units only** | [notes name-tree stack] |
+| Vocabulary rung (one candidate per word of the names) | 51- and 60-child scopes, nothing folds because word candidates share no links; markitdown 88% and serilog 69% in one box when the frontier yields one box | **discarded** | [design §3.5], [study grouper] |
+| Files rung (each file a candidate, kinship, graph fold, sub-floor groups pooled into "Loose files"), then a roles rung | files in leaves of at most seven: junit4 100%, eShop 93%, Polly 91%; cross-child leakage 0.35 against 0.79 for a random partition; almost no one-file leaves once the loose bucket exists | **kept** | [study leaf ladder, tests#34], [design §3.5] |
+| Declaration or method units below the file | equal the file in C#/Java, split 30–71% of Python/TS/Go files, group same-named functions, worse than random by calls on serilog, junit4 and Polly | **discarded** | [study leaf ladder] |
+| Island rung (one family against "Other X" when no link crosses) | fires on exactly two leaves in nine repositories, both right; the share-only variant made 14 arbitrary hub cuts | **kept as the last rung, with the link test** | [study leaf island, #563] |
+
+## 4. Counts and bounds
+
+| what we tried | what came out | decision, and why | source |
+|---|---|---|---|
+| Budget 9 as a soft target reached along links | folds small candidates toward nine; forced, it damages small roots (serilog 13 → 9: agent exact 1/8 against 5/8) | **kept as a target, never a count to force** | [notes budget study], [design §3.3] |
+| Limit 15 inside the affinity grouper's pool | no limit for the kinship or planner groupers; the fallback rule `_settle` appends can make 16; hubs spared made 23 | **discarded as the place for the limit** | [eval §5], [fix §5] |
+| Limit 15 in the ladder (`_settle` pools the smallest rules, room left for the fallback) | 0 scopes over 15 on 22 graphs, for every grouper | **kept.** The one function every rung passes through is where a guarantee belongs | this session |
+| Cap 60% on folds | a fold never makes a box that is most of its scope; a directory can still be that big (LMCache `v1` 71%, btcpayserver's app 66%) | **kept as a default for folds; not an invariant for directories.** Svilen: such a box may be right and split more evenly inside; depends on the case and the graph | Svilen, 11 Sep |
+| Floor 5% (`max(2, 5%)`) as "small enough to be a detail" | a 5% directory can be a core piece, rarely, and then it shows in the graph (a hub under the floor already stands) | **kept as a default** | Svilen, 11 Sep |
+| The 5% guard applied to the root frontier | kubernetes 74 boxes → 5 grab bags; identical on eShop and abp | **discarded.** The root takes no guard | [notes name-tree stack], [notes hub-fold study] |
+| Widening the old Leiden bracket [5,8] | the modularity peak sits at 8 whatever the bracket; forcing N regresses on eShop | **discarded** | [notes namespace grouping], [notes eShop fixture] |
+| Equal-sized children as a goal | across 22 graphs the median scope's largest child is 45–50% of it and 2.5–2.7× the median child, unchanged by every fold variant | **not a goal.** Sizes follow the directories | Svilen 11 Sep, `sizes.py` |
+| Components growing past the limit on incremental runs (a rule appended per new directory, nothing moved) | by design today | **deferred.** Svilen: not indefinitely, later | Svilen, 11 Sep |
+
+## 5. Rulers and harnesses
+
+- eShop's published architecture (`CodeBoarding-evals/src/codeboarding_evals/reference/eshop-depth-{1,2}.mmd`): the only maintainer-drawn ruler; compare module sets, never names; the depth-2 pair-F1 is meaningless (one same-box pair), use boxes reproduced (10/11).
+- abp: V-measure against `.csproj` projects at depths 1 and 2; depth 1 is 0.28 by construction (6 boxes over 200 projects).
+- Beacon, modulify, django, kubernetes, mermaid and spring-framework rulers over synthesised units in the name-tree research harness.
+- Hold-out protocol with five unseen graphs (`CodeBoarding-evals/runs/hub-aware-fold-holdout`): invariants gate, rulers tie-break, a repository that exposes a defect joins the tuning set.
+- Zero-LLM sweep over 17 tuning and 5 hold-out graphs in about 30 s: `CodeBoarding-Workspace/tools/cluster-study/limit-fix/`.
+- Validation order (Svilen, 11 Sep): eShop first at every depth, then one repository picked blind, each compared against the previous approach; continue if worse but sensible, restart if worse repeatedly. Priority: C#, Java, TypeScript, Python.
+
+## 6. The limit problem: candidates assessed before running (11 Sep)
+
+Discarded without a run, on the rows above: hub-count caps and density-relative hubs (§2), dominance everywhere (§2), the peer-size test (§2), freezing links (§2), the vocabulary merge in any form (§2), a limit inside one grouper (§4), opening a dominant directory (§2, and Svilen does not require it).
+
+Left standing, run in the protocol order from base #586 (eShop first at every depth, then the
+blind pick, then MassTransit, then all 22 graphs):
+
+1. The limit moves into the ladder (§4). **Measured:** eShop and jackson-databind identical to
+   base; MassTransit's core 23 → 15 children, but the fifteen include a 338-file box named
+   "JobService" (the bag the eval described, under a worse name) beside a 172-file pool of the
+   smallest hubs. Necessary, not sufficient.
+2. On top: the vocabulary rung deleted, "shared by three" counting hub callers, and the budget
+   fold's criterion replaced by dominance (half of the followable links; a quarter of all links
+   for a small home; under three units follows its links). **Measured:** eShop identical at
+   every depth (26 scopes); jackson-databind 12 → 14 root boxes, `annotation` (15 files) and
+   `jsonFormatVisitors` (19) out of a 35-file loose bucket, one root-level file left as a
+   one-file "Loose files"; MassTransit's core 15 = the fourteen largest directories plus a pool
+   of the twenty-four smallest, JobService and MessageData standing; across the 22 graphs no
+   scope over fifteen, 12 pooled scopes (base 9), roots identical on 20 of 22 (hugo 11 → 14
+   with four boxes of 2–5 files that base folded on two-link slivers), two-child scopes 51 →
+   55, abp depth-2 V 0.687 → 0.717. **Kept.** Write-up: `PR586-limit-fix.md` in the workspace.
+3. Not on top: replacing the role placement with one rule (§2), for the reason in its row.

--- a/docs/design/name-tree.md
+++ b/docs/design/name-tree.md
@@ -104,7 +104,7 @@ implementations behind one protocol, switchable by configuration (`CODEBOARDING_
 - `KinshipGrouper`: merge candidates sharing their distinctive word (`Ordering` +
   `OrderProcessor`, `Webhooks` + `WebhookClient`, `EventBus` + `EventBusRabbitMQ`).
   Recovers eShop's depth-1 drawing at 1.000 with no model.
-- `AffinityGrouper` (default): kinship, then the graph, in four steps that read the same at
+- `AffinityGrouper` (default): kinship, then the graph, in two steps that read the same at
   every depth. The context hands every grouper, per candidate, its size, the links it
   exchanges with each sibling (call edges plus `INHERITS`/`TYPEREF` reference edges,
   cross-file only) **with their direction**, the stems its units' names are made of, and
@@ -113,27 +113,45 @@ implementations behind one protocol, switchable by configuration (`CODEBOARDING_
   1. *Placement by role*, for every candidate under the scope's floor (5%). Read off the
      direction of the calls: a **hub** (called by 40% of its siblings, three at least) stays;
      an **application** (calls others, called by none) stays; a **project root** stays; one
-     **shared** by three siblings stays; a **helper**, called by one sibling only, goes inside
-     it; shared by exactly two, into the larger; linked to nothing, into the loose files; a
-     hub under three files, into the loose files. Loose files, residues, tests, samples,
+     **shared** by three siblings stays, the hubs among them counted (else in a scope where
+     most siblings are hubs every shared candidate reads as the helper of the few that are
+     not); a **helper**, called by one sibling only, goes inside it; shared by exactly two,
+     into the larger; linked to nothing, into the loose files; a hub under three files, into
+     the loose files. Loose files, residues, tests, samples,
      benches, docs and hubs own no helper: the bus dispatching to a service's handlers does
      not make the service its helper. Why direction: size cannot tell `core/` (3 files, a
      helper of the CLI) from `PaymentProcessor` (6 files, a service); who calls whom can.
   2. *Budget*: while the scope holds more than nine, the smallest candidate joins the
      sibling it exchanges the most links with, never a hub, never a consumer, never past 60%
-     of the scope, and only a sibling carrying at least half of the candidate's links, so a
-     real component is never folded on the two links a helper brought along. Why raw counts
-     and not observed-over-expected: the ratio was measured to send `WebAppComponents` to
-     `HybridApp` on three links over `WebApp` on fifteen, and to fold every service into the
-     event bus once the recovered call sites made the bus everyone's busiest partner; the
-     hub exclusion does what the ratio was meant to do, and does it by name.
-  3. *Limit*: while the scope holds more than fifteen, the two non-hub candidates whose
-     identifier vocabulary (TF-IDF over stems) is closest merge, under the cap.
-  4. *Pool*: still over fifteen, the smallest are one box, "Other files".
-  Measured on fifteen repositories at depth 3: no scope above fifteen anywhere (before: abp
-  31, nopCommerce 51, btcpayserver 27 at the root); eShop 9 of 9 published boxes from 5 of 9;
-  serilog and mermaid no longer forced from 13 to 9. A candidate with no home stays its own
-  box; the fold only ever merges. The persisted rules are still prefixes and words: a fold is
+     of the scope, and only a sibling that carries at least half of the links the candidate
+     could follow. A real component (at the floor) is measured against all its links, so it
+     is never folded on the two links a helper brought along; a small one against its links
+     to siblings able to take it, since the hub it mostly calls cannot; and when that home is
+     small too, the two joined are a new box, so the home must also carry a quarter of all the
+     candidate's links (`PARTNER_SHARE`). A candidate under three units follows its links
+     wherever they lead. Why raw counts and not observed-over-expected: the ratio was measured
+     to send `WebAppComponents` to `HybridApp` on three links over `WebApp` on fifteen, and to
+     fold every service into the event bus once the recovered call sites made the bus
+     everyone's busiest partner; the hub exclusion does what the ratio was meant to do, and
+     does it by name. Why the dominance test: in MassTransit's core (39 directories, 22 of
+     them hubs by the 40% rule) the hub exclusion left sixteen non-hubs as the only legal
+     homes, and the folds that piled them into one 344-file bag carried 1% to 18% of the
+     folded candidate's links; abp's package families (Kafka and RabbitMQ into EventBus,
+     MailKit into Emailing) carry 33% to 79%.
+  The grouper has no limit step: the ladder enforces the limit on every grouper's output
+  (§3.5). The vocabulary merge that used to run past the limit (closest TF-IDF pair) is
+  gone: it merged nothing on the wide scopes it was written for (abp's `framework`: the
+  budget fold took 76 to 15 alone) and, once hubs could join it, snowballed, since a merged
+  group's identifier vector is closer to everything, into a 1,183-file box named
+  "Configuration". Measured on seventeen repositories and the five hold-out graphs at depth 3:
+  no scope above fifteen anywhere (before: abp 31, nopCommerce 51, btcpayserver 27 at the
+  root, then MassTransit's core 23); eShop's tree identical at every depth, 9 of 9 published
+  boxes; abp's depth-2 V against its projects 0.69 to 0.72, the bags named `Ddd.Domain` (845
+  files) and `Features` (317) replaced by a 24% "Other files" beside EventBus,
+  EntityFrameworkCore, BlobStoring and Authorization standing on their own; the roots of 20 of
+  22 repositories identical (hugo 11 to 14, jackson-databind 12 to 14, two named boxes out of a
+  35-file loose bucket). A candidate with no home stays its own box; the fold only ever merges.
+  The ledger of everything tried and why it was kept or discarded is `clustering-ledger.md`. The persisted rules are still prefixes and words: a fold is
   one rule with the members' prefixes and the union of their words, so replay stays graph-free.
 - `TreePlannerAgent` (LLM): runs kinship first and, only when a scope is left with more
   than nine groups, shows the model those groups with their sizes and a few identifiers and
@@ -187,6 +205,15 @@ What no rule of a settled scope claims goes to a fallback-only "Loose files" rul
 scope's own prefix, drafted on the spot; there is no separate "Unassigned" bucket, so a reader
 meets one name for the files a scope holds directly, whether the walk found them or a later
 run added them.
+
+The limit is enforced here too: past fifteen rules, the loose-files rule the unplaced units
+will need counted, `_settle` pools the smallest rules that are not a fallback into one "Other
+files" rule whose parts are the pooled rules, whatever grouper drew them and whatever their
+roles. Why here: the one function every rung's rules pass through is where a guarantee
+belongs. Inside the affinity grouper it bound neither the kinship nor the planner grouper, a
+pool that spared hubs left MassTransit's core at 23 children, and the fallback rule appended
+after it made sixteen. The pool opens at the next depth through the un-merge rung like any
+fold.
 
 The ladder is the same at every depth. The un-merge rung hands a fold's parts back to the
 grouper inside their own scope (kinship skipped, since the parts are already one word apart),
@@ -397,6 +424,18 @@ perfect grouping) is the planner's to reach.
 
 ## 10. Open items
 
+- A directory holding most of a scope stays one box (MassTransit's core at 45%, btcpayserver's
+  app at 66%, LMCache's `v1` at 71%) and opens onto at most fifteen. Opening it was measured
+  two ways at 0.4 to 0.6 of the scope: its directories as the scope's candidates, and its own
+  drafted boxes promoted among its siblings. Neither ships. Raw opening hands a root 20 to 50
+  candidates that the fold then pools; promotion draws a main-like root for MassTransit
+  (14 boxes at 0.45, none under 1%) and lifts abp's depth-1 V from 0.28 to 0.50 at 0.5, but
+  the promoted boxes are folded again under a hub threshold and a kinship ubiquity computed
+  over the new candidate count (btcpayserver's six satellite projects merge by their shared
+  word, MassTransit's root shows two "Other files", `Abstractions` sweeps the test framework
+  in), and 0.45 sits one point above MassTransit's share. The design that would work protects
+  promoted boxes from the parent's fold and merges pools. Not required: a directory that big
+  may be right and splits more evenly inside (Svilen, 11 Sep).
 - Kubernetes-scale repos over-produce root boxes (44–53 against 16 sigs); grouping them
   is the planner's job and its variance must be measured across draws before it ships.
 - Inside a wide flat scope (abp's `framework`, a hundred packages) the rules give package

--- a/static_analyzer/clustering/names/draft.py
+++ b/static_analyzer/clustering/names/draft.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import math
 from pathlib import Path
 from collections import Counter
 from collections.abc import Callable, Iterable, Mapping, Sequence
@@ -50,19 +49,25 @@ BUDGET = 9
 at least half of what the folded candidate exchanges; the guard, not the budget, is what
 a rung must clear."""
 LIMIT = 15
-"""Components a scope never exceeds: past the budget nothing folds into a hub, past the
-limit the names' vocabulary and, last, a pool of the smallest bring it down."""
+"""Children a scope never exceeds. Every rung's rules pass through ``_settle``, which pools the
+smallest of them into one "Other files" past the limit, whatever grouper drew them and whatever
+their roles."""
 MIN_LINKS = 2
 """Graph links two candidates must exchange before they count as affine: one is noise."""
 HUB_SHARE = 0.4
 """Share of its siblings that must call a candidate for it to be shared infrastructure: a
-hub neither absorbs a sibling nor folds into one, whatever the counts say."""
+hub neither absorbs a sibling nor folds into one under the budget, whatever the counts say."""
 MIN_HUB_PARTNERS = 3
 """Siblings a hub is called by at the least, so a scope of three cannot hold one."""
 MIN_HUB_UNITS = 3
-"""Units a hub needs to be drawn on its own; a smaller one is a loose file everybody calls."""
+"""Units a hub needs to be drawn on its own; a smaller one is a loose file everybody calls, and
+a smaller candidate of any role follows its links over the budget."""
 CAP_SHARE = 0.6
 """No fold may grow a component past this share of its scope."""
+PARTNER_SHARE = 0.25
+"""Share of a small candidate's links a home under the floor must carry: two small candidates
+joined are a new box, and a home carrying less is one partner of many. Measured: the folds that
+built a bag carried at most 0.18 of them, the families kept at least 0.33."""
 LOOSE_NAME = "Loose files"
 OTHER_NAME = "Other files"
 ISLAND_SHARE = 1 / 3
@@ -94,8 +99,6 @@ class GroupingContext:
     """Graph edges between two candidates' units, keyed by their keys in sorted order."""
     calls: dict[tuple[str, str], int] = field(default_factory=dict)
     """The same edges with their direction kept: ``(calling candidate, called candidate)``."""
-    vocabulary: dict[str, Counter[str]] = field(default_factory=dict)
-    """Per candidate, the stems its units' names are made of, counted once per unit."""
     projects: frozenset[str] = frozenset()
     """Candidates whose directory is a project of its own (a manifest sits in it)."""
     floor: int = MIN_UNITS
@@ -153,19 +156,20 @@ class KinshipGrouper:
 
 
 class AffinityGrouper:
-    """Kinship, then the graph, in four steps that read the same at every depth.
+    """Kinship, then the graph, in two steps that read the same at every depth.
 
     1. Every small candidate is placed by its role: a hub or an application stays, a helper
-       (called by one sibling only) goes inside that sibling, one shared by exactly two goes
-       into the larger of them, one nobody links to goes to the loose files.
-    2. Over the budget, the smallest candidate joins the sibling it exchanges the most links
-       with, never a hub, until nothing affine is left.
-    3. Over the limit still, the two candidates whose names share the most vocabulary merge.
-    4. Over the limit still, the smallest are pooled into one box, named for what they are.
+       (called by one sibling only) goes inside that sibling, one shared by three stays, the
+       hubs among them counted, one shared by exactly two goes into the larger of them, one
+       nobody links to goes to the loose files.
+    2. Over the budget, the smallest candidate joins the sibling holding half of the links it
+       could follow, never a hub, until nothing affine is left.
 
-    Why hubs are out of every fold: shared infrastructure (an event bus, a ``core`` package)
-    is what every small sibling links to most, so by counts every service belongs to it; a
-    reader wants the infrastructure drawn as one box and the services that use it as theirs.
+    The limit is the ladder's: past fifteen rules ``_settle`` pools the smallest, whatever
+    their roles. Why hubs are out of the budget fold: shared infrastructure (an event bus, a
+    ``core`` package) is what every small sibling links to most, so by counts every service
+    belongs to it; a reader wants the infrastructure drawn as one box and the services that
+    use it as theirs.
     """
 
     name = "affinity"
@@ -174,8 +178,6 @@ class AffinityGrouper:
         fold = _Fold(KinshipGrouper().group(candidates, context), candidates, context)
         fold.place()
         fold.toward_budget()
-        fold.by_vocabulary()
-        fold.pool()
         return fold.groups()
 
 
@@ -197,9 +199,6 @@ class _Fold:
         ]
         for index in range(len(groups)):
             self.links[index][index] = self.calls[index][index] = 0
-        self.vocabulary = [
-            sum((context.vocabulary.get(key, Counter()) for key in group.keys), Counter()) for group in groups
-        ]
         self.floor = context.floor
         self.cap = CAP_SHARE * context.unit_count
         live = self.live()
@@ -214,7 +213,6 @@ class _Fold:
         self.loose = next(
             (i for i, keys in enumerate(self.members) if any(self.by_key[k].kind == LOOSE for k in keys)), None
         )
-        self.pooled: int | None = None
 
     def live(self) -> list[int]:
         return sorted((i for i in range(len(self.members)) if self.sizes[i]), key=lambda i: (self.sizes[i], i))
@@ -224,7 +222,6 @@ class _Fold:
         self.terms[target] = _dedupe(self.terms[target] + self.terms[source])
         self.sizes[target] += self.sizes[source]
         self.sizes[source] = 0
-        self.vocabulary[target].update(self.vocabulary[source])
         for other in range(len(self.members)):
             self.links[target][other] += self.links[source][other]
             self.links[other][target] += self.links[other][source]
@@ -242,18 +239,19 @@ class _Fold:
         """Every candidate under the floor, by its role in the calls.
 
         Loose files, residues, tests, samples, benches, docs and hubs own no helper; a helper
-        whose owner cannot take it under the cap stays.
+        whose owner cannot take it under the cap stays. A hub's calls still count toward
+        sharing: what three siblings call is shared, whoever they are, else in a scope where
+        most siblings are hubs every shared candidate reads as the helper of the few that are not.
         """
         for index in self.live():
             if self.sizes[index] >= self.floor or index in self.fallback:
                 continue
             callers = {
-                j: self.calls[j][index]
-                for j in self.live()
-                if j != index and j not in self.consumers and j not in self.hubs and self.calls[j][index] >= MIN_LINKS
+                j for j in self.live() if j != index and j not in self.consumers and self.calls[j][index] >= MIN_LINKS
             }
+            owners = callers - self.hubs
             outgoing = sum(self.calls[index][j] for j in self.live() if j != index)
-            fitting = [j for j in callers if self.sizes[j] + self.sizes[index] <= self.cap]
+            fitting = [j for j in owners if self.sizes[j] + self.sizes[index] <= self.cap]
             if index in self.hubs:
                 if self.sizes[index] < MIN_HUB_UNITS and self.loose is not None and self.loose != index:
                     self.merge(index, self.loose)
@@ -261,7 +259,7 @@ class _Fold:
                     self.kept.add(index)
             elif index in self.projects or len(callers) >= 3:
                 self.kept.add(index)
-            elif len(callers) in (1, 2) and fitting:
+            elif len(owners) in (1, 2) and fitting:
                 self.merge(index, max(fitting, key=lambda j: (self.sizes[j], -j)))
             elif callers or outgoing >= MIN_LINKS:
                 self.kept.add(index)
@@ -271,73 +269,54 @@ class _Fold:
                 self.kept.add(index)
 
     def toward_budget(self) -> None:
-        """The smallest candidate joins the sibling it exchanges the most links with, never a hub.
+        """The smallest candidate joins the sibling holding half of the links it could follow, never a hub.
 
-        Below the floor a candidate the placement left standing joins whoever it links to;
-        over the budget a candidate joins only a sibling carrying at least half of its links,
-        so a real component is never folded on the two links a helper brought along. A
-        consumer (tests, samples, docs) neither takes nor folds, and a fallback-only candidate
-        folds nowhere.
+        The links a candidate could follow lead to siblings able to take it: not a hub, not a
+        consumer (tests, samples, docs), not a fallback. Below the floor and within the budget,
+        a candidate the placement left standing joins whoever it links to most. Over the budget
+        a real component (at the floor) joins only a sibling holding half of all its links, so
+        it is never folded on the two links a helper brought along; a small one joins the
+        sibling holding half of the links it could follow, and, when that home is small too,
+        one holding a quarter of all its links, since two small candidates joined are a new box;
+        one under MIN_HUB_UNITS follows its links wherever they lead.
         """
         while True:
             live = self.live()
             over_budget = len(live) > BUDGET
             sources = live if over_budget else [i for i in live if self.sizes[i] < self.floor and i not in self.kept]
-            chosen = None
             for source in sources:
                 if source in self.hubs or source in self.fallback or source in self.consumers:
                     continue
-                degree = sum(self.links[source][other] for other in live)
-                best: tuple[int, int, int] | None = None
-                for target in live:
-                    count = self.links[source][target]
-                    if target == source or count < MIN_LINKS:
-                        continue
-                    if target in self.hubs or target in self.consumers or target in self.fallback:
-                        continue
-                    if self.sizes[source] + self.sizes[target] > self.cap:
-                        continue
-                    if over_budget and self.sizes[source] >= self.floor and count * 2 < degree:
-                        continue
-                    if best is None or (count, -self.sizes[target], -target) > best:
-                        best = (count, -self.sizes[target], -target)
-                if best is not None:
-                    chosen = (source, -best[2])
+                home = self._home(source, over_budget)
+                if home is not None:
+                    self.merge(source, home)
                     break
-            if chosen is None:
+            else:
                 return
-            self.merge(*chosen)
 
-    def by_vocabulary(self) -> None:
-        """Over the limit, the two candidates whose names share the most vocabulary merge, under the cap."""
-        while len(self.live()) > LIMIT:
-            live = [i for i in self.live() if i not in self.hubs and i not in self.consumers and i not in self.fallback]
-            vectors = self._tfidf(live)
-            best: tuple[float, int, int] | None = None
-            for a in range(len(live)):
-                for b in range(a + 1, len(live)):
-                    i, j = live[a], live[b]
-                    if self.sizes[i] + self.sizes[j] > self.cap:
-                        continue
-                    similarity = sum(weight * vectors[j].get(word, 0.0) for word, weight in vectors[i].items())
-                    if similarity > 0 and (best is None or similarity > best[0]):
-                        best = (similarity, i, j)
-            if best is None:
-                return
-            _, i, j = best
-            self.merge(j if self.sizes[i] >= self.sizes[j] else i, i if self.sizes[i] >= self.sizes[j] else j)
-
-    def pool(self) -> None:
-        """Over the limit still, the smallest non-hub candidates become one box."""
-        live = [i for i in self.live() if i not in self.hubs and i not in self.fallback]
-        excess = len(self.live()) - LIMIT
-        if excess <= 0 or len(live) < 2:
-            return
-        pooled = live[: excess + 1]
-        target = pooled[-1]
-        for source in pooled[:-1]:
-            self.merge(source, target)
-        self.pooled = target
+    def _home(self, source: int, over_budget: bool) -> int | None:
+        live = self.live()
+        takers = [
+            t for t in live if t != source and t not in self.hubs and t not in self.consumers and t not in self.fallback
+        ]
+        linked = [
+            t for t in takers if self.links[source][t] >= MIN_LINKS and self.sizes[source] + self.sizes[t] <= self.cap
+        ]
+        if not linked:
+            return None
+        home = max(linked, key=lambda t: (self.links[source][t], -self.sizes[t], -t))
+        if not over_budget:
+            return home
+        count = self.links[source][home]
+        degree = sum(self.links[source][other] for other in live)
+        if self.sizes[source] >= self.floor:
+            return home if count * 2 >= degree else None
+        if self.sizes[source] < MIN_HUB_UNITS:
+            return home
+        followable = sum(self.links[source][t] for t in takers)
+        if count * 2 < followable or (self.sizes[home] < self.floor and count < PARTNER_SHARE * degree):
+            return None
+        return home
 
     def groups(self) -> list[CandidateGroup]:
         groups = []
@@ -347,9 +326,6 @@ class _Fold:
             # Only shared infrastructure and a project stand under a rung's floor: at the files
             # rung every leaf script calls something, and a box per script is not a picture.
             standing = index in self.hubs or index in self.projects
-            if index == self.pooled:
-                groups.append(CandidateGroup(OTHER_NAME, tuple(keys), self.terms[index]))
-                continue
             loose = next((self.by_key[key] for key in keys if self.by_key[key].kind == LOOSE), None)
             if loose is not None:
                 # What joined the loose files is loose; the box keeps the name a reader knows.
@@ -373,22 +349,6 @@ class _Fold:
             return True
         labels = (self.by_key[key].label for key in self.members[index])
         return any(set(stems(label)) & CONSUMER_WORDS for label in labels)
-
-    def _tfidf(self, live: list[int]) -> dict[int, dict[str, float]]:
-        frequency: Counter[str] = Counter()
-        for index in live:
-            frequency.update(self.vocabulary[index].keys())
-        vectors: dict[int, dict[str, float]] = {}
-        for index in live:
-            total = sum(self.vocabulary[index].values()) or 1
-            weights = {
-                word: (count / total) * math.log(1 + len(live) / frequency[word])
-                for word, count in self.vocabulary[index].items()
-                if frequency[word] < 0.8 * len(live)
-            }
-            norm = math.sqrt(sum(weight * weight for weight in weights.values())) or 1.0
-            vectors[index] = {word: weight / norm for word, weight in weights.items()}
-        return vectors
 
 
 DETERMINISTIC_GROUPERS: dict[str, type[Grouper]] = {
@@ -725,7 +685,7 @@ def _context(
     rung: str,
     links: Links,
 ) -> GroupingContext:
-    """Size, a few identifiers, vocabulary, calls and projects per candidate, from a replay of the candidates as rules."""
+    """Size, a few identifiers, calls and projects per candidate, from a replay of the candidates as rules."""
     provisional = ScopeSpec(
         scope_id,
         [replace(_candidate_rule(candidate), component_id=candidate.key) for candidate in candidates],
@@ -740,23 +700,15 @@ def _context(
             between[(min(left_owner, right_owner), max(left_owner, right_owner))] += weight
             calls[(left_owner, right_owner)] += weight
     samples: dict[str, tuple[str, ...]] = {}
-    vocabulary: dict[str, Counter[str]] = {}
     projects: set[str] = set()
     for candidate in candidates:
         seen: dict[str, None] = {}
-        words: Counter[str] = Counter()
         for unit in partition.members.get(candidate.key, []):
             if unit.project is not None and unit.project in candidate.prefixes:
                 projects.add(candidate.key)
-            unit_words: set[str] = set()
             for name in unit.names:
-                parts = segments(name, ClusteringConfig.QUALIFIED_NAME_DELIMITER)
-                seen.setdefault(parts[-1], None)
-                for part in parts:
-                    unit_words.update(stems(part))
-            words.update(unit_words)
+                seen.setdefault(segments(name, ClusteringConfig.QUALIFIED_NAME_DELIMITER)[-1], None)
         samples[candidate.key] = tuple(list(seen)[:SAMPLE_IDENTIFIERS])
-        vocabulary[candidate.key] = words
     sizes = {candidate.key: partition.size(candidate.key) for candidate in candidates}
     return GroupingContext(
         scope_id,
@@ -767,7 +719,6 @@ def _context(
         samples,
         dict(between),
         dict(calls),
-        vocabulary,
         frozenset(projects),
         _floor(len(units)),
     )
@@ -836,14 +787,16 @@ def _settle(
     guard: bool,
     min_rules: int = 2,
 ) -> tuple[ScopeSpec, Partition] | None:
-    """Replay the rules, apply the guard, number the survivors, and bucket what is left.
+    """Replay the rules, apply the guard and the limit, number the survivors, and bucket what is left.
 
     The guard: at least ``min_rules`` rules with a prefix or a word must each hold
     ``max(MIN_UNITS, int(GUARD_SHARE * parent))`` units, else the rung does not count. A
     smaller rule the grouper found no sibling for stays its own small box: the names drew
     it, and folding it into the largest rule was measured to make a grab bag of that rule.
     A fallback-only rule (loose files, a layer's residue) is not counted: it is the scope's
-    last resort and stays its own box however small.
+    last resort and stays its own box however small. The limit: past ``LIMIT`` children, the
+    loose-files rule the unplaced units will need included, the smallest rules that are not a
+    fallback become one "Other files" rule, whatever grouper drew them.
     """
     if len(rules) < min_rules:
         return None
@@ -855,7 +808,7 @@ def _settle(
     if len(strong) < min_rules:
         return None
     kept = [rule for rule in provisional if sizes[rule.component_id] or rule.is_fallback_only]
-    ordered = sorted(kept, key=lambda rule: (-sizes[rule.component_id], rule.name))
+    ordered = _within_limit(kept, sizes, LIMIT - (1 if partition.unplaced else 0))
     scope = ScopeSpec(scope_id, rung=rung)
     for rule in ordered:
         scope.rules.append(replace(rule, component_id=scope.next_id()))
@@ -865,6 +818,28 @@ def _settle(
         scope.rules.append(replace(loose_rule(units), component_id=scope.next_id()))
         partition = replay(units, scope, role_words)
     return scope, partition
+
+
+def _within_limit(rules: list[ComponentRule], sizes: Mapping[str, int], room: int) -> list[ComponentRule]:
+    """The rules largest first, the smallest of them pooled into one "Other files" past ``room``."""
+    ordered = sorted(rules, key=lambda rule: (-sizes[rule.component_id], rule.name))
+    poolable = [rule for rule in reversed(ordered) if not rule.is_fallback_only]
+    excess = len(ordered) - room
+    if excess <= 0 or len(poolable) < 2:
+        return ordered
+    pooled = poolable[: excess + 1]
+    pool = ComponentRule(
+        component_id="?pool",
+        name=OTHER_NAME,
+        prefixes=tuple(prefix for rule in pooled for prefix in rule.prefixes),
+        terms=_dedupe(tuple(term for rule in pooled for term in rule.terms)),
+        fallback_prefixes=tuple(prefix for rule in pooled for prefix in rule.fallback_prefixes),
+        parts=tuple(pooled),
+        origin="grouped",
+    )
+    remaining = [rule for rule in ordered if rule not in pooled]
+    pooled_sizes = dict(sizes) | {pool.component_id: sum(sizes[rule.component_id] for rule in pooled)}
+    return sorted(remaining + [pool], key=lambda rule: (-pooled_sizes[rule.component_id], rule.name))
 
 
 def loose_rule(units: list[Unit]) -> ComponentRule:

--- a/tests/static_analyzer/names/test_draft.py
+++ b/tests/static_analyzer/names/test_draft.py
@@ -1,7 +1,6 @@
 """Drafting: the frontier grouped into components, the ladder below them, and the guard."""
 
 import re
-from collections import Counter
 from dataclasses import replace
 
 import pytest
@@ -33,6 +32,7 @@ from static_analyzer.clustering.names.draft import (
     LOOSE_NAME,
     MIN_LINKS,
     MIN_UNITS,
+    PARTNER_SHARE,
     ROLE,
     SEGMENT,
     UNMERGE,
@@ -687,6 +687,21 @@ class TestPlacementByRole:
         links = {("big", "helper"): 6}
         assert len(AffinityGrouper().group(boxes(*sizes), context(sizes, links, floor=5))) == 3
 
+    def test_what_three_siblings_call_is_shared_whoever_they_are(self):
+        """Two hubs and one service call ``data``: it is shared, not the service's helper."""
+        services = tuple(f"svc{index}" for index in range(6))
+        sizes = dict.fromkeys(services, 30) | {"bus": 30, "core": 30, "data": 4}
+        links = {(name, hub): 5 for name in services for hub in ("bus", "core")}
+        links |= {("bus", "data"): 2, ("core", "data"): 2, ("svc0", "data"): 2}
+        groups = AffinityGrouper().group(boxes(*sizes), context(sizes, links, floor=5))
+        assert members_of(groups)["data"] == ("data",)
+        one_service = {key: count for key, count in links.items() if key[1] != "data"} | {("svc0", "data"): 2}
+        folded = AffinityGrouper().group(boxes(*sizes), context(sizes, one_service, floor=5))
+        assert members_of(folded)["svc0"] == (
+            "svc0",
+            "data",
+        ), "called by one service alone, it is that service's helper"
+
     def test_a_small_hub_or_application_stands_at_the_files_rung(self):
         """A one-file event bus every feature calls is a box, not a loose file."""
         layout = {f"pkg/feat/{name}.py": [f"pkg.feat.{name}.{name.capitalize()}"] for name in ("bus",)}
@@ -706,16 +721,38 @@ class TestBudgetAndLimit:
         groups = AffinityGrouper().group(boxes(*sizes), context(sizes, links, floor=5))
         assert len(groups) == len(sizes), "the bus is a hub and two links out of thirty-two are not a home"
 
-    def test_over_the_limit_the_names_vocabulary_merges_the_closest_pair(self):
-        sizes = dict.fromkeys((f"pkg{i}" for i in range(15)), 20) | {"tenants": 20, "tenancy": 20}
-        ctx = context(sizes, {}, floor=5)
-        vocabulary = {key: Counter({key.removeprefix("box:"): 1}) for key in ctx.sizes}
-        vocabulary["box:tenants"] = Counter({"tenant": 3, "manager": 1})
-        vocabulary["box:tenancy"] = Counter({"tenant": 3, "resolver": 1})
-        groups = AffinityGrouper().group(boxes(*sizes), replace(ctx, vocabulary=vocabulary))
-        assert len(groups) == LIMIT
-        merged = next(group for group in groups if "box:tenants" in group.keys)
-        assert set(merged.keys) == {"box:tenants", "box:tenancy"}
+    def test_a_small_candidate_joins_only_a_home_carrying_half_of_the_links_it_could_follow(self):
+        """Both call the hub most; ``helper`` sends most of the rest to one box, ``shared`` spreads it."""
+        big = tuple(f"box{index}" for index in range(9))
+        sizes = dict.fromkeys(big, 20) | {"core": 5, "shared": 4, "helper": 4}
+        links = {(name, "core"): 10 for name in big} | {("shared", "core"): 20, ("helper", "core"): 20}
+        links |= {(name, "shared"): 2 for name in big[:4]}
+        links |= {("box0", "helper"): 6, ("box1", "helper"): 2, ("box2", "helper"): 2}
+        groups = AffinityGrouper().group(boxes(*sizes), context(sizes, links, floor=5))
+        assert members_of(groups)["box0"] == ("box0", "helper")
+        assert members_of(groups)["shared"] == ("shared",), "no box carries half of what it could follow"
+
+    def test_two_small_candidates_join_only_on_a_real_share_of_the_links(self):
+        """Kafka sends two fifths of its links to the small event bus and joins it; topology and data
+        send each other a sliver beside hundreds to the hubs, and folding them would start a bag."""
+        hubs = tuple(f"hub{index}" for index in range(6))
+        sizes = dict.fromkeys(hubs, 30) | {"topology": 8, "data": 6, "eventbus": 9, "kafka": 5}
+        links = {(a, b): 10 for a in hubs for b in hubs if a != b}
+        links |= {("topology", hub): 50 for hub in hubs} | {("data", hub): 40 for hub in hubs}
+        links |= {("topology", "data"): 12, ("hub0", "data"): 2, ("hub1", "data"): 2}
+        links |= {("kafka", hub): 5 for hub in hubs} | {("kafka", "eventbus"): 20}
+        links |= {("eventbus", hub): 3 for hub in hubs} | {("hub0", "eventbus"): 2, ("hub1", "eventbus"): 2}
+        assert 12 < PARTNER_SHARE * (6 * 50 + 12) and 20 >= PARTNER_SHARE * (6 * 5 + 20)
+        groups = AffinityGrouper().group(boxes(*sizes), context(sizes, links, floor=10))
+        assert members_of(groups)["eventbus"] == ("eventbus", "kafka")
+        assert members_of(groups)["topology"] == ("topology",) and members_of(groups)["data"] == ("data",)
+
+    def test_a_candidate_under_three_units_follows_its_links_wherever_they_lead(self):
+        big = tuple(f"box{index}" for index in range(9))
+        sizes = dict.fromkeys(big, 20) | {"core": 5, "shared": 2}
+        links = {(name, "core"): 10 for name in big} | {(name, "shared"): 2 for name in big[:3]}
+        groups = AffinityGrouper().group(boxes(*sizes), context(sizes, links, floor=5))
+        assert members_of(groups)["box0"] == ("box0", "shared")
 
     def test_a_consumer_takes_nothing_over_the_budget(self):
         sizes = dict.fromkeys((f"s{i}" for i in range(9)), 20) | {"samples": 20, "printer": 6}
@@ -723,21 +760,43 @@ class TestBudgetAndLimit:
         groups = AffinityGrouper().group(boxes(*sizes), context(sizes, links, floor=5))
         assert len(groups) == len(sizes)
 
-    def test_the_vocabulary_merge_respects_the_cap(self):
-        sizes = dict.fromkeys((f"pkg{i}" for i in range(14)), 2) | {"tenants": 35, "tenancy": 35}
-        ctx = context(sizes, {}, floor=1)
-        vocabulary = {key: Counter({key.removeprefix("box:"): 1}) for key in ctx.sizes}
-        vocabulary["box:tenants"] = Counter({"tenant": 3})
-        vocabulary["box:tenancy"] = Counter({"tenant": 3})
-        groups = AffinityGrouper().group(boxes(*sizes), replace(ctx, vocabulary=vocabulary))
-        assert not any({"box:tenants", "box:tenancy"} <= set(group.keys) for group in groups)
-
-    def test_over_the_limit_with_nothing_to_merge_the_smallest_are_pooled(self):
+    def test_the_grouper_may_return_more_than_the_limit_and_the_ladder_pools_the_smallest(self):
+        """The limit is the ladder's, not the grouper's: eighteen packages sharing no link draw as fifteen."""
         sizes = {f"pkg{i:02d}": 30 - i for i in range(18)}
-        groups = AffinityGrouper().group(boxes(*sizes), context(sizes, {}, floor=5))
-        assert len(groups) == LIMIT
-        pooled = next(group for group in groups if group.name == OTHER_NAME)
-        assert set(pooled.keys) == {f"box:pkg{i}" for i in (14, 15, 16, 17)}
+        assert len(AffinityGrouper().group(boxes(*sizes), context(sizes, {}, floor=5))) == 18
+        layout: dict[str, list[str]] = {}
+        for index in range(18):
+            layout |= project(f"Pkg{index:02d}", 30 - index)
+        root = scope_of(draft_tree(units_from_layout(layout, "csharp"), AffinityGrouper(), 1), ROOT_SCOPE_ID)
+        assert len(root.rules) == LIMIT
+        pooled = next(rule for rule in root.rules if rule.name == OTHER_NAME)
+        assert sorted(part.name for part in pooled.parts) == [f"Pkg{index}" for index in (14, 15, 16, 17)]
+
+    def test_over_the_limit_the_pool_takes_the_smallest_hubs_too(self):
+        """Sixteen packages call two three-file hubs: the pool takes the hubs and the two smallest packages."""
+        layout: dict[str, list[str]] = {}
+        for index in range(16):
+            layout |= project(f"Pkg{index:02d}", 20 + index)
+        layout |= project("Bus", 3) | project("Log", 3)
+        links = {
+            (f"src/Pkg{index:02d}//Pkg{index:02d}Type0.cs", f"src/{hub}//{hub}Type0.cs"): 3
+            for index in range(16)
+            for hub in ("Bus", "Log")
+        }
+        spec = draft_tree(units_from_layout(layout, "csharp"), AffinityGrouper(), 1, links=links)
+        root = scope_of(spec, ROOT_SCOPE_ID)
+        assert len(root.rules) == LIMIT
+        pooled = next(rule for rule in root.rules if rule.name == OTHER_NAME)
+        assert sorted(part.name for part in pooled.parts) == ["Bus", "Log", "Pkg00", "Pkg01"]
+
+    def test_the_pool_leaves_room_for_the_loose_files(self):
+        """Sixteen packages plus a root-level file: fourteen boxes, the pool and the loose files make fifteen."""
+        layout: dict[str, list[str]] = {"src/Program.cs": ["Program"]}
+        for index in range(16):
+            layout |= project(f"Pkg{index:02d}", 30 + index)
+        root = scope_of(draft_tree(units_from_layout(layout, "csharp"), AffinityGrouper(), 1), ROOT_SCOPE_ID)
+        assert len(root.rules) == LIMIT
+        assert [rule.name for rule in root.rules if rule.is_fallback_only] == ["Loose files in src"]
 
 
 class TestGroupingContractErrors:


### PR DESCRIPTION
On top of #586. The hold-out eval ([PR586-analysis](https://github.com/CodeBoarding/CodeBoarding-evals/blob/50c2582/runs/hub-aware-fold-holdout/README.md)) found MassTransit's core project drawn as **23 children with a 344-file "Other files" made of real components**, and the limit of fifteen not acting. This branch fixes that with one commit, keeps eShop's tree byte-identical at every depth, and makes the limit hold for every grouper.

## What was wrong, mechanically

Two mechanisms, neither the hub definition the eval blamed:

- **The funnel.** 22 of the core's 38 candidates are hubs (called by 40% of their siblings). A hub owns no helper and nothing folds into a hub, so the sixteen non-hubs were the only legal homes, and everything small drained into them on "most links": `JobService` grew from 83 files to 337 through placement, the budget fold and the vocabulary merge, and the pool renamed it "Other files". The 22 hubs stood: 23 boxes.
- **A limit that could not act.** Both limit steps spared hubs, the limit lived inside one grouper (none for the kinship or planner groupers), and the fallback rule `_settle` appends after the grouper could make sixteen.

The fold traces separate the arbitrary folds from the real ones: every fold that built a bag carried 1–18% of the folded candidate's links (Topology → MessageData 33 of 1,141); every family fold worth keeping carried at least 33% (Kafka → EventBus 0.39, MailKit → Emailing 0.79).

## The change

| change | kind |
|---|---|
| The limit moves into `_settle`: past fifteen rules, the loose-files rule counted, the smallest non-fallback rules become one "Other files" rule whose parts are the pooled rules. It holds for every grouper and never makes sixteen. | moved |
| The vocabulary merge over the limit and its `GroupingContext.vocabulary` field. It merged nothing on the wide scopes it was written for (abp's `framework`: the budget fold takes 76 → 15 alone) and snowballs once hubs may join it (a 1,183-file "Configuration"). | deleted |
| "Shared by three" counts hub callers; only non-hubs may own a helper. Before, MessageData (called by 8 siblings, 6 of them hubs) read as "shared by two" and became JobService's helper. | modified |
| The budget fold's criterion: a small candidate joins the sibling holding **half of the links it could follow** (to siblings able to take it), and **a quarter of all its links** when that home is small too; a real component keeps "half of all links"; under three units follows its links. `PARTNER_SHARE = 0.25` is the one new constant, sitting in the measured gap between bags (≤ 0.18) and families (≥ 0.33). | replaced |

Untouched: kinship, the hub definition and its protection under the budget, consumers, the cap, the role placement, the ladder. Everything tried and why it was kept or discarded is in `docs/design/clustering-ledger.md` (new), including what was measured and not shipped: dominance for every fold (inflates roots under the limit), one fold rule replacing the role placement (changes eShop below the root), hub caps, and opening the 45% root (raw and promoted, at 0.4–0.6).

## Screenshots

Same viewer and tooling as #586's pictures (CodeBoarding-evals PR #25, commit `66307d8`): the fold replayed from the same pickled graphs under each engine, no model. `#586` on the left, this branch on the right.

**MassTransit, inside the core project.** 23 boxes and 426 relations → 15 boxes and 194: the fourteen largest directories plus one pool of the twenty-four smallest (414 files, 21%). JobService and MessageData, which were the bag, stand.

![MassTransit core: #586 next to the limit fix](https://github.com/CodeBoarding/CodeBoarding-evals/blob/66307d8d2160306d6a25c4e3a8b21a69205dd32e/runs/type-reference-eval/shots/MassTransit-core-pr586-fold-vs-limit-fix-fold.png?raw=true)

**abp, inside `framework/`.** The boxes named `Volo.Abp.Ddd.Domain` (845 files) and `Volo.Abp.Features` (317) held EventBus, EntityFrameworkCore, Uow, Auditing, Localization and Settings; now those stand under their own names beside a 24% "Other files". Depth-2 V against the projects 0.687 → 0.717.

![abp framework: #586 next to the limit fix](https://github.com/CodeBoarding/CodeBoarding-evals/blob/66307d8d2160306d6a25c4e3a8b21a69205dd32e/runs/type-reference-eval/shots/abp-framework-pr586-fold-vs-limit-fix-fold.png?raw=true)

**jackson-databind, root.** The blind pick of the validation: 12 → 14 boxes, `annotation` (15 files) and `jsonFormatVisitors` (19) out of a 35-file loose bucket; the eval's own prior lists Annotations.

![jackson-databind: #586 next to the limit fix](https://github.com/CodeBoarding/CodeBoarding-evals/blob/66307d8d2160306d6a25c4e3a8b21a69205dd32e/runs/type-reference-eval/shots/jackson-databind-pr586-fold-vs-limit-fix-fold.png?raw=true)

## Measured, zero-LLM, 17 tuning + 5 hold-out graphs at depth 3

Run in the order Svilen asked for: eShop first at every depth, then a repository drawn blind, then MassTransit, then all.

| | #586 | this branch |
|---|---|---|
| scopes over fifteen children | 1 | **0** |
| eShop, whole tree (26 scopes) | | identical; 9/9 published boxes |
| MassTransit core | 23 children, 344-file pool of real components | 15 |
| roots identical to #586 | | 20 of 22 (hugo 11 → 14, jackson 12 → 14) |
| scopes with an "Other files" pool | 9 | 12 |
| two-child scopes | 51 | 55 |
| abp depth-2 V against its projects | 0.687 | 0.717 |
| median scope: largest child's share | 46% | 45% (sizes follow the directories; nothing equalizes them) |

The limit alone, measured: MassTransit's core at 15 with a 338-file box named "JobService". Necessary, not sufficient.

Costs: hugo's root 11 → 14 (four boxes of 2–5 files that #586 folded on two-link slivers; Go is last in priority); files-rung scopes at depth 3 change on 12 repositories because the rung's floor now pools before the limit does (bags named after one file become named groups); a scope can still hold both an "Other files" and a "Loose files" (3 scopes, #586 had 4).

## Tests and tooling

`tests/static_analyzer/names/test_draft.py` loses the two vocabulary tests and gains one per changed rule plus three ladder-limit tests. Full unit suite passes except `test_cli_parser.py::test_main_renders_after_any_successful_analysis`, which fails identically on the base branch. Zero-LLM harness and the base/final results: `CodeBoarding-Workspace/tools/cluster-study/limit-fix/` (22 graphs in ~30 s). Write-up: `CodeBoarding-Workspace/PR586-limit-fix.md`. The model-in-the-loop eval against main on C#, Java, TypeScript and Python is the next step: `CodeBoarding-Workspace/PR586-limit-fix-eval-prompt.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved component clustering for more consistent groupings based on relationship strength and shared links.
  - Added clearer handling for small candidates, hubs, and loosely connected files.
  - Large result sets now consolidate the smallest non-fallback groups into an “Other files” category.

- **Documentation**
  - Added a clustering decision ledger documenting evaluated approaches, outcomes, limits, and measurements.
  - Updated naming and grouping design documentation with current behavior and open considerations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->